### PR TITLE
Fix all compilation errors

### DIFF
--- a/specification/ai/Azure.AI.Unified/common/models.tsp
+++ b/specification/ai/Azure.AI.Unified/common/models.tsp
@@ -287,13 +287,23 @@ union ExtraParameters {
 // Define a URI alias for clarity.
 alias Uri = string;
 
-enum PendingUploadType {
-  None,
-  TemporaryBlobReference,
+@doc("The type of pending upload.")
+union PendingUploadType {
+  string,
+
+  @doc("No pending upload.")
+  none: "None",
+
+  @doc("Temporary Blob Reference is the only supported type.")
+  temporaryBlobReference: "TemporaryBlobReference",
 }
 
-enum PendingUploadCredentialType {
-  SAS,
+@doc("The type of credential used to access the storage account.")
+union PendingUploadCredentialType {
+  string,
+
+  @doc("SAS credential type.")
+  sas: "SAS",
 }
 
 model PendingUploadRequest {
@@ -301,7 +311,7 @@ model PendingUploadRequest {
   pendingUploadId?: string;
 
   /// TemporaryBlobReference is the only supported type.
-  pendingUploadType: PendingUploadType.TemporaryBlobReference;
+  pendingUploadType: PendingUploadType.temporaryBlobReference;
 }
 
 model PendingUploadResponse {
@@ -312,7 +322,7 @@ model PendingUploadResponse {
   pendingUploadId: string;
 
   /// TemporaryBlobReference is the only supported type.
-  pendingUploadType: PendingUploadType.TemporaryBlobReference;
+  pendingUploadType: PendingUploadType.temporaryBlobReference;
 }
 
 model BlobReferenceForConsumption {

--- a/specification/ai/Azure.AI.Unified/common/models.tsp
+++ b/specification/ai/Azure.AI.Unified/common/models.tsp
@@ -306,34 +306,36 @@ union PendingUploadCredentialType {
   sas: "SAS",
 }
 
+@doc("Represents a request for a pending upload.")
 model PendingUploadRequest {
-  /// If PendingUploadId is not provided, a random guid will be used.
+  @doc("If PendingUploadId is not provided, a random GUID will be used.")
   pendingUploadId?: string;
 
-  /// TemporaryBlobReference is the only supported type.
+  @doc("TemporaryBlobReference is the only supported type.")
   pendingUploadType: PendingUploadType.temporaryBlobReference;
 }
 
+@doc("Represents the response for a pending upload request")
 model PendingUploadResponse {
-  /// Container-level read, write, list SAS.
+  @doc("Container-level read, write, list SAS.")
   blobReferenceForConsumption: BlobReferenceForConsumption;
 
-  /// ID for this upload request.
+  @doc("ID for this upload request.")
   pendingUploadId: string;
 
-  /// TemporaryBlobReference is the only supported type.
+  @doc("TemporaryBlobReference is the only supported type")
   pendingUploadType: PendingUploadType.temporaryBlobReference;
 }
 
+@doc("Represents a reference to a blob for consumption")
 model BlobReferenceForConsumption {
-  /// Blob URI path for client to upload data.
-  /// Example: https://blob.windows.core.net/Container/Path
+  @doc("Blob URI path for client to upload data. Example: https://blob.windows.core.net/Container/Path")
   blobUri: Uri;
 
-  /// ARM ID of the storage account to use.
+  @doc("ARM ID of the storage account to use.")
   storageAccountArmId: string;
 
-  /// Credential info to access the storage account.
+  @doc("Credential info to access the storage account.")
   credential: SasCredential;
 }
 

--- a/specification/ai/Azure.AI.Unified/tspconfig.yaml
+++ b/specification/ai/Azure.AI.Unified/tspconfig.yaml
@@ -39,3 +39,4 @@ linter:
     "@azure-tools/typespec-azure-core/casing-style": "Since we have many names in the form XxxxAIXxxx"
     "@azure-tools/typespec-azure-core/no-string-discriminator": "Use an extensible union instead of a plain string"
     "@azure-tools/typespec-azure-core/bad-record-type": "We do want to use Record<unknown>, and not Record<string>. But this needs further investigation"
+    "@azure-tools/typespec-azure-core/use-standard-names": "PUT operations that return 200 should start with 'replace' or 'createOrReplace'"

--- a/specification/ai/Azure.AI.Unified/tspconfig.yaml
+++ b/specification/ai/Azure.AI.Unified/tspconfig.yaml
@@ -37,3 +37,5 @@ linter:
     - "@azure-tools/typespec-azure-rulesets/data-plane"
   disable:
     "@azure-tools/typespec-azure-core/casing-style": "Since we have many names in the form XxxxAIXxxx"
+    "@azure-tools/typespec-azure-core/no-string-discriminator": "Use an extensible union instead of a plain string"
+    "@azure-tools/typespec-azure-core/bad-record-type": "We do want to use Record<unknown>, and not Record<string>. But this needs further investigation"

--- a/specification/ai/data-plane/Azure.AI.Unified/preview/2025-05-01-preview/azure-ai-projects-1dp.json
+++ b/specification/ai/data-plane/Azure.AI.Unified/preview/2025-05-01-preview/azure-ai-projects-1dp.json
@@ -1,0 +1,12068 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Azure AI",
+    "version": "2025-05-01-preview",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "x-ms-parameterized-host": {
+    "hostTemplate": "{endpoint}",
+    "useSchemePrefix": false,
+    "parameters": [
+      {
+        "name": "endpoint",
+        "in": "path",
+        "description": "Project endpoint in the form of: https://<aiservices-id>.services.ai.azure.com/projects/<project-name>",
+        "required": true,
+        "type": "string",
+        "format": "uri",
+        "x-ms-skip-url-encoding": true
+      }
+    ]
+  },
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "OAuth2Auth": [
+        "https://cognitiveservices.azure.com/.default"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "OAuth2Auth": {
+      "type": "oauth2",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+      "scopes": {
+        "https://cognitiveservices.azure.com/.default": ""
+      }
+    }
+  },
+  "tags": [],
+  "paths": {
+    "/assistants": {
+      "get": {
+        "operationId": "Agents_ListAgents",
+        "description": "Gets a list of agents that were previously created.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 20.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "default": 20
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "description": "Sort order by the created_at timestamp of the objects. asc for ascending order and desc for descending order.",
+            "required": false,
+            "type": "string",
+            "default": "desc",
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "x-ms-enum": {
+              "name": "ListSortOrder",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "ascending",
+                  "value": "asc",
+                  "description": "Specifies an ascending sort order."
+                },
+                {
+                  "name": "descending",
+                  "value": "desc",
+                  "description": "Specifies a descending sort order."
+                }
+              ]
+            }
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "description": "A cursor for use in pagination. after is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include after=obj_foo in order to fetch the next page of the list.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "before",
+            "in": "query",
+            "description": "A cursor for use in pagination. before is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include before=obj_foo in order to fetch the previous page of the list.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The requested list of agents.",
+            "schema": {
+              "type": "object",
+              "description": "The response data for a requested list of items.",
+              "properties": {
+                "object": {
+                  "type": "string",
+                  "description": "The object type, which is always list.",
+                  "enum": [
+                    "list"
+                  ],
+                  "x-ms-enum": {
+                    "modelAsString": false
+                  }
+                },
+                "data": {
+                  "type": "array",
+                  "description": "The requested list of items.",
+                  "items": {
+                    "$ref": "#/definitions/Agents.Agent"
+                  }
+                },
+                "first_id": {
+                  "type": "string",
+                  "description": "The first ID represented in this list.",
+                  "x-ms-client-name": "firstId"
+                },
+                "last_id": {
+                  "type": "string",
+                  "description": "The last ID represented in this list.",
+                  "x-ms-client-name": "lastId"
+                },
+                "has_more": {
+                  "type": "boolean",
+                  "description": "A value indicating whether there are additional values available not captured in this list.",
+                  "x-ms-client-name": "hasMore"
+                }
+              },
+              "required": [
+                "object",
+                "data",
+                "first_id",
+                "last_id",
+                "has_more"
+              ]
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "Agents_CreateAgent",
+        "description": "Creates a new agent.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Agents.CreateAgentOptions"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The new agent instance.",
+            "schema": {
+              "$ref": "#/definitions/Agents.Agent"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/assistants/{assistantId}": {
+      "get": {
+        "operationId": "Agents_GetAgent",
+        "description": "Retrieves an existing agent.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "assistantId",
+            "in": "path",
+            "description": "Identifier of the agent.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The requested agent instance.",
+            "schema": {
+              "$ref": "#/definitions/Agents.Agent"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "Agents_UpdateAgent",
+        "description": "Modifies an existing agent.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/Agents.UpdateAgentOptions.assistantId"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Agents.UpdateAgentOptions"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The updated agent instance.",
+            "schema": {
+              "$ref": "#/definitions/Agents.Agent"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Agents_DeleteAgent",
+        "description": "Deletes an agent.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "assistantId",
+            "in": "path",
+            "description": "Identifier of the agent.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Status information about the requested deletion operation.",
+            "schema": {
+              "$ref": "#/definitions/Agents.AgentDeletionStatus"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/connections": {
+      "get": {
+        "operationId": "Connections_List",
+        "description": "List all connections in the project",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "$connectionCategory",
+            "in": "query",
+            "description": "Specific type of connection to return in list",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "AzureOpenAI",
+              "AzureBlob",
+              "CognitiveSearch",
+              "CosmosDB",
+              "ApiKey"
+            ],
+            "x-ms-enum": {
+              "name": "ConnectionCategory",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "AzureOpenAI",
+                  "value": "AzureOpenAI",
+                  "description": "Azure OpenAI Service"
+                },
+                {
+                  "name": "AzureBlobStorage",
+                  "value": "AzureBlob",
+                  "description": "Azure Blob Storage"
+                },
+                {
+                  "name": "AzureAISearch",
+                  "value": "CognitiveSearch",
+                  "description": "Azure AI Search"
+                },
+                {
+                  "name": "CosmosDB",
+                  "value": "CosmosDB",
+                  "description": "CosmosDB"
+                },
+                {
+                  "name": "APIKey",
+                  "value": "ApiKey",
+                  "description": "Generic connection that uses API Key authentication"
+                }
+              ]
+            },
+            "x-ms-client-name": "connectionCategory"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.TopQueryParameter"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.SkipQueryParameter"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.MaxPageSizeQueryParameter"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.ClientRequestIdHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/PagedConnection"
+            },
+            "headers": {
+              "x-ms-client-request-id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "An opaque, globally-unique, client-generated string identifier for the request."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/connections/{connectionName}": {
+      "get": {
+        "operationId": "Connections_Get",
+        "description": "Get a connection by name.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "The name of the resource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.ClientRequestIdHeader"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.ConditionalRequestHeaders.ifMatch"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.ConditionalRequestHeaders.ifNoneMatch"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.ConditionalRequestHeaders.ifUnmodifiedSince"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.ConditionalRequestHeaders.ifModifiedSince"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/Connection"
+            },
+            "headers": {
+              "ETag": {
+                "type": "string",
+                "description": "The entity tag for the response."
+              },
+              "x-ms-client-request-id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "An opaque, globally-unique, client-generated string identifier for the request."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/connections/{connectionName}:getWithCredentials": {
+      "post": {
+        "operationId": "Connections_GetWithCredentials",
+        "description": "Get connection with secrets by name.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "The name of the resource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.ClientRequestIdHeader"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.RepeatabilityRequestHeaders.repeatabilityRequestId"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.RepeatabilityRequestHeaders.repeatabilityFirstSent"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/Connection"
+            },
+            "headers": {
+              "Repeatability-Result": {
+                "type": "string",
+                "description": "Indicates whether the repeatable request was accepted or rejected.",
+                "enum": [
+                  "accepted",
+                  "rejected"
+                ],
+                "x-ms-enum": {
+                  "name": "RepeatabilityResult",
+                  "modelAsString": false,
+                  "values": [
+                    {
+                      "name": "accepted",
+                      "value": "accepted",
+                      "description": "If the request was accepted and the server guarantees that the server state reflects a single execution of the operation."
+                    },
+                    {
+                      "name": "rejected",
+                      "value": "rejected",
+                      "description": "If the request was rejected because the combination of Repeatability-First-Sent and Repeatability-Request-ID were invalid\nor because the Repeatability-First-Sent value was outside the range of values held by the server."
+                    }
+                  ]
+                }
+              },
+              "x-ms-client-request-id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "An opaque, globally-unique, client-generated string identifier for the request."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/datasets": {
+      "get": {
+        "operationId": "Datasets_ListLatestDatasets",
+        "description": "List latest version of each dataset in a project.",
+        "parameters": [
+          {
+            "name": "$continuationToken",
+            "in": "query",
+            "description": "Continuation token for pagination. This is the nextLink from the previous response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "listViewType",
+            "in": "query",
+            "description": "View type for including/excluding (for example) archived entities.",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "ActiveOnly",
+              "ArchivedOnly",
+              "All"
+            ],
+            "x-ms-enum": {
+              "name": "ListViewType",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "ActiveOnly",
+                  "value": "ActiveOnly",
+                  "description": "List only active items."
+                },
+                {
+                  "name": "ArchivedOnly",
+                  "value": "ArchivedOnly",
+                  "description": "List only archived items."
+                },
+                {
+                  "name": "All",
+                  "value": "All",
+                  "description": "List all items."
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/PagedDatasetVersion"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/datasets/{name}/versions": {
+      "get": {
+        "operationId": "Datasets_ListDatasetVersions",
+        "description": "List dataset versions of a specific dataset",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Container name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9\\-_]{0,254}$"
+          },
+          {
+            "name": "$orderBy",
+            "in": "query",
+            "description": "Please choose OrderBy value from ['createdtime', 'modifiedtime']",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Top count of results, top count cannot be greater than the page size. If topCount > page size, results with be default page size count will be returned",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Continuation token for pagination.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$tags",
+            "in": "query",
+            "description": "Comma-separated list of tag names (and optionally values). Example: tag1,tag2=value2",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "listViewType",
+            "in": "query",
+            "description": "[ListViewType.ActiveOnly, ListViewType.ArchivedOnly, ListViewType.All] View type for including/excluding (for example) archived entities.",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "ActiveOnly",
+              "ArchivedOnly",
+              "All"
+            ],
+            "x-ms-enum": {
+              "name": "ListViewType",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "ActiveOnly",
+                  "value": "ActiveOnly",
+                  "description": "List only active items."
+                },
+                {
+                  "name": "ArchivedOnly",
+                  "value": "ArchivedOnly",
+                  "description": "List only archived items."
+                },
+                {
+                  "name": "All",
+                  "value": "All",
+                  "description": "List all items."
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/PagedDatasetVersion"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/datasets/{name}/versions/{version}": {
+      "get": {
+        "operationId": "Datasets_GetVersion",
+        "description": "Get dataset version.",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Container name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9\\-_]{0,254}$"
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "Version identifier.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/DatasetVersion"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "Datasets_CreateOrUpdate",
+        "description": "Create or update version.",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Container name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9\\-_]{0,254}$"
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "Version identifier.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "datasetVersion",
+            "in": "body",
+            "description": "Version entity to create or update.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DatasetVersion"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/DatasetVersion"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Datasets_DeleteVersion",
+        "description": "Delete version.",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Container name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9\\-_]{0,254}$"
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "Version identifier.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful. "
+          }
+        }
+      }
+    },
+    "/datasets/{name}/versions/{version}/startPendingUpload": {
+      "post": {
+        "operationId": "Datasets_CreateOrGetStartPendingUpload",
+        "description": "Start pending upload.",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Container name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9\\-_]{0,254}$"
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "Version identifier.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "pendingUploadRequest",
+            "in": "body",
+            "description": "Pensing upload request.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PendingUploadRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/PendingUploadResponse"
+            }
+          }
+        }
+      }
+    },
+    "/deployments": {
+      "get": {
+        "operationId": "Deployments_List",
+        "description": "List all deployed models in the project",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "$modelPublisher",
+            "in": "query",
+            "description": "Model publisher to filter models by",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "modelPublisher"
+          },
+          {
+            "name": "$modelName",
+            "in": "query",
+            "description": "Model name (the publisher specific name) to filter models by",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "modelName"
+          },
+          {
+            "name": "$includeConnectedModels",
+            "in": "query",
+            "description": "Flag to include models from connections in response.",
+            "required": false,
+            "type": "boolean",
+            "x-ms-client-name": "includeConnectionModels"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.TopQueryParameter"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.SkipQueryParameter"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.MaxPageSizeQueryParameter"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.ClientRequestIdHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/PagedDeployment"
+            },
+            "headers": {
+              "x-ms-client-request-id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "An opaque, globally-unique, client-generated string identifier for the request."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/deployments/{deploymentName}": {
+      "get": {
+        "operationId": "Deployments_Get",
+        "description": "Get a deployed model.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "description": "Name of the deployment for the model",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.ClientRequestIdHeader"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.ConditionalRequestHeaders.ifMatch"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.ConditionalRequestHeaders.ifNoneMatch"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.ConditionalRequestHeaders.ifUnmodifiedSince"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.ConditionalRequestHeaders.ifModifiedSince"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/Deployment"
+            },
+            "headers": {
+              "ETag": {
+                "type": "string",
+                "description": "The entity tag for the response."
+              },
+              "x-ms-client-request-id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "An opaque, globally-unique, client-generated string identifier for the request."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/evaluations": {
+      "get": {
+        "operationId": "Evaluations_List",
+        "description": "List evaluations",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.TopQueryParameter"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.SkipQueryParameter"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.MaxPageSizeQueryParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/PagedEvaluation"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/evaluations/{id}": {
+      "get": {
+        "operationId": "Evaluations_Get",
+        "description": "Get an evaluation.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Identifier of the evaluation.",
+            "required": true,
+            "type": "string",
+            "maxLength": 254,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-_]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/Evaluation"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/evaluations:create": {
+      "post": {
+        "operationId": "Evaluations_Create",
+        "description": "Creates an evaluation.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Properties of Evaluation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Evaluation"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "The request has succeeded and a new resource has been created as a result.",
+            "schema": {
+              "$ref": "#/definitions/Evaluation"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/files": {
+      "get": {
+        "operationId": "Agents_ListFiles",
+        "description": "Gets a list of previously uploaded files.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "purpose",
+            "in": "query",
+            "description": "The purpose of the file.",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "fine-tune",
+              "fine-tune-results",
+              "assistants",
+              "assistants_output",
+              "batch",
+              "batch_output",
+              "vision"
+            ],
+            "x-ms-enum": {
+              "name": "FilePurpose",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "fineTune",
+                  "value": "fine-tune",
+                  "description": "Indicates a file is used for fine tuning input."
+                },
+                {
+                  "name": "fineTuneResults",
+                  "value": "fine-tune-results",
+                  "description": "Indicates a file is used for fine tuning results."
+                },
+                {
+                  "name": "agents",
+                  "value": "assistants",
+                  "description": "Indicates a file is used as input to agents."
+                },
+                {
+                  "name": "agentsOutput",
+                  "value": "assistants_output",
+                  "description": "Indicates a file is used as output by agents."
+                },
+                {
+                  "name": "batch",
+                  "value": "batch",
+                  "description": "Indicates a file is used as input to ."
+                },
+                {
+                  "name": "batchOutput",
+                  "value": "batch_output",
+                  "description": "Indicates a file is used as output by a vector store batch operation."
+                },
+                {
+                  "name": "vision",
+                  "value": "vision",
+                  "description": "Indicates a file is used as input to a vision operation."
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The requested list of files.",
+            "schema": {
+              "$ref": "#/definitions/Agents.FileListResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "Agents_UploadFile",
+        "description": "Uploads a file for use by other operations.",
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "file",
+            "in": "formData",
+            "description": "The file data, in bytes.",
+            "required": true,
+            "type": "file"
+          },
+          {
+            "name": "purpose",
+            "in": "formData",
+            "description": "The intended purpose of the uploaded file. Use `assistants` for Agents and Message files, `vision` for Agents image file inputs, `batch` for Batch API, and `fine-tune` for Fine-tuning.",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "fine-tune",
+              "fine-tune-results",
+              "assistants",
+              "assistants_output",
+              "batch",
+              "batch_output",
+              "vision"
+            ],
+            "x-ms-enum": {
+              "name": "FilePurpose",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "fineTune",
+                  "value": "fine-tune",
+                  "description": "Indicates a file is used for fine tuning input."
+                },
+                {
+                  "name": "fineTuneResults",
+                  "value": "fine-tune-results",
+                  "description": "Indicates a file is used for fine tuning results."
+                },
+                {
+                  "name": "agents",
+                  "value": "assistants",
+                  "description": "Indicates a file is used as input to agents."
+                },
+                {
+                  "name": "agentsOutput",
+                  "value": "assistants_output",
+                  "description": "Indicates a file is used as output by agents."
+                },
+                {
+                  "name": "batch",
+                  "value": "batch",
+                  "description": "Indicates a file is used as input to ."
+                },
+                {
+                  "name": "batchOutput",
+                  "value": "batch_output",
+                  "description": "Indicates a file is used as output by a vector store batch operation."
+                },
+                {
+                  "name": "vision",
+                  "value": "vision",
+                  "description": "Indicates a file is used as input to a vision operation."
+                }
+              ]
+            }
+          },
+          {
+            "name": "filename",
+            "in": "formData",
+            "description": "The name of the file.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A representation of the uploaded file.",
+            "schema": {
+              "$ref": "#/definitions/Agents.OpenAIFile"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/files/{fileId}": {
+      "get": {
+        "operationId": "Agents_GetFile",
+        "description": "Returns information about a specific file. Does not retrieve file content.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "fileId",
+            "in": "path",
+            "description": "The ID of the file to retrieve.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/Agents.OpenAIFile"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Agents_DeleteFile",
+        "description": "Delete a previously uploaded file.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "fileId",
+            "in": "path",
+            "description": "The ID of the file to delete.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/Agents.FileDeletionStatus"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/files/{fileId}/content": {
+      "get": {
+        "operationId": "Agents_GetFileContent",
+        "description": "Retrieves the raw content of a specific file.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "fileId",
+            "in": "path",
+            "description": "The ID of the file to retrieve.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "type": "string",
+              "format": "byte"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/indexes": {
+      "get": {
+        "operationId": "Indexes_ListLatestIndexes",
+        "description": "List latest version of each dataset in a project.",
+        "parameters": [
+          {
+            "name": "$continuationToken",
+            "in": "query",
+            "description": "Continuation token for pagination. This is the nextLink from the previous response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "listViewType",
+            "in": "query",
+            "description": "View type for including/excluding (for example) archived entities.",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "ActiveOnly",
+              "ArchivedOnly",
+              "All"
+            ],
+            "x-ms-enum": {
+              "name": "ListViewType",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "ActiveOnly",
+                  "value": "ActiveOnly",
+                  "description": "List only active items."
+                },
+                {
+                  "name": "ArchivedOnly",
+                  "value": "ArchivedOnly",
+                  "description": "List only archived items."
+                },
+                {
+                  "name": "All",
+                  "value": "All",
+                  "description": "List all items."
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/PagedDatasetVersion"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/indexes/{name}:create": {
+      "post": {
+        "operationId": "Indexes_CreateIndex",
+        "description": "Creates or updates a IndexVersion.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name of the index.",
+            "required": true,
+            "type": "string",
+            "maxLength": 254,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-_]*$"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Properties of an Index Version.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Index"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/Index"
+            }
+          },
+          "201": {
+            "description": "The request has succeeded and a new resource has been created as a result.",
+            "schema": {
+              "$ref": "#/definitions/Index"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/indexes/{name}/versions": {
+      "get": {
+        "operationId": "Indexes_ListIndexVersions",
+        "description": "List the versions of an Index given the name.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name of the index.",
+            "required": true,
+            "type": "string",
+            "maxLength": 254,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-_]*$"
+          },
+          {
+            "name": "listViewType",
+            "in": "query",
+            "description": "View type for including/excluding (for example) archived entities.",
+            "required": true,
+            "type": "string",
+            "default": "ActiveOnly"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "description": "Ordering of list: Please choose orderby value from ['createdAt', 'lastModifiedAt'].",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderby",
+            "in": "query",
+            "description": "Ordering of list: Please choose orderby value from ['createdAt', 'lastModifiedAt'].",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "Comma-separated list of tag names (and optionally values). Example: tag1,tag2=value2.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.TopQueryParameter"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.SkipQueryParameter"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.MaxPageSizeQueryParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/PagedIndex"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/indexes/{name}/versions/{version}": {
+      "get": {
+        "operationId": "Indexes_Get",
+        "description": "Get a specific version of an Index.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name of the index.",
+            "required": true,
+            "type": "string",
+            "maxLength": 254,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-_]*$"
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "Version of the index.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/Index"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Indexes_DeleteVersion",
+        "description": "Delete version.",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Container name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9\\-_]{0,254}$"
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "Version identifier.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful. "
+          }
+        }
+      }
+    },
+    "/models/chat/completions": {
+      "post": {
+        "operationId": "Models_GetChatCompletions",
+        "description": "Gets chat completions for the provided chat messages.\nCompletions support a wide variety of tasks and generate text that continues from or \"completes\"\nprovided prompt data. The method makes a REST API call to the `/chat/completions` route\non the given endpoint.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "extra-parameters",
+            "in": "header",
+            "description": "Controls what happens if extra parameters, undefined by the REST API,\nare passed in the JSON request payload.\nThis sets the HTTP request header `extra-parameters`.",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "error",
+              "drop",
+              "pass-through"
+            ],
+            "x-ms-enum": {
+              "name": "ExtraParameters",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "error",
+                  "value": "error",
+                  "description": "The service will error if it detected extra parameters in the request payload. This is the service default."
+                },
+                {
+                  "name": "drop",
+                  "value": "drop",
+                  "description": "The service will ignore (drop) extra parameters in the request payload. It will only pass the known parameters to the back-end AI model."
+                },
+                {
+                  "name": "pass_through",
+                  "value": "pass-through",
+                  "description": "The service will pass extra parameters to the back-end AI model."
+                }
+              ]
+            },
+            "x-ms-client-name": "extra_params"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "The parameters of the chat completions request.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ChatCompletionsOptions"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ChatCompletions"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/models/embeddings": {
+      "post": {
+        "operationId": "Models_GetEmbeddings",
+        "description": "Return the embedding vectors for given text prompts.\nThe method makes a REST API call to the `/embeddings` route on the given endpoint.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "extra-parameters",
+            "in": "header",
+            "description": "Controls what happens if extra parameters, undefined by the REST API,\nare passed in the JSON request payload.\nThis sets the HTTP request header `extra-parameters`.",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "error",
+              "drop",
+              "pass-through"
+            ],
+            "x-ms-enum": {
+              "name": "ExtraParameters",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "error",
+                  "value": "error",
+                  "description": "The service will error if it detected extra parameters in the request payload. This is the service default."
+                },
+                {
+                  "name": "drop",
+                  "value": "drop",
+                  "description": "The service will ignore (drop) extra parameters in the request payload. It will only pass the known parameters to the back-end AI model."
+                },
+                {
+                  "name": "pass_through",
+                  "value": "pass-through",
+                  "description": "The service will pass extra parameters to the back-end AI model."
+                }
+              ]
+            },
+            "x-ms-client-name": "extra_params"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "The parameters of the embeddings request.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EmbeddingsOptions"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/EmbeddingsResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/models/images/embeddings": {
+      "post": {
+        "operationId": "Models_GetImageEmbeddings",
+        "description": "Return the embedding vectors for given images.\nThe method makes a REST API call to the `/images/embeddings` route on the given endpoint.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "extra-parameters",
+            "in": "header",
+            "description": "Controls what happens if extra parameters, undefined by the REST API,\nare passed in the JSON request payload.\nThis sets the HTTP request header `extra-parameters`.",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "error",
+              "drop",
+              "pass-through"
+            ],
+            "x-ms-enum": {
+              "name": "ExtraParameters",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "error",
+                  "value": "error",
+                  "description": "The service will error if it detected extra parameters in the request payload. This is the service default."
+                },
+                {
+                  "name": "drop",
+                  "value": "drop",
+                  "description": "The service will ignore (drop) extra parameters in the request payload. It will only pass the known parameters to the back-end AI model."
+                },
+                {
+                  "name": "pass_through",
+                  "value": "pass-through",
+                  "description": "The service will pass extra parameters to the back-end AI model."
+                }
+              ]
+            },
+            "x-ms-client-name": "extra_params"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "The parameters of the image embeddings request.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ImageEmbeddingsOptions"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/EmbeddingsResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/threads": {
+      "post": {
+        "operationId": "Agents_CreateThread",
+        "description": "Creates a new thread. Threads contain messages and can be run by agents.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Agents.AgentThreadCreationOptions"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Information about the newly created thread.",
+            "schema": {
+              "$ref": "#/definitions/Agents.AgentThread"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/threads/{threadId}": {
+      "get": {
+        "operationId": "Agents_GetThread",
+        "description": "Gets information about an existing thread.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "threadId",
+            "in": "path",
+            "description": "Identifier of the thread.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Information about the requested thread.",
+            "schema": {
+              "$ref": "#/definitions/Agents.AgentThread"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "Agents_UpdateThread",
+        "description": "Modifies an existing thread.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/Agents.UpdateAgentThreadOptions.threadId"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Agents.UpdateAgentThreadOptions"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Information about the modified thread.",
+            "schema": {
+              "$ref": "#/definitions/Agents.AgentThread"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Agents_DeleteThread",
+        "description": "Deletes an existing thread.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "threadId",
+            "in": "path",
+            "description": "Identifier of the thread.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Status information about the requested thread deletion operation.",
+            "schema": {
+              "$ref": "#/definitions/Agents.ThreadDeletionStatus"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/threads/{threadId}/messages": {
+      "get": {
+        "operationId": "Agents_ListMessages",
+        "description": "Gets a list of messages that exist on a thread.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "threadId",
+            "in": "path",
+            "description": "Identifier of the thread.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "runId",
+            "in": "query",
+            "description": "Filter messages by the run ID that generated them.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 20.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "default": 20
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "description": "Sort order by the created_at timestamp of the objects. asc for ascending order and desc for descending order.",
+            "required": false,
+            "type": "string",
+            "default": "desc",
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "x-ms-enum": {
+              "name": "ListSortOrder",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "ascending",
+                  "value": "asc",
+                  "description": "Specifies an ascending sort order."
+                },
+                {
+                  "name": "descending",
+                  "value": "desc",
+                  "description": "Specifies a descending sort order."
+                }
+              ]
+            }
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "description": "A cursor for use in pagination. after is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include after=obj_foo in order to fetch the next page of the list.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "before",
+            "in": "query",
+            "description": "A cursor for use in pagination. before is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include before=obj_foo in order to fetch the previous page of the list.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The requested list of messages.",
+            "schema": {
+              "type": "object",
+              "description": "The response data for a requested list of items.",
+              "properties": {
+                "object": {
+                  "type": "string",
+                  "description": "The object type, which is always list.",
+                  "enum": [
+                    "list"
+                  ],
+                  "x-ms-enum": {
+                    "modelAsString": false
+                  }
+                },
+                "data": {
+                  "type": "array",
+                  "description": "The requested list of items.",
+                  "items": {
+                    "$ref": "#/definitions/Agents.ThreadMessage"
+                  }
+                },
+                "first_id": {
+                  "type": "string",
+                  "description": "The first ID represented in this list.",
+                  "x-ms-client-name": "firstId"
+                },
+                "last_id": {
+                  "type": "string",
+                  "description": "The last ID represented in this list.",
+                  "x-ms-client-name": "lastId"
+                },
+                "has_more": {
+                  "type": "boolean",
+                  "description": "A value indicating whether there are additional values available not captured in this list.",
+                  "x-ms-client-name": "hasMore"
+                }
+              },
+              "required": [
+                "object",
+                "data",
+                "first_id",
+                "last_id",
+                "has_more"
+              ]
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "Agents_CreateMessage",
+        "description": "Creates a new message on a specified thread.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "threadId",
+            "in": "path",
+            "description": "Identifier of the thread.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Agents.ThreadMessageOptions"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A representation of the new message.",
+            "schema": {
+              "$ref": "#/definitions/Agents.ThreadMessage"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/threads/{threadId}/messages/{messageId}": {
+      "get": {
+        "operationId": "Agents_GetMessage",
+        "description": "Gets an existing message from an existing thread.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "threadId",
+            "in": "path",
+            "description": "Identifier of the thread.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "messageId",
+            "in": "path",
+            "description": "Identifier of the message.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A representation of the requested message.",
+            "schema": {
+              "$ref": "#/definitions/Agents.ThreadMessage"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "Agents_UpdateMessage",
+        "description": "Modifies an existing message on an existing thread.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "threadId",
+            "in": "path",
+            "description": "Identifier of the thread.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "messageId",
+            "in": "path",
+            "description": "Identifier of the message.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "metadata": {
+                  "type": "object",
+                  "description": "A set of up to 16 key/value pairs that can be attached to an object, used for storing additional information about that object in a structured format. Keys may be up to 64 characters in length and values may be up to 512 characters in length.",
+                  "x-nullable": true,
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A representation of the modified message.",
+            "schema": {
+              "$ref": "#/definitions/Agents.ThreadMessage"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/threads/{threadId}/runs": {
+      "get": {
+        "operationId": "Agents_ListRuns",
+        "description": "Gets a list of runs for a specified thread.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "threadId",
+            "in": "path",
+            "description": "Identifier of the thread.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 20.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "default": 20
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "description": "Sort order by the created_at timestamp of the objects. asc for ascending order and desc for descending order.",
+            "required": false,
+            "type": "string",
+            "default": "desc",
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "x-ms-enum": {
+              "name": "ListSortOrder",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "ascending",
+                  "value": "asc",
+                  "description": "Specifies an ascending sort order."
+                },
+                {
+                  "name": "descending",
+                  "value": "desc",
+                  "description": "Specifies a descending sort order."
+                }
+              ]
+            }
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "description": "A cursor for use in pagination. after is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include after=obj_foo in order to fetch the next page of the list.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "before",
+            "in": "query",
+            "description": "A cursor for use in pagination. before is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include before=obj_foo in order to fetch the previous page of the list.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The requested list of thread runs.",
+            "schema": {
+              "type": "object",
+              "description": "The response data for a requested list of items.",
+              "properties": {
+                "object": {
+                  "type": "string",
+                  "description": "The object type, which is always list.",
+                  "enum": [
+                    "list"
+                  ],
+                  "x-ms-enum": {
+                    "modelAsString": false
+                  }
+                },
+                "data": {
+                  "type": "array",
+                  "description": "The requested list of items.",
+                  "items": {
+                    "$ref": "#/definitions/Agents.ThreadRun"
+                  }
+                },
+                "first_id": {
+                  "type": "string",
+                  "description": "The first ID represented in this list.",
+                  "x-ms-client-name": "firstId"
+                },
+                "last_id": {
+                  "type": "string",
+                  "description": "The last ID represented in this list.",
+                  "x-ms-client-name": "lastId"
+                },
+                "has_more": {
+                  "type": "boolean",
+                  "description": "A value indicating whether there are additional values available not captured in this list.",
+                  "x-ms-client-name": "hasMore"
+                }
+              },
+              "required": [
+                "object",
+                "data",
+                "first_id",
+                "last_id",
+                "has_more"
+              ]
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "Agents_CreateRun",
+        "description": "Creates a new run for an agent thread.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "threadId",
+            "in": "path",
+            "description": "Identifier of the thread.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "include[]",
+            "in": "query",
+            "description": "A list of additional fields to include in the response.\nCurrently the only supported value is `step_details.tool_calls[*].file_search.results[*].content` to fetch the file search result content.",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "step_details.tool_calls[*].file_search.results[*].content"
+              ],
+              "x-ms-enum": {
+                "name": "RunAdditionalFieldList",
+                "modelAsString": true,
+                "values": [
+                  {
+                    "name": "FileSearchContents",
+                    "value": "step_details.tool_calls[*].file_search.results[*].content",
+                    "description": "File search result content."
+                  }
+                ]
+              }
+            },
+            "collectionFormat": "csv",
+            "x-ms-client-name": "include"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Agents.CreateRunOptions"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Information about the new thread run.",
+            "schema": {
+              "$ref": "#/definitions/Agents.ThreadRun"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/threads/{threadId}/runs/{runId}": {
+      "get": {
+        "operationId": "Agents_GetRun",
+        "description": "Gets an existing run from an existing thread.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "threadId",
+            "in": "path",
+            "description": "Identifier of the thread.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "runId",
+            "in": "path",
+            "description": "Identifier of the run.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The requested information about the specified thread run.",
+            "schema": {
+              "$ref": "#/definitions/Agents.ThreadRun"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "Agents_UpdateRun",
+        "description": "Modifies an existing thread run.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "threadId",
+            "in": "path",
+            "description": "Identifier of the thread.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "runId",
+            "in": "path",
+            "description": "Identifier of the run.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "metadata": {
+                  "type": "object",
+                  "description": "A set of up to 16 key/value pairs that can be attached to an object, used for storing additional information about that object in a structured format. Keys may be up to 64 characters in length and values may be up to 512 characters in length.",
+                  "x-nullable": true,
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Information about the modified run.",
+            "schema": {
+              "$ref": "#/definitions/Agents.ThreadRun"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/threads/{threadId}/runs/{runId}/cancel": {
+      "post": {
+        "operationId": "Agents_CancelRun",
+        "description": "Cancels a run of an in progress thread.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "threadId",
+            "in": "path",
+            "description": "Identifier of the thread.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "runId",
+            "in": "path",
+            "description": "Identifier of the run.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Updated information about the cancelled run.",
+            "schema": {
+              "$ref": "#/definitions/Agents.ThreadRun"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/threads/{threadId}/runs/{runId}/steps": {
+      "get": {
+        "operationId": "Agents_ListRunSteps",
+        "description": "Gets a list of run steps from a thread run.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "threadId",
+            "in": "path",
+            "description": "Identifier of the thread.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "runId",
+            "in": "path",
+            "description": "Identifier of the run.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "include[]",
+            "in": "query",
+            "description": "A list of additional fields to include in the response.\nCurrently the only supported value is `step_details.tool_calls[*].file_search.results[*].content` to fetch the file search result content.",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "step_details.tool_calls[*].file_search.results[*].content"
+              ],
+              "x-ms-enum": {
+                "name": "RunAdditionalFieldList",
+                "modelAsString": true,
+                "values": [
+                  {
+                    "name": "FileSearchContents",
+                    "value": "step_details.tool_calls[*].file_search.results[*].content",
+                    "description": "File search result content."
+                  }
+                ]
+              }
+            },
+            "collectionFormat": "csv",
+            "x-ms-client-name": "include"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 20.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "default": 20
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "description": "Sort order by the created_at timestamp of the objects. asc for ascending order and desc for descending order.",
+            "required": false,
+            "type": "string",
+            "default": "desc",
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "x-ms-enum": {
+              "name": "ListSortOrder",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "ascending",
+                  "value": "asc",
+                  "description": "Specifies an ascending sort order."
+                },
+                {
+                  "name": "descending",
+                  "value": "desc",
+                  "description": "Specifies a descending sort order."
+                }
+              ]
+            }
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "description": "A cursor for use in pagination. after is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include after=obj_foo in order to fetch the next page of the list.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "before",
+            "in": "query",
+            "description": "A cursor for use in pagination. before is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include before=obj_foo in order to fetch the previous page of the list.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The requested list of run steps.",
+            "schema": {
+              "type": "object",
+              "description": "The response data for a requested list of items.",
+              "properties": {
+                "object": {
+                  "type": "string",
+                  "description": "The object type, which is always list.",
+                  "enum": [
+                    "list"
+                  ],
+                  "x-ms-enum": {
+                    "modelAsString": false
+                  }
+                },
+                "data": {
+                  "type": "array",
+                  "description": "The requested list of items.",
+                  "items": {
+                    "$ref": "#/definitions/Agents.RunStep"
+                  }
+                },
+                "first_id": {
+                  "type": "string",
+                  "description": "The first ID represented in this list.",
+                  "x-ms-client-name": "firstId"
+                },
+                "last_id": {
+                  "type": "string",
+                  "description": "The last ID represented in this list.",
+                  "x-ms-client-name": "lastId"
+                },
+                "has_more": {
+                  "type": "boolean",
+                  "description": "A value indicating whether there are additional values available not captured in this list.",
+                  "x-ms-client-name": "hasMore"
+                }
+              },
+              "required": [
+                "object",
+                "data",
+                "first_id",
+                "last_id",
+                "has_more"
+              ]
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/threads/{threadId}/runs/{runId}/steps/{stepId}": {
+      "get": {
+        "operationId": "Agents_GetRunStep",
+        "description": "Gets a single run step from a thread run.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "threadId",
+            "in": "path",
+            "description": "Identifier of the thread.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "runId",
+            "in": "path",
+            "description": "Identifier of the run.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "stepId",
+            "in": "path",
+            "description": "Identifier of the run step.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "include[]",
+            "in": "query",
+            "description": "A list of additional fields to include in the response.\nCurrently the only supported value is `step_details.tool_calls[*].file_search.results[*].content` to fetch the file search result content.",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "step_details.tool_calls[*].file_search.results[*].content"
+              ],
+              "x-ms-enum": {
+                "name": "RunAdditionalFieldList",
+                "modelAsString": true,
+                "values": [
+                  {
+                    "name": "FileSearchContents",
+                    "value": "step_details.tool_calls[*].file_search.results[*].content",
+                    "description": "File search result content."
+                  }
+                ]
+              }
+            },
+            "collectionFormat": "csv",
+            "x-ms-client-name": "include"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Information about the requested run step.",
+            "schema": {
+              "$ref": "#/definitions/Agents.RunStep"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/threads/{threadId}/runs/{runId}/submit_tool_outputs": {
+      "post": {
+        "operationId": "Agents_SubmitToolOutputsToRun",
+        "description": "Submits outputs from tools as requested by tool calls in a run. Runs that need submitted tool outputs will have a status of 'requires_action' with a required_action.type of 'submit_tool_outputs'.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "threadId",
+            "in": "path",
+            "description": "Identifier of the thread.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "runId",
+            "in": "path",
+            "description": "Identifier of the run.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "tool_outputs": {
+                  "type": "array",
+                  "description": "A list of tools for which the outputs are being submitted",
+                  "items": {
+                    "$ref": "#/definitions/Agents.ToolOutput"
+                  },
+                  "x-ms-client-name": "toolOutputs",
+                  "x-ms-identifiers": []
+                },
+                "stream": {
+                  "type": "boolean",
+                  "description": "If true, returns a stream of events that happen during the Run as server-sent events, terminating when the run enters a terminal state.",
+                  "x-nullable": true
+                }
+              },
+              "required": [
+                "tool_outputs"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Updated information about the run.",
+            "schema": {
+              "$ref": "#/definitions/Agents.ThreadRun"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/threads/runs": {
+      "post": {
+        "operationId": "Agents_CreateThreadAndRun",
+        "description": "Creates a new agent thread and immediately starts a run using that new thread.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Agents.CreateAndRunThreadOptions"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Information about the newly created thread.",
+            "schema": {
+              "$ref": "#/definitions/Agents.ThreadRun"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/vector_stores": {
+      "get": {
+        "operationId": "Agents_ListVectorStores",
+        "description": "Returns a list of vector stores.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 20.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "default": 20
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "description": "Sort order by the created_at timestamp of the objects. asc for ascending order and desc for descending order.",
+            "required": false,
+            "type": "string",
+            "default": "desc",
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "x-ms-enum": {
+              "name": "ListSortOrder",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "ascending",
+                  "value": "asc",
+                  "description": "Specifies an ascending sort order."
+                },
+                {
+                  "name": "descending",
+                  "value": "desc",
+                  "description": "Specifies a descending sort order."
+                }
+              ]
+            }
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "description": "A cursor for use in pagination. after is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include after=obj_foo in order to fetch the next page of the list.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "before",
+            "in": "query",
+            "description": "A cursor for use in pagination. before is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include before=obj_foo in order to fetch the previous page of the list.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "type": "object",
+              "description": "The response data for a requested list of items.",
+              "properties": {
+                "object": {
+                  "type": "string",
+                  "description": "The object type, which is always list.",
+                  "enum": [
+                    "list"
+                  ],
+                  "x-ms-enum": {
+                    "modelAsString": false
+                  }
+                },
+                "data": {
+                  "type": "array",
+                  "description": "The requested list of items.",
+                  "items": {
+                    "$ref": "#/definitions/Agents.VectorStore"
+                  }
+                },
+                "first_id": {
+                  "type": "string",
+                  "description": "The first ID represented in this list.",
+                  "x-ms-client-name": "firstId"
+                },
+                "last_id": {
+                  "type": "string",
+                  "description": "The last ID represented in this list.",
+                  "x-ms-client-name": "lastId"
+                },
+                "has_more": {
+                  "type": "boolean",
+                  "description": "A value indicating whether there are additional values available not captured in this list.",
+                  "x-ms-client-name": "hasMore"
+                }
+              },
+              "required": [
+                "object",
+                "data",
+                "first_id",
+                "last_id",
+                "has_more"
+              ]
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "Agents_CreateVectorStore",
+        "description": "Creates a vector store.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Agents.VectorStoreOptions"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/Agents.VectorStore"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/vector_stores/{vectorStoreId}": {
+      "get": {
+        "operationId": "Agents_GetVectorStore",
+        "description": "Returns the vector store object matching the specified ID.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "vectorStoreId",
+            "in": "path",
+            "description": "Identifier of the vector store.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/Agents.VectorStore"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "Agents_ModifyVectorStore",
+        "description": "The ID of the vector store to modify.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "vectorStoreId",
+            "in": "path",
+            "description": "Identifier of the vector store.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Agents.VectorStoreUpdateOptions"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/Agents.VectorStore"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Agents_DeleteVectorStore",
+        "description": "Deletes the vector store object matching the specified ID.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "vectorStoreId",
+            "in": "path",
+            "description": "Identifier of the vector store.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/Agents.VectorStoreDeletionStatus"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/vector_stores/{vectorStoreId}/file_batches": {
+      "post": {
+        "operationId": "Agents_CreateVectorStoreFileBatch",
+        "description": "Create a vector store file batch.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "vectorStoreId",
+            "in": "path",
+            "description": "Identifier of the vector store.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "file_ids": {
+                  "type": "array",
+                  "description": "List of file identifiers.",
+                  "minItems": 1,
+                  "maxItems": 500,
+                  "items": {
+                    "type": "string"
+                  },
+                  "x-ms-client-name": "fileIds"
+                },
+                "data_sources": {
+                  "type": "array",
+                  "description": "List of Azure assets.",
+                  "minItems": 1,
+                  "maxItems": 500,
+                  "items": {
+                    "$ref": "#/definitions/Agents.VectorStoreDataSource"
+                  },
+                  "x-ms-client-name": "dataSources",
+                  "x-ms-identifiers": []
+                },
+                "chunking_strategy": {
+                  "$ref": "#/definitions/Agents.VectorStoreChunkingStrategyRequest",
+                  "description": "The chunking strategy used to chunk the file(s). If not set, will use the auto strategy.",
+                  "x-ms-client-name": "chunkingStrategy"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/Agents.VectorStoreFileBatch"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/vector_stores/{vectorStoreId}/file_batches/{batchId}": {
+      "get": {
+        "operationId": "Agents_GetVectorStoreFileBatch",
+        "description": "Retrieve a vector store file batch.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "vectorStoreId",
+            "in": "path",
+            "description": "Identifier of the vector store.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "batchId",
+            "in": "path",
+            "description": "Identifier of the file batch.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/Agents.VectorStoreFileBatch"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/vector_stores/{vectorStoreId}/file_batches/{batchId}/cancel": {
+      "post": {
+        "operationId": "Agents_CancelVectorStoreFileBatch",
+        "description": "Cancel a vector store file batch. This attempts to cancel the processing of files in this batch as soon as possible.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "vectorStoreId",
+            "in": "path",
+            "description": "Identifier of the vector store.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "batchId",
+            "in": "path",
+            "description": "Identifier of the file batch.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/Agents.VectorStoreFileBatch"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/vector_stores/{vectorStoreId}/file_batches/{batchId}/files": {
+      "get": {
+        "operationId": "Agents_ListVectorStoreFileBatchFiles",
+        "description": "Returns a list of vector store files in a batch.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "vectorStoreId",
+            "in": "path",
+            "description": "Identifier of the vector store.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "batchId",
+            "in": "path",
+            "description": "Identifier of the file batch.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "Filter by file status.",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "failed",
+              "cancelled"
+            ],
+            "x-ms-enum": {
+              "name": "VectorStoreFileStatusFilter",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "inProgress",
+                  "value": "in_progress",
+                  "description": "Retrieve only files that are currently being processed"
+                },
+                {
+                  "name": "completed",
+                  "value": "completed",
+                  "description": "Retrieve only files that have been successfully processed"
+                },
+                {
+                  "name": "failed",
+                  "value": "failed",
+                  "description": "Retrieve only files that have failed to process"
+                },
+                {
+                  "name": "cancelled",
+                  "value": "cancelled",
+                  "description": "Retrieve only files that were cancelled"
+                }
+              ]
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 20.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "default": 20
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "description": "Sort order by the created_at timestamp of the objects. asc for ascending order and desc for descending order.",
+            "required": false,
+            "type": "string",
+            "default": "desc",
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "x-ms-enum": {
+              "name": "ListSortOrder",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "ascending",
+                  "value": "asc",
+                  "description": "Specifies an ascending sort order."
+                },
+                {
+                  "name": "descending",
+                  "value": "desc",
+                  "description": "Specifies a descending sort order."
+                }
+              ]
+            }
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "description": "A cursor for use in pagination. after is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include after=obj_foo in order to fetch the next page of the list.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "before",
+            "in": "query",
+            "description": "A cursor for use in pagination. before is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include before=obj_foo in order to fetch the previous page of the list.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "type": "object",
+              "description": "The response data for a requested list of items.",
+              "properties": {
+                "object": {
+                  "type": "string",
+                  "description": "The object type, which is always list.",
+                  "enum": [
+                    "list"
+                  ],
+                  "x-ms-enum": {
+                    "modelAsString": false
+                  }
+                },
+                "data": {
+                  "type": "array",
+                  "description": "The requested list of items.",
+                  "items": {
+                    "$ref": "#/definitions/Agents.VectorStoreFile"
+                  }
+                },
+                "first_id": {
+                  "type": "string",
+                  "description": "The first ID represented in this list.",
+                  "x-ms-client-name": "firstId"
+                },
+                "last_id": {
+                  "type": "string",
+                  "description": "The last ID represented in this list.",
+                  "x-ms-client-name": "lastId"
+                },
+                "has_more": {
+                  "type": "boolean",
+                  "description": "A value indicating whether there are additional values available not captured in this list.",
+                  "x-ms-client-name": "hasMore"
+                }
+              },
+              "required": [
+                "object",
+                "data",
+                "first_id",
+                "last_id",
+                "has_more"
+              ]
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/vector_stores/{vectorStoreId}/files": {
+      "get": {
+        "operationId": "Agents_ListVectorStoreFiles",
+        "description": "Returns a list of vector store files.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "vectorStoreId",
+            "in": "path",
+            "description": "Identifier of the vector store.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "Filter by file status.",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "failed",
+              "cancelled"
+            ],
+            "x-ms-enum": {
+              "name": "VectorStoreFileStatusFilter",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "inProgress",
+                  "value": "in_progress",
+                  "description": "Retrieve only files that are currently being processed"
+                },
+                {
+                  "name": "completed",
+                  "value": "completed",
+                  "description": "Retrieve only files that have been successfully processed"
+                },
+                {
+                  "name": "failed",
+                  "value": "failed",
+                  "description": "Retrieve only files that have failed to process"
+                },
+                {
+                  "name": "cancelled",
+                  "value": "cancelled",
+                  "description": "Retrieve only files that were cancelled"
+                }
+              ]
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 20.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "default": 20
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "description": "Sort order by the created_at timestamp of the objects. asc for ascending order and desc for descending order.",
+            "required": false,
+            "type": "string",
+            "default": "desc",
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "x-ms-enum": {
+              "name": "ListSortOrder",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "ascending",
+                  "value": "asc",
+                  "description": "Specifies an ascending sort order."
+                },
+                {
+                  "name": "descending",
+                  "value": "desc",
+                  "description": "Specifies a descending sort order."
+                }
+              ]
+            }
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "description": "A cursor for use in pagination. after is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include after=obj_foo in order to fetch the next page of the list.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "before",
+            "in": "query",
+            "description": "A cursor for use in pagination. before is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include before=obj_foo in order to fetch the previous page of the list.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "type": "object",
+              "description": "The response data for a requested list of items.",
+              "properties": {
+                "object": {
+                  "type": "string",
+                  "description": "The object type, which is always list.",
+                  "enum": [
+                    "list"
+                  ],
+                  "x-ms-enum": {
+                    "modelAsString": false
+                  }
+                },
+                "data": {
+                  "type": "array",
+                  "description": "The requested list of items.",
+                  "items": {
+                    "$ref": "#/definitions/Agents.VectorStoreFile"
+                  }
+                },
+                "first_id": {
+                  "type": "string",
+                  "description": "The first ID represented in this list.",
+                  "x-ms-client-name": "firstId"
+                },
+                "last_id": {
+                  "type": "string",
+                  "description": "The last ID represented in this list.",
+                  "x-ms-client-name": "lastId"
+                },
+                "has_more": {
+                  "type": "boolean",
+                  "description": "A value indicating whether there are additional values available not captured in this list.",
+                  "x-ms-client-name": "hasMore"
+                }
+              },
+              "required": [
+                "object",
+                "data",
+                "first_id",
+                "last_id",
+                "has_more"
+              ]
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "Agents_CreateVectorStoreFile",
+        "description": "Create a vector store file by attaching a file to a vector store.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "vectorStoreId",
+            "in": "path",
+            "description": "Identifier of the vector store.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "file_id": {
+                  "type": "string",
+                  "description": "Identifier of the file.",
+                  "x-ms-client-name": "fileId"
+                },
+                "data_source": {
+                  "$ref": "#/definitions/Agents.VectorStoreDataSource",
+                  "description": "Azure asset ID.",
+                  "x-ms-client-name": "dataSource"
+                },
+                "chunking_strategy": {
+                  "$ref": "#/definitions/Agents.VectorStoreChunkingStrategyRequest",
+                  "description": "The chunking strategy used to chunk the file(s). If not set, will use the auto strategy.",
+                  "x-ms-client-name": "chunkingStrategy"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/Agents.VectorStoreFile"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/vector_stores/{vectorStoreId}/files/{fileId}": {
+      "get": {
+        "operationId": "Agents_GetVectorStoreFile",
+        "description": "Retrieves a vector store file.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "vectorStoreId",
+            "in": "path",
+            "description": "Identifier of the vector store.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fileId",
+            "in": "path",
+            "description": "Identifier of the file.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/Agents.VectorStoreFile"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Agents_DeleteVectorStoreFile",
+        "description": "Delete a vector store file. This will remove the file from the vector store but the file itself will not be deleted.\nTo delete the file, use the delete file endpoint.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "vectorStoreId",
+            "in": "path",
+            "description": "Identifier of the vector store.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fileId",
+            "in": "path",
+            "description": "Identifier of the file.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/Agents.VectorStoreFileDeletionStatus"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "AadCredential": {
+      "type": "object",
+      "description": "AAD Credential definition",
+      "allOf": [
+        {
+          "$ref": "#/definitions/BaseCredential"
+        }
+      ],
+      "x-ms-discriminator-value": "AAD"
+    },
+    "Agents.Agent": {
+      "type": "object",
+      "description": "Represents an agent that can call the model and use tools.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The identifier, which can be referenced in API endpoints."
+        },
+        "object": {
+          "type": "string",
+          "description": "The object type, which is always assistant.",
+          "enum": [
+            "assistant"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        },
+        "created_at": {
+          "type": "integer",
+          "format": "unixtime",
+          "description": "The Unix timestamp, in seconds, representing when this object was created.",
+          "x-ms-client-name": "createdAt"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the agent.",
+          "x-nullable": true
+        },
+        "description": {
+          "type": "string",
+          "description": "The description of the agent.",
+          "x-nullable": true
+        },
+        "model": {
+          "type": "string",
+          "description": "The ID of the model to use."
+        },
+        "instructions": {
+          "type": "string",
+          "description": "The system instructions for the agent to use.",
+          "x-nullable": true
+        },
+        "tools": {
+          "type": "array",
+          "description": "The collection of tools enabled for the agent.",
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/Agents.ToolDefinition"
+          },
+          "x-ms-identifiers": []
+        },
+        "tool_resources": {
+          "type": "object",
+          "description": "A set of resources that are used by the agent's tools. The resources are specific to the type of tool. For example, the `code_interpreter`\ntool requires a list of file IDs, while the `file_search` tool requires a list of vector store IDs.",
+          "x-nullable": true,
+          "allOf": [
+            {
+              "$ref": "#/definitions/Agents.ToolResources"
+            }
+          ],
+          "x-ms-client-name": "toolResources"
+        },
+        "temperature": {
+          "type": "number",
+          "format": "float",
+          "description": "What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random,\nwhile lower values like 0.2 will make it more focused and deterministic.",
+          "default": 1,
+          "x-nullable": true
+        },
+        "top_p": {
+          "type": "number",
+          "format": "float",
+          "description": "An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass.\nSo 0.1 means only the tokens comprising the top 10% probability mass are considered.\n\nWe generally recommend altering this or temperature but not both.",
+          "default": 1,
+          "x-nullable": true,
+          "x-ms-client-name": "topP"
+        },
+        "response_format": {
+          "$ref": "#/definitions/Agents.AgentsApiResponseFormatOption",
+          "description": "The response format of the tool calls used by this agent.",
+          "x-nullable": true,
+          "x-ms-client-name": "responseFormat"
+        },
+        "metadata": {
+          "type": "object",
+          "description": "A set of up to 16 key/value pairs that can be attached to an object, used for storing additional information about that object in a structured format. Keys may be up to 64 characters in length and values may be up to 512 characters in length.",
+          "x-nullable": true,
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "id",
+        "object",
+        "created_at",
+        "name",
+        "description",
+        "model",
+        "instructions",
+        "tools",
+        "tool_resources",
+        "temperature",
+        "top_p",
+        "metadata"
+      ]
+    },
+    "Agents.AgentDeletionStatus": {
+      "type": "object",
+      "description": "The status of an agent deletion operation.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The ID of the resource specified for deletion."
+        },
+        "deleted": {
+          "type": "boolean",
+          "description": "A value indicating whether deletion was successful."
+        },
+        "object": {
+          "type": "string",
+          "description": "The object type, which is always 'assistant.deleted'.",
+          "enum": [
+            "assistant.deleted"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        }
+      },
+      "required": [
+        "id",
+        "deleted",
+        "object"
+      ]
+    },
+    "Agents.AgentStreamEvent": {
+      "type": "string",
+      "description": "Each event in a server-sent events stream has an `event` and `data` property:\n\n```\nevent: thread.created\ndata: {\"id\": \"thread_123\", \"object\": \"thread\", ...}\n```\n\nWe emit events whenever a new object is created, transitions to a new state, or is being\nstreamed in parts (deltas). For example, we emit `thread.run.created` when a new run\nis created, `thread.run.completed` when a run completes, and so on. When an Agent chooses\nto create a message during a run, we emit a `thread.message.created event`, a\n`thread.message.in_progress` event, many `thread.message.delta` events, and finally a\n`thread.message.completed` event.\n\nWe may add additional events over time, so we recommend handling unknown events gracefully\nin your code.",
+      "enum": [
+        "thread.created",
+        "thread.run.created",
+        "thread.run.queued",
+        "thread.run.in_progress",
+        "thread.run.requires_action",
+        "thread.run.completed",
+        "thread.run.incomplete",
+        "thread.run.failed",
+        "thread.run.cancelling",
+        "thread.run.cancelled",
+        "thread.run.expired",
+        "thread.run.step.created",
+        "thread.run.step.in_progress",
+        "thread.run.step.delta",
+        "thread.run.step.completed",
+        "thread.run.step.failed",
+        "thread.run.step.cancelled",
+        "thread.run.step.expired",
+        "thread.message.created",
+        "thread.message.in_progress",
+        "thread.message.delta",
+        "thread.message.completed",
+        "thread.message.incomplete",
+        "error",
+        "done"
+      ],
+      "x-ms-enum": {
+        "name": "AgentStreamEvent",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ThreadCreated",
+            "value": "thread.created",
+            "description": "Event sent when a new thread is created. The data of this event is of type AgentThread"
+          },
+          {
+            "name": "ThreadRunCreated",
+            "value": "thread.run.created",
+            "description": "Event sent when a new run is created. The data of this event is of type ThreadRun"
+          },
+          {
+            "name": "ThreadRunQueued",
+            "value": "thread.run.queued",
+            "description": "Event sent when a run moves to `queued` status. The data of this event is of type ThreadRun"
+          },
+          {
+            "name": "ThreadRunInProgress",
+            "value": "thread.run.in_progress",
+            "description": "Event sent when a run moves to `in_progress` status. The data of this event is of type ThreadRun"
+          },
+          {
+            "name": "ThreadRunRequiresAction",
+            "value": "thread.run.requires_action",
+            "description": "Event sent when a run moves to `requires_action` status. The data of this event is of type ThreadRun"
+          },
+          {
+            "name": "ThreadRunCompleted",
+            "value": "thread.run.completed",
+            "description": "Event sent when a run is completed. The data of this event is of type ThreadRun"
+          },
+          {
+            "name": "ThreadRunIncomplete",
+            "value": "thread.run.incomplete",
+            "description": "Event sent when a run ends incomplete. The data of this event is of type ThreadRun"
+          },
+          {
+            "name": "ThreadRunFailed",
+            "value": "thread.run.failed",
+            "description": "Event sent when a run fails. The data of this event is of type ThreadRun"
+          },
+          {
+            "name": "ThreadRunCancelling",
+            "value": "thread.run.cancelling",
+            "description": "Event sent when a run moves to `cancelling` status. The data of this event is of type ThreadRun"
+          },
+          {
+            "name": "ThreadRunCancelled",
+            "value": "thread.run.cancelled",
+            "description": "Event sent when a run is cancelled. The data of this event is of type ThreadRun"
+          },
+          {
+            "name": "ThreadRunExpired",
+            "value": "thread.run.expired",
+            "description": "Event sent when a run is expired. The data of this event is of type ThreadRun"
+          },
+          {
+            "name": "ThreadRunStepCreated",
+            "value": "thread.run.step.created",
+            "description": "Event sent when a new thread run step is created. The data of this event is of type RunStep"
+          },
+          {
+            "name": "ThreadRunStepInProgress",
+            "value": "thread.run.step.in_progress",
+            "description": "Event sent when a run step moves to `in_progress` status. The data of this event is of type RunStep"
+          },
+          {
+            "name": "ThreadRunStepDelta",
+            "value": "thread.run.step.delta",
+            "description": "Event sent when a run step is being streamed. The data of this event is of type RunStepDeltaChunk"
+          },
+          {
+            "name": "ThreadRunStepCompleted",
+            "value": "thread.run.step.completed",
+            "description": "Event sent when a run step is completed. The data of this event is of type RunStep"
+          },
+          {
+            "name": "ThreadRunStepFailed",
+            "value": "thread.run.step.failed",
+            "description": "Event sent when a run step fails. The data of this event is of type RunStep"
+          },
+          {
+            "name": "ThreadRunStepCancelled",
+            "value": "thread.run.step.cancelled",
+            "description": "Event sent when a run step is cancelled. The data of this event is of type RunStep"
+          },
+          {
+            "name": "ThreadRunStepExpired",
+            "value": "thread.run.step.expired",
+            "description": "Event sent when a run step is expired. The data of this event is of type RunStep"
+          },
+          {
+            "name": "ThreadMessageCreated",
+            "value": "thread.message.created",
+            "description": "Event sent when a new message is created. The data of this event is of type ThreadMessage"
+          },
+          {
+            "name": "ThreadMessageInProgress",
+            "value": "thread.message.in_progress",
+            "description": "Event sent when a message moves to `in_progress` status. The data of this event is of type ThreadMessage"
+          },
+          {
+            "name": "ThreadMessageDelta",
+            "value": "thread.message.delta",
+            "description": "Event sent when a message is being streamed. The data of this event is of type MessageDeltaChunk"
+          },
+          {
+            "name": "ThreadMessageCompleted",
+            "value": "thread.message.completed",
+            "description": "Event sent when a message is completed. The data of this event is of type ThreadMessage"
+          },
+          {
+            "name": "ThreadMessageIncomplete",
+            "value": "thread.message.incomplete",
+            "description": "Event sent before a message is completed. The data of this event is of type ThreadMessage"
+          },
+          {
+            "name": "Error",
+            "value": "error",
+            "description": "Event sent when an error occurs, such as an internal server error or a timeout."
+          },
+          {
+            "name": "Done",
+            "value": "done",
+            "description": "Event sent when the stream is done."
+          }
+        ]
+      }
+    },
+    "Agents.AgentThread": {
+      "type": "object",
+      "description": "Information about a single thread associated with an agent.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The identifier, which can be referenced in API endpoints."
+        },
+        "object": {
+          "type": "string",
+          "description": "The object type, which is always 'thread'.",
+          "enum": [
+            "thread"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        },
+        "created_at": {
+          "type": "integer",
+          "format": "unixtime",
+          "description": "The Unix timestamp, in seconds, representing when this object was created.",
+          "x-ms-client-name": "createdAt"
+        },
+        "tool_resources": {
+          "type": "object",
+          "description": "A set of resources that are made available to the agent's tools in this thread. The resources are specific to the type\nof tool. For example, the `code_interpreter` tool requires a list of file IDs, while the `file_search` tool requires a list\nof vector store IDs.",
+          "x-nullable": true,
+          "allOf": [
+            {
+              "$ref": "#/definitions/Agents.ToolResources"
+            }
+          ],
+          "x-ms-client-name": "toolResources"
+        },
+        "metadata": {
+          "type": "object",
+          "description": "A set of up to 16 key/value pairs that can be attached to an object, used for storing additional information about that object in a structured format. Keys may be up to 64 characters in length and values may be up to 512 characters in length.",
+          "x-nullable": true,
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "id",
+        "object",
+        "created_at",
+        "tool_resources",
+        "metadata"
+      ]
+    },
+    "Agents.AgentThreadCreationOptions": {
+      "type": "object",
+      "description": "The details used to create a new agent thread.",
+      "properties": {
+        "messages": {
+          "type": "array",
+          "description": "The initial messages to associate with the new thread.",
+          "items": {
+            "$ref": "#/definitions/Agents.ThreadMessageOptions"
+          },
+          "x-ms-identifiers": []
+        },
+        "tool_resources": {
+          "type": "object",
+          "description": "A set of resources that are made available to the agent's tools in this thread. The resources are specific to the\ntype of tool. For example, the `code_interpreter` tool requires a list of file IDs, while the `file_search` tool requires\na list of vector store IDs.",
+          "x-nullable": true,
+          "allOf": [
+            {
+              "$ref": "#/definitions/Agents.ToolResources"
+            }
+          ],
+          "x-ms-client-name": "toolResources"
+        },
+        "metadata": {
+          "type": "object",
+          "description": "A set of up to 16 key/value pairs that can be attached to an object, used for storing additional information about that object in a structured format. Keys may be up to 64 characters in length and values may be up to 512 characters in length.",
+          "x-nullable": true,
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Agents.AgentsApiResponseFormat": {
+      "type": "object",
+      "description": "An object describing the expected output of the model. If `json_object` only `function` type `tools` are allowed to be passed to the Run.\nIf `text` the model can return text or any value needed.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Must be one of `text` or `json_object`.",
+          "default": "text",
+          "enum": [
+            "text",
+            "json_object"
+          ],
+          "x-ms-enum": {
+            "name": "ResponseFormat",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "text",
+                "value": "text",
+                "description": "`text` format should be used for requests involving any sort of ToolCall."
+              },
+              {
+                "name": "jsonObject",
+                "value": "json_object",
+                "description": "Using `json_object` format will limit the usage of ToolCall to only functions."
+              }
+            ]
+          }
+        }
+      }
+    },
+    "Agents.AgentsApiResponseFormatMode": {
+      "type": "string",
+      "description": "Represents the mode in which the model will handle the return format of a tool call.",
+      "enum": [
+        "auto",
+        "none"
+      ],
+      "x-ms-enum": {
+        "name": "AgentsApiResponseFormatMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "auto",
+            "value": "auto",
+            "description": "Default value. Let the model handle the return format."
+          },
+          {
+            "name": "none",
+            "value": "none",
+            "description": "Setting the value to `none`, will result in a 400 Bad request."
+          }
+        ]
+      }
+    },
+    "Agents.AgentsApiResponseFormatOption": {},
+    "Agents.AgentsApiToolChoiceOption": {},
+    "Agents.AgentsApiToolChoiceOptionMode": {
+      "type": "string",
+      "description": "Specifies how the tool choice will be used",
+      "enum": [
+        "none",
+        "auto"
+      ],
+      "x-ms-enum": {
+        "name": "AgentsApiToolChoiceOptionMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "none",
+            "value": "none",
+            "description": "The model will not call a function and instead generates a message."
+          },
+          {
+            "name": "auto",
+            "value": "auto",
+            "description": "The model can pick between generating a message or calling a function."
+          }
+        ]
+      }
+    },
+    "Agents.AgentsNamedToolChoice": {
+      "type": "object",
+      "description": "Specifies a tool the model should use. Use to force the model to call a specific tool.",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/Agents.AgentsNamedToolChoiceType",
+          "description": "the type of tool. If type is `function`, the function name must be set."
+        },
+        "function": {
+          "$ref": "#/definitions/Agents.FunctionName",
+          "description": "The name of the function to call"
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "Agents.AgentsNamedToolChoiceType": {
+      "type": "string",
+      "description": "Available tool types for agents named tools.",
+      "enum": [
+        "function",
+        "code_interpreter",
+        "file_search",
+        "bing_grounding",
+        "fabric_aiskill",
+        "sharepoint_grounding",
+        "azure_ai_search"
+      ],
+      "x-ms-enum": {
+        "name": "AgentsNamedToolChoiceType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "function",
+            "value": "function",
+            "description": "Tool type `function`"
+          },
+          {
+            "name": "codeInterpreter",
+            "value": "code_interpreter",
+            "description": "Tool type `code_interpreter`"
+          },
+          {
+            "name": "fileSearch",
+            "value": "file_search",
+            "description": "Tool type `file_search`"
+          },
+          {
+            "name": "bingGrounding",
+            "value": "bing_grounding",
+            "description": "Tool type `bing_grounding`"
+          },
+          {
+            "name": "microsoftFabric",
+            "value": "fabric_aiskill",
+            "description": "Tool type `fabric_aiskill`"
+          },
+          {
+            "name": "sharepoint",
+            "value": "sharepoint_grounding",
+            "description": "Tool type `sharepoint_grounding`"
+          },
+          {
+            "name": "azureAISearch",
+            "value": "azure_ai_search",
+            "description": "Tool type `azure_ai_search`"
+          }
+        ]
+      }
+    },
+    "Agents.AzureAISearchResource": {
+      "type": "object",
+      "description": "A set of index resources used by the `azure_ai_search` tool.",
+      "properties": {
+        "indexes": {
+          "type": "array",
+          "description": "The indices attached to this agent. There can be a maximum of 1 index\nresource attached to the agent.",
+          "maxItems": 1,
+          "items": {
+            "$ref": "#/definitions/Agents.IndexResource"
+          },
+          "x-ms-client-name": "indexList",
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "Agents.AzureAISearchToolDefinition": {
+      "type": "object",
+      "description": "The input definition information for an Azure AI search tool as used to configure an agent.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.ToolDefinition"
+        }
+      ],
+      "x-ms-discriminator-value": "azure_ai_search"
+    },
+    "Agents.AzureFunctionBinding": {
+      "type": "object",
+      "description": "The structure for keeping storage queue name and URI.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The type of binding, which is always 'storage_queue'.",
+          "enum": [
+            "storage_queue"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        },
+        "storage_queue": {
+          "$ref": "#/definitions/Agents.AzureFunctionStorageQueue",
+          "description": "Storage queue.",
+          "x-ms-client-name": "storageQueue"
+        }
+      },
+      "required": [
+        "type",
+        "storage_queue"
+      ]
+    },
+    "Agents.AzureFunctionDefinition": {
+      "type": "object",
+      "description": "The definition of Azure function.",
+      "properties": {
+        "function": {
+          "$ref": "#/definitions/FunctionDefinition",
+          "description": "The definition of azure function and its parameters."
+        },
+        "input_binding": {
+          "$ref": "#/definitions/Agents.AzureFunctionBinding",
+          "description": "Input storage queue. The queue storage trigger runs a function as messages are added to it.",
+          "x-ms-client-name": "inputBinding"
+        },
+        "output_binding": {
+          "$ref": "#/definitions/Agents.AzureFunctionBinding",
+          "description": "Output storage queue. The function writes output to this queue when the input items are processed.",
+          "x-ms-client-name": "outputBinding"
+        }
+      },
+      "required": [
+        "function",
+        "input_binding",
+        "output_binding"
+      ]
+    },
+    "Agents.AzureFunctionStorageQueue": {
+      "type": "object",
+      "description": "The structure for keeping storage queue name and URI.",
+      "properties": {
+        "queue_service_endpoint": {
+          "type": "string",
+          "description": "URI to the Azure Storage Queue service allowing you to manipulate a queue.",
+          "x-ms-client-name": "storageServiceEndpoint"
+        },
+        "queue_name": {
+          "type": "string",
+          "description": "The name of an Azure function storage queue.",
+          "x-ms-client-name": "queueName"
+        }
+      },
+      "required": [
+        "queue_service_endpoint",
+        "queue_name"
+      ]
+    },
+    "Agents.AzureFunctionToolDefinition": {
+      "type": "object",
+      "description": "The input definition information for a azure function tool as used to configure an agent.",
+      "properties": {
+        "azure_function": {
+          "$ref": "#/definitions/Agents.AzureFunctionDefinition",
+          "description": "The definition of the concrete function that the function tool should call.",
+          "x-ms-client-name": "azureFunction"
+        }
+      },
+      "required": [
+        "azure_function"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.ToolDefinition"
+        }
+      ],
+      "x-ms-discriminator-value": "azure_function"
+    },
+    "Agents.BingGroundingToolDefinition": {
+      "type": "object",
+      "description": "The input definition information for a bing grounding search tool as used to configure an agent.",
+      "properties": {
+        "bing_grounding": {
+          "$ref": "#/definitions/Agents.ToolConnectionList",
+          "description": "The list of connections used by the bing grounding tool."
+        }
+      },
+      "required": [
+        "bing_grounding"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.ToolDefinition"
+        }
+      ],
+      "x-ms-discriminator-value": "bing_grounding"
+    },
+    "Agents.CodeInterpreterToolDefinition": {
+      "type": "object",
+      "description": "The input definition information for a code interpreter tool as used to configure an agent.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.ToolDefinition"
+        }
+      ],
+      "x-ms-discriminator-value": "code_interpreter"
+    },
+    "Agents.CodeInterpreterToolResource": {
+      "type": "object",
+      "description": "A set of resources that are used by the `code_interpreter` tool.",
+      "properties": {
+        "file_ids": {
+          "type": "array",
+          "description": "A list of file IDs made available to the `code_interpreter` tool. There can be a maximum of 20 files\nassociated with the tool.",
+          "default": [],
+          "maxItems": 20,
+          "items": {
+            "type": "string"
+          },
+          "x-ms-client-name": "fileIds"
+        },
+        "data_sources": {
+          "type": "array",
+          "description": "The data sources to be used. This option is mutually exclusive with the `fileIds` property.",
+          "maxItems": 20,
+          "items": {
+            "$ref": "#/definitions/Agents.VectorStoreDataSource"
+          },
+          "x-ms-client-name": "dataSources",
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "Agents.CreateAgentOptions": {
+      "type": "object",
+      "description": "The request details to use when creating a new agent.",
+      "properties": {
+        "model": {
+          "type": "string",
+          "description": "The ID of the model to use."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the new agent.",
+          "x-nullable": true
+        },
+        "description": {
+          "type": "string",
+          "description": "The description of the new agent.",
+          "x-nullable": true
+        },
+        "instructions": {
+          "type": "string",
+          "description": "The system instructions for the new agent to use.",
+          "x-nullable": true
+        },
+        "tools": {
+          "type": "array",
+          "description": "The collection of tools to enable for the new agent.",
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/Agents.ToolDefinition"
+          },
+          "x-ms-identifiers": []
+        },
+        "tool_resources": {
+          "type": "object",
+          "description": "A set of resources that are used by the agent's tools. The resources are specific to the type of tool. For example, the `code_interpreter`\ntool requires a list of file IDs, while the `file_search` tool requires a list of vector store IDs.",
+          "x-nullable": true,
+          "allOf": [
+            {
+              "$ref": "#/definitions/Agents.ToolResources"
+            }
+          ],
+          "x-ms-client-name": "toolResources"
+        },
+        "temperature": {
+          "type": "number",
+          "format": "float",
+          "description": "What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random,\nwhile lower values like 0.2 will make it more focused and deterministic.",
+          "default": 1,
+          "x-nullable": true
+        },
+        "top_p": {
+          "type": "number",
+          "format": "float",
+          "description": "An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass.\nSo 0.1 means only the tokens comprising the top 10% probability mass are considered.\n\nWe generally recommend altering this or temperature but not both.",
+          "default": 1,
+          "x-nullable": true,
+          "x-ms-client-name": "topP"
+        },
+        "response_format": {
+          "$ref": "#/definitions/Agents.AgentsApiResponseFormatOption",
+          "description": "The response format of the tool calls used by this agent.",
+          "x-nullable": true,
+          "x-ms-client-name": "responseFormat"
+        },
+        "metadata": {
+          "type": "object",
+          "description": "A set of up to 16 key/value pairs that can be attached to an object, used for storing additional information about that object in a structured format. Keys may be up to 64 characters in length and values may be up to 512 characters in length.",
+          "x-nullable": true,
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "model"
+      ]
+    },
+    "Agents.CreateAndRunThreadOptions": {
+      "type": "object",
+      "description": "The details used when creating and immediately running a new agent thread.",
+      "properties": {
+        "assistant_id": {
+          "type": "string",
+          "description": "The ID of the agent for which the thread should be created.",
+          "x-ms-client-name": "assistantId"
+        },
+        "thread": {
+          "$ref": "#/definitions/Agents.AgentThreadCreationOptions",
+          "description": "The details used to create the new thread. If no thread is provided, an empty one will be created."
+        },
+        "model": {
+          "type": "string",
+          "description": "The overridden model that the agent should use to run the thread.",
+          "x-nullable": true
+        },
+        "instructions": {
+          "type": "string",
+          "description": "The overridden system instructions the agent should use to run the thread.",
+          "x-nullable": true
+        },
+        "tools": {
+          "type": "array",
+          "description": "The overridden list of enabled tools the agent should use to run the thread.",
+          "x-nullable": true,
+          "items": {
+            "$ref": "#/definitions/Agents.ToolDefinition"
+          },
+          "x-ms-identifiers": []
+        },
+        "tool_resources": {
+          "type": "object",
+          "description": "Override the tools the agent can use for this run. This is useful for modifying the behavior on a per-run basis",
+          "x-nullable": true,
+          "allOf": [
+            {
+              "$ref": "#/definitions/Agents.UpdateToolResourcesOptions"
+            }
+          ],
+          "x-ms-client-name": "toolResources"
+        },
+        "stream": {
+          "type": "boolean",
+          "description": "If `true`, returns a stream of events that happen during the Run as server-sent events,\nterminating when the Run enters a terminal state with a `data: [DONE]` message."
+        },
+        "temperature": {
+          "type": "number",
+          "format": "float",
+          "description": "What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output\nmore random, while lower values like 0.2 will make it more focused and deterministic.",
+          "default": 1,
+          "x-nullable": true
+        },
+        "top_p": {
+          "type": "number",
+          "format": "float",
+          "description": "An alternative to sampling with temperature, called nucleus sampling, where the model\nconsiders the results of the tokens with top_p probability mass. So 0.1 means only the tokens\ncomprising the top 10% probability mass are considered.\n\nWe generally recommend altering this or temperature but not both.",
+          "default": 1,
+          "x-nullable": true,
+          "x-ms-client-name": "topP"
+        },
+        "max_prompt_tokens": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum number of prompt tokens that may be used over the course of the run. The run will make a best effort to use only\nthe number of prompt tokens specified, across multiple turns of the run. If the run exceeds the number of prompt tokens specified,\nthe run will end with status `incomplete`. See `incomplete_details` for more info.",
+          "x-nullable": true,
+          "x-ms-client-name": "maxPromptTokens"
+        },
+        "max_completion_tokens": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum number of completion tokens that may be used over the course of the run. The run will make a best effort to use only\nthe number of completion tokens specified, across multiple turns of the run. If the run exceeds the number of completion tokens\nspecified, the run will end with status `incomplete`. See `incomplete_details` for more info.",
+          "x-nullable": true,
+          "x-ms-client-name": "maxCompletionTokens"
+        },
+        "truncation_strategy": {
+          "type": "object",
+          "description": "The strategy to use for dropping messages as the context windows moves forward.",
+          "x-nullable": true,
+          "allOf": [
+            {
+              "$ref": "#/definitions/Agents.TruncationObject"
+            }
+          ],
+          "x-ms-client-name": "truncationStrategy"
+        },
+        "tool_choice": {
+          "$ref": "#/definitions/Agents.AgentsApiToolChoiceOption",
+          "description": "Controls whether or not and which tool is called by the model.",
+          "x-nullable": true,
+          "x-ms-client-name": "toolChoice"
+        },
+        "response_format": {
+          "$ref": "#/definitions/Agents.AgentsApiResponseFormatOption",
+          "description": "Specifies the format that the model must output.",
+          "x-nullable": true,
+          "x-ms-client-name": "responseFormat"
+        },
+        "parallel_tool_calls": {
+          "type": "boolean",
+          "description": "If `true` functions will run in parallel during tool use.",
+          "x-ms-client-name": "parallelToolCalls"
+        },
+        "metadata": {
+          "type": "object",
+          "description": "A set of up to 16 key/value pairs that can be attached to an object, used for storing additional information about that object in a structured format. Keys may be up to 64 characters in length and values may be up to 512 characters in length.",
+          "x-nullable": true,
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "assistant_id"
+      ]
+    },
+    "Agents.CreateCodeInterpreterToolResourceOptions": {
+      "type": "object",
+      "description": "A set of resources that will be used by the `code_interpreter` tool. Request object.",
+      "properties": {
+        "file_ids": {
+          "type": "array",
+          "description": "A list of file IDs made available to the `code_interpreter` tool.",
+          "default": [],
+          "maxItems": 20,
+          "items": {
+            "type": "string"
+          },
+          "x-ms-client-name": "fileIds"
+        }
+      }
+    },
+    "Agents.CreateFileSearchToolResourceOptions": {},
+    "Agents.CreateFileSearchToolResourceVectorStoreOptions": {
+      "type": "object",
+      "description": "File IDs associated to the vector store to be passed to the helper.",
+      "properties": {
+        "file_ids": {
+          "type": "array",
+          "description": "A list of file IDs to add to the vector store. There can be a maximum of 10000 files in a vector store.",
+          "maxItems": 10000,
+          "items": {
+            "type": "string"
+          },
+          "x-ms-client-name": "fileIds"
+        },
+        "chunking_strategy": {
+          "$ref": "#/definitions/Agents.VectorStoreChunkingStrategyRequest",
+          "description": "The chunking strategy used to chunk the file(s). If not set, will use the `auto` strategy.",
+          "x-ms-client-name": "chunkingStrategy"
+        },
+        "metadata": {
+          "type": "object",
+          "description": "A set of up to 16 key/value pairs that can be attached to an object, used for storing additional information about that object in a structured format. Keys may be up to 64 characters in length and values may be up to 512 characters in length.",
+          "x-nullable": true,
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "file_ids",
+        "chunking_strategy"
+      ]
+    },
+    "Agents.CreateRunOptions": {
+      "type": "object",
+      "description": "The details used when creating a new run of an agent thread.",
+      "properties": {
+        "assistant_id": {
+          "type": "string",
+          "description": "The ID of the agent that should run the thread.",
+          "x-ms-client-name": "assistantId"
+        },
+        "model": {
+          "type": "string",
+          "description": "The overridden model name that the agent should use to run the thread.",
+          "x-nullable": true
+        },
+        "instructions": {
+          "type": "string",
+          "description": "The overridden system instructions that the agent should use to run the thread.",
+          "x-nullable": true
+        },
+        "additional_instructions": {
+          "type": "string",
+          "description": "Additional instructions to append at the end of the instructions for the run. This is useful for modifying the behavior\non a per-run basis without overriding other instructions.",
+          "x-nullable": true,
+          "x-ms-client-name": "additionalInstructions"
+        },
+        "additional_messages": {
+          "type": "array",
+          "description": "Adds additional messages to the thread before creating the run.",
+          "x-nullable": true,
+          "items": {
+            "$ref": "#/definitions/Agents.ThreadMessageOptions"
+          },
+          "x-ms-client-name": "additionalMessages",
+          "x-ms-identifiers": []
+        },
+        "tools": {
+          "type": "array",
+          "description": "The overridden list of enabled tools that the agent should use to run the thread.",
+          "x-nullable": true,
+          "items": {
+            "$ref": "#/definitions/Agents.ToolDefinition"
+          },
+          "x-ms-identifiers": []
+        },
+        "stream": {
+          "type": "boolean",
+          "description": "If `true`, returns a stream of events that happen during the Run as server-sent events,\nterminating when the Run enters a terminal state with a `data: [DONE]` message."
+        },
+        "temperature": {
+          "type": "number",
+          "format": "float",
+          "description": "What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output\nmore random, while lower values like 0.2 will make it more focused and deterministic.",
+          "default": 1,
+          "x-nullable": true
+        },
+        "top_p": {
+          "type": "number",
+          "format": "float",
+          "description": "An alternative to sampling with temperature, called nucleus sampling, where the model\nconsiders the results of the tokens with top_p probability mass. So 0.1 means only the tokens\ncomprising the top 10% probability mass are considered.\n\nWe generally recommend altering this or temperature but not both.",
+          "default": 1,
+          "x-nullable": true,
+          "x-ms-client-name": "topP"
+        },
+        "max_prompt_tokens": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum number of prompt tokens that may be used over the course of the run. The run will make a best effort to use only\nthe number of prompt tokens specified, across multiple turns of the run. If the run exceeds the number of prompt tokens specified,\nthe run will end with status `incomplete`. See `incomplete_details` for more info.",
+          "x-nullable": true,
+          "x-ms-client-name": "maxPromptTokens"
+        },
+        "max_completion_tokens": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum number of completion tokens that may be used over the course of the run. The run will make a best effort\nto use only the number of completion tokens specified, across multiple turns of the run. If the run exceeds the number of\ncompletion tokens specified, the run will end with status `incomplete`. See `incomplete_details` for more info.",
+          "x-nullable": true,
+          "x-ms-client-name": "maxCompletionTokens"
+        },
+        "truncation_strategy": {
+          "type": "object",
+          "description": "The strategy to use for dropping messages as the context windows moves forward.",
+          "x-nullable": true,
+          "allOf": [
+            {
+              "$ref": "#/definitions/Agents.TruncationObject"
+            }
+          ],
+          "x-ms-client-name": "truncationStrategy"
+        },
+        "tool_choice": {
+          "$ref": "#/definitions/Agents.AgentsApiToolChoiceOption",
+          "description": "Controls whether or not and which tool is called by the model.",
+          "x-nullable": true,
+          "x-ms-client-name": "toolChoice"
+        },
+        "response_format": {
+          "$ref": "#/definitions/Agents.AgentsApiResponseFormatOption",
+          "description": "Specifies the format that the model must output.",
+          "x-nullable": true,
+          "x-ms-client-name": "responseFormat"
+        },
+        "parallel_tool_calls": {
+          "type": "boolean",
+          "description": "If `true` functions will run in parallel during tool use.",
+          "x-ms-client-name": "parallelToolCalls"
+        },
+        "metadata": {
+          "type": "object",
+          "description": "A set of up to 16 key/value pairs that can be attached to an object, used for storing additional information about that object in a structured format. Keys may be up to 64 characters in length and values may be up to 512 characters in length.",
+          "x-nullable": true,
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "assistant_id"
+      ]
+    },
+    "Agents.CreateToolResourcesOptions": {
+      "type": "object",
+      "description": "Request object. A set of resources that are used by the agent's tools. The resources are specific to the\ntype of tool. For example, the `code_interpreter` tool requires a list of file IDs, while the `file_search`\ntool requires a list of vector store IDs.",
+      "properties": {
+        "code_interpreter": {
+          "$ref": "#/definitions/Agents.CreateCodeInterpreterToolResourceOptions",
+          "description": "A list of file IDs made available to the `code_interpreter` tool. There can be a maximum of 20 files\nassociated with the tool.",
+          "x-ms-client-name": "codeInterpreter"
+        },
+        "file_search": {
+          "$ref": "#/definitions/Agents.CreateFileSearchToolResourceOptions",
+          "description": "A list of vector stores or their IDs made available to the `file_search` tool.",
+          "x-ms-client-name": "fileSearch"
+        },
+        "azure_ai_search": {
+          "$ref": "#/definitions/Agents.AzureAISearchResource",
+          "description": "Resources to be used by the `azure_ai_search` tool consisting of index IDs and names.",
+          "x-ms-client-name": "azureAISearch"
+        }
+      }
+    },
+    "Agents.DoneEvent": {
+      "type": "string",
+      "description": "Terminal event indicating the successful end of a stream.",
+      "enum": [
+        "done"
+      ],
+      "x-ms-enum": {
+        "name": "DoneEvent",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Done",
+            "value": "done",
+            "description": "Event sent when the stream is done."
+          }
+        ]
+      }
+    },
+    "Agents.ErrorEvent": {
+      "type": "string",
+      "description": "Terminal event indicating a server side error while streaming.",
+      "enum": [
+        "error"
+      ],
+      "x-ms-enum": {
+        "name": "ErrorEvent",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Error",
+            "value": "error",
+            "description": "Event sent when an error occurs, such as an internal server error or a timeout."
+          }
+        ]
+      }
+    },
+    "Agents.FileDeletionStatus": {
+      "type": "object",
+      "description": "A status response from a file deletion operation.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The ID of the resource specified for deletion."
+        },
+        "deleted": {
+          "type": "boolean",
+          "description": "A value indicating whether deletion was successful."
+        },
+        "object": {
+          "type": "string",
+          "description": "The object type, which is always 'file'.",
+          "enum": [
+            "file"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        }
+      },
+      "required": [
+        "id",
+        "deleted",
+        "object"
+      ]
+    },
+    "Agents.FileListResponse": {
+      "type": "object",
+      "description": "The response data from a file list operation.",
+      "properties": {
+        "object": {
+          "type": "string",
+          "description": "The object type, which is always 'list'.",
+          "enum": [
+            "list"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        },
+        "data": {
+          "type": "array",
+          "description": "The files returned for the request.",
+          "items": {
+            "$ref": "#/definitions/Agents.OpenAIFile"
+          }
+        }
+      },
+      "required": [
+        "object",
+        "data"
+      ]
+    },
+    "Agents.FilePurpose": {
+      "type": "string",
+      "description": "The possible values denoting the intended usage of a file.",
+      "enum": [
+        "fine-tune",
+        "fine-tune-results",
+        "assistants",
+        "assistants_output",
+        "batch",
+        "batch_output",
+        "vision"
+      ],
+      "x-ms-enum": {
+        "name": "FilePurpose",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "fineTune",
+            "value": "fine-tune",
+            "description": "Indicates a file is used for fine tuning input."
+          },
+          {
+            "name": "fineTuneResults",
+            "value": "fine-tune-results",
+            "description": "Indicates a file is used for fine tuning results."
+          },
+          {
+            "name": "agents",
+            "value": "assistants",
+            "description": "Indicates a file is used as input to agents."
+          },
+          {
+            "name": "agentsOutput",
+            "value": "assistants_output",
+            "description": "Indicates a file is used as output by agents."
+          },
+          {
+            "name": "batch",
+            "value": "batch",
+            "description": "Indicates a file is used as input to ."
+          },
+          {
+            "name": "batchOutput",
+            "value": "batch_output",
+            "description": "Indicates a file is used as output by a vector store batch operation."
+          },
+          {
+            "name": "vision",
+            "value": "vision",
+            "description": "Indicates a file is used as input to a vision operation."
+          }
+        ]
+      }
+    },
+    "Agents.FileSearchRankingOptions": {
+      "type": "object",
+      "description": "Ranking options for file search.",
+      "properties": {
+        "ranker": {
+          "type": "string",
+          "description": "File search ranker."
+        },
+        "score_threshold": {
+          "type": "number",
+          "format": "float",
+          "description": "Ranker search threshold.",
+          "x-ms-client-name": "scoreThreshold"
+        }
+      },
+      "required": [
+        "ranker",
+        "score_threshold"
+      ]
+    },
+    "Agents.FileSearchToolCallContent": {
+      "type": "object",
+      "description": "The file search result content object.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The type of the content.",
+          "enum": [
+            "text"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        },
+        "text": {
+          "type": "string",
+          "description": "The text content of the file."
+        }
+      },
+      "required": [
+        "type",
+        "text"
+      ]
+    },
+    "Agents.FileSearchToolDefinition": {
+      "type": "object",
+      "description": "The input definition information for a file search tool as used to configure an agent.",
+      "properties": {
+        "file_search": {
+          "$ref": "#/definitions/Agents.FileSearchToolDefinitionDetails",
+          "description": "Options overrides for the file search tool.",
+          "x-ms-client-name": "fileSearch"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.ToolDefinition"
+        }
+      ],
+      "x-ms-discriminator-value": "file_search"
+    },
+    "Agents.FileSearchToolDefinitionDetails": {
+      "type": "object",
+      "description": "Options overrides for the file search tool.",
+      "properties": {
+        "max_num_results": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum number of results the file search tool should output. The default is 20 for gpt-4* models and 5 for gpt-3.5-turbo. This number should be between 1 and 50 inclusive.\n\nNote that the file search tool may output fewer than `max_num_results` results. See the file search tool documentation for more information.",
+          "minimum": 1,
+          "maximum": 50,
+          "x-ms-client-name": "maxNumResults"
+        },
+        "ranking_options": {
+          "$ref": "#/definitions/Agents.FileSearchRankingOptions",
+          "description": "Ranking options for file search.",
+          "x-ms-client-name": "rankingOptions"
+        }
+      }
+    },
+    "Agents.FileSearchToolResource": {
+      "type": "object",
+      "description": "A set of resources that are used by the `file_search` tool.",
+      "properties": {
+        "vector_store_ids": {
+          "type": "array",
+          "description": "The ID of the vector store attached to this agent. There can be a maximum of 1 vector\nstore attached to the agent.",
+          "maxItems": 1,
+          "items": {
+            "type": "string"
+          },
+          "x-ms-client-name": "vectorStoreIds"
+        },
+        "vector_stores": {
+          "type": "array",
+          "description": "The list of vector store configuration objects from Azure.\nThis list is limited to one element.\nThe only element of this list contains the list of azure asset IDs used by the search tool.",
+          "maxItems": 1,
+          "items": {
+            "$ref": "#/definitions/Agents.VectorStoreConfigurations"
+          },
+          "x-ms-client-name": "vectorStores",
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "Agents.FileState": {
+      "type": "string",
+      "description": "The state of the file.",
+      "enum": [
+        "uploaded",
+        "pending",
+        "running",
+        "processed",
+        "error",
+        "deleting",
+        "deleted"
+      ],
+      "x-ms-enum": {
+        "name": "FileState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "uploaded",
+            "value": "uploaded",
+            "description": "The file has been uploaded but it's not yet processed. This state is not returned by Azure OpenAI and exposed only for\ncompatibility. It can be categorized as an inactive state."
+          },
+          {
+            "name": "pending",
+            "value": "pending",
+            "description": "The operation was created and is not queued to be processed in the future. It can be categorized as an inactive state."
+          },
+          {
+            "name": "running",
+            "value": "running",
+            "description": "The operation has started to be processed. It can be categorized as an active state."
+          },
+          {
+            "name": "processed",
+            "value": "processed",
+            "description": "The operation has successfully processed and is ready for consumption. It can be categorized as a terminal state."
+          },
+          {
+            "name": "error",
+            "value": "error",
+            "description": "The operation has completed processing with a failure and cannot be further consumed. It can be categorized as a terminal state."
+          },
+          {
+            "name": "deleting",
+            "value": "deleting",
+            "description": "The entity is in the process to be deleted. This state is not returned by Azure OpenAI and exposed only for compatibility.\nIt can be categorized as an active state."
+          },
+          {
+            "name": "deleted",
+            "value": "deleted",
+            "description": "The entity has been deleted but may still be referenced by other entities predating the deletion. It can be categorized as a\nterminal state."
+          }
+        ]
+      }
+    },
+    "Agents.FunctionName": {
+      "type": "object",
+      "description": "The function name that will be used, if using the `function` tool",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the function to call"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "Agents.FunctionToolDefinition": {
+      "type": "object",
+      "description": "The input definition information for a function tool as used to configure an agent.",
+      "properties": {
+        "function": {
+          "$ref": "#/definitions/FunctionDefinition",
+          "description": "The definition of the concrete function that the function tool should call."
+        }
+      },
+      "required": [
+        "function"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.ToolDefinition"
+        }
+      ],
+      "x-ms-discriminator-value": "function"
+    },
+    "Agents.IncompleteDetailsReason": {
+      "type": "string",
+      "description": "The reason why the run is incomplete. This will point to which specific token limit was reached over the course of the run.",
+      "enum": [
+        "max_completion_tokens",
+        "max_prompt_tokens"
+      ],
+      "x-ms-enum": {
+        "name": "IncompleteDetailsReason",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "maxCompletionTokens",
+            "value": "max_completion_tokens",
+            "description": "Maximum completion tokens exceeded"
+          },
+          {
+            "name": "maxPromptTokens",
+            "value": "max_prompt_tokens",
+            "description": "Maximum prompt tokens exceeded"
+          }
+        ]
+      }
+    },
+    "Agents.IncompleteRunDetails": {
+      "type": "object",
+      "description": "Details on why the run is incomplete. Will be `null` if the run is not incomplete.",
+      "properties": {
+        "reason": {
+          "$ref": "#/definitions/Agents.IncompleteDetailsReason",
+          "description": "The reason why the run is incomplete. This indicates which specific token limit was reached during the run."
+        }
+      },
+      "required": [
+        "reason"
+      ]
+    },
+    "Agents.IndexResource": {
+      "type": "object",
+      "description": "A Index resource.",
+      "properties": {
+        "index_connection_id": {
+          "type": "string",
+          "description": "An index connection id in an IndexResource attached to this agent.",
+          "x-ms-client-name": "indexConnectionId"
+        },
+        "index_name": {
+          "type": "string",
+          "description": "The name of an index in an IndexResource attached to this agent.",
+          "x-ms-client-name": "indexName"
+        }
+      },
+      "required": [
+        "index_connection_id",
+        "index_name"
+      ]
+    },
+    "Agents.ListSortOrder": {
+      "type": "string",
+      "description": "The available sorting options when requesting a list of response objects.",
+      "enum": [
+        "asc",
+        "desc"
+      ],
+      "x-ms-enum": {
+        "name": "ListSortOrder",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ascending",
+            "value": "asc",
+            "description": "Specifies an ascending sort order."
+          },
+          {
+            "name": "descending",
+            "value": "desc",
+            "description": "Specifies a descending sort order."
+          }
+        ]
+      }
+    },
+    "Agents.MessageAttachment": {
+      "type": "object",
+      "description": "This describes to which tools a file has been attached.",
+      "properties": {
+        "file_id": {
+          "type": "string",
+          "description": "The ID of the file to attach to the message.",
+          "x-ms-client-name": "fileId"
+        },
+        "data_source": {
+          "$ref": "#/definitions/Agents.VectorStoreDataSource",
+          "description": "Azure asset ID.",
+          "x-ms-client-name": "dataSource"
+        },
+        "tools": {
+          "type": "array",
+          "description": "The tools to add to this file.",
+          "items": {
+            "$ref": "#/definitions/Agents.MessageAttachmentToolDefinition"
+          }
+        }
+      },
+      "required": [
+        "tools"
+      ]
+    },
+    "Agents.MessageAttachmentToolDefinition": {
+      "x-nullable": false
+    },
+    "Agents.MessageContent": {
+      "type": "object",
+      "description": "An abstract representation of a single item of thread message content.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The object type."
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "type"
+      ]
+    },
+    "Agents.MessageDelta": {
+      "type": "object",
+      "description": "Represents the typed 'delta' payload within a streaming message delta chunk.",
+      "properties": {
+        "role": {
+          "$ref": "#/definitions/Agents.MessageRole",
+          "description": "The entity that produced the message."
+        },
+        "content": {
+          "type": "array",
+          "description": "The content of the message as an array of text and/or images.",
+          "items": {
+            "$ref": "#/definitions/Agents.MessageDeltaContent"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "required": [
+        "role",
+        "content"
+      ]
+    },
+    "Agents.MessageDeltaChunk": {
+      "type": "object",
+      "description": "Represents a message delta i.e. any changed fields on a message during streaming.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The identifier of the message, which can be referenced in API endpoints."
+        },
+        "object": {
+          "type": "string",
+          "description": "The object type, which is always `thread.message.delta`.",
+          "enum": [
+            "thread.message.delta"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        },
+        "delta": {
+          "$ref": "#/definitions/Agents.MessageDelta",
+          "description": "The delta containing the fields that have changed on the Message."
+        }
+      },
+      "required": [
+        "id",
+        "object",
+        "delta"
+      ]
+    },
+    "Agents.MessageDeltaContent": {
+      "type": "object",
+      "description": "The abstract base representation of a partial streamed message content payload.",
+      "properties": {
+        "index": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The index of the content part of the message."
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of content for this content part."
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "index",
+        "type"
+      ]
+    },
+    "Agents.MessageDeltaImageFileContent": {
+      "type": "object",
+      "description": "Represents a streamed image file content part within a streaming message delta chunk.",
+      "properties": {
+        "image_file": {
+          "$ref": "#/definitions/Agents.MessageDeltaImageFileContentObject",
+          "description": "The image_file data.",
+          "x-ms-client-name": "imageFile"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.MessageDeltaContent"
+        }
+      ],
+      "x-ms-discriminator-value": "image_file"
+    },
+    "Agents.MessageDeltaImageFileContentObject": {
+      "type": "object",
+      "description": "Represents the 'image_file' payload within streaming image file content.",
+      "properties": {
+        "file_id": {
+          "type": "string",
+          "description": "The file ID of the image in the message content.",
+          "x-ms-client-name": "fileId"
+        }
+      }
+    },
+    "Agents.MessageDeltaTextAnnotation": {
+      "type": "object",
+      "description": "The abstract base representation of a streamed text content part's text annotation.",
+      "properties": {
+        "index": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The index of the annotation within a text content part."
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of the text content annotation."
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "index",
+        "type"
+      ]
+    },
+    "Agents.MessageDeltaTextContent": {
+      "type": "object",
+      "description": "Represents a streamed text content part within a streaming message delta chunk.",
+      "properties": {
+        "text": {
+          "$ref": "#/definitions/Agents.MessageDeltaTextContentObject",
+          "description": "The text content details."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.MessageDeltaContent"
+        }
+      ],
+      "x-ms-discriminator-value": "text"
+    },
+    "Agents.MessageDeltaTextContentObject": {
+      "type": "object",
+      "description": "Represents the data of a streamed text content part within a streaming message delta chunk.",
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "The data that makes up the text."
+        },
+        "annotations": {
+          "type": "array",
+          "description": "Annotations for the text.",
+          "items": {
+            "$ref": "#/definitions/Agents.MessageDeltaTextAnnotation"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "Agents.MessageDeltaTextFileCitationAnnotation": {
+      "type": "object",
+      "description": "Represents a streamed file citation applied to a streaming text content part.",
+      "properties": {
+        "file_citation": {
+          "$ref": "#/definitions/Agents.MessageDeltaTextFileCitationAnnotationObject",
+          "description": "The file citation information.",
+          "x-ms-client-name": "fileCitation"
+        },
+        "text": {
+          "type": "string",
+          "description": "The text in the message content that needs to be replaced"
+        },
+        "start_index": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The start index of this annotation in the content text.",
+          "x-ms-client-name": "startIndex"
+        },
+        "end_index": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The end index of this annotation in the content text.",
+          "x-ms-client-name": "endIndex"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.MessageDeltaTextAnnotation"
+        }
+      ],
+      "x-ms-discriminator-value": "file_citation"
+    },
+    "Agents.MessageDeltaTextFileCitationAnnotationObject": {
+      "type": "object",
+      "description": "Represents the data of a streamed file citation as applied to a streaming text content part.",
+      "properties": {
+        "file_id": {
+          "type": "string",
+          "description": "The ID of the specific file the citation is from.",
+          "x-ms-client-name": "fileId"
+        },
+        "quote": {
+          "type": "string",
+          "description": "The specific quote in the cited file."
+        }
+      }
+    },
+    "Agents.MessageDeltaTextFilePathAnnotation": {
+      "type": "object",
+      "description": "Represents a streamed file path annotation applied to a streaming text content part.",
+      "properties": {
+        "file_path": {
+          "$ref": "#/definitions/Agents.MessageDeltaTextFilePathAnnotationObject",
+          "description": "The file path information.",
+          "x-ms-client-name": "filePath"
+        },
+        "start_index": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The start index of this annotation in the content text.",
+          "x-ms-client-name": "startIndex"
+        },
+        "end_index": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The end index of this annotation in the content text.",
+          "x-ms-client-name": "endIndex"
+        },
+        "text": {
+          "type": "string",
+          "description": "The text in the message content that needs to be replaced"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.MessageDeltaTextAnnotation"
+        }
+      ],
+      "x-ms-discriminator-value": "file_path"
+    },
+    "Agents.MessageDeltaTextFilePathAnnotationObject": {
+      "type": "object",
+      "description": "Represents the data of a streamed file path annotation as applied to a streaming text content part.",
+      "properties": {
+        "file_id": {
+          "type": "string",
+          "description": "The file ID for the annotation.",
+          "x-ms-client-name": "fileId"
+        }
+      }
+    },
+    "Agents.MessageDeltaTextUrlCitationDetails": {
+      "type": "object",
+      "description": "A representation of the URL used for the text citation.",
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "The URL where the citation is from."
+        },
+        "title": {
+          "type": "string",
+          "description": "The title of the URL."
+        }
+      }
+    },
+    "Agents.MessageImageFileContent": {
+      "type": "object",
+      "description": "A representation of image file content in a thread message.",
+      "properties": {
+        "image_file": {
+          "$ref": "#/definitions/Agents.MessageImageFileDetails",
+          "description": "The image file for this thread message content item.",
+          "x-ms-client-name": "imageFile"
+        }
+      },
+      "required": [
+        "image_file"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.MessageContent"
+        }
+      ],
+      "x-ms-discriminator-value": "image_file"
+    },
+    "Agents.MessageImageFileDetails": {
+      "type": "object",
+      "description": "An image reference, as represented in thread message content.",
+      "properties": {
+        "file_id": {
+          "type": "string",
+          "description": "The ID for the file associated with this image.",
+          "x-ms-client-name": "fileId"
+        }
+      },
+      "required": [
+        "file_id"
+      ]
+    },
+    "Agents.MessageIncompleteDetails": {
+      "type": "object",
+      "description": "Information providing additional detail about a message entering an incomplete status.",
+      "properties": {
+        "reason": {
+          "$ref": "#/definitions/Agents.MessageIncompleteDetailsReason",
+          "description": "The provided reason describing why the message was marked as incomplete."
+        }
+      },
+      "required": [
+        "reason"
+      ]
+    },
+    "Agents.MessageIncompleteDetailsReason": {
+      "type": "string",
+      "description": "A set of reasons describing why a message is marked as incomplete.",
+      "enum": [
+        "content_filter",
+        "max_tokens",
+        "run_cancelled",
+        "run_failed",
+        "run_expired"
+      ],
+      "x-ms-enum": {
+        "name": "MessageIncompleteDetailsReason",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "contentFilter",
+            "value": "content_filter",
+            "description": "The run generating the message was terminated due to content filter flagging."
+          },
+          {
+            "name": "maxTokens",
+            "value": "max_tokens",
+            "description": "The run generating the message exhausted available tokens before completion."
+          },
+          {
+            "name": "runCancelled",
+            "value": "run_cancelled",
+            "description": "The run generating the message was cancelled before completion."
+          },
+          {
+            "name": "runFailed",
+            "value": "run_failed",
+            "description": "The run generating the message failed."
+          },
+          {
+            "name": "runExpired",
+            "value": "run_expired",
+            "description": "The run generating the message expired."
+          }
+        ]
+      }
+    },
+    "Agents.MessageRole": {
+      "type": "string",
+      "description": "The possible values for roles attributed to messages in a thread.",
+      "enum": [
+        "user",
+        "assistant"
+      ],
+      "x-ms-enum": {
+        "name": "MessageRole",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "user",
+            "value": "user",
+            "description": "The role representing the end-user."
+          },
+          {
+            "name": "agent",
+            "value": "assistant",
+            "description": "The role representing the agent."
+          }
+        ]
+      }
+    },
+    "Agents.MessageStatus": {
+      "type": "string",
+      "description": "The possible execution status values for a thread message.",
+      "enum": [
+        "in_progress",
+        "incomplete",
+        "completed"
+      ],
+      "x-ms-enum": {
+        "name": "MessageStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "inProgress",
+            "value": "in_progress",
+            "description": "A run is currently creating this message."
+          },
+          {
+            "name": "incomplete",
+            "value": "incomplete",
+            "description": "This message is incomplete. See incomplete_details for more information."
+          },
+          {
+            "name": "completed",
+            "value": "completed",
+            "description": "This message was successfully completed by a run."
+          }
+        ]
+      }
+    },
+    "Agents.MessageStreamEvent": {
+      "type": "string",
+      "description": "Message operation related streaming events",
+      "enum": [
+        "thread.message.created",
+        "thread.message.in_progress",
+        "thread.message.delta",
+        "thread.message.completed",
+        "thread.message.incomplete"
+      ],
+      "x-ms-enum": {
+        "name": "MessageStreamEvent",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ThreadMessageCreated",
+            "value": "thread.message.created",
+            "description": "Event sent when a new message is created. The data of this event is of type ThreadMessage"
+          },
+          {
+            "name": "ThreadMessageInProgress",
+            "value": "thread.message.in_progress",
+            "description": "Event sent when a message moves to `in_progress` status. The data of this event is of type ThreadMessage"
+          },
+          {
+            "name": "ThreadMessageDelta",
+            "value": "thread.message.delta",
+            "description": "Event sent when a message is being streamed. The data of this event is of type MessageDeltaChunk"
+          },
+          {
+            "name": "ThreadMessageCompleted",
+            "value": "thread.message.completed",
+            "description": "Event sent when a message is completed. The data of this event is of type ThreadMessage"
+          },
+          {
+            "name": "ThreadMessageIncomplete",
+            "value": "thread.message.incomplete",
+            "description": "Event sent before a message is completed. The data of this event is of type ThreadMessage"
+          }
+        ]
+      }
+    },
+    "Agents.MessageTextAnnotation": {
+      "type": "object",
+      "description": "An abstract representation of an annotation to text thread message content.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The object type."
+        },
+        "text": {
+          "type": "string",
+          "description": "The textual content associated with this text annotation item."
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "type",
+        "text"
+      ]
+    },
+    "Agents.MessageTextContent": {
+      "type": "object",
+      "description": "A representation of a textual item of thread message content.",
+      "properties": {
+        "text": {
+          "$ref": "#/definitions/Agents.MessageTextDetails",
+          "description": "The text and associated annotations for this thread message content item."
+        }
+      },
+      "required": [
+        "text"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.MessageContent"
+        }
+      ],
+      "x-ms-discriminator-value": "text"
+    },
+    "Agents.MessageTextDetails": {
+      "type": "object",
+      "description": "The text and associated annotations for a single item of agent thread message content.",
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "The text data."
+        },
+        "annotations": {
+          "type": "array",
+          "description": "A list of annotations associated with this text.",
+          "items": {
+            "$ref": "#/definitions/Agents.MessageTextAnnotation"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "required": [
+        "value",
+        "annotations"
+      ]
+    },
+    "Agents.MessageTextFileCitationAnnotation": {
+      "type": "object",
+      "description": "A citation within the message that points to a specific quote from a specific File associated with the agent or the message. Generated when the agent uses the 'file_search' tool to search files.",
+      "properties": {
+        "file_citation": {
+          "$ref": "#/definitions/Agents.MessageTextFileCitationDetails",
+          "description": "A citation within the message that points to a specific quote from a specific file.\nGenerated when the agent uses the \"file_search\" tool to search files.",
+          "x-ms-client-name": "fileCitation"
+        },
+        "start_index": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The first text index associated with this text annotation.",
+          "x-ms-client-name": "startIndex"
+        },
+        "end_index": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The last text index associated with this text annotation.",
+          "x-ms-client-name": "endIndex"
+        }
+      },
+      "required": [
+        "file_citation"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.MessageTextAnnotation"
+        }
+      ],
+      "x-ms-discriminator-value": "file_citation"
+    },
+    "Agents.MessageTextFileCitationDetails": {
+      "type": "object",
+      "description": "A representation of a file-based text citation, as used in a file-based annotation of text thread message content.",
+      "properties": {
+        "file_id": {
+          "type": "string",
+          "description": "The ID of the file associated with this citation.",
+          "x-ms-client-name": "fileId"
+        },
+        "quote": {
+          "type": "string",
+          "description": "The specific quote cited in the associated file."
+        }
+      },
+      "required": [
+        "file_id",
+        "quote"
+      ]
+    },
+    "Agents.MessageTextFilePathAnnotation": {
+      "type": "object",
+      "description": "A citation within the message that points to a file located at a specific path.",
+      "properties": {
+        "file_path": {
+          "$ref": "#/definitions/Agents.MessageTextFilePathDetails",
+          "description": "A URL for the file that's generated when the agent used the code_interpreter tool to generate a file.",
+          "x-ms-client-name": "filePath"
+        },
+        "start_index": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The first text index associated with this text annotation.",
+          "x-ms-client-name": "startIndex"
+        },
+        "end_index": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The last text index associated with this text annotation.",
+          "x-ms-client-name": "endIndex"
+        }
+      },
+      "required": [
+        "file_path"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.MessageTextAnnotation"
+        }
+      ],
+      "x-ms-discriminator-value": "file_path"
+    },
+    "Agents.MessageTextFilePathDetails": {
+      "type": "object",
+      "description": "An encapsulation of an image file ID, as used by message image content.",
+      "properties": {
+        "file_id": {
+          "type": "string",
+          "description": "The ID of the specific file that the citation is from.",
+          "x-ms-client-name": "fileId"
+        }
+      },
+      "required": [
+        "file_id"
+      ]
+    },
+    "Agents.MicrosoftFabricToolDefinition": {
+      "type": "object",
+      "description": "The input definition information for a Microsoft Fabric tool as used to configure an agent.",
+      "properties": {
+        "fabric_aiskill": {
+          "$ref": "#/definitions/Agents.ToolConnectionList",
+          "description": "The list of connections used by the Microsoft Fabric tool."
+        }
+      },
+      "required": [
+        "fabric_aiskill"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.ToolDefinition"
+        }
+      ],
+      "x-ms-discriminator-value": "fabric_aiskill"
+    },
+    "Agents.OpenAIFile": {
+      "type": "object",
+      "description": "Represents an agent that can call the model and use tools.",
+      "properties": {
+        "object": {
+          "type": "string",
+          "description": "The object type, which is always 'file'.",
+          "enum": [
+            "file"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        },
+        "id": {
+          "type": "string",
+          "description": "The identifier, which can be referenced in API endpoints."
+        },
+        "bytes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The size of the file, in bytes."
+        },
+        "filename": {
+          "type": "string",
+          "description": "The name of the file."
+        },
+        "created_at": {
+          "type": "integer",
+          "format": "unixtime",
+          "description": "The Unix timestamp, in seconds, representing when this object was created.",
+          "x-ms-client-name": "createdAt"
+        },
+        "purpose": {
+          "$ref": "#/definitions/Agents.FilePurpose",
+          "description": "The intended purpose of a file."
+        },
+        "status": {
+          "$ref": "#/definitions/Agents.FileState",
+          "description": "The state of the file. This field is available in Azure OpenAI only."
+        },
+        "status_details": {
+          "type": "string",
+          "description": "The error message with details in case processing of this file failed. This field is available in Azure OpenAI only.",
+          "x-ms-client-name": "statusDetails"
+        }
+      },
+      "required": [
+        "object",
+        "id",
+        "bytes",
+        "filename",
+        "created_at",
+        "purpose"
+      ]
+    },
+    "Agents.OpenApiAnonymousAuthDetails": {
+      "type": "object",
+      "description": "Security details for OpenApi anonymous authentication",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.OpenApiAuthDetails"
+        }
+      ],
+      "x-ms-discriminator-value": "anonymous"
+    },
+    "Agents.OpenApiAuthDetails": {
+      "type": "object",
+      "description": "authentication details for OpenApiFunctionDefinition",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/Agents.OpenApiAuthType",
+          "description": "The type of authentication, must be anonymous/connection/managed_identity"
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "type"
+      ]
+    },
+    "Agents.OpenApiAuthType": {
+      "type": "string",
+      "description": "  Authentication type for OpenApi endpoint. Allowed types are:\n  - Anonymous (no authentication required)\n  - Connection (requires connection_id to endpoint, as setup in AI Foundry)\n  - Managed_Identity (requires audience for identity based auth)",
+      "enum": [
+        "anonymous",
+        "connection",
+        "managed_identity"
+      ],
+      "x-ms-enum": {
+        "name": "OpenApiAuthType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "anonymous",
+            "value": "anonymous"
+          },
+          {
+            "name": "connection",
+            "value": "connection"
+          },
+          {
+            "name": "managedIdentity",
+            "value": "managed_identity"
+          }
+        ]
+      }
+    },
+    "Agents.OpenApiConnectionAuthDetails": {
+      "type": "object",
+      "description": "Security details for OpenApi connection authentication",
+      "properties": {
+        "security_scheme": {
+          "$ref": "#/definitions/Agents.OpenApiConnectionSecurityScheme",
+          "description": "Connection auth security details"
+        }
+      },
+      "required": [
+        "security_scheme"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.OpenApiAuthDetails"
+        }
+      ],
+      "x-ms-discriminator-value": "connection"
+    },
+    "Agents.OpenApiConnectionSecurityScheme": {
+      "type": "object",
+      "description": "Security scheme for OpenApi managed_identity authentication",
+      "properties": {
+        "connection_id": {
+          "type": "string",
+          "description": "Connection id for Connection auth type"
+        }
+      },
+      "required": [
+        "connection_id"
+      ]
+    },
+    "Agents.OpenApiFunctionDefinition": {
+      "type": "object",
+      "description": "The input definition information for an openapi function.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the function to be called."
+        },
+        "description": {
+          "type": "string",
+          "description": "A description of what the function does, used by the model to choose when and how to call the function."
+        },
+        "spec": {
+          "description": "The openapi function shape, described as a JSON Schema object."
+        },
+        "auth": {
+          "$ref": "#/definitions/Agents.OpenApiAuthDetails",
+          "description": "Open API authentication details"
+        }
+      },
+      "required": [
+        "name",
+        "spec",
+        "auth"
+      ]
+    },
+    "Agents.OpenApiManagedAuthDetails": {
+      "type": "object",
+      "description": "Security details for OpenApi managed_identity authentication",
+      "properties": {
+        "security_scheme": {
+          "$ref": "#/definitions/Agents.OpenApiManagedSecurityScheme",
+          "description": "Connection auth security details"
+        }
+      },
+      "required": [
+        "security_scheme"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.OpenApiAuthDetails"
+        }
+      ],
+      "x-ms-discriminator-value": "managed_identity"
+    },
+    "Agents.OpenApiManagedSecurityScheme": {
+      "type": "object",
+      "description": "Security scheme for OpenApi managed_identity authentication",
+      "properties": {
+        "audience": {
+          "type": "string",
+          "description": "Authentication scope for managed_identity auth type"
+        }
+      },
+      "required": [
+        "audience"
+      ]
+    },
+    "Agents.OpenApiToolDefinition": {
+      "type": "object",
+      "description": "The input definition information for an OpenAPI tool as used to configure an agent.",
+      "properties": {
+        "openapi": {
+          "$ref": "#/definitions/Agents.OpenApiFunctionDefinition",
+          "description": "The openapi function definition."
+        }
+      },
+      "required": [
+        "openapi"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.ToolDefinition"
+        }
+      ],
+      "x-ms-discriminator-value": "openapi"
+    },
+    "Agents.RequiredAction": {
+      "type": "object",
+      "description": "An abstract representation of a required action for an agent thread run to continue.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The object type."
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "type"
+      ]
+    },
+    "Agents.RequiredFunctionToolCall": {
+      "type": "object",
+      "description": "A representation of a requested call to a function tool, needed by the model to continue evaluation of a run.",
+      "properties": {
+        "function": {
+          "$ref": "#/definitions/Agents.RequiredFunctionToolCallDetails",
+          "description": "Detailed information about the function to be executed by the tool that includes name and arguments."
+        }
+      },
+      "required": [
+        "function"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.RequiredToolCall"
+        }
+      ],
+      "x-ms-discriminator-value": "function"
+    },
+    "Agents.RequiredFunctionToolCallDetails": {
+      "type": "object",
+      "description": "The detailed information for a function invocation, as provided by a required action invoking a function tool, that includes the name of and arguments to the function.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the function."
+        },
+        "arguments": {
+          "type": "string",
+          "description": "The arguments to use when invoking the named function, as provided by the model. Arguments are presented as a JSON document that should be validated and parsed for evaluation."
+        }
+      },
+      "required": [
+        "name",
+        "arguments"
+      ]
+    },
+    "Agents.RequiredToolCall": {
+      "type": "object",
+      "description": "An abstract representation of a tool invocation needed by the model to continue a run.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The object type for the required tool call."
+        },
+        "id": {
+          "type": "string",
+          "description": "The ID of the tool call. This ID must be referenced when submitting tool outputs."
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "type",
+        "id"
+      ]
+    },
+    "Agents.ResponseFormat": {
+      "type": "string",
+      "description": "Possible API response formats.",
+      "enum": [
+        "text",
+        "json_object"
+      ],
+      "x-ms-enum": {
+        "name": "ResponseFormat",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "text",
+            "value": "text",
+            "description": "`text` format should be used for requests involving any sort of ToolCall."
+          },
+          {
+            "name": "jsonObject",
+            "value": "json_object",
+            "description": "Using `json_object` format will limit the usage of ToolCall to only functions."
+          }
+        ]
+      }
+    },
+    "Agents.ResponseFormatJsonSchema": {
+      "type": "object",
+      "description": "A description of what the response format is for, used by the model to determine how to respond in the format.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "A description of what the response format is for, used by the model to determine how to respond in the format."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of a schema."
+        },
+        "schema": {
+          "description": "The JSON schema object, describing the response format."
+        }
+      },
+      "required": [
+        "name",
+        "schema"
+      ]
+    },
+    "Agents.ResponseFormatJsonSchemaType": {
+      "type": "object",
+      "description": "The type of response format being defined: `json_schema`",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Type",
+          "enum": [
+            "json_schema"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        },
+        "json_schema": {
+          "$ref": "#/definitions/Agents.ResponseFormatJsonSchema",
+          "description": "The JSON schema, describing response format.",
+          "x-ms-client-name": "jsonSchema"
+        }
+      },
+      "required": [
+        "type",
+        "json_schema"
+      ]
+    },
+    "Agents.RunAdditionalFieldList": {
+      "type": "string",
+      "description": "A list of additional fields to include in the response.",
+      "enum": [
+        "step_details.tool_calls[*].file_search.results[*].content"
+      ],
+      "x-ms-enum": {
+        "name": "RunAdditionalFieldList",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "FileSearchContents",
+            "value": "step_details.tool_calls[*].file_search.results[*].content",
+            "description": "File search result content."
+          }
+        ]
+      }
+    },
+    "Agents.RunCompletionUsage": {
+      "type": "object",
+      "description": "Usage statistics related to the run. This value will be `null` if the run is not in a terminal state (i.e. `in_progress`, `queued`, etc.).",
+      "properties": {
+        "completion_tokens": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Number of completion tokens used over the course of the run.",
+          "x-ms-client-name": "completionTokens"
+        },
+        "prompt_tokens": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Number of prompt tokens used over the course of the run.",
+          "x-ms-client-name": "promptTokens"
+        },
+        "total_tokens": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Total number of tokens used (prompt + completion).",
+          "x-ms-client-name": "totalTokens"
+        }
+      },
+      "required": [
+        "completion_tokens",
+        "prompt_tokens",
+        "total_tokens"
+      ]
+    },
+    "Agents.RunError": {
+      "type": "object",
+      "description": "The details of an error as encountered by an agent thread run.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "The status for the error."
+        },
+        "message": {
+          "type": "string",
+          "description": "The human-readable text associated with the error."
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ]
+    },
+    "Agents.RunStatus": {
+      "type": "string",
+      "description": "Possible values for the status of an agent thread run.",
+      "enum": [
+        "queued",
+        "in_progress",
+        "requires_action",
+        "cancelling",
+        "cancelled",
+        "failed",
+        "completed",
+        "expired"
+      ],
+      "x-ms-enum": {
+        "name": "RunStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "queued",
+            "value": "queued",
+            "description": "Represents a run that is queued to start."
+          },
+          {
+            "name": "inProgress",
+            "value": "in_progress",
+            "description": "Represents a run that is in progress."
+          },
+          {
+            "name": "requiresAction",
+            "value": "requires_action",
+            "description": "Represents a run that needs another operation, such as tool output submission, to continue."
+          },
+          {
+            "name": "cancelling",
+            "value": "cancelling",
+            "description": "Represents a run that is in the process of cancellation."
+          },
+          {
+            "name": "cancelled",
+            "value": "cancelled",
+            "description": "Represents a run that has been cancelled."
+          },
+          {
+            "name": "failed",
+            "value": "failed",
+            "description": "Represents a run that failed."
+          },
+          {
+            "name": "completed",
+            "value": "completed",
+            "description": "Represents a run that successfully completed."
+          },
+          {
+            "name": "expired",
+            "value": "expired",
+            "description": "Represents a run that expired before it could otherwise finish."
+          }
+        ]
+      }
+    },
+    "Agents.RunStep": {
+      "type": "object",
+      "description": "Detailed information about a single step of an agent thread run.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The identifier, which can be referenced in API endpoints."
+        },
+        "object": {
+          "type": "string",
+          "description": "The object type, which is always 'thread.run.step'.",
+          "enum": [
+            "thread.run.step"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        },
+        "type": {
+          "$ref": "#/definitions/Agents.RunStepType",
+          "description": "The type of run step, which can be either message_creation or tool_calls."
+        },
+        "assistant_id": {
+          "type": "string",
+          "description": "The ID of the agent associated with the run step.",
+          "x-ms-client-name": "assistantId"
+        },
+        "thread_id": {
+          "type": "string",
+          "description": "The ID of the thread that was run.",
+          "x-ms-client-name": "threadId"
+        },
+        "run_id": {
+          "type": "string",
+          "description": "The ID of the run that this run step is a part of.",
+          "x-ms-client-name": "runId"
+        },
+        "status": {
+          "$ref": "#/definitions/Agents.RunStepStatus",
+          "description": "The status of this run step."
+        },
+        "step_details": {
+          "$ref": "#/definitions/Agents.RunStepDetails",
+          "description": "The details for this run step.",
+          "x-ms-client-name": "stepDetails"
+        },
+        "last_error": {
+          "type": "object",
+          "description": "If applicable, information about the last error encountered by this run step.",
+          "x-nullable": true,
+          "allOf": [
+            {
+              "$ref": "#/definitions/Agents.RunStepError"
+            }
+          ],
+          "x-ms-client-name": "lastError"
+        },
+        "created_at": {
+          "type": "integer",
+          "format": "unixtime",
+          "description": "The Unix timestamp, in seconds, representing when this object was created.",
+          "x-ms-client-name": "createdAt"
+        },
+        "expired_at": {
+          "type": "integer",
+          "format": "unixtime",
+          "description": "The Unix timestamp, in seconds, representing when this item expired.",
+          "x-nullable": true,
+          "x-ms-client-name": "expiredAt"
+        },
+        "completed_at": {
+          "type": "integer",
+          "format": "unixtime",
+          "description": "The Unix timestamp, in seconds, representing when this completed.",
+          "x-nullable": true,
+          "x-ms-client-name": "completedAt"
+        },
+        "cancelled_at": {
+          "type": "integer",
+          "format": "unixtime",
+          "description": "The Unix timestamp, in seconds, representing when this was cancelled.",
+          "x-nullable": true,
+          "x-ms-client-name": "cancelledAt"
+        },
+        "failed_at": {
+          "type": "integer",
+          "format": "unixtime",
+          "description": "The Unix timestamp, in seconds, representing when this failed.",
+          "x-nullable": true,
+          "x-ms-client-name": "failedAt"
+        },
+        "usage": {
+          "type": "object",
+          "description": "Usage statistics related to the run step. This value will be `null` while the run step's status is `in_progress`.",
+          "x-nullable": true,
+          "allOf": [
+            {
+              "$ref": "#/definitions/Agents.RunStepCompletionUsage"
+            }
+          ]
+        },
+        "metadata": {
+          "type": "object",
+          "description": "A set of up to 16 key/value pairs that can be attached to an object, used for storing additional information about that object in a structured format. Keys may be up to 64 characters in length and values may be up to 512 characters in length.",
+          "x-nullable": true,
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "id",
+        "object",
+        "type",
+        "assistant_id",
+        "thread_id",
+        "run_id",
+        "status",
+        "step_details",
+        "last_error",
+        "created_at",
+        "expired_at",
+        "completed_at",
+        "cancelled_at",
+        "failed_at",
+        "metadata"
+      ]
+    },
+    "Agents.RunStepAzureAISearchToolCall": {
+      "type": "object",
+      "description": "A record of a call to an Azure AI Search tool, issued by the model in evaluation of a defined tool, that represents\nexecuted Azure AI search.",
+      "properties": {
+        "azure_ai_search": {
+          "type": "object",
+          "description": "Reserved for future use.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-client-name": "azureAISearch"
+        }
+      },
+      "required": [
+        "azure_ai_search"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.RunStepToolCall"
+        }
+      ],
+      "x-ms-discriminator-value": "azure_ai_search"
+    },
+    "Agents.RunStepBingGroundingToolCall": {
+      "type": "object",
+      "description": "A record of a call to a bing grounding tool, issued by the model in evaluation of a defined tool, that represents\nexecuted search with bing grounding.",
+      "properties": {
+        "bing_grounding": {
+          "type": "object",
+          "description": "Reserved for future use.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-client-name": "bingGrounding"
+        }
+      },
+      "required": [
+        "bing_grounding"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.RunStepToolCall"
+        }
+      ],
+      "x-ms-discriminator-value": "bing_grounding"
+    },
+    "Agents.RunStepCodeInterpreterImageOutput": {
+      "type": "object",
+      "description": "A representation of an image output emitted by a code interpreter tool in response to a tool call by the model.",
+      "properties": {
+        "image": {
+          "$ref": "#/definitions/Agents.RunStepCodeInterpreterImageReference",
+          "description": "Referential information for the image associated with this output."
+        }
+      },
+      "required": [
+        "image"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.RunStepCodeInterpreterToolCallOutput"
+        }
+      ],
+      "x-ms-discriminator-value": "image"
+    },
+    "Agents.RunStepCodeInterpreterImageReference": {
+      "type": "object",
+      "description": "An image reference emitted by a code interpreter tool in response to a tool call by the model.",
+      "properties": {
+        "file_id": {
+          "type": "string",
+          "description": "The ID of the file associated with this image.",
+          "x-ms-client-name": "fileId"
+        }
+      },
+      "required": [
+        "file_id"
+      ]
+    },
+    "Agents.RunStepCodeInterpreterLogOutput": {
+      "type": "object",
+      "description": "A representation of a log output emitted by a code interpreter tool in response to a tool call by the model.",
+      "properties": {
+        "logs": {
+          "type": "string",
+          "description": "The serialized log output emitted by the code interpreter."
+        }
+      },
+      "required": [
+        "logs"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.RunStepCodeInterpreterToolCallOutput"
+        }
+      ],
+      "x-ms-discriminator-value": "logs"
+    },
+    "Agents.RunStepCodeInterpreterToolCall": {
+      "type": "object",
+      "description": "A record of a call to a code interpreter tool, issued by the model in evaluation of a defined tool, that\nrepresents inputs and outputs consumed and emitted by the code interpreter.",
+      "properties": {
+        "code_interpreter": {
+          "$ref": "#/definitions/Agents.RunStepCodeInterpreterToolCallDetails",
+          "description": "The details of the tool call to the code interpreter tool.",
+          "x-ms-client-name": "codeInterpreter"
+        }
+      },
+      "required": [
+        "code_interpreter"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.RunStepToolCall"
+        }
+      ],
+      "x-ms-discriminator-value": "code_interpreter"
+    },
+    "Agents.RunStepCodeInterpreterToolCallDetails": {
+      "type": "object",
+      "description": "The detailed information about a code interpreter invocation by the model.",
+      "properties": {
+        "input": {
+          "type": "string",
+          "description": "The input provided by the model to the code interpreter tool."
+        },
+        "outputs": {
+          "type": "array",
+          "description": "The outputs produced by the code interpreter tool back to the model in response to the tool call.",
+          "items": {
+            "$ref": "#/definitions/Agents.RunStepCodeInterpreterToolCallOutput"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "required": [
+        "input",
+        "outputs"
+      ]
+    },
+    "Agents.RunStepCodeInterpreterToolCallOutput": {
+      "type": "object",
+      "description": "An abstract representation of an emitted output from a code interpreter tool.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The object type."
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "type"
+      ]
+    },
+    "Agents.RunStepCompletionUsage": {
+      "type": "object",
+      "description": "Usage statistics related to the run step.",
+      "properties": {
+        "completion_tokens": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Number of completion tokens used over the course of the run step.",
+          "x-ms-client-name": "completionTokens"
+        },
+        "prompt_tokens": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Number of prompt tokens used over the course of the run step.",
+          "x-ms-client-name": "promptTokens"
+        },
+        "total_tokens": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Total number of tokens used (prompt + completion).",
+          "x-ms-client-name": "totalTokens"
+        }
+      },
+      "required": [
+        "completion_tokens",
+        "prompt_tokens",
+        "total_tokens"
+      ]
+    },
+    "Agents.RunStepDelta": {
+      "type": "object",
+      "description": "Represents the delta payload in a streaming run step delta chunk.",
+      "properties": {
+        "step_details": {
+          "$ref": "#/definitions/Agents.RunStepDeltaDetail",
+          "description": "The details of the run step.",
+          "x-ms-client-name": "stepDetails"
+        }
+      }
+    },
+    "Agents.RunStepDeltaChunk": {
+      "type": "object",
+      "description": "Represents a run step delta i.e. any changed fields on a run step during streaming.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The identifier of the run step, which can be referenced in API endpoints."
+        },
+        "object": {
+          "type": "string",
+          "description": "The object type, which is always `thread.run.step.delta`.",
+          "enum": [
+            "thread.run.step.delta"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        },
+        "delta": {
+          "$ref": "#/definitions/Agents.RunStepDelta",
+          "description": "The delta containing the fields that have changed on the run step."
+        }
+      },
+      "required": [
+        "id",
+        "object",
+        "delta"
+      ]
+    },
+    "Agents.RunStepDeltaCodeInterpreterDetailItemObject": {
+      "type": "object",
+      "description": "Represents the Code Interpreter tool call data in a streaming run step's tool calls.",
+      "properties": {
+        "input": {
+          "type": "string",
+          "description": "The input into the Code Interpreter tool call."
+        },
+        "outputs": {
+          "type": "array",
+          "description": "The outputs from the Code Interpreter tool call. Code Interpreter can output one or more\nitems, including text (`logs`) or images (`image`). Each of these are represented by a\ndifferent object type.",
+          "items": {
+            "$ref": "#/definitions/Agents.RunStepDeltaCodeInterpreterOutput"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "Agents.RunStepDeltaCodeInterpreterImageOutput": {
+      "type": "object",
+      "description": "Represents an image output as produced the Code interpreter tool and as represented in a streaming run step's delta tool calls collection.",
+      "properties": {
+        "image": {
+          "$ref": "#/definitions/Agents.RunStepDeltaCodeInterpreterImageOutputObject",
+          "description": "The image data for the Code Interpreter tool call output."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.RunStepDeltaCodeInterpreterOutput"
+        }
+      ],
+      "x-ms-discriminator-value": "image"
+    },
+    "Agents.RunStepDeltaCodeInterpreterImageOutputObject": {
+      "type": "object",
+      "description": "Represents the data for a streaming run step's Code Interpreter tool call image output.",
+      "properties": {
+        "file_id": {
+          "type": "string",
+          "description": "The file ID for the image.",
+          "x-ms-client-name": "fileId"
+        }
+      }
+    },
+    "Agents.RunStepDeltaCodeInterpreterLogOutput": {
+      "type": "object",
+      "description": "Represents a log output as produced by the Code Interpreter tool and as represented in a streaming run step's delta tool calls collection.",
+      "properties": {
+        "logs": {
+          "type": "string",
+          "description": "The text output from the Code Interpreter tool call."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.RunStepDeltaCodeInterpreterOutput"
+        }
+      ],
+      "x-ms-discriminator-value": "logs"
+    },
+    "Agents.RunStepDeltaCodeInterpreterOutput": {
+      "type": "object",
+      "description": "The abstract base representation of a streaming run step tool call's Code Interpreter tool output.",
+      "properties": {
+        "index": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The index of the output in the streaming run step tool call's Code Interpreter outputs array."
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of the streaming run step tool call's Code Interpreter output."
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "index",
+        "type"
+      ]
+    },
+    "Agents.RunStepDeltaCodeInterpreterToolCall": {
+      "type": "object",
+      "description": "Represents a Code Interpreter tool call within a streaming run step's tool call details.",
+      "properties": {
+        "code_interpreter": {
+          "$ref": "#/definitions/Agents.RunStepDeltaCodeInterpreterDetailItemObject",
+          "description": "The Code Interpreter data for the tool call.",
+          "x-ms-client-name": "codeInterpreter"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.RunStepDeltaToolCall"
+        }
+      ],
+      "x-ms-discriminator-value": "code_interpreter"
+    },
+    "Agents.RunStepDeltaDetail": {
+      "type": "object",
+      "description": "Represents a single run step detail item in a streaming run step's delta payload.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The object type for the run step detail object."
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "type"
+      ]
+    },
+    "Agents.RunStepDeltaFileSearchToolCall": {
+      "type": "object",
+      "description": "Represents a file search tool call within a streaming run step's tool call details.",
+      "properties": {
+        "file_search": {
+          "type": "object",
+          "description": "Reserved for future use.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-client-name": "fileSearch"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.RunStepDeltaToolCall"
+        }
+      ],
+      "x-ms-discriminator-value": "file_search"
+    },
+    "Agents.RunStepDeltaFunction": {
+      "type": "object",
+      "description": "Represents the function data in a streaming run step delta's function tool call.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the function."
+        },
+        "arguments": {
+          "type": "string",
+          "description": "The arguments passed to the function as input."
+        },
+        "output": {
+          "type": "string",
+          "description": "The output of the function, null if outputs have not yet been submitted.",
+          "x-nullable": true
+        }
+      }
+    },
+    "Agents.RunStepDeltaFunctionToolCall": {
+      "type": "object",
+      "description": "Represents a function tool call within a streaming run step's tool call details.",
+      "properties": {
+        "function": {
+          "$ref": "#/definitions/Agents.RunStepDeltaFunction",
+          "description": "The function data for the tool call."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.RunStepDeltaToolCall"
+        }
+      ],
+      "x-ms-discriminator-value": "function"
+    },
+    "Agents.RunStepDeltaMessageCreation": {
+      "type": "object",
+      "description": "Represents a message creation within a streaming run step delta.",
+      "properties": {
+        "message_creation": {
+          "$ref": "#/definitions/Agents.RunStepDeltaMessageCreationObject",
+          "description": "The message creation data.",
+          "x-ms-client-name": "messageCreation"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.RunStepDeltaDetail"
+        }
+      ],
+      "x-ms-discriminator-value": "message_creation"
+    },
+    "Agents.RunStepDeltaMessageCreationObject": {
+      "type": "object",
+      "description": "Represents the data within a streaming run step message creation response object.",
+      "properties": {
+        "message_id": {
+          "type": "string",
+          "description": "The ID of the newly-created message.",
+          "x-ms-client-name": "messageId"
+        }
+      }
+    },
+    "Agents.RunStepDeltaToolCall": {
+      "type": "object",
+      "description": "The abstract base representation of a single tool call within a streaming run step's delta tool call details.",
+      "properties": {
+        "index": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The index of the tool call detail in the run step's tool_calls array."
+        },
+        "id": {
+          "type": "string",
+          "description": "The ID of the tool call, used when submitting outputs to the run."
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of the tool call detail item in a streaming run step's details."
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "index",
+        "id",
+        "type"
+      ]
+    },
+    "Agents.RunStepDeltaToolCallObject": {
+      "type": "object",
+      "description": "Represents an invocation of tool calls as part of a streaming run step.",
+      "properties": {
+        "tool_calls": {
+          "type": "array",
+          "description": "The collection of tool calls for the tool call detail item.",
+          "items": {
+            "$ref": "#/definitions/Agents.RunStepDeltaToolCall"
+          },
+          "x-ms-client-name": "toolCalls"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.RunStepDeltaDetail"
+        }
+      ],
+      "x-ms-discriminator-value": "tool_calls"
+    },
+    "Agents.RunStepDetails": {
+      "type": "object",
+      "description": "An abstract representation of the details for a run step.",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/Agents.RunStepType",
+          "description": "The object type."
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "type"
+      ]
+    },
+    "Agents.RunStepError": {
+      "type": "object",
+      "description": "The error information associated with a failed run step.",
+      "properties": {
+        "code": {
+          "$ref": "#/definitions/Agents.RunStepErrorCode",
+          "description": "The error code for this error."
+        },
+        "message": {
+          "type": "string",
+          "description": "The human-readable text associated with this error."
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ]
+    },
+    "Agents.RunStepErrorCode": {
+      "type": "string",
+      "description": "Possible error code values attributable to a failed run step.",
+      "enum": [
+        "server_error",
+        "rate_limit_exceeded"
+      ],
+      "x-ms-enum": {
+        "name": "RunStepErrorCode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "serverError",
+            "value": "server_error",
+            "description": "Represents a server error."
+          },
+          {
+            "name": "rateLimitExceeded",
+            "value": "rate_limit_exceeded",
+            "description": "Represents an error indicating configured rate limits were exceeded."
+          }
+        ]
+      }
+    },
+    "Agents.RunStepFileSearchToolCall": {
+      "type": "object",
+      "description": "A record of a call to a file search tool, issued by the model in evaluation of a defined tool, that represents\nexecuted file search.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The ID of the tool call. This ID must be referenced when you submit tool outputs."
+        },
+        "file_search": {
+          "$ref": "#/definitions/Agents.RunStepFileSearchToolCallResults",
+          "description": "For now, this is always going to be an empty object.",
+          "x-ms-client-name": "fileSearch"
+        }
+      },
+      "required": [
+        "id",
+        "file_search"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.RunStepToolCall"
+        }
+      ],
+      "x-ms-discriminator-value": "file_search"
+    },
+    "Agents.RunStepFileSearchToolCallResult": {
+      "type": "object",
+      "description": "  File search tool call result.",
+      "properties": {
+        "file_id": {
+          "type": "string",
+          "description": "The ID of the file that result was found in.",
+          "x-ms-client-name": "fileId"
+        },
+        "file_name": {
+          "type": "string",
+          "description": "The name of the file that result was found in.",
+          "x-ms-client-name": "fileName"
+        },
+        "score": {
+          "type": "number",
+          "format": "float",
+          "description": "The score of the result. All values must be a floating point number between 0 and 1.",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "content": {
+          "type": "array",
+          "description": "The content of the result that was found. The content is only included if requested via the include query parameter.",
+          "items": {
+            "$ref": "#/definitions/Agents.FileSearchToolCallContent"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "required": [
+        "file_id",
+        "file_name",
+        "score"
+      ]
+    },
+    "Agents.RunStepFileSearchToolCallResults": {
+      "type": "object",
+      "description": "The results of the file search.",
+      "properties": {
+        "ranking_options": {
+          "$ref": "#/definitions/Agents.FileSearchRankingOptions",
+          "description": "Ranking options for file search.",
+          "x-ms-client-name": "rankingOptions"
+        },
+        "results": {
+          "type": "array",
+          "description": "The array of a file search results",
+          "items": {
+            "$ref": "#/definitions/Agents.RunStepFileSearchToolCallResult"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "required": [
+        "results"
+      ]
+    },
+    "Agents.RunStepFunctionToolCall": {
+      "type": "object",
+      "description": "A record of a call to a function tool, issued by the model in evaluation of a defined tool, that represents the inputs\nand output consumed and emitted by the specified function.",
+      "properties": {
+        "function": {
+          "$ref": "#/definitions/Agents.RunStepFunctionToolCallDetails",
+          "description": "The detailed information about the function called by the model."
+        }
+      },
+      "required": [
+        "function"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.RunStepToolCall"
+        }
+      ],
+      "x-ms-discriminator-value": "function"
+    },
+    "Agents.RunStepFunctionToolCallDetails": {
+      "type": "object",
+      "description": "The detailed information about the function called by the model.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the function."
+        },
+        "arguments": {
+          "type": "string",
+          "description": "The arguments that the model requires are provided to the named function."
+        },
+        "output": {
+          "type": "string",
+          "description": "The output of the function, only populated for function calls that have already have had their outputs submitted.",
+          "x-nullable": true
+        }
+      },
+      "required": [
+        "name",
+        "arguments",
+        "output"
+      ]
+    },
+    "Agents.RunStepMessageCreationDetails": {
+      "type": "object",
+      "description": "The detailed information associated with a message creation run step.",
+      "properties": {
+        "message_creation": {
+          "$ref": "#/definitions/Agents.RunStepMessageCreationReference",
+          "description": "Information about the message creation associated with this run step.",
+          "x-ms-client-name": "messageCreation"
+        }
+      },
+      "required": [
+        "message_creation"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.RunStepDetails"
+        }
+      ],
+      "x-ms-discriminator-value": "message_creation"
+    },
+    "Agents.RunStepMessageCreationReference": {
+      "type": "object",
+      "description": "The details of a message created as a part of a run step.",
+      "properties": {
+        "message_id": {
+          "type": "string",
+          "description": "The ID of the message created by this run step.",
+          "x-ms-client-name": "messageId"
+        }
+      },
+      "required": [
+        "message_id"
+      ]
+    },
+    "Agents.RunStepMicrosoftFabricToolCall": {
+      "type": "object",
+      "description": "A record of a call to a Microsoft Fabric tool, issued by the model in evaluation of a defined tool, that represents\nexecuted Microsoft Fabric operations.",
+      "properties": {
+        "fabric_aiskill": {
+          "type": "object",
+          "description": "Reserved for future use.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-client-name": "microsoftFabric"
+        }
+      },
+      "required": [
+        "fabric_aiskill"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.RunStepToolCall"
+        }
+      ],
+      "x-ms-discriminator-value": "fabric_aiskill"
+    },
+    "Agents.RunStepSharepointToolCall": {
+      "type": "object",
+      "description": "A record of a call to a SharePoint tool, issued by the model in evaluation of a defined tool, that represents\nexecuted SharePoint actions.",
+      "properties": {
+        "sharepoint_grounding": {
+          "type": "object",
+          "description": "Reserved for future use.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-client-name": "sharePoint"
+        }
+      },
+      "required": [
+        "sharepoint_grounding"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.RunStepToolCall"
+        }
+      ],
+      "x-ms-discriminator-value": "sharepoint_grounding"
+    },
+    "Agents.RunStepStatus": {
+      "type": "string",
+      "description": "Possible values for the status of a run step.",
+      "enum": [
+        "in_progress",
+        "cancelled",
+        "failed",
+        "completed",
+        "expired"
+      ],
+      "x-ms-enum": {
+        "name": "RunStepStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "inProgress",
+            "value": "in_progress",
+            "description": "Represents a run step still in progress."
+          },
+          {
+            "name": "cancelled",
+            "value": "cancelled",
+            "description": "Represents a run step that was cancelled."
+          },
+          {
+            "name": "failed",
+            "value": "failed",
+            "description": "Represents a run step that failed."
+          },
+          {
+            "name": "completed",
+            "value": "completed",
+            "description": "Represents a run step that successfully completed."
+          },
+          {
+            "name": "expired",
+            "value": "expired",
+            "description": "Represents a run step that expired before otherwise finishing."
+          }
+        ]
+      }
+    },
+    "Agents.RunStepStreamEvent": {
+      "type": "string",
+      "description": "Run step operation related streaming events",
+      "enum": [
+        "thread.run.step.created",
+        "thread.run.step.in_progress",
+        "thread.run.step.delta",
+        "thread.run.step.completed",
+        "thread.run.step.failed",
+        "thread.run.step.cancelled",
+        "thread.run.step.expired"
+      ],
+      "x-ms-enum": {
+        "name": "RunStepStreamEvent",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ThreadRunStepCreated",
+            "value": "thread.run.step.created",
+            "description": "Event sent when a new thread run step is created. The data of this event is of type RunStep"
+          },
+          {
+            "name": "ThreadRunStepInProgress",
+            "value": "thread.run.step.in_progress",
+            "description": "Event sent when a run step moves to `in_progress` status. The data of this event is of type RunStep"
+          },
+          {
+            "name": "ThreadRunStepDelta",
+            "value": "thread.run.step.delta",
+            "description": "Event sent when a run step is being streamed. The data of this event is of type RunStepDeltaChunk"
+          },
+          {
+            "name": "ThreadRunStepCompleted",
+            "value": "thread.run.step.completed",
+            "description": "Event sent when a run step is completed. The data of this event is of type RunStep"
+          },
+          {
+            "name": "ThreadRunStepFailed",
+            "value": "thread.run.step.failed",
+            "description": "Event sent when a run step fails. The data of this event is of type RunStep"
+          },
+          {
+            "name": "ThreadRunStepCancelled",
+            "value": "thread.run.step.cancelled",
+            "description": "Event sent when a run step is cancelled. The data of this event is of type RunStep"
+          },
+          {
+            "name": "ThreadRunStepExpired",
+            "value": "thread.run.step.expired",
+            "description": "Event sent when a run step is expired. The data of this event is of type RunStep"
+          }
+        ]
+      }
+    },
+    "Agents.RunStepToolCall": {
+      "type": "object",
+      "description": "An abstract representation of a detailed tool call as recorded within a run step for an existing run.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The object type."
+        },
+        "id": {
+          "type": "string",
+          "description": "The ID of the tool call. This ID must be referenced when you submit tool outputs."
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "type",
+        "id"
+      ]
+    },
+    "Agents.RunStepToolCallDetails": {
+      "type": "object",
+      "description": "The detailed information associated with a run step calling tools.",
+      "properties": {
+        "tool_calls": {
+          "type": "array",
+          "description": "A list of tool call details for this run step.",
+          "items": {
+            "$ref": "#/definitions/Agents.RunStepToolCall"
+          },
+          "x-ms-client-name": "toolCalls"
+        }
+      },
+      "required": [
+        "tool_calls"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.RunStepDetails"
+        }
+      ],
+      "x-ms-discriminator-value": "tool_calls"
+    },
+    "Agents.RunStepType": {
+      "type": "string",
+      "description": "The possible types of run steps.",
+      "enum": [
+        "message_creation",
+        "tool_calls"
+      ],
+      "x-ms-enum": {
+        "name": "RunStepType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "messageCreation",
+            "value": "message_creation",
+            "description": "Represents a run step to create a message."
+          },
+          {
+            "name": "toolCalls",
+            "value": "tool_calls",
+            "description": "Represents a run step that calls tools."
+          }
+        ]
+      }
+    },
+    "Agents.RunStreamEvent": {
+      "type": "string",
+      "description": "Run operation related streaming events",
+      "enum": [
+        "thread.run.created",
+        "thread.run.queued",
+        "thread.run.in_progress",
+        "thread.run.requires_action",
+        "thread.run.completed",
+        "thread.run.incomplete",
+        "thread.run.failed",
+        "thread.run.cancelling",
+        "thread.run.cancelled",
+        "thread.run.expired"
+      ],
+      "x-ms-enum": {
+        "name": "RunStreamEvent",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ThreadRunCreated",
+            "value": "thread.run.created",
+            "description": "Event sent when a new run is created. The data of this event is of type ThreadRun"
+          },
+          {
+            "name": "ThreadRunQueued",
+            "value": "thread.run.queued",
+            "description": "Event sent when a run moves to `queued` status. The data of this event is of type ThreadRun"
+          },
+          {
+            "name": "ThreadRunInProgress",
+            "value": "thread.run.in_progress",
+            "description": "Event sent when a run moves to `in_progress` status. The data of this event is of type ThreadRun"
+          },
+          {
+            "name": "ThreadRunRequiresAction",
+            "value": "thread.run.requires_action",
+            "description": "Event sent when a run moves to `requires_action` status. The data of this event is of type ThreadRun"
+          },
+          {
+            "name": "ThreadRunCompleted",
+            "value": "thread.run.completed",
+            "description": "Event sent when a run is completed. The data of this event is of type ThreadRun"
+          },
+          {
+            "name": "ThreadRunIncomplete",
+            "value": "thread.run.incomplete",
+            "description": "Event sent when a run ends incomplete. The data of this event is of type ThreadRun"
+          },
+          {
+            "name": "ThreadRunFailed",
+            "value": "thread.run.failed",
+            "description": "Event sent when a run fails. The data of this event is of type ThreadRun"
+          },
+          {
+            "name": "ThreadRunCancelling",
+            "value": "thread.run.cancelling",
+            "description": "Event sent when a run moves to `cancelling` status. The data of this event is of type ThreadRun"
+          },
+          {
+            "name": "ThreadRunCancelled",
+            "value": "thread.run.cancelled",
+            "description": "Event sent when a run is cancelled. The data of this event is of type ThreadRun"
+          },
+          {
+            "name": "ThreadRunExpired",
+            "value": "thread.run.expired",
+            "description": "Event sent when a run is expired. The data of this event is of type ThreadRun"
+          }
+        ]
+      }
+    },
+    "Agents.SharepointToolDefinition": {
+      "type": "object",
+      "description": "The input definition information for a sharepoint tool as used to configure an agent.",
+      "properties": {
+        "sharepoint_grounding": {
+          "$ref": "#/definitions/Agents.ToolConnectionList",
+          "description": "The list of connections used by the SharePoint tool."
+        }
+      },
+      "required": [
+        "sharepoint_grounding"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.ToolDefinition"
+        }
+      ],
+      "x-ms-discriminator-value": "sharepoint_grounding"
+    },
+    "Agents.SubmitToolOutputsAction": {
+      "type": "object",
+      "description": "The details for required tool calls that must be submitted for an agent thread run to continue.",
+      "properties": {
+        "submit_tool_outputs": {
+          "$ref": "#/definitions/Agents.SubmitToolOutputsDetails",
+          "description": "The details describing tools that should be called to submit tool outputs.",
+          "x-ms-client-name": "submitToolOutputs"
+        }
+      },
+      "required": [
+        "submit_tool_outputs"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.RequiredAction"
+        }
+      ],
+      "x-ms-discriminator-value": "submit_tool_outputs"
+    },
+    "Agents.SubmitToolOutputsDetails": {
+      "type": "object",
+      "description": "The details describing tools that should be called to submit tool outputs.",
+      "properties": {
+        "tool_calls": {
+          "type": "array",
+          "description": "The list of tool calls that must be resolved for the agent thread run to continue.",
+          "items": {
+            "$ref": "#/definitions/Agents.RequiredToolCall"
+          },
+          "x-ms-client-name": "toolCalls"
+        }
+      },
+      "required": [
+        "tool_calls"
+      ]
+    },
+    "Agents.ThreadDeletionStatus": {
+      "type": "object",
+      "description": "The status of a thread deletion operation.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The ID of the resource specified for deletion."
+        },
+        "deleted": {
+          "type": "boolean",
+          "description": "A value indicating whether deletion was successful."
+        },
+        "object": {
+          "type": "string",
+          "description": "The object type, which is always 'thread.deleted'.",
+          "enum": [
+            "thread.deleted"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        }
+      },
+      "required": [
+        "id",
+        "deleted",
+        "object"
+      ]
+    },
+    "Agents.ThreadMessage": {
+      "type": "object",
+      "description": "A single, existing message within an agent thread.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The identifier, which can be referenced in API endpoints."
+        },
+        "object": {
+          "type": "string",
+          "description": "The object type, which is always 'thread.message'.",
+          "enum": [
+            "thread.message"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        },
+        "created_at": {
+          "type": "integer",
+          "format": "unixtime",
+          "description": "The Unix timestamp, in seconds, representing when this object was created.",
+          "x-ms-client-name": "createdAt"
+        },
+        "thread_id": {
+          "type": "string",
+          "description": "The ID of the thread that this message belongs to.",
+          "x-ms-client-name": "threadId"
+        },
+        "status": {
+          "$ref": "#/definitions/Agents.MessageStatus",
+          "description": "The status of the message."
+        },
+        "incomplete_details": {
+          "type": "object",
+          "description": "On an incomplete message, details about why the message is incomplete.",
+          "x-nullable": true,
+          "allOf": [
+            {
+              "$ref": "#/definitions/Agents.MessageIncompleteDetails"
+            }
+          ],
+          "x-ms-client-name": "incompleteDetails"
+        },
+        "completed_at": {
+          "type": "integer",
+          "format": "unixtime",
+          "description": "The Unix timestamp (in seconds) for when the message was completed.",
+          "x-nullable": true,
+          "x-ms-client-name": "completedAt"
+        },
+        "incomplete_at": {
+          "type": "integer",
+          "format": "unixtime",
+          "description": "The Unix timestamp (in seconds) for when the message was marked as incomplete.",
+          "x-nullable": true,
+          "x-ms-client-name": "incompleteAt"
+        },
+        "role": {
+          "$ref": "#/definitions/Agents.MessageRole",
+          "description": "The role associated with the agent thread message."
+        },
+        "content": {
+          "type": "array",
+          "description": "The list of content items associated with the agent thread message.",
+          "items": {
+            "$ref": "#/definitions/Agents.MessageContent"
+          },
+          "x-ms-identifiers": []
+        },
+        "assistant_id": {
+          "type": "string",
+          "description": "If applicable, the ID of the agent that authored this message.",
+          "x-nullable": true,
+          "x-ms-client-name": "assistantId"
+        },
+        "run_id": {
+          "type": "string",
+          "description": "If applicable, the ID of the run associated with the authoring of this message.",
+          "x-nullable": true,
+          "x-ms-client-name": "runId"
+        },
+        "attachments": {
+          "type": "array",
+          "description": "A list of files attached to the message, and the tools they were added to.",
+          "x-nullable": true,
+          "items": {
+            "$ref": "#/definitions/Agents.MessageAttachment"
+          },
+          "x-ms-identifiers": []
+        },
+        "metadata": {
+          "type": "object",
+          "description": "A set of up to 16 key/value pairs that can be attached to an object, used for storing additional information about that object in a structured format. Keys may be up to 64 characters in length and values may be up to 512 characters in length.",
+          "x-nullable": true,
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "id",
+        "object",
+        "created_at",
+        "thread_id",
+        "status",
+        "incomplete_details",
+        "completed_at",
+        "incomplete_at",
+        "role",
+        "content",
+        "assistant_id",
+        "run_id",
+        "attachments",
+        "metadata"
+      ]
+    },
+    "Agents.ThreadMessageOptions": {
+      "type": "object",
+      "description": "A single message within an agent thread, as provided during that thread's creation for its initial state.",
+      "properties": {
+        "role": {
+          "$ref": "#/definitions/Agents.MessageRole",
+          "description": "The role of the entity that is creating the message. Allowed values include:\n- `user`: Indicates the message is sent by an actual user and should be used in most\ncases to represent user-generated messages.\n- `assistant`: Indicates the message is generated by the agent. Use this value to insert\nmessages from the agent into the\nconversation."
+        },
+        "content": {
+          "type": "string",
+          "description": "The textual content of the initial message. Currently, robust input including images and annotated text may only be provided via\na separate call to the create message API."
+        },
+        "attachments": {
+          "type": "array",
+          "description": "A list of files attached to the message, and the tools they should be added to.",
+          "x-nullable": true,
+          "items": {
+            "$ref": "#/definitions/Agents.MessageAttachment"
+          },
+          "x-ms-identifiers": []
+        },
+        "metadata": {
+          "type": "object",
+          "description": "A set of up to 16 key/value pairs that can be attached to an object, used for storing additional information about that object in a structured format. Keys may be up to 64 characters in length and values may be up to 512 characters in length.",
+          "x-nullable": true,
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "role",
+        "content"
+      ]
+    },
+    "Agents.ThreadRun": {
+      "type": "object",
+      "description": "Data representing a single evaluation run of an agent thread.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The identifier, which can be referenced in API endpoints."
+        },
+        "object": {
+          "type": "string",
+          "description": "The object type, which is always 'thread.run'.",
+          "enum": [
+            "thread.run"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        },
+        "thread_id": {
+          "type": "string",
+          "description": "The ID of the thread associated with this run.",
+          "x-ms-client-name": "threadId"
+        },
+        "assistant_id": {
+          "type": "string",
+          "description": "The ID of the agent associated with the thread this run was performed against.",
+          "x-ms-client-name": "assistantId"
+        },
+        "status": {
+          "$ref": "#/definitions/Agents.RunStatus",
+          "description": "The status of the agent thread run."
+        },
+        "required_action": {
+          "type": "object",
+          "description": "The details of the action required for the agent thread run to continue.",
+          "x-nullable": true,
+          "allOf": [
+            {
+              "$ref": "#/definitions/Agents.RequiredAction"
+            }
+          ],
+          "x-ms-client-name": "requiredAction"
+        },
+        "last_error": {
+          "type": "object",
+          "description": "The last error, if any, encountered by this agent thread run.",
+          "x-nullable": true,
+          "allOf": [
+            {
+              "$ref": "#/definitions/Agents.RunError"
+            }
+          ],
+          "x-ms-client-name": "lastError"
+        },
+        "model": {
+          "type": "string",
+          "description": "The ID of the model to use."
+        },
+        "instructions": {
+          "type": "string",
+          "description": "The overridden system instructions used for this agent thread run."
+        },
+        "tools": {
+          "type": "array",
+          "description": "The overridden enabled tools used for this agent thread run.",
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/Agents.ToolDefinition"
+          },
+          "x-ms-identifiers": []
+        },
+        "created_at": {
+          "type": "integer",
+          "format": "unixtime",
+          "description": "The Unix timestamp, in seconds, representing when this object was created.",
+          "x-ms-client-name": "createdAt"
+        },
+        "expires_at": {
+          "type": "integer",
+          "format": "unixtime",
+          "description": "The Unix timestamp, in seconds, representing when this item expires.",
+          "x-nullable": true,
+          "x-ms-client-name": "expiresAt"
+        },
+        "started_at": {
+          "type": "integer",
+          "format": "unixtime",
+          "description": "The Unix timestamp, in seconds, representing when this item was started.",
+          "x-nullable": true,
+          "x-ms-client-name": "startedAt"
+        },
+        "completed_at": {
+          "type": "integer",
+          "format": "unixtime",
+          "description": "The Unix timestamp, in seconds, representing when this completed.",
+          "x-nullable": true,
+          "x-ms-client-name": "completedAt"
+        },
+        "cancelled_at": {
+          "type": "integer",
+          "format": "unixtime",
+          "description": "The Unix timestamp, in seconds, representing when this was cancelled.",
+          "x-nullable": true,
+          "x-ms-client-name": "cancelledAt"
+        },
+        "failed_at": {
+          "type": "integer",
+          "format": "unixtime",
+          "description": "The Unix timestamp, in seconds, representing when this failed.",
+          "x-nullable": true,
+          "x-ms-client-name": "failedAt"
+        },
+        "incomplete_details": {
+          "type": "object",
+          "description": "Details on why the run is incomplete. Will be `null` if the run is not incomplete.",
+          "x-nullable": true,
+          "allOf": [
+            {
+              "$ref": "#/definitions/Agents.IncompleteRunDetails"
+            }
+          ],
+          "x-ms-client-name": "incompleteDetails"
+        },
+        "usage": {
+          "type": "object",
+          "description": "Usage statistics related to the run. This value will be `null` if the run is not in a terminal state (i.e. `in_progress`, `queued`, etc.).",
+          "x-nullable": true,
+          "allOf": [
+            {
+              "$ref": "#/definitions/Agents.RunCompletionUsage"
+            }
+          ]
+        },
+        "temperature": {
+          "type": "number",
+          "format": "float",
+          "description": "The sampling temperature used for this run. If not set, defaults to 1.",
+          "x-nullable": true
+        },
+        "top_p": {
+          "type": "number",
+          "format": "float",
+          "description": "The nucleus sampling value used for this run. If not set, defaults to 1.",
+          "x-nullable": true,
+          "x-ms-client-name": "topP"
+        },
+        "max_prompt_tokens": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum number of prompt tokens specified to have been used over the course of the run.",
+          "x-nullable": true,
+          "x-ms-client-name": "maxPromptTokens"
+        },
+        "max_completion_tokens": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum number of completion tokens specified to have been used over the course of the run.",
+          "x-nullable": true,
+          "x-ms-client-name": "maxCompletionTokens"
+        },
+        "truncation_strategy": {
+          "type": "object",
+          "description": "The strategy to use for dropping messages as the context windows moves forward.",
+          "x-nullable": true,
+          "allOf": [
+            {
+              "$ref": "#/definitions/Agents.TruncationObject"
+            }
+          ],
+          "x-ms-client-name": "truncationStrategy"
+        },
+        "tool_choice": {
+          "$ref": "#/definitions/Agents.AgentsApiToolChoiceOption",
+          "description": "Controls whether or not and which tool is called by the model.",
+          "x-nullable": true,
+          "x-ms-client-name": "toolChoice"
+        },
+        "response_format": {
+          "$ref": "#/definitions/Agents.AgentsApiResponseFormatOption",
+          "description": "The response format of the tool calls used in this run.",
+          "x-nullable": true,
+          "x-ms-client-name": "responseFormat"
+        },
+        "metadata": {
+          "type": "object",
+          "description": "A set of up to 16 key/value pairs that can be attached to an object, used for storing additional information about that object in a structured format. Keys may be up to 64 characters in length and values may be up to 512 characters in length.",
+          "x-nullable": true,
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "tool_resources": {
+          "type": "object",
+          "description": "Override the tools the agent can use for this run. This is useful for modifying the behavior on a per-run basis",
+          "x-nullable": true,
+          "allOf": [
+            {
+              "$ref": "#/definitions/Agents.UpdateToolResourcesOptions"
+            }
+          ],
+          "x-ms-client-name": "toolResources"
+        },
+        "parallel_tool_calls": {
+          "type": "boolean",
+          "description": "Determines if tools can be executed in parallel within the run.",
+          "x-ms-client-name": "parallelToolCalls"
+        }
+      },
+      "required": [
+        "id",
+        "object",
+        "thread_id",
+        "assistant_id",
+        "status",
+        "last_error",
+        "model",
+        "instructions",
+        "tools",
+        "created_at",
+        "expires_at",
+        "started_at",
+        "completed_at",
+        "cancelled_at",
+        "failed_at",
+        "incomplete_details",
+        "usage",
+        "max_prompt_tokens",
+        "max_completion_tokens",
+        "truncation_strategy",
+        "tool_choice",
+        "response_format",
+        "metadata",
+        "parallel_tool_calls"
+      ]
+    },
+    "Agents.ThreadStreamEvent": {
+      "type": "string",
+      "description": "Thread operation related streaming events",
+      "enum": [
+        "thread.created"
+      ],
+      "x-ms-enum": {
+        "name": "ThreadStreamEvent",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ThreadCreated",
+            "value": "thread.created",
+            "description": "Event sent when a new thread is created. The data of this event is of type AgentThread"
+          }
+        ]
+      }
+    },
+    "Agents.ToolConnection": {
+      "type": "object",
+      "description": "A connection resource.",
+      "properties": {
+        "connection_id": {
+          "type": "string",
+          "description": "A connection in a ToolConnectionList attached to this tool.",
+          "x-ms-client-name": "connectionId"
+        }
+      },
+      "required": [
+        "connection_id"
+      ]
+    },
+    "Agents.ToolConnectionList": {
+      "type": "object",
+      "description": "A set of connection resources currently used by either the `bing_grounding`, `fabric_aiskill`, or `sharepoint_grounding` tools.",
+      "properties": {
+        "connections": {
+          "type": "array",
+          "description": "The connections attached to this tool. There can be a maximum of 1 connection\nresource attached to the tool.",
+          "maxItems": 1,
+          "items": {
+            "$ref": "#/definitions/Agents.ToolConnection"
+          },
+          "x-ms-client-name": "connectionList",
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "Agents.ToolDefinition": {
+      "type": "object",
+      "description": "An abstract representation of an input tool definition that an agent can use.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The object type."
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "type"
+      ]
+    },
+    "Agents.ToolOutput": {
+      "type": "object",
+      "description": "The data provided during a tool outputs submission to resolve pending tool calls and allow the model to continue.",
+      "properties": {
+        "tool_call_id": {
+          "type": "string",
+          "description": "The ID of the tool call being resolved, as provided in the tool calls of a required action from a run.",
+          "x-ms-client-name": "toolCallId"
+        },
+        "output": {
+          "type": "string",
+          "description": "The output from the tool to be submitted."
+        }
+      }
+    },
+    "Agents.ToolResources": {
+      "type": "object",
+      "description": "A set of resources that are used by the agent's tools. The resources are specific to the type of\ntool. For example, the `code_interpreter` tool requires a list of file IDs, while the `file_search`\ntool requires a list of vector store IDs.",
+      "properties": {
+        "code_interpreter": {
+          "$ref": "#/definitions/Agents.CodeInterpreterToolResource",
+          "description": "Resources to be used by the `code_interpreter` tool consisting of file IDs.",
+          "x-ms-client-name": "codeInterpreter"
+        },
+        "file_search": {
+          "$ref": "#/definitions/Agents.FileSearchToolResource",
+          "description": "Resources to be used by the `file_search` tool consisting of vector store IDs.",
+          "x-ms-client-name": "fileSearch"
+        },
+        "azure_ai_search": {
+          "$ref": "#/definitions/Agents.AzureAISearchResource",
+          "description": "Resources to be used by the `azure_ai_search` tool consisting of index IDs and names.",
+          "x-ms-client-name": "azureAISearch"
+        }
+      }
+    },
+    "Agents.TruncationObject": {
+      "type": "object",
+      "description": "Controls for how a thread will be truncated prior to the run. Use this to control the initial\ncontext window of the run.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The truncation strategy to use for the thread. The default is `auto`. If set to `last_messages`, the thread will\nbe truncated to the `lastMessages` count most recent messages in the thread. When set to `auto`, messages in the middle of the thread\nwill be dropped to fit the context length of the model, `max_prompt_tokens`.",
+          "default": "auto",
+          "enum": [
+            "auto",
+            "last_messages"
+          ],
+          "x-ms-enum": {
+            "name": "TruncationStrategy",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "auto",
+                "value": "auto",
+                "description": "Default value. Messages in the middle of the thread will be dropped to fit the context length of the model."
+              },
+              {
+                "name": "lastMessages",
+                "value": "last_messages",
+                "description": "The thread will truncate to the `lastMessages` count of recent messages."
+              }
+            ]
+          }
+        },
+        "last_messages": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of most recent messages from the thread when constructing the context for the run.",
+          "x-nullable": true,
+          "x-ms-client-name": "lastMessages"
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "Agents.TruncationStrategy": {
+      "type": "string",
+      "description": "Possible truncation strategies for the thread.",
+      "enum": [
+        "auto",
+        "last_messages"
+      ],
+      "x-ms-enum": {
+        "name": "TruncationStrategy",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "auto",
+            "value": "auto",
+            "description": "Default value. Messages in the middle of the thread will be dropped to fit the context length of the model."
+          },
+          {
+            "name": "lastMessages",
+            "value": "last_messages",
+            "description": "The thread will truncate to the `lastMessages` count of recent messages."
+          }
+        ]
+      }
+    },
+    "Agents.UpdateAgentOptions": {
+      "type": "object",
+      "description": "The request details to use when modifying an existing agent.",
+      "properties": {
+        "model": {
+          "type": "string",
+          "description": "The ID of the model to use."
+        },
+        "name": {
+          "type": "string",
+          "description": "The modified name for the agent to use.",
+          "x-nullable": true
+        },
+        "description": {
+          "type": "string",
+          "description": "The modified description for the agent to use.",
+          "x-nullable": true
+        },
+        "instructions": {
+          "type": "string",
+          "description": "The modified system instructions for the new agent to use.",
+          "x-nullable": true
+        },
+        "tools": {
+          "type": "array",
+          "description": "The modified collection of tools to enable for the agent.",
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/Agents.ToolDefinition"
+          },
+          "x-ms-identifiers": []
+        },
+        "tool_resources": {
+          "$ref": "#/definitions/Agents.ToolResources",
+          "description": "A set of resources that are used by the agent's tools. The resources are specific to the type of tool. For example,\nthe `code_interpreter` tool requires a list of file IDs, while the `file_search` tool requires a list of vector store IDs.",
+          "x-ms-client-name": "toolResources"
+        },
+        "temperature": {
+          "type": "number",
+          "format": "float",
+          "description": "What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random,\nwhile lower values like 0.2 will make it more focused and deterministic.",
+          "default": 1,
+          "x-nullable": true
+        },
+        "top_p": {
+          "type": "number",
+          "format": "float",
+          "description": "An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass.\nSo 0.1 means only the tokens comprising the top 10% probability mass are considered.\n\nWe generally recommend altering this or temperature but not both.",
+          "default": 1,
+          "x-nullable": true,
+          "x-ms-client-name": "topP"
+        },
+        "response_format": {
+          "$ref": "#/definitions/Agents.AgentsApiResponseFormatOption",
+          "description": "The response format of the tool calls used by this agent.",
+          "x-nullable": true,
+          "x-ms-client-name": "responseFormat"
+        },
+        "metadata": {
+          "type": "object",
+          "description": "A set of up to 16 key/value pairs that can be attached to an object, used for storing additional information about that object in a structured format. Keys may be up to 64 characters in length and values may be up to 512 characters in length.",
+          "x-nullable": true,
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Agents.UpdateAgentThreadOptions": {
+      "type": "object",
+      "description": "The details used to update an existing agent thread",
+      "properties": {
+        "tool_resources": {
+          "type": "object",
+          "description": "A set of resources that are made available to the agent's tools in this thread. The resources are specific to the\ntype of tool. For example, the `code_interpreter` tool requires a list of file IDs, while the `file_search` tool requires\na list of vector store IDs",
+          "x-nullable": true,
+          "allOf": [
+            {
+              "$ref": "#/definitions/Agents.ToolResources"
+            }
+          ],
+          "x-ms-client-name": "toolResources"
+        },
+        "metadata": {
+          "type": "object",
+          "description": "A set of up to 16 key/value pairs that can be attached to an object, used for storing additional information about that object in a structured format. Keys may be up to 64 characters in length and values may be up to 512 characters in length.",
+          "x-nullable": true,
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Agents.UpdateCodeInterpreterToolResourceOptions": {
+      "type": "object",
+      "description": "Request object to update `code_interpreted` tool resources.",
+      "properties": {
+        "file_ids": {
+          "type": "array",
+          "description": "A list of file IDs to override the current list of the agent.",
+          "maxItems": 20,
+          "items": {
+            "type": "string"
+          },
+          "x-ms-client-name": "fileIds"
+        }
+      }
+    },
+    "Agents.UpdateFileSearchToolResourceOptions": {
+      "type": "object",
+      "description": "Request object to update `file_search` tool resources.",
+      "properties": {
+        "vector_store_ids": {
+          "type": "array",
+          "description": "A list of vector store IDs to override the current list of the agent.",
+          "maxItems": 1,
+          "items": {
+            "type": "string"
+          },
+          "x-ms-client-name": "vectorStoreIds"
+        }
+      }
+    },
+    "Agents.UpdateToolResourcesOptions": {
+      "type": "object",
+      "description": "Request object. A set of resources that are used by the agent's tools. The resources are specific to the type of tool.\nFor example, the `code_interpreter` tool requires a list of file IDs, while the `file_search` tool requires a list of\nvector store IDs.",
+      "properties": {
+        "code_interpreter": {
+          "$ref": "#/definitions/Agents.UpdateCodeInterpreterToolResourceOptions",
+          "description": "Overrides the list of file IDs made available to the `code_interpreter` tool. There can be a maximum of 20 files\nassociated with the tool.",
+          "x-ms-client-name": "codeInterpreter"
+        },
+        "file_search": {
+          "$ref": "#/definitions/Agents.UpdateFileSearchToolResourceOptions",
+          "description": "Overrides the vector store attached to this agent. There can be a maximum of 1 vector store attached to the agent.",
+          "x-ms-client-name": "fileSearch"
+        },
+        "azure_ai_search": {
+          "$ref": "#/definitions/Agents.AzureAISearchResource",
+          "description": "Overrides the resources to be used by the `azure_ai_search` tool consisting of index IDs and names.",
+          "x-ms-client-name": "azureAISearch"
+        }
+      }
+    },
+    "Agents.VectorStore": {
+      "type": "object",
+      "description": "A vector store is a collection of processed files can be used by the `file_search` tool.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The identifier, which can be referenced in API endpoints."
+        },
+        "object": {
+          "type": "string",
+          "description": "The object type, which is always `vector_store`",
+          "enum": [
+            "vector_store"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        },
+        "created_at": {
+          "type": "integer",
+          "format": "unixtime",
+          "description": "The Unix timestamp (in seconds) for when the vector store was created.",
+          "x-ms-client-name": "createdAt"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the vector store."
+        },
+        "usage_bytes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The total number of bytes used by the files in the vector store.",
+          "x-ms-client-name": "usageBytes"
+        },
+        "file_counts": {
+          "$ref": "#/definitions/Agents.VectorStoreFileCount",
+          "description": "Files count grouped by status processed or being processed by this vector store.",
+          "x-ms-client-name": "fileCounts"
+        },
+        "status": {
+          "$ref": "#/definitions/Agents.VectorStoreStatus",
+          "description": "The status of the vector store, which can be either `expired`, `in_progress`, or `completed`. A status of `completed` indicates that the vector store is ready for use."
+        },
+        "expires_after": {
+          "$ref": "#/definitions/Agents.VectorStoreExpirationPolicy",
+          "description": "Details on when this vector store expires",
+          "x-ms-client-name": "expiresAfter"
+        },
+        "expires_at": {
+          "type": "integer",
+          "format": "unixtime",
+          "description": "The Unix timestamp (in seconds) for when the vector store will expire.",
+          "x-nullable": true,
+          "x-ms-client-name": "expiresAt"
+        },
+        "last_active_at": {
+          "type": "integer",
+          "format": "unixtime",
+          "description": "The Unix timestamp (in seconds) for when the vector store was last active.",
+          "x-nullable": true,
+          "x-ms-client-name": "lastActiveAt"
+        },
+        "metadata": {
+          "type": "object",
+          "description": "A set of up to 16 key/value pairs that can be attached to an object, used for storing additional information about that object in a structured format. Keys may be up to 64 characters in length and values may be up to 512 characters in length.",
+          "x-nullable": true,
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "id",
+        "object",
+        "created_at",
+        "name",
+        "usage_bytes",
+        "file_counts",
+        "status",
+        "last_active_at",
+        "metadata"
+      ]
+    },
+    "Agents.VectorStoreAutoChunkingStrategyRequest": {
+      "type": "object",
+      "description": "The default strategy. This strategy currently uses a max_chunk_size_tokens of 800 and chunk_overlap_tokens of 400.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.VectorStoreChunkingStrategyRequest"
+        }
+      ],
+      "x-ms-discriminator-value": "auto"
+    },
+    "Agents.VectorStoreAutoChunkingStrategyResponse": {
+      "type": "object",
+      "description": "This is returned when the chunking strategy is unknown. Typically, this is because the file was indexed before the chunking_strategy concept was introduced in the API.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.VectorStoreChunkingStrategyResponse"
+        }
+      ],
+      "x-ms-discriminator-value": "other"
+    },
+    "Agents.VectorStoreChunkingStrategyRequest": {
+      "type": "object",
+      "description": "An abstract representation of a vector store chunking strategy configuration.",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/Agents.VectorStoreChunkingStrategyRequestType",
+          "description": "The object type."
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "type"
+      ]
+    },
+    "Agents.VectorStoreChunkingStrategyRequestType": {
+      "type": "string",
+      "description": "Type of chunking strategy",
+      "enum": [
+        "auto",
+        "static"
+      ],
+      "x-ms-enum": {
+        "name": "VectorStoreChunkingStrategyRequestType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "auto",
+            "value": "auto"
+          },
+          {
+            "name": "static",
+            "value": "static"
+          }
+        ]
+      }
+    },
+    "Agents.VectorStoreChunkingStrategyResponse": {
+      "type": "object",
+      "description": "An abstract representation of a vector store chunking strategy configuration.",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/Agents.VectorStoreChunkingStrategyResponseType",
+          "description": "The object type."
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "type"
+      ]
+    },
+    "Agents.VectorStoreChunkingStrategyResponseType": {
+      "type": "string",
+      "description": "Type of chunking strategy",
+      "enum": [
+        "other",
+        "static"
+      ],
+      "x-ms-enum": {
+        "name": "VectorStoreChunkingStrategyResponseType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "other",
+            "value": "other"
+          },
+          {
+            "name": "static",
+            "value": "static"
+          }
+        ]
+      }
+    },
+    "Agents.VectorStoreConfiguration": {
+      "type": "object",
+      "description": "Vector storage configuration is the list of data sources, used when multiple\nfiles can be used for the enterprise file search.",
+      "properties": {
+        "data_sources": {
+          "type": "array",
+          "description": "Data sources",
+          "items": {
+            "$ref": "#/definitions/Agents.VectorStoreDataSource"
+          },
+          "x-ms-client-name": "dataSources",
+          "x-ms-identifiers": []
+        }
+      },
+      "required": [
+        "data_sources"
+      ]
+    },
+    "Agents.VectorStoreConfigurations": {
+      "type": "object",
+      "description": "The structure, containing the list of vector storage configurations i.e. the list of azure asset IDs.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name",
+          "x-ms-client-name": "storeName"
+        },
+        "configuration": {
+          "$ref": "#/definitions/Agents.VectorStoreConfiguration",
+          "description": "Configurations",
+          "x-ms-client-name": "storeConfiguration"
+        }
+      },
+      "required": [
+        "name",
+        "configuration"
+      ]
+    },
+    "Agents.VectorStoreDataSource": {
+      "type": "object",
+      "description": "The structure, containing Azure asset URI path and the asset type of the file used as a data source\nfor the enterprise file search.",
+      "properties": {
+        "uri": {
+          "type": "string",
+          "description": "Asset URI.",
+          "x-ms-client-name": "assetIdentifier"
+        },
+        "type": {
+          "$ref": "#/definitions/Agents.VectorStoreDataSourceAssetType",
+          "description": "The asset type",
+          "x-ms-client-name": "assetType"
+        }
+      },
+      "required": [
+        "uri",
+        "type"
+      ]
+    },
+    "Agents.VectorStoreDataSourceAssetType": {
+      "type": "string",
+      "description": "Type of vector storage asset. Asset type may be a uri_asset, in this case it should contain asset URI ID,\nin the case of id_asset it should contain the data ID.",
+      "enum": [
+        "uri_asset",
+        "id_asset"
+      ],
+      "x-ms-enum": {
+        "name": "VectorStoreDataSourceAssetType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "uri_asset",
+            "value": "uri_asset",
+            "description": "Azure URI"
+          },
+          {
+            "name": "id_asset",
+            "value": "id_asset",
+            "description": "The data ID"
+          }
+        ]
+      }
+    },
+    "Agents.VectorStoreDeletionStatus": {
+      "type": "object",
+      "description": "Response object for deleting a vector store.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The ID of the resource specified for deletion."
+        },
+        "deleted": {
+          "type": "boolean",
+          "description": "A value indicating whether deletion was successful."
+        },
+        "object": {
+          "type": "string",
+          "description": "The object type, which is always 'vector_store.deleted'.",
+          "enum": [
+            "vector_store.deleted"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        }
+      },
+      "required": [
+        "id",
+        "deleted",
+        "object"
+      ]
+    },
+    "Agents.VectorStoreExpirationPolicy": {
+      "type": "object",
+      "description": "The expiration policy for a vector store.",
+      "properties": {
+        "anchor": {
+          "$ref": "#/definitions/Agents.VectorStoreExpirationPolicyAnchor",
+          "description": "Anchor timestamp after which the expiration policy applies. Supported anchors: `last_active_at`."
+        },
+        "days": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The anchor timestamp after which the expiration policy applies.",
+          "minimum": 1,
+          "maximum": 365
+        }
+      },
+      "required": [
+        "anchor",
+        "days"
+      ]
+    },
+    "Agents.VectorStoreExpirationPolicyAnchor": {
+      "type": "string",
+      "description": "Describes the relationship between the days and the expiration of this vector store",
+      "enum": [
+        "last_active_at"
+      ],
+      "x-ms-enum": {
+        "name": "VectorStoreExpirationPolicyAnchor",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "lastActiveAt",
+            "value": "last_active_at",
+            "description": "The expiration policy is based on the last time the vector store was active."
+          }
+        ]
+      }
+    },
+    "Agents.VectorStoreFile": {
+      "type": "object",
+      "description": "Description of a file attached to a vector store.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The identifier, which can be referenced in API endpoints."
+        },
+        "object": {
+          "type": "string",
+          "description": "The object type, which is always `vector_store.file`.",
+          "enum": [
+            "vector_store.file"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        },
+        "usage_bytes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The total vector store usage in bytes. Note that this may be different from the original file\nsize.",
+          "x-ms-client-name": "usageBytes"
+        },
+        "created_at": {
+          "type": "integer",
+          "format": "unixtime",
+          "description": "The Unix timestamp (in seconds) for when the vector store file was created.",
+          "x-ms-client-name": "createdAt"
+        },
+        "vector_store_id": {
+          "type": "string",
+          "description": "The ID of the vector store that the file is attached to.",
+          "x-ms-client-name": "vectorStoreId"
+        },
+        "status": {
+          "$ref": "#/definitions/Agents.VectorStoreFileStatus",
+          "description": "The status of the vector store file, which can be either `in_progress`, `completed`, `cancelled`, or `failed`. The status `completed` indicates that the vector store file is ready for use."
+        },
+        "last_error": {
+          "type": "object",
+          "description": "The last error associated with this vector store file. Will be `null` if there are no errors.",
+          "x-nullable": true,
+          "allOf": [
+            {
+              "$ref": "#/definitions/Agents.VectorStoreFileError"
+            }
+          ],
+          "x-ms-client-name": "lastError"
+        },
+        "chunking_strategy": {
+          "$ref": "#/definitions/Agents.VectorStoreChunkingStrategyResponse",
+          "description": "The strategy used to chunk the file.",
+          "x-ms-client-name": "chunkingStrategy"
+        }
+      },
+      "required": [
+        "id",
+        "object",
+        "usage_bytes",
+        "created_at",
+        "vector_store_id",
+        "status",
+        "last_error",
+        "chunking_strategy"
+      ]
+    },
+    "Agents.VectorStoreFileBatch": {
+      "type": "object",
+      "description": "A batch of files attached to a vector store.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The identifier, which can be referenced in API endpoints."
+        },
+        "object": {
+          "type": "string",
+          "description": "The object type, which is always `vector_store.file_batch`.",
+          "enum": [
+            "vector_store.files_batch"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        },
+        "created_at": {
+          "type": "integer",
+          "format": "unixtime",
+          "description": "The Unix timestamp (in seconds) for when the vector store files batch was created.",
+          "x-ms-client-name": "createdAt"
+        },
+        "vector_store_id": {
+          "type": "string",
+          "description": "The ID of the vector store that the file is attached to.",
+          "x-ms-client-name": "vectorStoreId"
+        },
+        "status": {
+          "$ref": "#/definitions/Agents.VectorStoreFileBatchStatus",
+          "description": "The status of the vector store files batch, which can be either `in_progress`, `completed`, `cancelled` or `failed`."
+        },
+        "file_counts": {
+          "$ref": "#/definitions/Agents.VectorStoreFileCount",
+          "description": "Files count grouped by status processed or being processed by this vector store.",
+          "x-ms-client-name": "fileCounts"
+        }
+      },
+      "required": [
+        "id",
+        "object",
+        "created_at",
+        "vector_store_id",
+        "status",
+        "file_counts"
+      ]
+    },
+    "Agents.VectorStoreFileBatchStatus": {
+      "type": "string",
+      "description": "The status of the vector store file batch.",
+      "enum": [
+        "in_progress",
+        "completed",
+        "cancelled",
+        "failed"
+      ],
+      "x-ms-enum": {
+        "name": "VectorStoreFileBatchStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "inProgress",
+            "value": "in_progress",
+            "description": "The vector store is still processing this file batch."
+          },
+          {
+            "name": "completed",
+            "value": "completed",
+            "description": "the vector store file batch is ready for use."
+          },
+          {
+            "name": "cancelled",
+            "value": "cancelled",
+            "description": "The vector store file batch was cancelled."
+          },
+          {
+            "name": "failed",
+            "value": "failed",
+            "description": "The vector store file batch failed to process."
+          }
+        ]
+      }
+    },
+    "Agents.VectorStoreFileCount": {
+      "type": "object",
+      "description": "Counts of files processed or being processed by this vector store grouped by status.",
+      "properties": {
+        "in_progress": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of files that are currently being processed.",
+          "x-ms-client-name": "inProgress"
+        },
+        "completed": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of files that have been successfully processed."
+        },
+        "failed": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of files that have failed to process."
+        },
+        "cancelled": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of files that were cancelled."
+        },
+        "total": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The total number of files."
+        }
+      },
+      "required": [
+        "in_progress",
+        "completed",
+        "failed",
+        "cancelled",
+        "total"
+      ]
+    },
+    "Agents.VectorStoreFileDeletionStatus": {
+      "type": "object",
+      "description": "Response object for deleting a vector store file relationship.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The ID of the resource specified for deletion."
+        },
+        "deleted": {
+          "type": "boolean",
+          "description": "A value indicating whether deletion was successful."
+        },
+        "object": {
+          "type": "string",
+          "description": "The object type, which is always 'vector_store.deleted'.",
+          "enum": [
+            "vector_store.file.deleted"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        }
+      },
+      "required": [
+        "id",
+        "deleted",
+        "object"
+      ]
+    },
+    "Agents.VectorStoreFileError": {
+      "type": "object",
+      "description": "Details on the error that may have occurred while processing a file for this vector store",
+      "properties": {
+        "code": {
+          "$ref": "#/definitions/Agents.VectorStoreFileErrorCode",
+          "description": "One of `server_error` or `rate_limit_exceeded`."
+        },
+        "message": {
+          "type": "string",
+          "description": "A human-readable description of the error."
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ]
+    },
+    "Agents.VectorStoreFileErrorCode": {
+      "type": "string",
+      "description": "Error code variants for vector store file processing",
+      "enum": [
+        "server_error",
+        "invalid_file",
+        "unsupported_file"
+      ],
+      "x-ms-enum": {
+        "name": "VectorStoreFileErrorCode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "serverError",
+            "value": "server_error",
+            "description": "An server error occurred."
+          },
+          {
+            "name": "invalidFile",
+            "value": "invalid_file",
+            "description": "The file is not valid."
+          },
+          {
+            "name": "unsupportedFile",
+            "value": "unsupported_file",
+            "description": "The file is of unsupported type."
+          }
+        ]
+      }
+    },
+    "Agents.VectorStoreFileStatus": {
+      "type": "string",
+      "description": "Vector store file status",
+      "enum": [
+        "in_progress",
+        "completed",
+        "failed",
+        "cancelled"
+      ],
+      "x-ms-enum": {
+        "name": "VectorStoreFileStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "inProgress",
+            "value": "in_progress",
+            "description": "The file is currently being processed."
+          },
+          {
+            "name": "completed",
+            "value": "completed",
+            "description": "The file has been successfully processed."
+          },
+          {
+            "name": "failed",
+            "value": "failed",
+            "description": "The file has failed to process."
+          },
+          {
+            "name": "cancelled",
+            "value": "cancelled",
+            "description": "The file was cancelled."
+          }
+        ]
+      }
+    },
+    "Agents.VectorStoreFileStatusFilter": {
+      "type": "string",
+      "description": "Query parameter filter for vector store file retrieval endpoint",
+      "enum": [
+        "in_progress",
+        "completed",
+        "failed",
+        "cancelled"
+      ],
+      "x-ms-enum": {
+        "name": "VectorStoreFileStatusFilter",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "inProgress",
+            "value": "in_progress",
+            "description": "Retrieve only files that are currently being processed"
+          },
+          {
+            "name": "completed",
+            "value": "completed",
+            "description": "Retrieve only files that have been successfully processed"
+          },
+          {
+            "name": "failed",
+            "value": "failed",
+            "description": "Retrieve only files that have failed to process"
+          },
+          {
+            "name": "cancelled",
+            "value": "cancelled",
+            "description": "Retrieve only files that were cancelled"
+          }
+        ]
+      }
+    },
+    "Agents.VectorStoreOptions": {
+      "type": "object",
+      "description": "Request object for creating a vector store.",
+      "properties": {
+        "file_ids": {
+          "type": "array",
+          "description": "A list of file IDs that the vector store should use. Useful for tools like `file_search` that can access files.",
+          "maxItems": 500,
+          "items": {
+            "type": "string"
+          },
+          "x-ms-client-name": "fileIds"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the vector store."
+        },
+        "configuration": {
+          "$ref": "#/definitions/Agents.VectorStoreConfiguration",
+          "description": "The vector store configuration, used when vector store is created from Azure asset URIs.",
+          "x-ms-client-name": "storeConfiguration"
+        },
+        "expires_after": {
+          "$ref": "#/definitions/Agents.VectorStoreExpirationPolicy",
+          "description": "Details on when this vector store expires",
+          "x-ms-client-name": "expiresAfter"
+        },
+        "chunking_strategy": {
+          "$ref": "#/definitions/Agents.VectorStoreChunkingStrategyRequest",
+          "description": "The chunking strategy used to chunk the file(s). If not set, will use the auto strategy. Only applicable if file_ids is non-empty.",
+          "x-ms-client-name": "chunkingStrategy"
+        },
+        "metadata": {
+          "type": "object",
+          "description": "A set of up to 16 key/value pairs that can be attached to an object, used for storing additional information about that object in a structured format. Keys may be up to 64 characters in length and values may be up to 512 characters in length.",
+          "x-nullable": true,
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Agents.VectorStoreStaticChunkingStrategyOptions": {
+      "type": "object",
+      "description": "Options to configure a vector store static chunking strategy.",
+      "properties": {
+        "max_chunk_size_tokens": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum number of tokens in each chunk. The default value is 800. The minimum value is 100 and the maximum value is 4096.",
+          "minimum": 100,
+          "maximum": 4096,
+          "x-ms-client-name": "maxChunkSizeTokens"
+        },
+        "chunk_overlap_tokens": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of tokens that overlap between chunks. The default value is 400.\nNote that the overlap must not exceed half of max_chunk_size_tokens.",
+          "x-ms-client-name": "chunkOverlapTokens"
+        }
+      },
+      "required": [
+        "max_chunk_size_tokens",
+        "chunk_overlap_tokens"
+      ]
+    },
+    "Agents.VectorStoreStaticChunkingStrategyRequest": {
+      "type": "object",
+      "description": "A statically configured chunking strategy.",
+      "properties": {
+        "static": {
+          "$ref": "#/definitions/Agents.VectorStoreStaticChunkingStrategyOptions",
+          "description": "The options for the static chunking strategy."
+        }
+      },
+      "required": [
+        "static"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.VectorStoreChunkingStrategyRequest"
+        }
+      ],
+      "x-ms-discriminator-value": "static"
+    },
+    "Agents.VectorStoreStaticChunkingStrategyResponse": {
+      "type": "object",
+      "description": "A statically configured chunking strategy.",
+      "properties": {
+        "static": {
+          "$ref": "#/definitions/Agents.VectorStoreStaticChunkingStrategyOptions",
+          "description": "The options for the static chunking strategy."
+        }
+      },
+      "required": [
+        "static"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/Agents.VectorStoreChunkingStrategyResponse"
+        }
+      ],
+      "x-ms-discriminator-value": "static"
+    },
+    "Agents.VectorStoreStatus": {
+      "type": "string",
+      "description": "Vector store possible status",
+      "enum": [
+        "expired",
+        "in_progress",
+        "completed"
+      ],
+      "x-ms-enum": {
+        "name": "VectorStoreStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "expired",
+            "value": "expired",
+            "description": "expired status indicates that this vector store has expired and is no longer available for use."
+          },
+          {
+            "name": "inProgress",
+            "value": "in_progress",
+            "description": "in_progress status indicates that this vector store is still processing files."
+          },
+          {
+            "name": "completed",
+            "value": "completed",
+            "description": "completed status indicates that this vector store is ready for use."
+          }
+        ]
+      }
+    },
+    "Agents.VectorStoreUpdateOptions": {
+      "type": "object",
+      "description": "Request object for updating a vector store.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the vector store.",
+          "x-nullable": true
+        },
+        "expires_after": {
+          "type": "object",
+          "description": "Details on when this vector store expires",
+          "x-nullable": true,
+          "allOf": [
+            {
+              "$ref": "#/definitions/Agents.VectorStoreExpirationPolicy"
+            }
+          ],
+          "x-ms-client-name": "expiresAfter"
+        },
+        "metadata": {
+          "type": "object",
+          "description": "A set of up to 16 key/value pairs that can be attached to an object, used for storing additional information about that object in a structured format. Keys may be up to 64 characters in length and values may be up to 512 characters in length.",
+          "x-nullable": true,
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ApiKeyCredential": {
+      "type": "object",
+      "description": "ApiKey Credential definition",
+      "properties": {
+        "apiKey": {
+          "type": "string",
+          "description": "API Key",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "apiKey"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/BaseCredential"
+        }
+      ],
+      "x-ms-discriminator-value": "ApiKey"
+    },
+    "ApiResponseFormat": {
+      "type": "string",
+      "description": "Possible API response formats.",
+      "enum": [
+        "text",
+        "json_object"
+      ],
+      "x-ms-enum": {
+        "name": "ApiResponseFormat",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "text",
+            "value": "text",
+            "description": "`text` format should be used for requests involving any sort of ToolCall."
+          },
+          {
+            "name": "jsonObject",
+            "value": "json_object",
+            "description": "Using `json_object` format will limit the usage of ToolCall to only functions."
+          }
+        ]
+      }
+    },
+    "AssetReferenceBase": {
+      "type": "object",
+      "description": "Base definition for asset references.",
+      "properties": {
+        "referenceType": {
+          "$ref": "#/definitions/ReferenceType",
+          "description": "Asset reference type."
+        }
+      },
+      "discriminator": "referenceType",
+      "required": [
+        "referenceType"
+      ]
+    },
+    "AssistantsApiResponseFormat": {
+      "type": "object",
+      "description": "An object describing the expected output of the model. If `json_object` only `function` type `tools` are allowed to be passed to the Run. If `text` the model can return text or any value needed.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Must be one of `text` or `json_object`.",
+          "default": "text",
+          "enum": [
+            "text",
+            "json_object"
+          ],
+          "x-ms-enum": {
+            "name": "ApiResponseFormat",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "text",
+                "value": "text",
+                "description": "`text` format should be used for requests involving any sort of ToolCall."
+              },
+              {
+                "name": "jsonObject",
+                "value": "json_object",
+                "description": "Using `json_object` format will limit the usage of ToolCall to only functions."
+              }
+            ]
+          }
+        }
+      }
+    },
+    "AssistantsApiResponseFormatMode": {
+      "type": "string",
+      "description": "Represents the mode in which the model will handle the return format of a tool call.",
+      "enum": [
+        "auto",
+        "none"
+      ],
+      "x-ms-enum": {
+        "name": "AssistantsApiResponseFormatMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "auto",
+            "value": "auto",
+            "description": "Default value. Let the model handle the return format."
+          },
+          {
+            "name": "none",
+            "value": "none",
+            "description": "Setting the value to `none`, will result in a 400 Bad request."
+          }
+        ]
+      }
+    },
+    "AssistantsApiResponseFormatOption": {},
+    "AudioContentFormat": {
+      "type": "string",
+      "description": "A representation of the possible audio formats for audio.",
+      "enum": [
+        "wav",
+        "mp3"
+      ],
+      "x-ms-enum": {
+        "name": "AudioContentFormat",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "wav",
+            "value": "wav",
+            "description": "Specifies audio in WAV format."
+          },
+          {
+            "name": "mp3",
+            "value": "mp3",
+            "description": "Specifies audio in MP3 format."
+          }
+        ]
+      }
+    },
+    "Azure.Core.Foundations.Error": {
+      "type": "object",
+      "description": "The error object.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "One of a server-defined set of error codes."
+        },
+        "message": {
+          "type": "string",
+          "description": "A human-readable representation of the error."
+        },
+        "target": {
+          "type": "string",
+          "description": "The target of the error."
+        },
+        "details": {
+          "type": "array",
+          "description": "An array of details about specific errors that led to this reported error.",
+          "items": {
+            "$ref": "#/definitions/Azure.Core.Foundations.Error"
+          },
+          "x-ms-identifiers": []
+        },
+        "innererror": {
+          "$ref": "#/definitions/Azure.Core.Foundations.InnerError",
+          "description": "An object containing more specific information than the current object about the error."
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ]
+    },
+    "Azure.Core.Foundations.ErrorResponse": {
+      "type": "object",
+      "description": "A response containing error details.",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/Azure.Core.Foundations.Error",
+          "description": "The error object."
+        }
+      },
+      "required": [
+        "error"
+      ]
+    },
+    "Azure.Core.Foundations.InnerError": {
+      "type": "object",
+      "description": "An object containing more specific information about the error. As per Microsoft One API guidelines - https://github.com/Microsoft/api-guidelines/blob/vNext/Guidelines.md#7102-error-condition-responses.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "One of a server-defined set of error codes."
+        },
+        "innererror": {
+          "$ref": "#/definitions/Azure.Core.Foundations.InnerError",
+          "description": "Inner error."
+        }
+      }
+    },
+    "AzureAISearchIndex": {
+      "type": "object",
+      "description": "Azure AI Search Index Definition",
+      "properties": {
+        "connectionId": {
+          "type": "string",
+          "description": "Connection id to Azure AI Search"
+        },
+        "indexName": {
+          "type": "string",
+          "description": "Name of index in Azure AI Search resource to attach"
+        }
+      },
+      "required": [
+        "connectionId",
+        "indexName"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/Index"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureSearch"
+    },
+    "BaseCredential": {
+      "type": "object",
+      "description": "Base Credential definition",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/CredentialType",
+          "description": "Type of credential. Possible values are: AAD, SAS, ApiKey",
+          "readOnly": true
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "type"
+      ]
+    },
+    "BlobReferenceForConsumption": {
+      "type": "object",
+      "description": "Represents a reference to a blob for consumption",
+      "properties": {
+        "blobUri": {
+          "type": "string",
+          "description": "Blob URI path for client to upload data. Example: https://blob.windows.core.net/Container/Path"
+        },
+        "storageAccountArmId": {
+          "type": "string",
+          "description": "ARM ID of the storage account to use."
+        },
+        "credential": {
+          "$ref": "#/definitions/SasCredential",
+          "description": "Credential info to access the storage account."
+        }
+      },
+      "required": [
+        "blobUri",
+        "storageAccountArmId",
+        "credential"
+      ]
+    },
+    "ChatChoice": {
+      "type": "object",
+      "description": "The representation of a single prompt completion as part of an overall chat completions request.\nGenerally, `n` choices are generated per provided prompt with a default value of 1.\nToken limits and other settings may limit the number of choices generated.",
+      "properties": {
+        "index": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The ordered index associated with this chat completions choice."
+        },
+        "finish_reason": {
+          "$ref": "#/definitions/CompletionsFinishReason",
+          "description": "The reason that this chat completions choice completed its generated.",
+          "x-nullable": true
+        },
+        "message": {
+          "$ref": "#/definitions/ChatResponseMessage",
+          "description": "The chat message for a given chat completions prompt."
+        }
+      },
+      "required": [
+        "index",
+        "finish_reason",
+        "message"
+      ]
+    },
+    "ChatCompletions": {
+      "type": "object",
+      "description": "Representation of the response data from a chat completions request.\nCompletions support a wide variety of tasks and generate text that continues from or \"completes\"\nprovided prompt data.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "A unique identifier associated with this chat completions response."
+        },
+        "object": {
+          "type": "string",
+          "description": "The response object type, which is always `chat.completion`.",
+          "enum": [
+            "chat.completion"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        },
+        "created": {
+          "type": "integer",
+          "format": "unixtime",
+          "description": "The first timestamp associated with generation activity for this completions response,\nrepresented as seconds since the beginning of the Unix epoch of 00:00 on 1 Jan 1970."
+        },
+        "model": {
+          "type": "string",
+          "description": "The model used for the chat completion."
+        },
+        "choices": {
+          "type": "array",
+          "description": "The collection of completions choices associated with this completions response.\nGenerally, `n` choices are generated per provided prompt with a default value of 1.\nToken limits and other settings may limit the number of choices generated.",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/ChatChoice"
+          },
+          "x-ms-identifiers": []
+        },
+        "usage": {
+          "$ref": "#/definitions/CompletionsUsage",
+          "description": "  Usage information for tokens processed and generated as part of this completions operation."
+        }
+      },
+      "required": [
+        "id",
+        "object",
+        "created",
+        "model",
+        "choices",
+        "usage"
+      ]
+    },
+    "ChatCompletionsAudio": {
+      "type": "object",
+      "description": "A representation of the audio generated by the model.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "  Unique identifier for the audio response. This value can be used in chat history messages instead of passing \n  the full audio object."
+        },
+        "expires_at": {
+          "type": "integer",
+          "format": "unixtime",
+          "description": "The Unix timestamp (in seconds) at which the audio piece expires and can't be any longer referenced by its ID in \nmulti-turn conversations.",
+          "x-ms-client-name": "expiresAt"
+        },
+        "data": {
+          "type": "string",
+          "description": "Base64 encoded audio data"
+        },
+        "format": {
+          "$ref": "#/definitions/AudioContentFormat",
+          "description": "The format of the audio content. If format is not provided, it will match the format used in the\ninput audio request."
+        },
+        "transcript": {
+          "type": "string",
+          "description": "The transcript of the audio file."
+        }
+      },
+      "required": [
+        "id",
+        "expires_at",
+        "data",
+        "transcript"
+      ]
+    },
+    "ChatCompletionsModality": {
+      "type": "string",
+      "description": "The modalities that the model is allowed to use for the chat completions response.",
+      "enum": [
+        "text",
+        "audio"
+      ],
+      "x-ms-enum": {
+        "name": "ChatCompletionsModality",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "text",
+            "value": "text",
+            "description": "The model is only allowed to generate text."
+          },
+          {
+            "name": "audio",
+            "value": "audio",
+            "description": "The model is allowed to generate audio."
+          }
+        ]
+      }
+    },
+    "ChatCompletionsNamedToolChoice": {
+      "type": "object",
+      "description": "A tool selection of a specific, named function tool that will limit chat completions to using the named function.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The type of the tool. Currently, only `function` is supported.",
+          "enum": [
+            "function"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        },
+        "function": {
+          "$ref": "#/definitions/ChatCompletionsNamedToolChoiceFunction",
+          "description": "The function that should be called."
+        }
+      },
+      "required": [
+        "type",
+        "function"
+      ]
+    },
+    "ChatCompletionsNamedToolChoiceFunction": {
+      "type": "object",
+      "description": "A tool selection of a specific, named function tool that will limit chat completions to using the named function.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the function that should be called."
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "ChatCompletionsOptions": {
+      "type": "object",
+      "description": "The configuration information for a chat completions request.\nCompletions support a wide variety of tasks and generate text that continues from or \"completes\"\nprovided prompt data.",
+      "properties": {
+        "messages": {
+          "type": "array",
+          "description": "The collection of context messages associated with this chat completions request.\nTypical usage begins with a chat message for the System role that provides instructions for\nthe behavior of the assistant, followed by alternating messages between the User and\nAssistant roles.",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/ChatRequestMessage"
+          },
+          "x-ms-identifiers": []
+        },
+        "frequency_penalty": {
+          "type": "number",
+          "format": "float",
+          "description": "A value that influences the probability of generated tokens appearing based on their cumulative\nfrequency in generated text.\nPositive values will make tokens less likely to appear as their frequency increases and\ndecrease the likelihood of the model repeating the same statements verbatim.\nSupported range is [-2, 2].",
+          "default": 0,
+          "minimum": -2,
+          "maximum": 2
+        },
+        "stream": {
+          "type": "boolean",
+          "description": "A value indicating whether chat completions should be streamed for this request."
+        },
+        "presence_penalty": {
+          "type": "number",
+          "format": "float",
+          "description": "A value that influences the probability of generated tokens appearing based on their existing\npresence in generated text.\nPositive values will make tokens less likely to appear when they already exist and increase the\nmodel's likelihood to output new topics.\nSupported range is [-2, 2].",
+          "default": 0,
+          "minimum": -2,
+          "maximum": 2
+        },
+        "temperature": {
+          "type": "number",
+          "format": "float",
+          "description": "The sampling temperature to use that controls the apparent creativity of generated completions.\nHigher values will make output more random while lower values will make results more focused\nand deterministic.\nIt is not recommended to modify temperature and top_p for the same completions request as the\ninteraction of these two settings is difficult to predict.\nSupported range is [0, 1].",
+          "default": 0.7,
+          "minimum": 0,
+          "maximum": 1
+        },
+        "top_p": {
+          "type": "number",
+          "format": "float",
+          "description": "An alternative to sampling with temperature called nucleus sampling. This value causes the\nmodel to consider the results of tokens with the provided probability mass. As an example, a\nvalue of 0.15 will cause only the tokens comprising the top 15% of probability mass to be\nconsidered.\nIt is not recommended to modify temperature and top_p for the same completions request as the\ninteraction of these two settings is difficult to predict.\nSupported range is [0, 1].",
+          "default": 1,
+          "minimum": 0,
+          "maximum": 1
+        },
+        "max_tokens": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum number of tokens to generate.",
+          "minimum": 0
+        },
+        "response_format": {
+          "$ref": "#/definitions/ChatCompletionsResponseFormat",
+          "description": "An object specifying the format that the model must output.\n\nSetting to `{ \"type\": \"json_schema\", \"json_schema\": {...} }` enables Structured Outputs which ensures the model will match your supplied JSON schema.\n\nSetting to `{ \"type\": \"json_object\" }` enables JSON mode, which ensures the message the model generates is valid JSON.\n\n**Important:** when using JSON mode, you **must** also instruct the model to produce JSON yourself via a system or user message. Without this, the model may generate an unending stream of whitespace until the generation reaches the token limit, resulting in a long-running and seemingly \"stuck\" request. Also note that the message content may be partially cut off if `finish_reason=\"length\"`, which indicates the generation exceeded `max_tokens` or the conversation exceeded the max context length."
+        },
+        "stop": {
+          "type": "array",
+          "description": "A collection of textual sequences that will end completions generation.",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "tools": {
+          "type": "array",
+          "description": "A list of tools the model may request to call. Currently, only functions are supported as a tool. The model\nmay response with a function call request and provide the input arguments in JSON format for that function.",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/ChatCompletionsToolDefinition"
+          },
+          "x-ms-identifiers": []
+        },
+        "tool_choice": {
+          "description": "If specified, the model will configure which of the provided tools it can use for the chat completions response.",
+          "x-ms-client-name": "toolChoice"
+        },
+        "seed": {
+          "type": "integer",
+          "format": "int64",
+          "description": "If specified, the system will make a best effort to sample deterministically such that repeated requests with the\nsame seed and parameters should return the same result. Determinism is not guaranteed."
+        },
+        "model": {
+          "type": "string",
+          "description": "ID of the specific AI model to use, if more than one model is available on the endpoint."
+        },
+        "modalities": {
+          "type": "array",
+          "description": "The modalities that the model is allowed to use for the chat completions response. The default modality\nis `text`. Indicating an unsupported modality combination results in an 422 error.",
+          "items": {
+            "$ref": "#/definitions/ChatCompletionsModality"
+          }
+        }
+      },
+      "required": [
+        "messages"
+      ],
+      "additionalProperties": {}
+    },
+    "ChatCompletionsResponseFormat": {
+      "type": "object",
+      "description": "Represents the format that the model must output. Use this to enable JSON mode instead of the default text mode.\nNote that to enable JSON mode, some AI models may also require you to instruct the model to produce JSON\nvia a system or user message.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The response format type to use for chat completions."
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "type"
+      ]
+    },
+    "ChatCompletionsResponseFormatJsonObject": {
+      "type": "object",
+      "description": "A response format for Chat Completions that restricts responses to emitting valid JSON objects.\nNote that to enable JSON mode, some AI models may also require you to instruct the model to produce JSON\nvia a system or user message.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ChatCompletionsResponseFormat"
+        }
+      ],
+      "x-ms-discriminator-value": "json_object"
+    },
+    "ChatCompletionsResponseFormatJsonSchema": {
+      "type": "object",
+      "description": "A response format for Chat Completions that restricts responses to emitting valid JSON objects, with a\nJSON schema specified by the caller.",
+      "properties": {
+        "json_schema": {
+          "$ref": "#/definitions/ChatCompletionsResponseFormatJsonSchemaDefinition",
+          "description": "The definition of the required JSON schema in the response, and associated metadata."
+        }
+      },
+      "required": [
+        "json_schema"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ChatCompletionsResponseFormat"
+        }
+      ],
+      "x-ms-discriminator-value": "json_schema"
+    },
+    "ChatCompletionsResponseFormatJsonSchemaDefinition": {
+      "type": "object",
+      "description": "The definition of the required JSON schema in the response, and associated metadata.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the response format. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 64."
+        },
+        "schema": {
+          "type": "object",
+          "description": "The definition of the JSON schema",
+          "additionalProperties": {}
+        },
+        "description": {
+          "type": "string",
+          "description": "A description of the response format, used by the AI model to determine how to generate responses in this format."
+        },
+        "strict": {
+          "type": "boolean",
+          "description": "Whether to enable strict schema adherence when generating the output.\nIf set to true, the model will always follow the exact schema defined in the `schema` field. Only a subset of\nJSON Schema is supported when `strict` is `true`.",
+          "default": false
+        }
+      },
+      "required": [
+        "name",
+        "schema"
+      ]
+    },
+    "ChatCompletionsResponseFormatText": {
+      "type": "object",
+      "description": "A response format for Chat Completions that emits text responses. This is the default response format.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ChatCompletionsResponseFormat"
+        }
+      ],
+      "x-ms-discriminator-value": "text"
+    },
+    "ChatCompletionsToolCall": {
+      "type": "object",
+      "description": "A function tool call requested by the AI model.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The ID of the tool call."
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of tool call. Currently, only `function` is supported.",
+          "enum": [
+            "function"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        },
+        "function": {
+          "$ref": "#/definitions/FunctionCall",
+          "description": "The details of the function call requested by the AI model."
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "function"
+      ]
+    },
+    "ChatCompletionsToolChoicePreset": {
+      "type": "string",
+      "description": "Represents a generic policy for how a chat completions tool may be selected.",
+      "enum": [
+        "auto",
+        "none",
+        "required"
+      ],
+      "x-ms-enum": {
+        "name": "ChatCompletionsToolChoicePreset",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "auto",
+            "value": "auto",
+            "description": "Specifies that the model may either use any of the tools provided in this chat completions request or\ninstead return a standard chat completions response as if no tools were provided."
+          },
+          {
+            "name": "none",
+            "value": "none",
+            "description": "Specifies that the model should not respond with a tool call and should instead provide a standard chat\ncompletions response. Response content may still be influenced by the provided tool definitions."
+          },
+          {
+            "name": "required",
+            "value": "required",
+            "description": "Specifies that the model should respond with a call to one or more tools."
+          }
+        ]
+      }
+    },
+    "ChatCompletionsToolDefinition": {
+      "type": "object",
+      "description": "The definition of a chat completions tool that can call a function.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The type of the tool. Currently, only `function` is supported.",
+          "enum": [
+            "function"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        },
+        "function": {
+          "$ref": "#/definitions/FunctionDefinition",
+          "description": "The function definition details for the function tool."
+        }
+      },
+      "required": [
+        "type",
+        "function"
+      ]
+    },
+    "ChatMessageAudioContentItem": {
+      "type": "object",
+      "description": "A structured chat content item containing an audio reference.",
+      "properties": {
+        "audio_url": {
+          "$ref": "#/definitions/ChatMessageAudioUrl",
+          "description": "An internet location, which must be accessible to the model, from which the audio may be retrieved.",
+          "x-ms-client-name": "audioUrl"
+        }
+      },
+      "required": [
+        "audio_url"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ChatMessageContentItem"
+        }
+      ],
+      "x-ms-discriminator-value": "audio_url"
+    },
+    "ChatMessageAudioUrl": {
+      "type": "object",
+      "description": "An internet location from which the model may retrieve an audio.",
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "The URL of the audio."
+        }
+      },
+      "required": [
+        "url"
+      ]
+    },
+    "ChatMessageContentItem": {
+      "type": "object",
+      "description": "An abstract representation of a structured content item within a chat message.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The discriminated object type."
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "type"
+      ]
+    },
+    "ChatMessageImageContentItem": {
+      "type": "object",
+      "description": "A structured chat content item containing an image reference.",
+      "properties": {
+        "image_url": {
+          "$ref": "#/definitions/ChatMessageImageUrl",
+          "description": "An internet location, which must be accessible to the model,from which the image may be retrieved.",
+          "x-ms-client-name": "imageUrl"
+        }
+      },
+      "required": [
+        "image_url"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ChatMessageContentItem"
+        }
+      ],
+      "x-ms-discriminator-value": "image_url"
+    },
+    "ChatMessageImageDetailLevel": {
+      "type": "string",
+      "description": "A representation of the possible image detail levels for image-based chat completions message content.",
+      "enum": [
+        "auto",
+        "low",
+        "high"
+      ],
+      "x-ms-enum": {
+        "name": "ChatMessageImageDetailLevel",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "auto",
+            "value": "auto",
+            "description": "Specifies that the model should determine which detail level to apply using heuristics like image size."
+          },
+          {
+            "name": "low",
+            "value": "low",
+            "description": "Specifies that image evaluation should be constrained to the 'low-res' model that may be faster and consume fewer\ntokens but may also be less accurate for highly detailed images."
+          },
+          {
+            "name": "high",
+            "value": "high",
+            "description": "Specifies that image evaluation should enable the 'high-res' model that may be more accurate for highly detailed\nimages but may also be slower and consume more tokens."
+          }
+        ]
+      }
+    },
+    "ChatMessageImageUrl": {
+      "type": "object",
+      "description": "An internet location from which the model may retrieve an image.",
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "The URL of the image."
+        },
+        "detail": {
+          "$ref": "#/definitions/ChatMessageImageDetailLevel",
+          "description": "The evaluation quality setting to use, which controls relative prioritization of speed, token consumption, and\naccuracy."
+        }
+      },
+      "required": [
+        "url"
+      ]
+    },
+    "ChatMessageInputAudio": {
+      "type": "object",
+      "description": "The details of an audio chat message content part.",
+      "properties": {
+        "data": {
+          "type": "string",
+          "description": "Base64 encoded audio data"
+        },
+        "format": {
+          "$ref": "#/definitions/AudioContentFormat",
+          "description": "The audio format of the audio content."
+        }
+      },
+      "required": [
+        "data",
+        "format"
+      ]
+    },
+    "ChatMessageInputAudioContentItem": {
+      "type": "object",
+      "description": "A structured chat content item containing an audio content.",
+      "properties": {
+        "format": {
+          "$ref": "#/definitions/AudioContentFormat",
+          "description": "The audio format of the audio reference."
+        }
+      },
+      "required": [
+        "format"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ChatMessageContentItem"
+        }
+      ],
+      "x-ms-discriminator-value": "input_audio"
+    },
+    "ChatMessageTextContentItem": {
+      "type": "object",
+      "description": "A structured chat content item containing plain text.",
+      "properties": {
+        "text": {
+          "type": "string",
+          "description": "The content of the message."
+        }
+      },
+      "required": [
+        "text"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ChatMessageContentItem"
+        }
+      ],
+      "x-ms-discriminator-value": "text"
+    },
+    "ChatRequestAssistantMessage": {
+      "type": "object",
+      "description": "A request chat message representing response or action from the assistant.",
+      "properties": {
+        "content": {
+          "type": "string",
+          "description": "The content of the message."
+        },
+        "tool_calls": {
+          "type": "array",
+          "description": "The tool calls that must be resolved and have their outputs appended to subsequent input messages for the chat\ncompletions request to resolve as configured.",
+          "items": {
+            "$ref": "#/definitions/ChatCompletionsToolCall"
+          },
+          "x-ms-client-name": "toolCalls"
+        },
+        "audio": {
+          "$ref": "#/definitions/ChatRequestAudioReference",
+          "description": "  The audio generated by a previous response in a multi-turn conversation."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ChatRequestMessage"
+        }
+      ],
+      "x-ms-discriminator-value": "assistant"
+    },
+    "ChatRequestAudioReference": {
+      "type": "object",
+      "description": "A reference to an audio response generated by the model.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "  Unique identifier for the audio response. This value corresponds to the id of a previous audio completion."
+        }
+      },
+      "required": [
+        "id"
+      ]
+    },
+    "ChatRequestMessage": {
+      "type": "object",
+      "description": "An abstract representation of a chat message as provided in a request.",
+      "properties": {
+        "role": {
+          "$ref": "#/definitions/ChatRole",
+          "description": "The chat role associated with this message."
+        }
+      },
+      "discriminator": "role",
+      "required": [
+        "role"
+      ]
+    },
+    "ChatRequestSystemMessage": {
+      "type": "object",
+      "description": "A request chat message containing system instructions that influence how the model will generate a chat completions\nresponse.",
+      "properties": {
+        "content": {
+          "type": "string",
+          "description": "The contents of the system message."
+        }
+      },
+      "required": [
+        "content"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ChatRequestMessage"
+        }
+      ],
+      "x-ms-discriminator-value": "system"
+    },
+    "ChatRequestToolMessage": {
+      "type": "object",
+      "description": "A request chat message representing requested output from a configured tool.",
+      "properties": {
+        "content": {
+          "type": "string",
+          "description": "The content of the message."
+        },
+        "tool_call_id": {
+          "type": "string",
+          "description": "The ID of the tool call resolved by the provided content.",
+          "x-ms-client-name": "toolCallId"
+        }
+      },
+      "required": [
+        "tool_call_id"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ChatRequestMessage"
+        }
+      ],
+      "x-ms-discriminator-value": "tool"
+    },
+    "ChatRequestUserMessage": {
+      "type": "object",
+      "description": "A request chat message representing user input to the assistant.",
+      "properties": {
+        "content": {
+          "description": "The contents of the user message, with available input types varying by selected model."
+        }
+      },
+      "required": [
+        "content"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ChatRequestMessage"
+        }
+      ],
+      "x-ms-discriminator-value": "user"
+    },
+    "ChatResponseMessage": {
+      "type": "object",
+      "description": "A representation of a chat message as received in a response.",
+      "properties": {
+        "role": {
+          "$ref": "#/definitions/ChatRole",
+          "description": "The chat role associated with the message."
+        },
+        "content": {
+          "type": "string",
+          "description": "The content of the message.",
+          "x-nullable": true
+        },
+        "tool_calls": {
+          "type": "array",
+          "description": "The tool calls that must be resolved and have their outputs appended to subsequent input messages for the chat\ncompletions request to resolve as configured.",
+          "items": {
+            "$ref": "#/definitions/ChatCompletionsToolCall"
+          },
+          "x-ms-client-name": "toolCalls"
+        },
+        "audio": {
+          "$ref": "#/definitions/ChatCompletionsAudio",
+          "description": "  The audio generated by the model as a response to the messages if the model is configured to generate audio."
+        }
+      },
+      "required": [
+        "role",
+        "content"
+      ]
+    },
+    "ChatRole": {
+      "type": "string",
+      "description": "A description of the intended purpose of a message within a chat completions interaction.",
+      "enum": [
+        "system",
+        "developer",
+        "user",
+        "assistant",
+        "tool"
+      ],
+      "x-ms-enum": {
+        "name": "ChatRole",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "system",
+            "value": "system",
+            "description": "The role that instructs or sets the behavior of the assistant."
+          },
+          {
+            "name": "developer",
+            "value": "developer",
+            "description": "The role that provides instructions to the model prioritized ahead of user messages."
+          },
+          {
+            "name": "user",
+            "value": "user",
+            "description": "The role that provides input for chat completions."
+          },
+          {
+            "name": "assistant",
+            "value": "assistant",
+            "description": "The role that provides responses to system-instructed, user-prompted input."
+          },
+          {
+            "name": "tool",
+            "value": "tool",
+            "description": "The role that represents extension tool activity within a chat completions operation."
+          }
+        ]
+      }
+    },
+    "CompletionsFinishReason": {
+      "type": "string",
+      "description": "Representation of the manner in which a completions response concluded.",
+      "enum": [
+        "stop",
+        "length",
+        "content_filter",
+        "tool_calls"
+      ],
+      "x-ms-enum": {
+        "name": "CompletionsFinishReason",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "stopped",
+            "value": "stop",
+            "description": "Completions ended normally and reached its end of token generation."
+          },
+          {
+            "name": "tokenLimitReached",
+            "value": "length",
+            "description": "Completions exhausted available token limits before generation could complete."
+          },
+          {
+            "name": "contentFiltered",
+            "value": "content_filter",
+            "description": "Completions generated a response that was identified as potentially sensitive per content\nmoderation policies."
+          },
+          {
+            "name": "toolCalls",
+            "value": "tool_calls",
+            "description": "Completion ended with the model calling a provided tool for output."
+          }
+        ]
+      }
+    },
+    "CompletionsUsage": {
+      "type": "object",
+      "description": "Representation of the token counts processed for a completions request.\nCounts consider all tokens across prompts, choices, choice alternates, best_of generations, and\nother consumers.",
+      "properties": {
+        "completion_tokens": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of tokens generated across all completions emissions."
+        },
+        "prompt_tokens": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of tokens in the provided prompts for the completions request."
+        },
+        "total_tokens": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The total number of tokens processed for the completions request and response."
+        },
+        "completion_tokens_details": {
+          "$ref": "#/definitions/CompletionsUsageDetails",
+          "description": "Breakdown of tokens used in a completion."
+        },
+        "prompt_tokens_details": {
+          "$ref": "#/definitions/PromptUsageDetails",
+          "description": "Breakdown of tokens used in the prompt/chat history."
+        }
+      },
+      "required": [
+        "completion_tokens",
+        "prompt_tokens",
+        "total_tokens"
+      ]
+    },
+    "CompletionsUsageDetails": {
+      "type": "object",
+      "description": "A breakdown of tokens used in a completion.",
+      "properties": {
+        "audio_tokens": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of tokens corresponding to audio input."
+        },
+        "total_tokens": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The total number of tokens processed for the completions request and response."
+        }
+      },
+      "required": [
+        "audio_tokens",
+        "total_tokens"
+      ]
+    },
+    "Connection": {
+      "type": "object",
+      "description": "Response from the listSecrets operation",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Fully qualified resource identifier",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource",
+          "readOnly": true
+        },
+        "credentials": {
+          "$ref": "#/definitions/BaseCredential",
+          "description": "Credential used to connect to the external resource.",
+          "readOnly": true
+        },
+        "category": {
+          "$ref": "#/definitions/ConnectionCategory",
+          "description": "Category of the connection",
+          "readOnly": true
+        },
+        "target": {
+          "type": "string",
+          "description": "The connection URL to be used for this service",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "credentials",
+        "category",
+        "target"
+      ]
+    },
+    "ConnectionCategory": {
+      "type": "string",
+      "description": "The Type (or category) of the connection",
+      "enum": [
+        "AzureOpenAI",
+        "AzureBlob",
+        "CognitiveSearch",
+        "CosmosDB",
+        "ApiKey"
+      ],
+      "x-ms-enum": {
+        "name": "ConnectionCategory",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "AzureOpenAI",
+            "value": "AzureOpenAI",
+            "description": "Azure OpenAI Service"
+          },
+          {
+            "name": "AzureBlobStorage",
+            "value": "AzureBlob",
+            "description": "Azure Blob Storage"
+          },
+          {
+            "name": "AzureAISearch",
+            "value": "CognitiveSearch",
+            "description": "Azure AI Search"
+          },
+          {
+            "name": "CosmosDB",
+            "value": "CosmosDB",
+            "description": "CosmosDB"
+          },
+          {
+            "name": "APIKey",
+            "value": "ApiKey",
+            "description": "Generic connection that uses API Key authentication"
+          }
+        ]
+      }
+    },
+    "CosmosDBIndex": {
+      "type": "object",
+      "description": "CosmosDB Vector Store Index Definition",
+      "properties": {
+        "connectionId": {
+          "type": "string",
+          "description": "Connection id to CosmosDB"
+        },
+        "databaseName": {
+          "type": "string",
+          "description": "Name of the CosmosDB Database"
+        },
+        "containerName": {
+          "type": "string",
+          "description": "Name of CosmosDB Container"
+        },
+        "embeddingConfiguration": {
+          "$ref": "#/definitions/EmbeddingConfiguration",
+          "description": "Embedding model configuration"
+        }
+      },
+      "required": [
+        "connectionId",
+        "databaseName",
+        "containerName",
+        "embeddingConfiguration"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/Index"
+        }
+      ],
+      "x-ms-discriminator-value": "CosmosDBNoSqlVectorStore"
+    },
+    "CredentialType": {
+      "type": "string",
+      "description": "The different Credential types",
+      "enum": [
+        "ApiKey",
+        "AAD",
+        "SAS"
+      ],
+      "x-ms-enum": {
+        "name": "CredentialType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ApiKey",
+            "value": "ApiKey"
+          },
+          {
+            "name": "AAD",
+            "value": "AAD"
+          },
+          {
+            "name": "SAS",
+            "value": "SAS"
+          }
+        ]
+      }
+    },
+    "DataPathAssetReference": {
+      "type": "object",
+      "description": "Reference to an asset via its path in a datastore.",
+      "properties": {
+        "datastoreId": {
+          "type": "string",
+          "description": "ARM resource ID of the datastore where the asset is located."
+        },
+        "path": {
+          "type": "string",
+          "description": "The path of the file/directory in the datastore."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AssetReferenceBase"
+        }
+      ],
+      "x-ms-discriminator-value": "DataPath"
+    },
+    "Dataset": {
+      "type": "object",
+      "description": "Dataset as source for evaluation.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Evaluation input data"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/InputData"
+        }
+      ],
+      "x-ms-discriminator-value": "dataset"
+    },
+    "DatasetType": {
+      "type": "string",
+      "description": "Enum to determine the type of data.",
+      "enum": [
+        "uri_file"
+      ],
+      "x-ms-enum": {
+        "name": "DatasetType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "uri_file",
+            "value": "uri_file",
+            "description": "URI file."
+          }
+        ]
+      }
+    },
+    "DatasetVersion": {
+      "type": "object",
+      "description": "DatasetVersion Definition",
+      "properties": {
+        "datasetUri": {
+          "type": "string",
+          "description": "[Required] Uri of the data. Example: https://go.microsoft.com/fwlink/?linkid=2202330",
+          "minLength": 1,
+          "pattern": "[a-zA-Z0-9_]",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "datasetType": {
+          "$ref": "#/definitions/DatasetType",
+          "description": "Data type"
+        },
+        "stage": {
+          "type": "string",
+          "description": "Asset stage",
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        },
+        "id": {
+          "type": "string",
+          "description": "A unique identifier for the asset, assetId probably?",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource",
+          "readOnly": true
+        },
+        "version": {
+          "type": "string",
+          "description": "The version of the resource",
+          "readOnly": true
+        },
+        "description": {
+          "type": "string",
+          "description": "The asset description text."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Tag dictionary. Tags can be added, removed, and updated.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "systemData": {
+          "$ref": "#/definitions/SystemData",
+          "description": "System data of the resource",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "datasetUri",
+        "datasetType"
+      ]
+    },
+    "Deployment": {
+      "type": "object",
+      "description": "Model Deployment Definition",
+      "properties": {
+        "deploymentName": {
+          "type": "string",
+          "description": "Name of the deployment for the model",
+          "readOnly": true
+        },
+        "modelName": {
+          "type": "string",
+          "description": "Publisher-specific name of the model",
+          "readOnly": true
+        },
+        "modelVersion": {
+          "type": "string",
+          "description": "Publisher-specific version of the model",
+          "readOnly": true
+        },
+        "publisher": {
+          "type": "string",
+          "description": "Name of the model publisher",
+          "readOnly": true
+        },
+        "capabilities": {
+          "type": "object",
+          "description": "Capabilities of model",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "raiPolicyName": {
+          "type": "string",
+          "description": "RAI policy enabled for model",
+          "readOnly": true
+        },
+        "sku": {
+          "$ref": "#/definitions/Sku",
+          "description": "Sku of the model deployment",
+          "readOnly": true
+        },
+        "connectionName": {
+          "type": "string",
+          "description": "Name of the connection the model comes from",
+          "readOnly": true
+        },
+        "systemData": {
+          "$ref": "#/definitions/SystemData",
+          "description": "System data of the resource",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "deploymentName",
+        "modelName",
+        "modelVersion",
+        "publisher",
+        "capabilities",
+        "raiPolicyName",
+        "sku",
+        "systemData"
+      ]
+    },
+    "EmbeddingConfiguration": {
+      "type": "object",
+      "description": "Embedding configuration class",
+      "properties": {
+        "connectionId": {
+          "type": "string",
+          "description": "Connection id to embedding model"
+        },
+        "deploymentName": {
+          "type": "string",
+          "description": "Deployment name of embedding model"
+        },
+        "embeddingField": {
+          "type": "string",
+          "description": "Embedding field"
+        }
+      },
+      "required": [
+        "deploymentName",
+        "embeddingField"
+      ]
+    },
+    "EmbeddingEncodingFormat": {
+      "type": "string",
+      "description": "Specifies the types of embeddings to generate. Compressed embeddings types like `uint8`, `int8`, `ubinary` and \n`binary`, may reduce storage costs without sacrificing the integrity of the data. Returns a 422 error if the\nmodel doesn't support the value or parameter. Read the model's documentation to know the values supported by\nthe your model.",
+      "enum": [
+        "base64",
+        "binary",
+        "float",
+        "int8",
+        "ubinary",
+        "uint8"
+      ],
+      "x-ms-enum": {
+        "name": "EmbeddingEncodingFormat",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "base64",
+            "value": "base64",
+            "description": "Get back binary representation of the embeddings encoded as Base64 string. OpenAI Python library retrieves \nembeddings from the API as encoded binary data, rather than using intermediate decimal representations as is \nusually done."
+          },
+          {
+            "name": "binary",
+            "value": "binary",
+            "description": "Get back signed binary embeddings"
+          },
+          {
+            "name": "float",
+            "value": "float",
+            "description": "Get back full precision embeddings"
+          },
+          {
+            "name": "int8",
+            "value": "int8",
+            "description": "Get back signed int8 embeddings"
+          },
+          {
+            "name": "ubinary",
+            "value": "ubinary",
+            "description": "Get back unsigned binary embeddings"
+          },
+          {
+            "name": "uint8",
+            "value": "uint8",
+            "description": "Get back unsigned int8 embeddings"
+          }
+        ]
+      }
+    },
+    "EmbeddingInputType": {
+      "type": "string",
+      "description": "Represents the input types used for embedding search.",
+      "enum": [
+        "text",
+        "query",
+        "document"
+      ],
+      "x-ms-enum": {
+        "name": "EmbeddingInputType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "text",
+            "value": "text",
+            "description": "Indicates the input is a general text input."
+          },
+          {
+            "name": "query",
+            "value": "query",
+            "description": "Indicates the input represents a search query to find the most relevant documents in your vector database."
+          },
+          {
+            "name": "document",
+            "value": "document",
+            "description": "Indicates the input represents a document that is stored in a vector database."
+          }
+        ]
+      }
+    },
+    "EmbeddingItem": {
+      "type": "object",
+      "description": "Representation of a single embeddings relatedness comparison.",
+      "properties": {
+        "embedding": {
+          "type": "array",
+          "description": "List of embedding values for the input prompt. These represent a measurement of the\nvector-based relatedness of the provided input. Or a base64 encoded string of the embedding vector.",
+          "items": {
+            "type": "number",
+            "format": "float"
+          }
+        },
+        "index": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Index of the prompt to which the EmbeddingItem corresponds."
+        },
+        "object": {
+          "type": "string",
+          "description": "The object type of this embeddings item. Will always be `embedding`.",
+          "enum": [
+            "embedding"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        }
+      },
+      "required": [
+        "embedding",
+        "index",
+        "object"
+      ]
+    },
+    "EmbeddingsOptions": {
+      "type": "object",
+      "description": "The configuration information for an embeddings request.",
+      "properties": {
+        "input": {
+          "type": "array",
+          "description": "Input text to embed, encoded as a string or array of tokens.\nTo embed multiple inputs in a single request, pass an array\nof strings or array of token arrays.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "dimensions": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Optional. The number of dimensions the resulting output embeddings should have.\nPassing null causes the model to use its default value.\nReturns a 422 error if the model doesn't support the value or parameter."
+        },
+        "encoding_format": {
+          "$ref": "#/definitions/EmbeddingEncodingFormat",
+          "description": "Optional. The desired format for the returned embeddings."
+        },
+        "input_type": {
+          "$ref": "#/definitions/EmbeddingInputType",
+          "description": "Optional. The type of the input.\nReturns a 422 error if the model doesn't support the value or parameter."
+        },
+        "model": {
+          "type": "string",
+          "description": "ID of the specific AI model to use, if more than one model is available on the endpoint."
+        }
+      },
+      "required": [
+        "input"
+      ],
+      "additionalProperties": {}
+    },
+    "EmbeddingsResult": {
+      "type": "object",
+      "description": "Representation of the response data from an embeddings request.\nEmbeddings measure the relatedness of text strings and are commonly used for search, clustering,\nrecommendations, and other similar scenarios.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique identifier for the embeddings result."
+        },
+        "data": {
+          "type": "array",
+          "description": "Embedding values for the prompts submitted in the request.",
+          "items": {
+            "$ref": "#/definitions/EmbeddingItem"
+          },
+          "x-ms-identifiers": []
+        },
+        "usage": {
+          "$ref": "#/definitions/EmbeddingsUsage",
+          "description": "Usage counts for tokens input using the embeddings API."
+        },
+        "object": {
+          "type": "string",
+          "description": "The object type of the embeddings result. Will always be `list`.",
+          "enum": [
+            "list"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        },
+        "model": {
+          "type": "string",
+          "description": "The model ID used to generate this result."
+        }
+      },
+      "required": [
+        "id",
+        "data",
+        "usage",
+        "object",
+        "model"
+      ]
+    },
+    "EmbeddingsUsage": {
+      "type": "object",
+      "description": "Measurement of the amount of tokens used in this request and response.",
+      "properties": {
+        "prompt_tokens": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of tokens in the request."
+        },
+        "total_tokens": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Total number of tokens transacted in this request/response. Should equal the\nnumber of tokens in the request."
+        }
+      },
+      "required": [
+        "prompt_tokens",
+        "total_tokens"
+      ]
+    },
+    "Evaluation": {
+      "type": "object",
+      "description": "Evaluation Definition",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Identifier of the evaluation."
+        },
+        "data": {
+          "$ref": "#/definitions/InputData",
+          "description": "Data for evaluation."
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Update stage to 'Archive' to archive the asset. Default is Development, which means the asset is under development."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the evaluation. It can be used to store additional information about the evaluation and is mutable."
+        },
+        "systemData": {
+          "$ref": "#/definitions/SystemData",
+          "description": "Metadata containing createdBy and modifiedBy information.",
+          "readOnly": true
+        },
+        "status": {
+          "type": "string",
+          "description": "Status of the evaluation. It is set by service and is read-only.",
+          "readOnly": true
+        },
+        "tags": {
+          "type": "object",
+          "description": "Evaluation's tags. Unlike properties, tags are fully mutable.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "properties": {
+          "type": "object",
+          "description": "Evaluation's properties. Unlike tags, properties are add-only. Once added, a property cannot be removed.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "evaluators": {
+          "type": "object",
+          "description": "Evaluators to be used for the evaluation.",
+          "additionalProperties": {
+            "$ref": "#/definitions/EvaluatorConfiguration"
+          }
+        }
+      },
+      "required": [
+        "data",
+        "evaluators"
+      ]
+    },
+    "EvaluatorConfiguration": {
+      "type": "object",
+      "description": "Evaluator Configuration",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Identifier of the evaluator."
+        },
+        "initParams": {
+          "type": "object",
+          "description": "Initialization parameters of the evaluator.",
+          "additionalProperties": {}
+        },
+        "dataMapping": {
+          "type": "object",
+          "description": "Data parameters of the evaluator.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "id"
+      ]
+    },
+    "ExtraParameters": {
+      "type": "string",
+      "description": "Controls what happens if extra parameters, undefined by the REST API, are passed in the JSON request payload.",
+      "enum": [
+        "error",
+        "drop",
+        "pass-through"
+      ],
+      "x-ms-enum": {
+        "name": "ExtraParameters",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "error",
+            "value": "error",
+            "description": "The service will error if it detected extra parameters in the request payload. This is the service default."
+          },
+          {
+            "name": "drop",
+            "value": "drop",
+            "description": "The service will ignore (drop) extra parameters in the request payload. It will only pass the known parameters to the back-end AI model."
+          },
+          {
+            "name": "pass_through",
+            "value": "pass-through",
+            "description": "The service will pass extra parameters to the back-end AI model."
+          }
+        ]
+      }
+    },
+    "FunctionCall": {
+      "type": "object",
+      "description": "The name and arguments of a function that should be called, as generated by the model.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the function to call."
+        },
+        "arguments": {
+          "type": "string",
+          "description": "The arguments to call the function with, as generated by the model in JSON format.\nNote that the model does not always generate valid JSON, and may hallucinate parameters\nnot defined by your function schema. Validate the arguments in your code before calling\nyour function."
+        }
+      },
+      "required": [
+        "name",
+        "arguments"
+      ]
+    },
+    "FunctionDefinition": {
+      "type": "object",
+      "description": "The definition of a caller-specified function that chat completions may invoke in response to matching user input.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the function to be called."
+        },
+        "description": {
+          "type": "string",
+          "description": "A description of what the function does. The model will use this description when selecting the function and\ninterpreting its parameters."
+        },
+        "parameters": {
+          "type": "object",
+          "description": "The parameters the function accepts, described as a JSON Schema object.",
+          "additionalProperties": {}
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "IdAssetReference": {
+      "type": "object",
+      "description": "Reference to an asset via its ARM resource ID.",
+      "properties": {
+        "assetId": {
+          "type": "string",
+          "description": "[Required] ARM resource ID of the asset.",
+          "minLength": 1,
+          "pattern": "[a-zA-Z0-9_]"
+        }
+      },
+      "required": [
+        "assetId"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/AssetReferenceBase"
+        }
+      ],
+      "x-ms-discriminator-value": "Id"
+    },
+    "ImageEmbeddingInput": {
+      "type": "object",
+      "description": "Represents an image with optional text.",
+      "properties": {
+        "image": {
+          "type": "string",
+          "description": "The input image encoded in base64 string as a data URL. Example: `data:image/{format};base64,{data}`."
+        },
+        "text": {
+          "type": "string",
+          "description": "Optional. The text input to feed into the model (like DINO, CLIP).\nReturns a 422 error if the model doesn't support the value or parameter."
+        }
+      },
+      "required": [
+        "image"
+      ]
+    },
+    "ImageEmbeddingsOptions": {
+      "type": "object",
+      "description": "The configuration information for an image embeddings request.",
+      "properties": {
+        "input": {
+          "type": "array",
+          "description": "Input image to embed. To embed multiple inputs in a single request, pass an array.\nThe input must not exceed the max input tokens for the model.",
+          "items": {
+            "$ref": "#/definitions/ImageEmbeddingInput"
+          },
+          "x-ms-identifiers": []
+        },
+        "dimensions": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Optional. The number of dimensions the resulting output embeddings should have.\nPassing null causes the model to use its default value.\nReturns a 422 error if the model doesn't support the value or parameter."
+        },
+        "encoding_format": {
+          "$ref": "#/definitions/EmbeddingEncodingFormat",
+          "description": "Optional. The number of dimensions the resulting output embeddings should have.\nPassing null causes the model to use its default value.\nReturns a 422 error if the model doesn't support the value or parameter."
+        },
+        "input_type": {
+          "$ref": "#/definitions/EmbeddingInputType",
+          "description": "Optional. The type of the input.\nReturns a 422 error if the model doesn't support the value or parameter."
+        },
+        "model": {
+          "type": "string",
+          "description": "ID of the specific AI model to use, if more than one model is available on the endpoint."
+        }
+      },
+      "required": [
+        "input"
+      ],
+      "additionalProperties": {}
+    },
+    "Index": {
+      "type": "object",
+      "description": "Index resource Definition",
+      "properties": {
+        "indexType": {
+          "$ref": "#/definitions/IndexType",
+          "description": "Type of index"
+        },
+        "stage": {
+          "type": "string",
+          "description": "Asset stage",
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        },
+        "id": {
+          "type": "string",
+          "description": "A unique identifier for the asset, assetId probably?",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource",
+          "readOnly": true
+        },
+        "version": {
+          "type": "string",
+          "description": "The version of the resource",
+          "readOnly": true
+        },
+        "description": {
+          "type": "string",
+          "description": "The asset description text."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Tag dictionary. Tags can be added, removed, and updated.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "systemData": {
+          "$ref": "#/definitions/SystemData",
+          "description": "System data of the resource",
+          "readOnly": true
+        }
+      },
+      "discriminator": "indexType",
+      "required": [
+        "indexType"
+      ]
+    },
+    "IndexType": {
+      "type": "string",
+      "enum": [
+        "AzureSearch",
+        "CosmosDBNoSqlVectorStore",
+        "ManagedAzureSearch"
+      ],
+      "x-ms-enum": {
+        "name": "IndexType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "azureSearch",
+            "value": "AzureSearch",
+            "description": "Azure search"
+          },
+          {
+            "name": "cosmosDB",
+            "value": "CosmosDBNoSqlVectorStore",
+            "description": "CosmosDB"
+          },
+          {
+            "name": "managedAzureSearch",
+            "value": "ManagedAzureSearch",
+            "description": "Managed Azure Search"
+          }
+        ]
+      }
+    },
+    "InputData": {
+      "type": "object",
+      "description": "Abstract data class.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Type of the data"
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "type"
+      ]
+    },
+    "ListSortOrder": {
+      "type": "string",
+      "description": "The available sorting options when requesting a list of response objects.",
+      "enum": [
+        "asc",
+        "desc"
+      ],
+      "x-ms-enum": {
+        "name": "ListSortOrder",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ascending",
+            "value": "asc",
+            "description": "Specifies an ascending sort order."
+          },
+          {
+            "name": "descending",
+            "value": "desc",
+            "description": "Specifies a descending sort order."
+          }
+        ]
+      }
+    },
+    "ListViewType": {
+      "type": "string",
+      "description": "List View Type Definition",
+      "enum": [
+        "ActiveOnly",
+        "ArchivedOnly",
+        "All"
+      ],
+      "x-ms-enum": {
+        "name": "ListViewType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ActiveOnly",
+            "value": "ActiveOnly",
+            "description": "List only active items."
+          },
+          {
+            "name": "ArchivedOnly",
+            "value": "ArchivedOnly",
+            "description": "List only archived items."
+          },
+          {
+            "name": "All",
+            "value": "All",
+            "description": "List all items."
+          }
+        ]
+      }
+    },
+    "ManagedAzureAISearchIndex": {
+      "type": "object",
+      "description": "Managed Azure AI Search Index Definition",
+      "properties": {
+        "vectorStoreId": {
+          "type": "string",
+          "description": "Vector store id of managed index"
+        }
+      },
+      "required": [
+        "vectorStoreId"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/Index"
+        }
+      ],
+      "x-ms-discriminator-value": "ManagedAzureSearch"
+    },
+    "MessageRole": {
+      "type": "string",
+      "description": "The possible values for roles attributed to messages in a thread.",
+      "enum": [
+        "user",
+        "assistant"
+      ],
+      "x-ms-enum": {
+        "name": "MessageRole",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "user",
+            "value": "user",
+            "description": "The role representing the end-user."
+          },
+          {
+            "name": "assistant",
+            "value": "assistant",
+            "description": "The role representing the assistant."
+          }
+        ]
+      }
+    },
+    "OutputPathAssetReference": {
+      "type": "object",
+      "description": "Reference to an asset via its path in a job output.",
+      "properties": {
+        "jobId": {
+          "type": "string",
+          "description": "ARM resource ID of the job."
+        },
+        "path": {
+          "type": "string",
+          "description": "The path of the file/directory in the job output."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AssetReferenceBase"
+        }
+      ],
+      "x-ms-discriminator-value": "OutputPath"
+    },
+    "PagedConnection": {
+      "type": "object",
+      "description": "Paged collection of Connection items",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Connection items on this page",
+          "items": {
+            "$ref": "#/definitions/Connection"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PagedDatasetVersion": {
+      "type": "object",
+      "description": "PagedDataVersionBase Definition",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The list of DatasetVersions.",
+          "items": {
+            "$ref": "#/definitions/DatasetVersion"
+          },
+          "x-ms-identifiers": []
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The link to the next page of results, if any."
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PagedDeployment": {
+      "type": "object",
+      "description": "Paged collection of Deployment items",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Deployment items on this page",
+          "items": {
+            "$ref": "#/definitions/Deployment"
+          },
+          "x-ms-identifiers": []
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PagedEvaluation": {
+      "type": "object",
+      "description": "Paged evaluation items",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The list of Evaluations.",
+          "items": {
+            "$ref": "#/definitions/Evaluation"
+          },
+          "x-ms-identifiers": []
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PagedIndex": {
+      "type": "object",
+      "description": "Paged collection of Index items.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The list of Indexes.",
+          "items": {
+            "$ref": "#/definitions/Index"
+          },
+          "x-ms-identifiers": []
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PendingUploadCredentialType": {
+      "type": "string",
+      "description": "The type of credential used to access the storage account.",
+      "enum": [
+        "SAS"
+      ],
+      "x-ms-enum": {
+        "name": "PendingUploadCredentialType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "sas",
+            "value": "SAS",
+            "description": "SAS credential type."
+          }
+        ]
+      }
+    },
+    "PendingUploadRequest": {
+      "type": "object",
+      "description": "Represents a request for a pending upload.",
+      "properties": {
+        "pendingUploadId": {
+          "type": "string",
+          "description": "If PendingUploadId is not provided, a random GUID will be used."
+        },
+        "pendingUploadType": {
+          "type": "string",
+          "description": "TemporaryBlobReference is the only supported type.",
+          "enum": [
+            "TemporaryBlobReference"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        }
+      },
+      "required": [
+        "pendingUploadType"
+      ]
+    },
+    "PendingUploadResponse": {
+      "type": "object",
+      "description": "Represents the response for a pending upload request",
+      "properties": {
+        "blobReferenceForConsumption": {
+          "$ref": "#/definitions/BlobReferenceForConsumption",
+          "description": "Container-level read, write, list SAS."
+        },
+        "pendingUploadId": {
+          "type": "string",
+          "description": "ID for this upload request."
+        },
+        "pendingUploadType": {
+          "type": "string",
+          "description": "TemporaryBlobReference is the only supported type",
+          "enum": [
+            "TemporaryBlobReference"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        }
+      },
+      "required": [
+        "blobReferenceForConsumption",
+        "pendingUploadId",
+        "pendingUploadType"
+      ]
+    },
+    "PendingUploadType": {
+      "type": "string",
+      "description": "The type of pending upload.",
+      "enum": [
+        "None",
+        "TemporaryBlobReference"
+      ],
+      "x-ms-enum": {
+        "name": "PendingUploadType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "none",
+            "value": "None",
+            "description": "No pending upload."
+          },
+          {
+            "name": "temporaryBlobReference",
+            "value": "TemporaryBlobReference",
+            "description": "Temporary Blob Reference is the only supported type."
+          }
+        ]
+      }
+    },
+    "PromptUsageDetails": {
+      "type": "object",
+      "description": "A breakdown of tokens used in the prompt/chat history.",
+      "properties": {
+        "audio_tokens": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of tokens corresponding to audio input."
+        },
+        "cached_tokens": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The total number of tokens cached."
+        }
+      },
+      "required": [
+        "audio_tokens",
+        "cached_tokens"
+      ]
+    },
+    "ReferenceType": {
+      "type": "string",
+      "description": "Enum to determine which reference method to use for an asset.",
+      "enum": [
+        "Id",
+        "DataPath",
+        "OutputPath"
+      ],
+      "x-ms-enum": {
+        "name": "ReferenceType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Id",
+            "value": "Id",
+            "description": "Id"
+          },
+          {
+            "name": "DataPath",
+            "value": "DataPath",
+            "description": "DataPath"
+          },
+          {
+            "name": "OutputPath",
+            "value": "OutputPath",
+            "description": "OutputPath"
+          }
+        ]
+      }
+    },
+    "SasCredential": {
+      "type": "object",
+      "description": "SAS Credential definition",
+      "properties": {
+        "sasToken": {
+          "type": "string",
+          "description": "SAS Token",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "sasToken"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/BaseCredential"
+        }
+      ],
+      "x-ms-discriminator-value": "SAS"
+    },
+    "Sku": {
+      "type": "object",
+      "description": "Sku information",
+      "properties": {
+        "capacity": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Sku capacity"
+        },
+        "family": {
+          "type": "string",
+          "description": "Sku family"
+        },
+        "name": {
+          "type": "string",
+          "description": "Sku name"
+        },
+        "size": {
+          "type": "string",
+          "description": "Sku size"
+        },
+        "tier": {
+          "type": "string",
+          "description": "Sku tier"
+        }
+      },
+      "required": [
+        "capacity",
+        "family",
+        "name",
+        "size",
+        "tier"
+      ]
+    },
+    "StreamingChatChoiceUpdate": {
+      "type": "object",
+      "description": "Represents an update to a single prompt completion when the service is streaming updates \nusing Server Sent Events (SSE).\nGenerally, `n` choices are generated per provided prompt with a default value of 1.\nToken limits and other settings may limit the number of choices generated.",
+      "properties": {
+        "index": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The ordered index associated with this chat completions choice."
+        },
+        "finish_reason": {
+          "$ref": "#/definitions/CompletionsFinishReason",
+          "description": "The reason that this chat completions choice completed its generated.",
+          "x-nullable": true
+        },
+        "delta": {
+          "$ref": "#/definitions/StreamingChatResponseMessageUpdate",
+          "description": "An update to the chat message for a given chat completions prompt."
+        }
+      },
+      "required": [
+        "index",
+        "finish_reason",
+        "delta"
+      ]
+    },
+    "StreamingChatCompletionsUpdate": {
+      "type": "object",
+      "description": "Represents a response update to a chat completions request, when the service is streaming updates \nusing Server Sent Events (SSE).\nCompletions support a wide variety of tasks and generate text that continues from or \"completes\"\nprovided prompt data.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "A unique identifier associated with this chat completions response."
+        },
+        "object": {
+          "type": "string",
+          "description": "The response object type, which is always `chat.completion`.",
+          "enum": [
+            "chat.completion"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        },
+        "created": {
+          "type": "integer",
+          "format": "unixtime",
+          "description": "The first timestamp associated with generation activity for this completions response,\nrepresented as seconds since the beginning of the Unix epoch of 00:00 on 1 Jan 1970."
+        },
+        "model": {
+          "type": "string",
+          "description": "The model used for the chat completion."
+        },
+        "choices": {
+          "type": "array",
+          "description": "An update to the collection of completion choices associated with this completions response.\nGenerally, `n` choices are generated per provided prompt with a default value of 1.\nToken limits and other settings may limit the number of choices generated.",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/StreamingChatChoiceUpdate"
+          },
+          "x-ms-identifiers": []
+        },
+        "usage": {
+          "$ref": "#/definitions/CompletionsUsage",
+          "description": "Usage information for tokens processed and generated as part of this completions operation."
+        }
+      },
+      "required": [
+        "id",
+        "object",
+        "created",
+        "model",
+        "choices"
+      ]
+    },
+    "StreamingChatResponseMessageUpdate": {
+      "type": "object",
+      "description": "A representation of a chat message update as received in a streaming response.",
+      "properties": {
+        "role": {
+          "$ref": "#/definitions/ChatRole",
+          "description": "The chat role associated with the message. If present, should always be 'assistant'"
+        },
+        "content": {
+          "type": "string",
+          "description": "The content of the message."
+        },
+        "tool_calls": {
+          "type": "array",
+          "description": "The tool calls that must be resolved and have their outputs appended to subsequent input messages for the chat\ncompletions request to resolve as configured.",
+          "items": {
+            "$ref": "#/definitions/StreamingChatResponseToolCallUpdate"
+          },
+          "x-ms-client-name": "toolCalls"
+        }
+      }
+    },
+    "StreamingChatResponseToolCallUpdate": {
+      "type": "object",
+      "description": "An update to the function tool call information requested by the AI model.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The ID of the tool call."
+        },
+        "function": {
+          "$ref": "#/definitions/FunctionCall",
+          "description": "Updates to the function call requested by the AI model."
+        }
+      },
+      "required": [
+        "id",
+        "function"
+      ]
+    },
+    "SystemData": {
+      "type": "object",
+      "description": "Metadata pertaining to creation and last modification of the resource.",
+      "properties": {
+        "createdAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The timestamp the resource was created at.",
+          "readOnly": true
+        },
+        "createdBy": {
+          "type": "string",
+          "description": "The identity that created the resource.",
+          "readOnly": true
+        },
+        "createdByType": {
+          "type": "string",
+          "description": "The identity type that created the resource.",
+          "readOnly": true
+        },
+        "lastModifiedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The timestamp of resource last modification (UTC)",
+          "readOnly": true
+        }
+      }
+    }
+  },
+  "parameters": {
+    "Agents.UpdateAgentOptions.assistantId": {
+      "name": "assistantId",
+      "in": "path",
+      "description": "The ID of the agent to modify.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "Agents.UpdateAgentThreadOptions.threadId": {
+      "name": "threadId",
+      "in": "path",
+      "description": "The ID of the thread to modify.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "Azure.Core.ClientRequestIdHeader": {
+      "name": "x-ms-client-request-id",
+      "in": "header",
+      "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+      "required": false,
+      "type": "string",
+      "format": "uuid",
+      "x-ms-parameter-location": "method",
+      "x-ms-client-name": "clientRequestId"
+    },
+    "Azure.Core.ConditionalRequestHeaders.ifMatch": {
+      "name": "If-Match",
+      "in": "header",
+      "description": "The request should only proceed if an entity matches this string.",
+      "required": false,
+      "type": "string",
+      "x-ms-parameter-location": "method",
+      "x-ms-client-name": "ifMatch"
+    },
+    "Azure.Core.ConditionalRequestHeaders.ifModifiedSince": {
+      "name": "If-Modified-Since",
+      "in": "header",
+      "description": "The request should only proceed if the entity was modified after this time.",
+      "required": false,
+      "type": "string",
+      "format": "date-time",
+      "x-ms-parameter-location": "method",
+      "x-ms-client-name": "ifModifiedSince"
+    },
+    "Azure.Core.ConditionalRequestHeaders.ifNoneMatch": {
+      "name": "If-None-Match",
+      "in": "header",
+      "description": "The request should only proceed if no entity matches this string.",
+      "required": false,
+      "type": "string",
+      "x-ms-parameter-location": "method",
+      "x-ms-client-name": "ifNoneMatch"
+    },
+    "Azure.Core.ConditionalRequestHeaders.ifUnmodifiedSince": {
+      "name": "If-Unmodified-Since",
+      "in": "header",
+      "description": "The request should only proceed if the entity was not modified after this time.",
+      "required": false,
+      "type": "string",
+      "format": "date-time",
+      "x-ms-parameter-location": "method",
+      "x-ms-client-name": "ifUnmodifiedSince"
+    },
+    "Azure.Core.Foundations.ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "description": "The API version to use for this operation.",
+      "required": true,
+      "type": "string",
+      "minLength": 1,
+      "x-ms-parameter-location": "method",
+      "x-ms-client-name": "apiVersion"
+    },
+    "Azure.Core.MaxPageSizeQueryParameter": {
+      "name": "maxpagesize",
+      "in": "query",
+      "description": "The maximum number of result items per page.",
+      "required": false,
+      "type": "integer",
+      "format": "int32",
+      "x-ms-parameter-location": "method"
+    },
+    "Azure.Core.RepeatabilityRequestHeaders.repeatabilityFirstSent": {
+      "name": "Repeatability-First-Sent",
+      "in": "header",
+      "description": "Specifies the date and time at which the request was first created.",
+      "required": false,
+      "type": "string",
+      "format": "date-time",
+      "x-ms-parameter-location": "method",
+      "x-ms-client-name": "repeatabilityFirstSent"
+    },
+    "Azure.Core.RepeatabilityRequestHeaders.repeatabilityRequestId": {
+      "name": "Repeatability-Request-ID",
+      "in": "header",
+      "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+      "required": false,
+      "type": "string",
+      "x-ms-parameter-location": "method",
+      "x-ms-client-name": "repeatabilityRequestId"
+    },
+    "Azure.Core.SkipQueryParameter": {
+      "name": "skip",
+      "in": "query",
+      "description": "The number of result items to skip.",
+      "required": false,
+      "type": "integer",
+      "format": "int32",
+      "default": 0,
+      "x-ms-parameter-location": "method"
+    },
+    "Azure.Core.TopQueryParameter": {
+      "name": "top",
+      "in": "query",
+      "description": "The number of result items to return.",
+      "required": false,
+      "type": "integer",
+      "format": "int32",
+      "x-ms-parameter-location": "method"
+    }
+  }
+}


### PR DESCRIPTION
- Suppress some linter errors. We do the same in the Inference SDK TypeSpec.
- Use Union with string instead of Enum
- Per Johan, okay to suppress this: PUT operations that return 200 should start with 'replace' or 'createOrReplace'
- Add some missing doc strings