### PR TITLE
Rename Python package and folder to `azure-ai-projects-dp1`

### DIFF
--- a/specification/ai/Azure.AI.Projects/tspconfig.yaml
+++ b/specification/ai/Azure.AI.Projects/tspconfig.yaml
@@ -11,7 +11,7 @@ options:
     output-file: "{azure-resource-provider-folder}/{service-name}/{version-status}/{version}/azure-ai-projects-1dp.json"
   "@azure-tools/typespec-python":
     package-mode: "dataplane"
-    package-dir: "azure-ai-projects-1dp"
+    package-dir: "azure-ai-projects-dp1"
     package-name: "{package-dir}"
     flavor: azure
     generate-test: false


### PR DESCRIPTION
Unfortunately, `azure-ai-projects-1dp` is not valid name space in Python. Using `azure-ai-projects-dp1` instead for package and folder name. This is not really important, as this will only be a short-lived internal package until we all migrate to the new 1DP code base, at which point, we'll go back to using the original package name / name space `azure-ai-projects`.
