### PR TITLE
[.github] Add Windows to test matrix

### DIFF
--- a/.github/workflows/github-test.yaml
+++ b/.github/workflows/github-test.yaml
@@ -21,7 +21,11 @@ defaults:
 
 jobs:
   test:
-    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        os: [ubuntu, windows]
+
+    runs-on: ${{ fromJSON('{"ubuntu":"ubuntu-24.04", "windows":"windows-2022"}')[matrix.os] }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/github-test.yaml
+++ b/.github/workflows/github-test.yaml
@@ -46,6 +46,6 @@ jobs:
       - name: Archive code coverage results
         uses: actions/upload-artifact@v4
         with:
-          name: code-coverage-report
+          name: code-coverage-report-${{ matrix.os }}
           path: ./.github/coverage
           if-no-files-found: ignore

--- a/.github/workflows/github-test.yaml
+++ b/.github/workflows/github-test.yaml
@@ -16,7 +16,6 @@ permissions:
 
 defaults:
   run:
-    shell: bash
     working-directory: ./.github
 
 jobs:

--- a/.github/workflows/src/arm-incremental-typespec-preview.js
+++ b/.github/workflows/src/arm-incremental-typespec-preview.js
@@ -1,6 +1,7 @@
 // @ts-check
 
-import { dirname, join } from "path";
+// For now, treat all paths as posix, since this is the format returned from git commands
+import { dirname, join } from "path/posix";
 import {
   example,
   getChangedFiles,


### PR DESCRIPTION
- Most actions only use Linux at runtime, but dev on Windows needs to be supported

More complete fix is planned: https://github.com/Azure/azure-rest-api-specs/issues/33193