### PR TITLE
Bulk fix broken link report (#32827)

### DIFF
--- a/specification/app/resource-manager/Microsoft.App/preview/2022-01-01-preview/AuthConfigs.json
+++ b/specification/app/resource-manager/Microsoft.App/preview/2022-01-01-preview/AuthConfigs.json
@@ -555,7 +555,7 @@
       "type": "object",
       "properties": {
         "openIdIssuer": {
-          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://login.microsoftonline.com/v2.0/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://login.microsoftonline.com/v2.0/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
           "type": "string"
         },
         "clientId": {

--- a/specification/app/resource-manager/Microsoft.App/preview/2022-06-01-preview/AuthConfigs.json
+++ b/specification/app/resource-manager/Microsoft.App/preview/2022-06-01-preview/AuthConfigs.json
@@ -555,7 +555,7 @@
       "type": "object",
       "properties": {
         "openIdIssuer": {
-          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://login.microsoftonline.com/v2.0/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://login.microsoftonline.com/v2.0/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
           "type": "string"
         },
         "clientId": {

--- a/specification/app/resource-manager/Microsoft.App/preview/2022-11-01-preview/AuthConfigs.json
+++ b/specification/app/resource-manager/Microsoft.App/preview/2022-11-01-preview/AuthConfigs.json
@@ -555,7 +555,7 @@
       "type": "object",
       "properties": {
         "openIdIssuer": {
-          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://login.microsoftonline.com/v2.0/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://login.microsoftonline.com/v2.0/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
           "type": "string"
         },
         "clientId": {

--- a/specification/app/resource-manager/Microsoft.App/preview/2023-04-01-preview/AuthConfigs.json
+++ b/specification/app/resource-manager/Microsoft.App/preview/2023-04-01-preview/AuthConfigs.json
@@ -555,7 +555,7 @@
       "type": "object",
       "properties": {
         "openIdIssuer": {
-          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://login.microsoftonline.com/v2.0/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://login.microsoftonline.com/v2.0/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
           "type": "string"
         },
         "clientId": {

--- a/specification/app/resource-manager/Microsoft.App/preview/2023-05-02-preview/AuthConfigs.json
+++ b/specification/app/resource-manager/Microsoft.App/preview/2023-05-02-preview/AuthConfigs.json
@@ -609,7 +609,7 @@
       "type": "object",
       "properties": {
         "openIdIssuer": {
-          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://login.microsoftonline.com/v2.0/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://login.microsoftonline.com/v2.0/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
           "type": "string"
         },
         "clientId": {

--- a/specification/app/resource-manager/Microsoft.App/preview/2023-08-01-preview/AuthConfigs.json
+++ b/specification/app/resource-manager/Microsoft.App/preview/2023-08-01-preview/AuthConfigs.json
@@ -609,7 +609,7 @@
       "type": "object",
       "properties": {
         "openIdIssuer": {
-          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://login.microsoftonline.com/v2.0/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://login.microsoftonline.com/v2.0/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
           "type": "string"
         },
         "clientId": {

--- a/specification/app/resource-manager/Microsoft.App/preview/2023-11-02-preview/AuthConfigs.json
+++ b/specification/app/resource-manager/Microsoft.App/preview/2023-11-02-preview/AuthConfigs.json
@@ -609,7 +609,7 @@
       "type": "object",
       "properties": {
         "openIdIssuer": {
-          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://login.microsoftonline.com/v2.0/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://login.microsoftonline.com/v2.0/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
           "type": "string"
         },
         "clientId": {

--- a/specification/app/resource-manager/Microsoft.App/preview/2024-02-02-preview/AuthConfigs.json
+++ b/specification/app/resource-manager/Microsoft.App/preview/2024-02-02-preview/AuthConfigs.json
@@ -609,7 +609,7 @@
       "type": "object",
       "properties": {
         "openIdIssuer": {
-          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://login.microsoftonline.com/v2.0/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://login.microsoftonline.com/v2.0/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
           "type": "string"
         },
         "clientId": {

--- a/specification/app/resource-manager/Microsoft.App/preview/2024-08-02-preview/AuthConfigs.json
+++ b/specification/app/resource-manager/Microsoft.App/preview/2024-08-02-preview/AuthConfigs.json
@@ -609,7 +609,7 @@
       "type": "object",
       "properties": {
         "openIdIssuer": {
-          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://login.microsoftonline.com/v2.0/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://login.microsoftonline.com/v2.0/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
           "type": "string"
         },
         "clientId": {

--- a/specification/app/resource-manager/Microsoft.App/preview/2024-10-02-preview/AuthConfigs.json
+++ b/specification/app/resource-manager/Microsoft.App/preview/2024-10-02-preview/AuthConfigs.json
@@ -624,7 +624,7 @@
       "type": "object",
       "properties": {
         "openIdIssuer": {
-          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://login.microsoftonline.com/v2.0/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://login.microsoftonline.com/v2.0/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
           "type": "string"
         },
         "clientId": {

--- a/specification/app/resource-manager/Microsoft.App/stable/2022-03-01/AuthConfigs.json
+++ b/specification/app/resource-manager/Microsoft.App/stable/2022-03-01/AuthConfigs.json
@@ -555,7 +555,7 @@
       "type": "object",
       "properties": {
         "openIdIssuer": {
-          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://login.microsoftonline.com/v2.0/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://login.microsoftonline.com/v2.0/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
           "type": "string"
         },
         "clientId": {

--- a/specification/app/resource-manager/Microsoft.App/stable/2022-10-01/AuthConfigs.json
+++ b/specification/app/resource-manager/Microsoft.App/stable/2022-10-01/AuthConfigs.json
@@ -555,7 +555,7 @@
       "type": "object",
       "properties": {
         "openIdIssuer": {
-          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://login.microsoftonline.com/v2.0/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://login.microsoftonline.com/v2.0/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
           "type": "string"
         },
         "clientId": {

--- a/specification/app/resource-manager/Microsoft.App/stable/2023-05-01/AuthConfigs.json
+++ b/specification/app/resource-manager/Microsoft.App/stable/2023-05-01/AuthConfigs.json
@@ -555,7 +555,7 @@
       "type": "object",
       "properties": {
         "openIdIssuer": {
-          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://login.microsoftonline.com/v2.0/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://login.microsoftonline.com/v2.0/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
           "type": "string"
         },
         "clientId": {

--- a/specification/app/resource-manager/Microsoft.App/stable/2024-03-01/AuthConfigs.json
+++ b/specification/app/resource-manager/Microsoft.App/stable/2024-03-01/AuthConfigs.json
@@ -609,7 +609,7 @@
       "type": "object",
       "properties": {
         "openIdIssuer": {
-          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://login.microsoftonline.com/v2.0/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://login.microsoftonline.com/v2.0/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
           "type": "string"
         },
         "clientId": {

--- a/specification/datafactory/resource-manager/Microsoft.DataFactory/stable/2018-06-01/entityTypes/LinkedService.json
+++ b/specification/datafactory/resource-manager/Microsoft.DataFactory/stable/2018-06-01/entityTypes/LinkedService.json
@@ -1766,10 +1766,7 @@
           "type": "string",
           "description": "The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager. Type: string."
         }
-      },
-      "required": [
-        "connectionString"
-      ]
+      }
     },
     "AmazonRdsForOracleLinkedService": {
       "x-ms-discriminator-value": "AmazonRdsForOracle",

--- a/specification/keyvault/resource-manager/readme.python.md
+++ b/specification/keyvault/resource-manager/readme.python.md
@@ -19,35 +19,27 @@ Generate all API versions currently shipped for this package
 
 ```yaml $(python)
 multiapi: true
-default-api-version: "2023-07-01"
+default-api-version: "2024-11-01"
 clear-output-folder: true
 batch:
-  - tag: package-2019-09
-  - tag: package-2018-02
-  - tag: package-2016-10
-  - tag: package-preview-2020-04-full
-  - tag: package-preview-2021-04
-  - tag: package-preview-2021-06
-  - tag: package-2021-10
-  - tag: package-2022-07
+  - tag: package-2024-11-01
   - tag: package-2023-02
-  - tag: package-2023-07
+  - tag: package-2016-10
   - multiapiscript: true
 ```
 
 ``` yaml $(multiapiscript)
 output-folder: $(python-sdks-folder)/keyvault/azure-mgmt-keyvault/azure/mgmt/keyvault/
-clear-output-folder: false
 perform-load: false
 ```
 
-### Tag: package-2023-07 and python
+### Tag: package-2024-11-01 and python
 
-These settings apply only when `--tag=package-2023-07 --python` is specified on the command line.
+These settings apply only when `--tag=package-2024-11-01 --python` is specified on the command line.
 
-``` yaml $(tag) == 'package-2023-07'
-namespace: azure.mgmt.keyvault.v2023_07_01
-output-folder: $(python-sdks-folder)/keyvault/azure-mgmt-keyvault/azure/mgmt/keyvault/v2023_07_01
+``` yaml $(tag) == 'package-2024-11-01'
+namespace: azure.mgmt.keyvault.v2024_11_01
+output-folder: $(python-sdks-folder)/keyvault/azure-mgmt-keyvault/azure/mgmt/keyvault/v2024_11_01
 ```
 
 ### Tag: package-2023-02 and python
@@ -57,69 +49,6 @@ These settings apply only when `--tag=package-2023-02 --python` is specified on 
 ``` yaml $(tag) == 'package-2023-02'
 namespace: azure.mgmt.keyvault.v2023_02_01
 output-folder: $(python-sdks-folder)/keyvault/azure-mgmt-keyvault/azure/mgmt/keyvault/v2023_02_01
-```
-
-### Tag: package-2022-07 and python
-
-These settings apply only when `--tag=package-2022-07 --python` is specified on the command line.
-
-``` yaml $(tag) == 'package-2022-07'
-namespace: azure.mgmt.keyvault.v2022_07_01
-output-folder: $(python-sdks-folder)/keyvault/azure-mgmt-keyvault/azure/mgmt/keyvault/v2022_07_01
-```
-
-### Tag: package-2021-10 and python
-
-These settings apply only when `--tag=package-2021-10 --python` is specified on the command line.
-
-``` yaml $(tag) == 'package-2021-10'
-namespace: azure.mgmt.keyvault.v2021_10_01
-output-folder: $(python-sdks-folder)/keyvault/azure-mgmt-keyvault/azure/mgmt/keyvault/v2021_10_01
-```
-
-### Tag: package-preview-2021-06 and python
-
-These settings apply only when `--tag=package-preview-2021-06 --python` is specified on the command line.
-
-``` yaml $(tag) == 'package-preview-2021-06'
-namespace: azure.mgmt.keyvault.v2021_06_01_preview
-output-folder: $(python-sdks-folder)/keyvault/azure-mgmt-keyvault/azure/mgmt/keyvault/v2021_06_01_preview
-```
-
-### Tag: package-preview-2021-04 and python
-
-These settings apply only when `--tag=package-preview-2021-04 --python` is specified on the command line.
-
-``` yaml $(tag) == 'package-preview-2021-04'
-namespace: azure.mgmt.keyvault.v2021_04_01_preview
-output-folder: $(python-sdks-folder)/keyvault/azure-mgmt-keyvault/azure/mgmt/keyvault/v2021_04_01_preview
-```
-
-### Tag: package-preview-2020-04-full and python
-
-These settings apply only when `--tag=package-preview-2020-04-full --python` is specified on the command line.
-
-``` yaml $(tag) == 'package-preview-2020-04-full'
-namespace: azure.mgmt.keyvault.v2020_04_01_preview
-output-folder: $(python-sdks-folder)/keyvault/azure-mgmt-keyvault/azure/mgmt/keyvault/v2020_04_01_preview
-```
-
-### Tag: package-2019-09 and python
-
-These settings apply only when `--tag=package-2019-09 --python` is specified on the command line.
-
-``` yaml $(tag) == 'package-2019-09'
-namespace: azure.mgmt.keyvault.v2019_09_01
-output-folder: $(python-sdks-folder)/keyvault/azure-mgmt-keyvault/azure/mgmt/keyvault/v2019_09_01
-```
-
-### Tag: package-2018-02 and python
-
-These settings apply only when `--tag=package-2018-02 --python` is specified on the command line.
-
-``` yaml $(tag) == 'package-2018-02'
-namespace: azure.mgmt.keyvault.v2018_02_14
-output-folder: $(python-sdks-folder)/keyvault/azure-mgmt-keyvault/azure/mgmt/keyvault/v2018_02_14
 ```
 
 ### Tag: package-2016-10 and python

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/acquirePolicyToken.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/acquirePolicyToken.json
@@ -1,0 +1,67 @@
+{
+  "parameters": {
+    "subscriptionId": "ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "api-version": "2025-03-01",
+    "parameters": {
+      "operation": {
+        "uri": "https://management.azure.com/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/resourceGroups/testRG/providers/Microsoft.Compute/virtualMachines/testVM?api-version=2024-01-01",
+        "httpMethod": "delete"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "result": "Succeeded",
+        "results": [
+          {
+            "policyInfo": {
+              "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/5ed64d02",
+              "policyAssignmentId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyAssignments/3f2def86"
+            },
+            "result": "Succeeded",
+            "message": "Coin flip successful (success probability: '1').",
+            "claims": {
+              "isValid": false,
+              "string": "testString",
+              "int": 2,
+              "double": 0.99,
+              "date": "2025-01-01T19:30:00.00Z",
+              "testObject": {
+                "id": 12345,
+                "name": "Complex Object",
+                "details": {
+                  "createdBy": "John Doe",
+                  "createdDate": "2024-12-13T12:00:00Z",
+                  "metadata": {
+                    "version": "1.0.0",
+                    "isActive": true,
+                    "tags": [
+                      "example",
+                      "test",
+                      "object"
+                    ]
+                  }
+                }
+              },
+              "testArray": [
+                "Apple",
+                "Banana",
+                "Cherry"
+              ]
+            },
+            "expiration": "2025-01-01T21:30:00.00Z"
+          }
+        ],
+        "token": "PoP 7zmVse52pjMKPQd5m2uiNjz5UV2pZ.LPGtRiTeuCDBomEVbzj9kIaL9odEmlNv4D9VzyrQLTAyv4HHnUR7oNytWnL.AQrZ5bSGAQZzr8eySqvugzrD-ceRVL311SL3Nn6f-4c9kgPgU_u1ArXQKW25QCxMlsAuWmaE",
+        "tokenId": "0da8a969-c660-4de0-a6a4-b2034d4325e4",
+        "expiration": "2025-01-01T21:30:00.00Z"
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/operationResults/h723ksf8"
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createOrUpdatePolicyDefinition.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createOrUpdatePolicyDefinition.json
@@ -1,0 +1,95 @@
+{
+  "parameters": {
+    "subscriptionId": "ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "policyDefinitionName": "ResourceNaming",
+    "api-version": "2025-03-01",
+    "parameters": {
+      "properties": {
+        "mode": "All",
+        "displayName": "Enforce resource naming convention",
+        "description": "Force resource names to begin with given 'prefix' and/or end with given 'suffix'",
+        "metadata": {
+          "category": "Naming"
+        },
+        "policyRule": {
+          "if": {
+            "not": {
+              "field": "name",
+              "like": "[concat(parameters('prefix'), '*', parameters('suffix'))]"
+            }
+          },
+          "then": {
+            "effect": "deny"
+          }
+        },
+        "parameters": {
+          "prefix": {
+            "type": "String",
+            "metadata": {
+              "displayName": "Prefix",
+              "description": "Resource name prefix"
+            }
+          },
+          "suffix": {
+            "type": "String",
+            "metadata": {
+              "displayName": "Suffix",
+              "description": "Resource name suffix"
+            }
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "headers": {},
+      "body": {
+        "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+        "type": "Microsoft.Authorization/policyDefinitions",
+        "name": "ResourceNaming",
+        "properties": {
+          "mode": "All",
+          "displayName": "Naming Convention",
+          "description": "Force resource names to begin with 'prefix' and end with 'suffix'",
+          "metadata": {
+            "category": "Naming"
+          },
+          "version": "1.2.1",
+          "versions": [
+            "1.2.1",
+            "1.0.0"
+          ],
+          "policyRule": {
+            "if": {
+              "not": {
+                "field": "name",
+                "like": "[concat(parameters('prefix'), '*', parameters('suffix'))]"
+              }
+            },
+            "then": {
+              "effect": "deny"
+            }
+          },
+          "parameters": {
+            "prefix": {
+              "type": "String",
+              "metadata": {
+                "displayName": "Prefix",
+                "description": "Resource name prefix"
+              }
+            },
+            "suffix": {
+              "type": "String",
+              "metadata": {
+                "displayName": "Suffix",
+                "description": "Resource name suffix"
+              }
+            }
+          },
+          "policyType": "Custom"
+        }
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createOrUpdatePolicyDefinitionAdvancedParams.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createOrUpdatePolicyDefinitionAdvancedParams.json
@@ -1,0 +1,122 @@
+{
+  "parameters": {
+    "subscriptionId": "ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "policyDefinitionName": "EventHubDiagnosticLogs",
+    "api-version": "2025-03-01",
+    "parameters": {
+      "properties": {
+        "mode": "Indexed",
+        "displayName": "Event Hubs should have diagnostic logging enabled",
+        "description": "Audit enabling of logs and retain them up to a year. This enables recreation of activity trails for investigation purposes when a security incident occurs or your network is compromised",
+        "metadata": {
+          "category": "Event Hub"
+        },
+        "policyRule": {
+          "if": {
+            "field": "type",
+            "equals": "Microsoft.EventHub/namespaces"
+          },
+          "then": {
+            "effect": "AuditIfNotExists",
+            "details": {
+              "type": "Microsoft.Insights/diagnosticSettings",
+              "existenceCondition": {
+                "allOf": [
+                  {
+                    "field": "Microsoft.Insights/diagnosticSettings/logs[*].retentionPolicy.enabled",
+                    "equals": "true"
+                  },
+                  {
+                    "field": "Microsoft.Insights/diagnosticSettings/logs[*].retentionPolicy.days",
+                    "equals": "[parameters('requiredRetentionDays')]"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "parameters": {
+          "requiredRetentionDays": {
+            "type": "Integer",
+            "defaultValue": 365,
+            "allowedValues": [
+              0,
+              30,
+              90,
+              180,
+              365
+            ],
+            "metadata": {
+              "displayName": "Required retention (days)",
+              "description": "The required diagnostic logs retention in days"
+            }
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "headers": {},
+      "body": {
+        "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+        "type": "Microsoft.Authorization/policyDefinitions",
+        "name": "ResourceNaming",
+        "properties": {
+          "mode": "Indexed",
+          "displayName": "Event Hubs should have diagnostic logging enabled",
+          "description": "Audit enabling of logs and retain them up to a year. This enables recreation of activity trails for investigation purposes when a security incident occurs or your network is compromised",
+          "metadata": {
+            "category": "Event Hub"
+          },
+          "version": "1.2.1",
+          "versions": [
+            "1.2.1",
+            "1.0.0"
+          ],
+          "policyRule": {
+            "if": {
+              "field": "type",
+              "equals": "Microsoft.EventHub/namespaces"
+            },
+            "then": {
+              "effect": "AuditIfNotExists",
+              "details": {
+                "type": "Microsoft.Insights/diagnosticSettings",
+                "existenceCondition": {
+                  "allOf": [
+                    {
+                      "field": "Microsoft.Insights/diagnosticSettings/logs[*].retentionPolicy.enabled",
+                      "equals": "true"
+                    },
+                    {
+                      "field": "Microsoft.Insights/diagnosticSettings/logs[*].retentionPolicy.days",
+                      "equals": "[parameters('requiredRetentionDays')]"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "parameters": {
+            "requiredRetentionDays": {
+              "type": "Integer",
+              "defaultValue": 365,
+              "allowedValues": [
+                0,
+                30,
+                90,
+                180,
+                365
+              ],
+              "metadata": {
+                "displayName": "Required retention (days)",
+                "description": "The required diagnostic logs retention in days"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createOrUpdatePolicyDefinitionAtManagementGroup.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createOrUpdatePolicyDefinitionAtManagementGroup.json
@@ -1,0 +1,95 @@
+{
+  "parameters": {
+    "managementGroupId": "MyManagementGroup",
+    "policyDefinitionName": "ResourceNaming",
+    "api-version": "2025-03-01",
+    "parameters": {
+      "properties": {
+        "mode": "All",
+        "displayName": "Enforce resource naming convention",
+        "description": "Force resource names to begin with given 'prefix' and/or end with given 'suffix'",
+        "metadata": {
+          "category": "Naming"
+        },
+        "policyRule": {
+          "if": {
+            "not": {
+              "field": "name",
+              "like": "[concat(parameters('prefix'), '*', parameters('suffix'))]"
+            }
+          },
+          "then": {
+            "effect": "deny"
+          }
+        },
+        "parameters": {
+          "prefix": {
+            "type": "String",
+            "metadata": {
+              "displayName": "Prefix",
+              "description": "Resource name prefix"
+            }
+          },
+          "suffix": {
+            "type": "String",
+            "metadata": {
+              "displayName": "Suffix",
+              "description": "Resource name suffix"
+            }
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "headers": {},
+      "body": {
+        "id": "/providers/Microsoft.Management/managementgroups/MyManagementGroup/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+        "type": "Microsoft.Authorization/policyDefinitions",
+        "name": "ResourceNaming",
+        "properties": {
+          "mode": "All",
+          "displayName": "Naming Convention",
+          "description": "Force resource names to begin with 'prefix' and end with 'suffix'",
+          "metadata": {
+            "category": "Naming"
+          },
+          "version": "1.2.1",
+          "versions": [
+            "1.2.1",
+            "1.0.0"
+          ],
+          "policyRule": {
+            "if": {
+              "not": {
+                "field": "name",
+                "like": "[concat(parameters('prefix'), '*', parameters('suffix'))]"
+              }
+            },
+            "then": {
+              "effect": "deny"
+            }
+          },
+          "parameters": {
+            "prefix": {
+              "type": "String",
+              "metadata": {
+                "displayName": "Prefix",
+                "description": "Resource name prefix"
+              }
+            },
+            "suffix": {
+              "type": "String",
+              "metadata": {
+                "displayName": "Suffix",
+                "description": "Resource name suffix"
+              }
+            }
+          },
+          "policyType": "Custom"
+        }
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createOrUpdatePolicyDefinitionExternalEvaluationEnforcementSettings.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createOrUpdatePolicyDefinitionExternalEvaluationEnforcementSettings.json
@@ -1,0 +1,107 @@
+{
+  "parameters": {
+    "subscriptionId": "ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "policyDefinitionName": "RandomizeVMAllocation",
+    "api-version": "2025-03-01",
+    "parameters": {
+      "properties": {
+        "mode": "Indexed",
+        "displayName": "Randomize VM Allocation",
+        "description": "Randomly disable VM allocation in eastus by having policy rule reference the outcome of invoking an external endpoint using the CoinFlip endpoint that returns random values.",
+        "metadata": {
+          "category": "VM"
+        },
+        "policyRule": {
+          "if": {
+            "allOf": [
+              {
+                "field": "type",
+                "equals": "Microsoft.Compute/virtualMachines"
+              },
+              {
+                "field": "location",
+                "equals": "eastus"
+              },
+              {
+                "value": "[claims().isValid]",
+                "equals": "false"
+              }
+            ]
+          },
+          "then": {
+            "effect": "deny"
+          }
+        },
+        "externalEvaluationEnforcementSettings": {
+          "missingTokenAction": "audit",
+          "endpointSettings": {
+            "kind": "CoinFlip",
+            "details": {
+              "successProbability": 0.5
+            }
+          },
+          "roleDefinitionIds": [
+            "subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/roleDefinitions/f0cc2aea-b517-48f6-8f9e-0c01c687907b"
+          ]
+        }
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "headers": {},
+      "body": {
+        "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/RandomizeVMAllocation",
+        "type": "Microsoft.Authorization/policyDefinitions",
+        "name": "RandomizeVMAllocation",
+        "properties": {
+          "mode": "Indexed",
+          "displayName": "Randomize VM Allocation",
+          "description": "Randomly disable VM allocation in eastus by having policy rule reference the outcome of invoking an external endpoint using the CoinFlip endpoint that returns random values.",
+          "metadata": {
+            "category": "VM"
+          },
+          "version": "1.2.1",
+          "versions": [
+            "1.2.1",
+            "1.0.0"
+          ],
+          "policyRule": {
+            "if": {
+              "allOf": [
+                {
+                  "field": "type",
+                  "equals": "Microsoft.Compute/virtualMachines"
+                },
+                {
+                  "field": "location",
+                  "equals": "eastus"
+                },
+                {
+                  "value": "[claims().isValid]",
+                  "equals": "false"
+                }
+              ]
+            },
+            "then": {
+              "effect": "deny"
+            }
+          },
+          "externalEvaluationEnforcementSettings": {
+            "missingTokenAction": "audit",
+            "endpointSettings": {
+              "kind": "CoinFlip",
+              "details": {
+                "successProbability": 0.5
+              }
+            },
+            "roleDefinitionIds": [
+              "subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/roleDefinitions/f0cc2aea-b517-48f6-8f9e-0c01c687907b"
+            ]
+          },
+          "policyType": "Custom"
+        }
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createOrUpdatePolicyDefinitionVersion.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createOrUpdatePolicyDefinitionVersion.json
@@ -1,0 +1,138 @@
+{
+  "parameters": {
+    "subscriptionId": "ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "policyDefinitionName": "ResourceNaming",
+    "policyDefinitionVersion": "1.2.1",
+    "api-version": "2025-03-01",
+    "parameters": {
+      "properties": {
+        "mode": "All",
+        "displayName": "Enforce resource naming convention",
+        "description": "Force resource names to begin with given 'prefix' and/or end with given 'suffix'",
+        "metadata": {
+          "category": "Naming"
+        },
+        "version": "1.2.1",
+        "policyRule": {
+          "if": {
+            "not": {
+              "field": "name",
+              "like": "[concat(parameters('prefix'), '*', parameters('suffix'))]"
+            }
+          },
+          "then": {
+            "effect": "deny"
+          }
+        },
+        "parameters": {
+          "prefix": {
+            "type": "String",
+            "metadata": {
+              "displayName": "Prefix",
+              "description": "Resource name prefix"
+            }
+          },
+          "suffix": {
+            "type": "String",
+            "metadata": {
+              "displayName": "Suffix",
+              "description": "Resource name suffix"
+            }
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming/versions/1.2.1",
+        "type": "Microsoft.Authorization/policyDefinitions/versions",
+        "name": "1.2.1",
+        "properties": {
+          "mode": "All",
+          "displayName": "Naming Convention",
+          "description": "Force resource names to begin with 'prefix' and end with 'suffix'",
+          "metadata": {
+            "category": "Naming"
+          },
+          "version": "1.2.1",
+          "policyRule": {
+            "if": {
+              "not": {
+                "field": "name",
+                "like": "[concat(parameters('prefix'), '*', parameters('suffix'))]"
+              }
+            },
+            "then": {
+              "effect": "deny"
+            }
+          },
+          "parameters": {
+            "prefix": {
+              "type": "String",
+              "metadata": {
+                "displayName": "Prefix",
+                "description": "Resource name prefix"
+              }
+            },
+            "suffix": {
+              "type": "String",
+              "metadata": {
+                "displayName": "Suffix",
+                "description": "Resource name suffix"
+              }
+            }
+          },
+          "policyType": "Custom"
+        }
+      }
+    },
+    "201": {
+      "headers": {},
+      "body": {
+        "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming/versions/1.2.1",
+        "type": "Microsoft.Authorization/policyDefinitions/versions",
+        "name": "1.2.1",
+        "properties": {
+          "mode": "All",
+          "displayName": "Naming Convention",
+          "description": "Force resource names to begin with 'prefix' and end with 'suffix'",
+          "metadata": {
+            "category": "Naming"
+          },
+          "version": "1.2.1",
+          "policyRule": {
+            "if": {
+              "not": {
+                "field": "name",
+                "like": "[concat(parameters('prefix'), '*', parameters('suffix'))]"
+              }
+            },
+            "then": {
+              "effect": "deny"
+            }
+          },
+          "parameters": {
+            "prefix": {
+              "type": "String",
+              "metadata": {
+                "displayName": "Prefix",
+                "description": "Resource name prefix"
+              }
+            },
+            "suffix": {
+              "type": "String",
+              "metadata": {
+                "displayName": "Suffix",
+                "description": "Resource name suffix"
+              }
+            }
+          },
+          "policyType": "Custom"
+        }
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createOrUpdatePolicyDefinitionVersionAtManagementGroup.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createOrUpdatePolicyDefinitionVersionAtManagementGroup.json
@@ -1,0 +1,138 @@
+{
+  "parameters": {
+    "managementGroupName": "MyManagementGroup",
+    "policyDefinitionName": "ResourceNaming",
+    "policyDefinitionVersion": "1.2.1",
+    "api-version": "2025-03-01",
+    "parameters": {
+      "properties": {
+        "mode": "All",
+        "displayName": "Enforce resource naming convention",
+        "description": "Force resource names to begin with given 'prefix' and/or end with given 'suffix'",
+        "metadata": {
+          "category": "Naming"
+        },
+        "version": "1.2.1",
+        "policyRule": {
+          "if": {
+            "not": {
+              "field": "name",
+              "like": "[concat(parameters('prefix'), '*', parameters('suffix'))]"
+            }
+          },
+          "then": {
+            "effect": "deny"
+          }
+        },
+        "parameters": {
+          "prefix": {
+            "type": "String",
+            "metadata": {
+              "displayName": "Prefix",
+              "description": "Resource name prefix"
+            }
+          },
+          "suffix": {
+            "type": "String",
+            "metadata": {
+              "displayName": "Suffix",
+              "description": "Resource name suffix"
+            }
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "id": "/providers/Microsoft.Management/managementgroups/MyManagementGroup/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming/versions/1.2.1",
+        "type": "Microsoft.Authorization/policyDefinitions/versions",
+        "name": "1.2.1",
+        "properties": {
+          "mode": "All",
+          "displayName": "Naming Convention",
+          "description": "Force resource names to begin with 'prefix' and end with 'suffix'",
+          "metadata": {
+            "category": "Naming"
+          },
+          "version": "1.2.1",
+          "policyRule": {
+            "if": {
+              "not": {
+                "field": "name",
+                "like": "[concat(parameters('prefix'), '*', parameters('suffix'))]"
+              }
+            },
+            "then": {
+              "effect": "deny"
+            }
+          },
+          "parameters": {
+            "prefix": {
+              "type": "String",
+              "metadata": {
+                "displayName": "Prefix",
+                "description": "Resource name prefix"
+              }
+            },
+            "suffix": {
+              "type": "String",
+              "metadata": {
+                "displayName": "Suffix",
+                "description": "Resource name suffix"
+              }
+            }
+          },
+          "policyType": "Custom"
+        }
+      }
+    },
+    "201": {
+      "headers": {},
+      "body": {
+        "id": "/providers/Microsoft.Management/managementgroups/MyManagementGroup/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming/versions/1.2.1",
+        "type": "Microsoft.Authorization/policyDefinitions/versions",
+        "name": "1.2.1",
+        "properties": {
+          "mode": "All",
+          "displayName": "Naming Convention",
+          "description": "Force resource names to begin with 'prefix' and end with 'suffix'",
+          "metadata": {
+            "category": "Naming"
+          },
+          "version": "1.2.1",
+          "policyRule": {
+            "if": {
+              "not": {
+                "field": "name",
+                "like": "[concat(parameters('prefix'), '*', parameters('suffix'))]"
+              }
+            },
+            "then": {
+              "effect": "deny"
+            }
+          },
+          "parameters": {
+            "prefix": {
+              "type": "String",
+              "metadata": {
+                "displayName": "Prefix",
+                "description": "Resource name prefix"
+              }
+            },
+            "suffix": {
+              "type": "String",
+              "metadata": {
+                "displayName": "Suffix",
+                "description": "Resource name suffix"
+              }
+            }
+          },
+          "policyType": "Custom"
+        }
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createOrUpdatePolicySetDefinition.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createOrUpdatePolicySetDefinition.json
@@ -1,0 +1,160 @@
+{
+  "parameters": {
+    "subscriptionId": "ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "policySetDefinitionName": "CostManagement",
+    "api-version": "2025-03-01",
+    "parameters": {
+      "properties": {
+        "displayName": "Cost Management",
+        "description": "Policies to enforce low cost storage SKUs",
+        "metadata": {
+          "category": "Cost Management"
+        },
+        "parameters": {
+          "namePrefix": {
+            "type": "String",
+            "defaultValue": "myPrefix",
+            "metadata": {
+              "displayName": "Prefix to enforce on resource names"
+            }
+          }
+        },
+        "policyDefinitions": [
+          {
+            "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+            "policyDefinitionReferenceId": "Limit_Skus",
+            "parameters": {
+              "listOfAllowedSKUs": {
+                "value": [
+                  "Standard_GRS",
+                  "Standard_LRS"
+                ]
+              }
+            }
+          },
+          {
+            "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+            "policyDefinitionReferenceId": "Resource_Naming",
+            "parameters": {
+              "prefix": {
+                "value": "[parameters('namePrefix')]"
+              },
+              "suffix": {
+                "value": "-LC"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "headers": {},
+      "body": {
+        "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policySetDefinitions/CostManagement",
+        "type": "Microsoft.Authorization/policySetDefinitions",
+        "name": "CostManagement",
+        "properties": {
+          "displayName": "Cost Management",
+          "description": "Policies to enforce low cost storage SKUs",
+          "metadata": {
+            "category": "Cost Management"
+          },
+          "version": "1.2.1",
+          "versions": [
+            "1.2.1",
+            "1.0.0"
+          ],
+          "parameters": {
+            "namePrefix": {
+              "type": "String",
+              "defaultValue": "myPrefix",
+              "metadata": {
+                "displayName": "Prefix to enforce on resource names"
+              }
+            }
+          },
+          "policyDefinitions": [
+            {
+              "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "Limit_Skus",
+              "parameters": {
+                "listOfAllowedSKUs": {
+                  "value": [
+                    "Standard_GRS",
+                    "Standard_LRS"
+                  ]
+                }
+              }
+            },
+            {
+              "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "Resource_Naming",
+              "parameters": {
+                "prefix": {
+                  "value": "[parameters('namePrefix')]"
+                },
+                "suffix": {
+                  "value": "-LC"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "200": {
+      "headers": {},
+      "body": {
+        "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policySetDefinitions/CostManagement",
+        "type": "Microsoft.Authorization/policySetDefinitions",
+        "name": "CostManagement",
+        "properties": {
+          "displayName": "Cost Management",
+          "description": "Policies to enforce low cost storage SKUs",
+          "metadata": {
+            "category": "Cost Management"
+          },
+          "parameters": {
+            "namePrefix": {
+              "type": "String",
+              "defaultValue": "myPrefix",
+              "metadata": {
+                "displayName": "Prefix to enforce on resource names"
+              }
+            }
+          },
+          "policyDefinitions": [
+            {
+              "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+              "policyDefinitionReferenceId": "Limit_Skus",
+              "parameters": {
+                "listOfAllowedSKUs": {
+                  "value": [
+                    "Standard_GRS",
+                    "Standard_LRS"
+                  ]
+                }
+              }
+            },
+            {
+              "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+              "policyDefinitionReferenceId": "Resource_Naming",
+              "parameters": {
+                "prefix": {
+                  "value": "[parameters('namePrefix')]"
+                },
+                "suffix": {
+                  "value": "-LC"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createOrUpdatePolicySetDefinitionAtManagementGroup.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createOrUpdatePolicySetDefinitionAtManagementGroup.json
@@ -1,0 +1,135 @@
+{
+  "parameters": {
+    "managementGroupId": "MyManagementGroup",
+    "policySetDefinitionName": "CostManagement",
+    "api-version": "2025-03-01",
+    "parameters": {
+      "properties": {
+        "displayName": "Cost Management",
+        "description": "Policies to enforce low cost storage SKUs",
+        "metadata": {
+          "category": "Cost Management"
+        },
+        "policyDefinitions": [
+          {
+            "policyDefinitionId": "/providers/Microsoft.Management/managementgroups/MyManagementGroup/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+            "policyDefinitionReferenceId": "Limit_Skus",
+            "parameters": {
+              "listOfAllowedSKUs": {
+                "value": [
+                  "Standard_GRS",
+                  "Standard_LRS"
+                ]
+              }
+            }
+          },
+          {
+            "policyDefinitionId": "/providers/Microsoft.Management/managementgroups/MyManagementGroup/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+            "policyDefinitionReferenceId": "Resource_Naming",
+            "parameters": {
+              "prefix": {
+                "value": "DeptA"
+              },
+              "suffix": {
+                "value": "-LC"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "headers": {},
+      "body": {
+        "id": "/providers/Microsoft.Management/managementgroups/MyManagementGroup/providers/Microsoft.Authorization/policySetDefinitions/CostManagement",
+        "type": "Microsoft.Authorization/policySetDefinitions",
+        "name": "CostManagement",
+        "properties": {
+          "displayName": "Cost Management",
+          "description": "Policies to enforce low cost storage SKUs",
+          "metadata": {
+            "category": "Cost Management"
+          },
+          "version": "1.2.1",
+          "versions": [
+            "1.2.1",
+            "1.0.0"
+          ],
+          "policyDefinitions": [
+            {
+              "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "Limit_Skus",
+              "parameters": {
+                "listOfAllowedSKUs": {
+                  "value": [
+                    "Standard_GRS",
+                    "Standard_LRS"
+                  ]
+                }
+              }
+            },
+            {
+              "policyDefinitionId": "/providers/Microsoft.Management/managementgroups/MyManagementGroup/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "Resource_Naming",
+              "parameters": {
+                "prefix": {
+                  "value": "DeptA"
+                },
+                "suffix": {
+                  "value": "-LC"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "200": {
+      "headers": {},
+      "body": {
+        "id": "/providers/Microsoft.Management/managementgroups/MyManagementGroup/providers/Microsoft.Authorization/policySetDefinitions/CostManagement",
+        "type": "Microsoft.Authorization/policySetDefinitions",
+        "name": "CostManagement",
+        "properties": {
+          "displayName": "Cost Management",
+          "description": "Policies to enforce low cost storage SKUs",
+          "metadata": {
+            "category": "Cost Management"
+          },
+          "policyDefinitions": [
+            {
+              "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "Limit_Skus",
+              "parameters": {
+                "listOfAllowedSKUs": {
+                  "value": [
+                    "Standard_GRS",
+                    "Standard_LRS"
+                  ]
+                }
+              }
+            },
+            {
+              "policyDefinitionId": "/providers/Microsoft.Management/managementgroups/MyManagementGroup/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "Resource_Naming",
+              "parameters": {
+                "prefix": {
+                  "value": "DeptA"
+                },
+                "suffix": {
+                  "value": "-LC"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createOrUpdatePolicySetDefinitionVersion.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createOrUpdatePolicySetDefinitionVersion.json
@@ -1,0 +1,161 @@
+{
+  "parameters": {
+    "subscriptionId": "ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "policySetDefinitionName": "CostManagement",
+    "policyDefinitionVersion": "1.2.1",
+    "api-version": "2025-03-01",
+    "parameters": {
+      "properties": {
+        "displayName": "Cost Management",
+        "description": "Policies to enforce low cost storage SKUs",
+        "metadata": {
+          "category": "Cost Management"
+        },
+        "version": "1.2.1",
+        "parameters": {
+          "namePrefix": {
+            "type": "String",
+            "defaultValue": "myPrefix",
+            "metadata": {
+              "displayName": "Prefix to enforce on resource names"
+            }
+          }
+        },
+        "policyDefinitions": [
+          {
+            "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+            "policyDefinitionReferenceId": "Limit_Skus",
+            "parameters": {
+              "listOfAllowedSKUs": {
+                "value": [
+                  "Standard_GRS",
+                  "Standard_LRS"
+                ]
+              }
+            }
+          },
+          {
+            "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+            "policyDefinitionReferenceId": "Resource_Naming",
+            "parameters": {
+              "prefix": {
+                "value": "[parameters('namePrefix')]"
+              },
+              "suffix": {
+                "value": "-LC"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "headers": {},
+      "body": {
+        "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policySetDefinitions/CostManagement/versions/1.2.1",
+        "type": "Microsoft.Authorization/policySetDefinitions/versions",
+        "name": "1.2.1",
+        "properties": {
+          "displayName": "Cost Management",
+          "description": "Policies to enforce low cost storage SKUs",
+          "metadata": {
+            "category": "Cost Management"
+          },
+          "version": "1.2.1",
+          "parameters": {
+            "namePrefix": {
+              "type": "String",
+              "defaultValue": "myPrefix",
+              "metadata": {
+                "displayName": "Prefix to enforce on resource names"
+              }
+            }
+          },
+          "policyDefinitions": [
+            {
+              "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "Limit_Skus",
+              "parameters": {
+                "listOfAllowedSKUs": {
+                  "value": [
+                    "Standard_GRS",
+                    "Standard_LRS"
+                  ]
+                }
+              }
+            },
+            {
+              "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "Resource_Naming",
+              "parameters": {
+                "prefix": {
+                  "value": "[parameters('namePrefix')]"
+                },
+                "suffix": {
+                  "value": "-LC"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "200": {
+      "headers": {},
+      "body": {
+        "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policySetDefinitions/CostManagement/versions/1.2.1",
+        "type": "Microsoft.Authorization/policySetDefinitions/versions",
+        "name": "1.2.1",
+        "properties": {
+          "displayName": "Cost Management",
+          "description": "Policies to enforce low cost storage SKUs",
+          "metadata": {
+            "category": "Cost Management"
+          },
+          "version": "1.2.1",
+          "parameters": {
+            "namePrefix": {
+              "type": "String",
+              "defaultValue": "myPrefix",
+              "metadata": {
+                "displayName": "Prefix to enforce on resource names"
+              }
+            }
+          },
+          "policyDefinitions": [
+            {
+              "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "Limit_Skus",
+              "parameters": {
+                "listOfAllowedSKUs": {
+                  "value": [
+                    "Standard_GRS",
+                    "Standard_LRS"
+                  ]
+                }
+              }
+            },
+            {
+              "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "Resource_Naming",
+              "parameters": {
+                "prefix": {
+                  "value": "[parameters('namePrefix')]"
+                },
+                "suffix": {
+                  "value": "-LC"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createOrUpdatePolicySetDefinitionVersionAtManagementGroup.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createOrUpdatePolicySetDefinitionVersionAtManagementGroup.json
@@ -1,0 +1,133 @@
+{
+  "parameters": {
+    "managementGroupName": "MyManagementGroup",
+    "policySetDefinitionName": "CostManagement",
+    "policyDefinitionVersion": "1.2.1",
+    "api-version": "2025-03-01",
+    "parameters": {
+      "properties": {
+        "displayName": "Cost Management",
+        "description": "Policies to enforce low cost storage SKUs",
+        "metadata": {
+          "category": "Cost Management"
+        },
+        "version": "1.2.1",
+        "policyDefinitions": [
+          {
+            "policyDefinitionId": "/providers/Microsoft.Management/managementgroups/MyManagementGroup/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+            "policyDefinitionReferenceId": "Limit_Skus",
+            "parameters": {
+              "listOfAllowedSKUs": {
+                "value": [
+                  "Standard_GRS",
+                  "Standard_LRS"
+                ]
+              }
+            }
+          },
+          {
+            "policyDefinitionId": "/providers/Microsoft.Management/managementgroups/MyManagementGroup/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+            "policyDefinitionReferenceId": "Resource_Naming",
+            "parameters": {
+              "prefix": {
+                "value": "DeptA"
+              },
+              "suffix": {
+                "value": "-LC"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "headers": {},
+      "body": {
+        "id": "/providers/Microsoft.Management/managementgroups/MyManagementGroup/providers/Microsoft.Authorization/policySetDefinitions/CostManagement/versions/1.2.1",
+        "type": "Microsoft.Authorization/policySetDefinitions/versions",
+        "name": "1.2.1",
+        "properties": {
+          "displayName": "Cost Management",
+          "description": "Policies to enforce low cost storage SKUs",
+          "metadata": {
+            "category": "Cost Management"
+          },
+          "version": "1.2.1",
+          "policyDefinitions": [
+            {
+              "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "Limit_Skus",
+              "parameters": {
+                "listOfAllowedSKUs": {
+                  "value": [
+                    "Standard_GRS",
+                    "Standard_LRS"
+                  ]
+                }
+              }
+            },
+            {
+              "policyDefinitionId": "/providers/Microsoft.Management/managementgroups/MyManagementGroup/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "Resource_Naming",
+              "parameters": {
+                "prefix": {
+                  "value": "DeptA"
+                },
+                "suffix": {
+                  "value": "-LC"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "200": {
+      "headers": {},
+      "body": {
+        "id": "/providers/Microsoft.Management/managementgroups/MyManagementGroup/providers/Microsoft.Authorization/policySetDefinitions/CostManagement",
+        "type": "Microsoft.Authorization/policySetDefinitions",
+        "name": "CostManagement",
+        "properties": {
+          "displayName": "Cost Management",
+          "description": "Policies to enforce low cost storage SKUs",
+          "metadata": {
+            "category": "Cost Management"
+          },
+          "policyDefinitions": [
+            {
+              "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "Limit_Skus",
+              "parameters": {
+                "listOfAllowedSKUs": {
+                  "value": [
+                    "Standard_GRS",
+                    "Standard_LRS"
+                  ]
+                }
+              }
+            },
+            {
+              "policyDefinitionId": "/providers/Microsoft.Management/managementgroups/MyManagementGroup/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "Resource_Naming",
+              "parameters": {
+                "prefix": {
+                  "value": "DeptA"
+                },
+                "suffix": {
+                  "value": "-LC"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createOrUpdatePolicySetDefinitionWithGroups.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createOrUpdatePolicySetDefinitionWithGroups.json
@@ -1,0 +1,196 @@
+{
+  "parameters": {
+    "subscriptionId": "ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "policySetDefinitionName": "CostManagement",
+    "api-version": "2025-03-01",
+    "parameters": {
+      "properties": {
+        "displayName": "Cost Management",
+        "description": "Policies to enforce low cost storage SKUs",
+        "metadata": {
+          "category": "Cost Management"
+        },
+        "policyDefinitionGroups": [
+          {
+            "name": "CostSaving",
+            "displayName": "Cost Management Policies",
+            "description": "Policies designed to control spend within a subscription."
+          },
+          {
+            "name": "Organizational",
+            "displayName": "Organizational Policies",
+            "description": "Policies that help enforce resource organization standards within a subscription."
+          }
+        ],
+        "policyDefinitions": [
+          {
+            "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+            "definitionVersion": "1.*.*",
+            "policyDefinitionReferenceId": "Limit_Skus",
+            "groupNames": [
+              "CostSaving"
+            ],
+            "parameters": {
+              "listOfAllowedSKUs": {
+                "value": [
+                  "Standard_GRS",
+                  "Standard_LRS"
+                ]
+              }
+            }
+          },
+          {
+            "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+            "definitionVersion": "1.*.*",
+            "policyDefinitionReferenceId": "Resource_Naming",
+            "groupNames": [
+              "Organizational"
+            ],
+            "parameters": {
+              "prefix": {
+                "value": "DeptA"
+              },
+              "suffix": {
+                "value": "-LC"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "headers": {},
+      "body": {
+        "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policySetDefinitions/CostManagement",
+        "type": "Microsoft.Authorization/policySetDefinitions",
+        "name": "CostManagement",
+        "properties": {
+          "displayName": "Cost Management",
+          "description": "Policies to enforce low cost storage SKUs",
+          "metadata": {
+            "category": "Cost Management"
+          },
+          "version": "1.2.1",
+          "versions": [
+            "1.2.1",
+            "1.0.0"
+          ],
+          "policyDefinitionGroups": [
+            {
+              "name": "CostSaving",
+              "displayName": "Cost Management Policies",
+              "description": "Policies designed to control spend within a subscription."
+            },
+            {
+              "name": "Organizational",
+              "displayName": "Organizational Policies",
+              "description": "Policies that help enforce resource organization standards within a subscription."
+            }
+          ],
+          "policyDefinitions": [
+            {
+              "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "Limit_Skus",
+              "groupNames": [
+                "CostSaving"
+              ],
+              "parameters": {
+                "listOfAllowedSKUs": {
+                  "value": [
+                    "Standard_GRS",
+                    "Standard_LRS"
+                  ]
+                }
+              }
+            },
+            {
+              "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "Resource_Naming",
+              "groupNames": [
+                "Organizational"
+              ],
+              "parameters": {
+                "prefix": {
+                  "value": "DeptA"
+                },
+                "suffix": {
+                  "value": "-LC"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "200": {
+      "headers": {},
+      "body": {
+        "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policySetDefinitions/CostManagement",
+        "type": "Microsoft.Authorization/policySetDefinitions",
+        "name": "CostManagement",
+        "properties": {
+          "displayName": "Cost Management",
+          "description": "Policies to enforce low cost storage SKUs",
+          "metadata": {
+            "category": "Cost Management"
+          },
+          "version": "1.2.1",
+          "versions": [
+            "1.2.1",
+            "1.0.0"
+          ],
+          "policyDefinitionGroups": [
+            {
+              "name": "CostSaving",
+              "displayName": "Cost Management Policies",
+              "description": "Policies designed to control spend within a subscription."
+            },
+            {
+              "name": "Organizational",
+              "displayName": "Organizational Policies",
+              "description": "Policies that help enforce resource organization standards within a subscription."
+            }
+          ],
+          "policyDefinitions": [
+            {
+              "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "Limit_Skus",
+              "groupNames": [
+                "CostSaving"
+              ],
+              "parameters": {
+                "listOfAllowedSKUs": {
+                  "value": [
+                    "Standard_GRS",
+                    "Standard_LRS"
+                  ]
+                }
+              }
+            },
+            {
+              "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "Resource_Naming",
+              "groupNames": [
+                "Organizational"
+              ],
+              "parameters": {
+                "prefix": {
+                  "value": "DeptA"
+                },
+                "suffix": {
+                  "value": "-LC"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createOrUpdatePolicySetDefinitionWithGroupsAtManagementGroup.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createOrUpdatePolicySetDefinitionWithGroupsAtManagementGroup.json
@@ -1,0 +1,194 @@
+{
+  "parameters": {
+    "managementGroupId": "MyManagementGroup",
+    "policySetDefinitionName": "CostManagement",
+    "api-version": "2025-03-01",
+    "parameters": {
+      "properties": {
+        "displayName": "Cost Management",
+        "description": "Policies to enforce low cost storage SKUs",
+        "metadata": {
+          "category": "Cost Management"
+        },
+        "policyDefinitionGroups": [
+          {
+            "name": "CostSaving",
+            "displayName": "Cost Management Policies",
+            "description": "Policies designed to control spend within a subscription."
+          },
+          {
+            "name": "Organizational",
+            "displayName": "Organizational Policies",
+            "description": "Policies that help enforce resource organization standards within a subscription."
+          }
+        ],
+        "policyDefinitions": [
+          {
+            "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+            "policyDefinitionReferenceId": "Limit_Skus",
+            "groupNames": [
+              "CostSaving"
+            ],
+            "parameters": {
+              "listOfAllowedSKUs": {
+                "value": [
+                  "Standard_GRS",
+                  "Standard_LRS"
+                ]
+              }
+            }
+          },
+          {
+            "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+            "policyDefinitionReferenceId": "Resource_Naming",
+            "groupNames": [
+              "Organizational"
+            ],
+            "parameters": {
+              "prefix": {
+                "value": "DeptA"
+              },
+              "suffix": {
+                "value": "-LC"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "headers": {},
+      "body": {
+        "id": "/providers/Microsoft.Management/managementgroups/MyManagementGroup/providers/Microsoft.Authorization/policySetDefinitions/CostManagement",
+        "type": "Microsoft.Authorization/policySetDefinitions",
+        "name": "CostManagement",
+        "properties": {
+          "displayName": "Cost Management",
+          "description": "Policies to enforce low cost storage SKUs",
+          "metadata": {
+            "category": "Cost Management"
+          },
+          "version": "1.2.1",
+          "versions": [
+            "1.2.1",
+            "1.0.0"
+          ],
+          "policyDefinitionGroups": [
+            {
+              "name": "CostSaving",
+              "displayName": "Cost Management Policies",
+              "description": "Policies designed to control spend within a subscription."
+            },
+            {
+              "name": "Organizational",
+              "displayName": "Organizational Policies",
+              "description": "Policies that help enforce resource organization standards within a subscription."
+            }
+          ],
+          "policyDefinitions": [
+            {
+              "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "Limit_Skus",
+              "groupNames": [
+                "CostSaving"
+              ],
+              "parameters": {
+                "listOfAllowedSKUs": {
+                  "value": [
+                    "Standard_GRS",
+                    "Standard_LRS"
+                  ]
+                }
+              }
+            },
+            {
+              "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "Resource_Naming",
+              "groupNames": [
+                "Organizational"
+              ],
+              "parameters": {
+                "prefix": {
+                  "value": "DeptA"
+                },
+                "suffix": {
+                  "value": "-LC"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "200": {
+      "headers": {},
+      "body": {
+        "id": "/providers/Microsoft.Management/managementgroups/MyManagementGroup/providers/Microsoft.Authorization/policySetDefinitions/CostManagement",
+        "type": "Microsoft.Authorization/policySetDefinitions",
+        "name": "CostManagement",
+        "properties": {
+          "displayName": "Cost Management",
+          "description": "Policies to enforce low cost storage SKUs",
+          "metadata": {
+            "category": "Cost Management"
+          },
+          "version": "1.2.1",
+          "versions": [
+            "1.2.1",
+            "1.0.0"
+          ],
+          "policyDefinitionGroups": [
+            {
+              "name": "CostSaving",
+              "displayName": "Cost Management Policies",
+              "description": "Policies designed to control spend within a subscription."
+            },
+            {
+              "name": "Organizational",
+              "displayName": "Organizational Policies",
+              "description": "Policies that help enforce resource organization standards within a subscription."
+            }
+          ],
+          "policyDefinitions": [
+            {
+              "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "Limit_Skus",
+              "groupNames": [
+                "CostSaving"
+              ],
+              "parameters": {
+                "listOfAllowedSKUs": {
+                  "value": [
+                    "Standard_GRS",
+                    "Standard_LRS"
+                  ]
+                }
+              }
+            },
+            {
+              "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "Resource_Naming",
+              "groupNames": [
+                "Organizational"
+              ],
+              "parameters": {
+                "prefix": {
+                  "value": "DeptA"
+                },
+                "suffix": {
+                  "value": "-LC"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createPolicyAssignment.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createPolicyAssignment.json
@@ -1,0 +1,66 @@
+{
+  "parameters": {
+    "scope": "subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "policyAssignmentName": "EnforceNaming",
+    "api-version": "2025-03-01",
+    "parameters": {
+      "properties": {
+        "displayName": "Enforce resource naming rules",
+        "description": "Force resource names to begin with given DeptA and end with -LC",
+        "metadata": {
+          "assignedBy": "Special Someone"
+        },
+        "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+        "parameters": {
+          "prefix": {
+            "value": "DeptA"
+          },
+          "suffix": {
+            "value": "-LC"
+          }
+        },
+        "nonComplianceMessages": [
+          {
+            "message": "Resource names must start with 'DeptA' and end with '-LC'."
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "displayName": "Enforce resource naming rules",
+          "description": "Force resource names to begin with given DeptA and end with -LC",
+          "metadata": {
+            "assignedBy": "Special Someone"
+          },
+          "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+          "definitionVersion": "1.*.*",
+          "notScopes": [],
+          "parameters": {
+            "prefix": {
+              "value": "DeptA"
+            },
+            "suffix": {
+              "value": "-LC"
+            }
+          },
+          "enforcementMode": "Default",
+          "scope": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+          "nonComplianceMessages": [
+            {
+              "message": "Resource names must start with 'DeptA' and end with '-LC'."
+            }
+          ],
+          "instanceId": "e4b0f5a6-7c8d-4e9f-8a1b-2c3d4e5f6a7b"
+        },
+        "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyAssignments/EnforceNaming",
+        "type": "Microsoft.Authorization/policyAssignments",
+        "name": "EnforceNaming"
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createPolicyAssignmentById.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createPolicyAssignmentById.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "policyAssignmentId": "providers/Microsoft.Management/managementGroups/MyManagementGroup/providers/Microsoft.Authorization/policyAssignments/LowCostStorage",
+    "api-version": "2025-03-01",
+    "parameters": {
+      "properties": {
+        "displayName": "Enforce storage account SKU",
+        "description": "Allow only storage accounts of SKU Standard_GRS or Standard_LRS to be created",
+        "metadata": {
+          "assignedBy": "Cheapskate Boss"
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+        "definitionVersion": "1.*.*",
+        "parameters": {
+          "listOfAllowedSKUs": {
+            "value": [
+              "Standard_GRS",
+              "Standard_LRS"
+            ]
+          }
+        },
+        "enforcementMode": "Default"
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "displayName": "Enforce storage account SKU",
+          "description": "Allow only storage accounts of SKU Standard_GRS or Standard_LRS to be created",
+          "metadata": {
+            "assignedBy": "Cheapskate Boss"
+          },
+          "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+          "definitionVersion": "1.*.*",
+          "notScopes": [],
+          "parameters": {
+            "listOfAllowedSKUs": {
+              "value": [
+                "Standard_GRS",
+                "Standard_LRS"
+              ]
+            }
+          },
+          "enforcementMode": "Default",
+          "instanceId": "b7e0f8a9-1c2d-4e3f-8b4c-5d6e7f8a9b0c"
+        },
+        "id": "/providers/Microsoft.Management/managementGroups/MyManagementGroup/providers/Microsoft.Authorization/policyAssignments/LowCostStorage",
+        "type": "Microsoft.Authorization/policyAssignments",
+        "name": "LowCostStorage"
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createPolicyAssignmentNonComplianceMessages.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createPolicyAssignmentNonComplianceMessages.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "scope": "subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "policyAssignmentName": "securityInitAssignment",
+    "api-version": "2025-03-01",
+    "parameters": {
+      "properties": {
+        "displayName": "Enforce security policies",
+        "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policySetDefinitions/securityInitiative",
+        "nonComplianceMessages": [
+          {
+            "message": "Resources must comply with all internal security policies. See <internal site URL> for more info."
+          },
+          {
+            "message": "Resource names must start with 'DeptA' and end with '-LC'.",
+            "policyDefinitionReferenceId": "10420126870854049575"
+          },
+          {
+            "message": "Storage accounts must have firewall rules configured.",
+            "policyDefinitionReferenceId": "8572513655450389710"
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "displayName": "Enforce security policies",
+          "metadata": {
+            "assignedBy": "User 1"
+          },
+          "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policySetDefinitions/securityInitiative",
+          "definitionVersion": "1.*.*",
+          "notScopes": [],
+          "enforcementMode": "Default",
+          "scope": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+          "nonComplianceMessages": [
+            {
+              "message": "Resources must comply with all internal security policies. See <internal site URL> for more info."
+            },
+            {
+              "message": "Resource names must start with 'DeptA' and end with '-LC'.",
+              "policyDefinitionReferenceId": "10420126870854049575"
+            },
+            {
+              "message": "Storage accounts must have firewall rules configured.",
+              "policyDefinitionReferenceId": "8572513655450389710"
+            }
+          ],
+          "instanceId": "b7e0f8a9-1c2d-4e3f-8b4c-5d6e7f8a9b0c"
+        },
+        "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyAssignments/securityInitAssignment",
+        "type": "Microsoft.Authorization/policyAssignments",
+        "name": "securityInitAssignment"
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createPolicyAssignmentWithEnrollEnforcement.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createPolicyAssignmentWithEnrollEnforcement.json
@@ -1,0 +1,57 @@
+{
+  "parameters": {
+    "scope": "subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "policyAssignmentName": "EnforceNamingEnroll",
+    "api-version": "2025-03-01",
+    "parameters": {
+      "properties": {
+        "displayName": "Enforce resource naming rules",
+        "description": "Force resource names to begin with given DeptA and end with -LC",
+        "metadata": {
+          "assignedBy": "Special Someone"
+        },
+        "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+        "parameters": {
+          "prefix": {
+            "value": "DeptA"
+          },
+          "suffix": {
+            "value": "-LC"
+          }
+        },
+        "enforcementMode": "Enroll"
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "displayName": "Enforce resource naming rules",
+          "description": "Force resource names to begin with given DeptA and end with -LC",
+          "metadata": {
+            "assignedBy": "Special Someone"
+          },
+          "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+          "definitionVersion": "1.*.*",
+          "notScopes": [],
+          "parameters": {
+            "prefix": {
+              "value": "DeptA"
+            },
+            "suffix": {
+              "value": "-LC"
+            }
+          },
+          "enforcementMode": "Enroll",
+          "scope": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+          "instanceId": "f2b3c4d5-e6f7-8a9b-0c1d-2e3f4a5b6c7d"
+        },
+        "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyAssignments/EnforceNamingEnroll",
+        "type": "Microsoft.Authorization/policyAssignments",
+        "name": "EnforceNamingEnroll"
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createPolicyAssignmentWithIdentity.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createPolicyAssignmentWithIdentity.json
@@ -1,0 +1,67 @@
+{
+  "parameters": {
+    "scope": "subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "policyAssignmentName": "EnforceNaming",
+    "api-version": "2025-03-01",
+    "parameters": {
+      "location": "eastus",
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "properties": {
+        "displayName": "Enforce resource naming rules",
+        "description": "Force resource names to begin with given DeptA and end with -LC",
+        "metadata": {
+          "assignedBy": "Foo Bar"
+        },
+        "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+        "parameters": {
+          "prefix": {
+            "value": "DeptA"
+          },
+          "suffix": {
+            "value": "-LC"
+          }
+        },
+        "enforcementMode": "Default"
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "displayName": "Enforce resource naming rules",
+          "description": "Force resource names to begin with given DeptA and end with -LC",
+          "metadata": {
+            "assignedBy": "Special Someone"
+          },
+          "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+          "definitionVersion": "1.*.*",
+          "notScopes": [],
+          "parameters": {
+            "prefix": {
+              "value": "DeptA"
+            },
+            "suffix": {
+              "value": "-LC"
+            }
+          },
+          "enforcementMode": "Default",
+          "scope": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+          "instanceId": "e4b0f5a6-7c8d-4e9f-8a1b-2c3d4e5f6a7b"
+        },
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "e6d23f8d-af97-4fbc-bda6-00604e4e3d0a",
+          "tenantId": "4bee2b8a-1bee-47c2-90e9-404241551135"
+        },
+        "location": "eastus",
+        "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyAssignments/EnforceNaming",
+        "type": "Microsoft.Authorization/policyAssignments",
+        "name": "EnforceNaming"
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createPolicyAssignmentWithIdentityById.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createPolicyAssignmentWithIdentityById.json
@@ -1,0 +1,66 @@
+{
+  "parameters": {
+    "policyAssignmentId": "providers/Microsoft.Management/managementGroups/MyManagementGroup/providers/Microsoft.Authorization/policyAssignments/LowCostStorage",
+    "api-version": "2025-03-01",
+    "parameters": {
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "location": "eastus",
+      "properties": {
+        "displayName": "Enforce storage account SKU",
+        "description": "Allow only storage accounts of SKU Standard_GRS or Standard_LRS to be created",
+        "metadata": {
+          "assignedBy": "Cheapskate Boss"
+        },
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+        "definitionVersion": "1.*.*",
+        "parameters": {
+          "listOfAllowedSKUs": {
+            "value": [
+              "Standard_GRS",
+              "Standard_LRS"
+            ]
+          }
+        },
+        "enforcementMode": "Default"
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "displayName": "Enforce storage account SKU",
+          "description": "Allow only storage accounts of SKU Standard_GRS or Standard_LRS to be created",
+          "metadata": {
+            "assignedBy": "Cheapskate Boss"
+          },
+          "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+          "definitionVersion": "1.*.*",
+          "notScopes": [],
+          "parameters": {
+            "listOfAllowedSKUs": {
+              "value": [
+                "Standard_GRS",
+                "Standard_LRS"
+              ]
+            }
+          },
+          "enforcementMode": "Default",
+          "instanceId": "b7e0f8a9-1c2d-4e3f-8b4c-5d6e7f8a9b0c"
+        },
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "e6d23f8d-af97-4fbc-bda6-00604e4e3d0a",
+          "tenantId": "4bee2b8a-1bee-47c2-90e9-404241551135"
+        },
+        "location": "eastus",
+        "id": "/providers/Microsoft.Management/managementGroups/MyManagementGroup/providers/Microsoft.Authorization/policyAssignments/LowCostStorage",
+        "type": "Microsoft.Authorization/policyAssignments",
+        "name": "LowCostStorage"
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createPolicyAssignmentWithOverrides.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createPolicyAssignmentWithOverrides.json
@@ -1,0 +1,84 @@
+{
+  "parameters": {
+    "scope": "subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "policyAssignmentName": "CostManagement",
+    "api-version": "2025-03-01",
+    "parameters": {
+      "properties": {
+        "displayName": "Limit the resource location and resource SKU",
+        "description": "Limit the resource location and resource SKU",
+        "metadata": {
+          "assignedBy": "Special Someone"
+        },
+        "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policySetDefinitions/CostManagement",
+        "definitionVersion": "1.*.*",
+        "overrides": [
+          {
+            "kind": "policyEffect",
+            "value": "Audit",
+            "selectors": [
+              {
+                "kind": "policyDefinitionReferenceId",
+                "in": [
+                  "Limit_Skus",
+                  "Limit_Locations"
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "definitionVersion",
+            "value": "2.*.*",
+            "selectors": [
+              {
+                "kind": "resourceLocation",
+                "in": [
+                  "eastUSEuap",
+                  "centralUSEuap"
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "displayName": "Limit the resource location and resource SKU",
+          "description": "Limit the resource location and resource SKU",
+          "metadata": {
+            "assignedBy": "Special Someone"
+          },
+          "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policySetDefinitions/CostManagement",
+          "definitionVersion": "1.*.*",
+          "notScopes": [],
+          "enforcementMode": "Default",
+          "scope": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+          "overrides": [
+            {
+              "kind": "policyEffect",
+              "value": "Audit",
+              "selectors": [
+                {
+                  "kind": "policyDefinitionReferenceId",
+                  "in": [
+                    "Limit_Skus",
+                    "Limit_Locations"
+                  ]
+                }
+              ]
+            }
+          ],
+          "instanceId": "a3c4d5e6-f7a8-9b0c-1d2e-3f4a5b6c7d8e"
+        },
+        "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyAssignments/CostManagement",
+        "type": "Microsoft.Authorization/policyAssignments",
+        "name": "CostManagement"
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createPolicyAssignmentWithResourceSelectors.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createPolicyAssignmentWithResourceSelectors.json
@@ -1,0 +1,68 @@
+{
+  "parameters": {
+    "scope": "subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "policyAssignmentName": "CostManagement",
+    "api-version": "2025-03-01",
+    "parameters": {
+      "properties": {
+        "displayName": "Limit the resource location and resource SKU",
+        "description": "Limit the resource location and resource SKU",
+        "metadata": {
+          "assignedBy": "Special Someone"
+        },
+        "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policySetDefinitions/CostManagement",
+        "resourceSelectors": [
+          {
+            "name": "SDPRegions",
+            "selectors": [
+              {
+                "kind": "resourceLocation",
+                "in": [
+                  "eastus2euap",
+                  "centraluseuap"
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "displayName": "Limit the resource location and resource SKU",
+          "description": "Limit the resource location and resource SKU",
+          "metadata": {
+            "assignedBy": "Special Someone"
+          },
+          "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policySetDefinitions/CostManagement",
+          "definitionVersion": "1.*.*",
+          "notScopes": [],
+          "enforcementMode": "Default",
+          "scope": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+          "resourceSelectors": [
+            {
+              "name": "SDPRegions",
+              "selectors": [
+                {
+                  "kind": "resourceLocation",
+                  "in": [
+                    "eastus2euap",
+                    "centraluseuap"
+                  ]
+                }
+              ]
+            }
+          ],
+          "instanceId": "a3c4d5e6-f7a8-9b0c-1d2e-3f4a5b6c7d8e"
+        },
+        "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyAssignments/CostManagement",
+        "type": "Microsoft.Authorization/policyAssignments",
+        "name": "CostManagement"
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createPolicyAssignmentWithUserAssignedIdentity.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createPolicyAssignmentWithUserAssignedIdentity.json
@@ -1,0 +1,74 @@
+{
+  "parameters": {
+    "scope": "subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "policyAssignmentName": "EnforceNaming",
+    "api-version": "2025-03-01",
+    "parameters": {
+      "location": "eastus",
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/resourceGroups/testResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-identity": {}
+        }
+      },
+      "properties": {
+        "displayName": "Enforce resource naming rules",
+        "description": "Force resource names to begin with given DeptA and end with -LC",
+        "metadata": {
+          "assignedBy": "Foo Bar"
+        },
+        "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+        "parameters": {
+          "prefix": {
+            "value": "DeptA"
+          },
+          "suffix": {
+            "value": "-LC"
+          }
+        },
+        "enforcementMode": "Default"
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "displayName": "Enforce resource naming rules",
+          "description": "Force resource names to begin with given DeptA and end with -LC",
+          "metadata": {
+            "assignedBy": "Special Someone"
+          },
+          "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+          "definitionVersion": "1.*.*",
+          "notScopes": [],
+          "parameters": {
+            "prefix": {
+              "value": "DeptA"
+            },
+            "suffix": {
+              "value": "-LC"
+            }
+          },
+          "enforcementMode": "Default",
+          "scope": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+          "instanceId": "e4b0f5a6-7c8d-4e9f-8a1b-2c3d4e5f6a7b"
+        },
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/resourceGroups/testResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-identity": {
+              "principalId": "e6d23f8d-af97-4fbc-bda6-00604e4e3d0a",
+              "clientId": "4bee2b8a-1bee-47c2-90e9-404241551135"
+            }
+          }
+        },
+        "location": "eastus",
+        "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyAssignments/EnforceNaming",
+        "type": "Microsoft.Authorization/policyAssignments",
+        "name": "EnforceNaming"
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createPolicyAssignmentWithoutEnforcement.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/createPolicyAssignmentWithoutEnforcement.json
@@ -1,0 +1,57 @@
+{
+  "parameters": {
+    "scope": "subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "policyAssignmentName": "EnforceNaming",
+    "api-version": "2025-03-01",
+    "parameters": {
+      "properties": {
+        "displayName": "Enforce resource naming rules",
+        "description": "Force resource names to begin with given DeptA and end with -LC",
+        "metadata": {
+          "assignedBy": "Special Someone"
+        },
+        "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+        "parameters": {
+          "prefix": {
+            "value": "DeptA"
+          },
+          "suffix": {
+            "value": "-LC"
+          }
+        },
+        "enforcementMode": "DoNotEnforce"
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "displayName": "Enforce resource naming rules",
+          "description": "Force resource names to begin with given DeptA and end with -LC",
+          "metadata": {
+            "assignedBy": "Special Someone"
+          },
+          "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+          "definitionVersion": "1.*.*",
+          "notScopes": [],
+          "parameters": {
+            "prefix": {
+              "value": "DeptA"
+            },
+            "suffix": {
+              "value": "-LC"
+            }
+          },
+          "enforcementMode": "DoNotEnforce",
+          "scope": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+          "instanceId": "e4b0f5a6-7c8d-4e9f-8a1b-2c3d4e5f6a7b"
+        },
+        "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyAssignments/EnforceNaming",
+        "type": "Microsoft.Authorization/policyAssignments",
+        "name": "EnforceNaming"
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/deletePolicyAssignment.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/deletePolicyAssignment.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "scope": "subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "policyAssignmentName": "EnforceNaming",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "displayName": "Enforce resource naming rules",
+          "description": "Force resource names to begin with given DeptA and end with -LC",
+          "metadata": {
+            "assignedBy": "Special Someone"
+          },
+          "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+          "definitionVersion": "1.*.*",
+          "notScopes": [],
+          "parameters": {
+            "prefix": {
+              "value": "DeptA"
+            },
+            "suffix": {
+              "value": "-LC"
+            }
+          },
+          "scope": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+          "instanceId": "e4b0f5a6-7c8d-4e9f-8a1b-2c3d4e5f6a7b"
+        },
+        "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyAssignments/EnforceNaming",
+        "type": "Microsoft.Authorization/policyAssignments",
+        "name": "EnforceNaming"
+      }
+    },
+    "204": {
+      "headers": {}
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/deletePolicyAssignmentById.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/deletePolicyAssignmentById.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "policyAssignmentId": "providers/Microsoft.Management/managementGroups/MyManagementGroup/providers/Microsoft.Authorization/policyAssignments/LowCostStorage",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "displayName": "Enforce storage account SKU",
+          "description": "Allow only storage accounts of SKU Standard_GRS or Standard_LRS to be created",
+          "metadata": {
+            "assignedBy": "Cheapskate Boss"
+          },
+          "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+          "definitionVersion": "1.*.*",
+          "notScopes": [],
+          "parameters": {
+            "listOfAllowedSKUs": {
+              "value": [
+                "Standard_GRS",
+                "Standard_LRS"
+              ]
+            }
+          },
+          "instanceId": "b7e0f8a9-1c2d-4e3f-8b4c-5d6e7f8a9b0c"
+        },
+        "id": "/providers/Microsoft.Management/managementGroups/MyManagementGroup/providers/Microsoft.Authorization/policyAssignments/LowCostStorage",
+        "type": "Microsoft.Authorization/policyAssignments",
+        "name": "LowCostStorage"
+      }
+    },
+    "204": {
+      "headers": {}
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/deletePolicyDefinition.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/deletePolicyDefinition.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "subscriptionId": "ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "policyDefinitionName": "ResourceNaming",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {}
+    },
+    "204": {
+      "headers": {}
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/deletePolicyDefinitionAtManagementGroup.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/deletePolicyDefinitionAtManagementGroup.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "managementGroupId": "MyManagementGroup",
+    "policyDefinitionName": "ResourceNaming",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {}
+    },
+    "204": {
+      "headers": {}
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/deletePolicyDefinitionVersion.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/deletePolicyDefinitionVersion.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "subscriptionId": "ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "policyDefinitionName": "ResourceNaming",
+    "policyDefinitionVersion": "1.2.1",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {}
+    },
+    "204": {
+      "headers": {}
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/deletePolicyDefinitionVersionAtManagementGroup.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/deletePolicyDefinitionVersionAtManagementGroup.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "managementGroupName": "MyManagementGroup",
+    "policyDefinitionName": "ResourceNaming",
+    "policyDefinitionVersion": "1.2.1",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {}
+    },
+    "204": {
+      "headers": {}
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/deletePolicySetDefinition.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/deletePolicySetDefinition.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "subscriptionId": "ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "policySetDefinitionName": "CostManagement",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {}
+    },
+    "204": {
+      "headers": {}
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/deletePolicySetDefinitionAtManagementGroup.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/deletePolicySetDefinitionAtManagementGroup.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "managementGroupId": "MyManagementGroup",
+    "policySetDefinitionName": "CostManagement",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {}
+    },
+    "204": {
+      "headers": {}
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/deletePolicySetDefinitionVersion.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/deletePolicySetDefinitionVersion.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "subscriptionId": "ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "policySetDefinitionName": "CostManagement",
+    "policyDefinitionVersion": "1.2.1",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {}
+    },
+    "204": {
+      "headers": {}
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/deletePolicySetDefinitionVersionAtManagementGroup.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/deletePolicySetDefinitionVersionAtManagementGroup.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "managementGroupName": "MyManagementGroup",
+    "policySetDefinitionName": "CostManagement",
+    "policyDefinitionVersion": "1.2.1",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {}
+    },
+    "204": {
+      "headers": {}
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/getBuiltInPolicySetDefinition.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/getBuiltInPolicySetDefinition.json
@@ -1,0 +1,82 @@
+{
+  "parameters": {
+    "policySetDefinitionName": "1f3afdf9-d0c9-4c3d-847f-89da613e70a8",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "displayName": "[Preview]: Enable Monitoring in Azure Security Center",
+          "policyType": "BuiltIn",
+          "description": "Monitor all the available security recommendations in Azure Security Center. This is the default policy for Azure Security Center.",
+          "metadata": {
+            "category": "Security Center"
+          },
+          "version": "1.2.1",
+          "versions": [
+            "1.2.1",
+            "1.0.0"
+          ],
+          "parameters": {},
+          "policyDefinitions": [
+            {
+              "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/a8bef009-a5c9-4d0f-90d7-6018734e8a16",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "RefId1"
+            },
+            {
+              "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/af8051bf-258b-44e2-a2bf-165330459f9d",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "RefId2"
+            },
+            {
+              "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/86b3d65f-7626-441e-b690-81a8b71cff60",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "RefId3"
+            },
+            {
+              "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/655cb504-bcee-4362-bd4c-402e6aa38759",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "RefId4"
+            },
+            {
+              "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/b0f33259-77d7-4c9e-aac6-3aabcfae693c",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "RefId5"
+            },
+            {
+              "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/47a6b606-51aa-4496-8bb7-64b11cf66adc",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "RefId6"
+            },
+            {
+              "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/44452482-524f-4bf4-b852-0bff7cc4a3ed",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "RefId7"
+            },
+            {
+              "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/e1e5fd5d-3e4c-4ce1-8661-7d1873ae6b15",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "RefId8"
+            },
+            {
+              "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/af6cd1bd-1635-48cb-bde7-5b15693900b9",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "RefId9"
+            },
+            {
+              "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/0961003e-5a0a-4549-abde-af6a37f2724d",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "RefId10"
+            }
+          ]
+        },
+        "id": "/providers/Microsoft.Authorization/policySetDefinitions/1f3afdf9-d0c9-4c3d-847f-89da613e70a8",
+        "type": "Microsoft.Authorization/policySetDefinitions",
+        "name": "1f3afdf9-d0c9-4c3d-847f-89da613e70a8"
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/getBuiltInPolicySetDefinitionVersion.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/getBuiltInPolicySetDefinitionVersion.json
@@ -1,0 +1,79 @@
+{
+  "parameters": {
+    "policySetDefinitionName": "1f3afdf9-d0c9-4c3d-847f-89da613e70a8",
+    "policyDefinitionVersion": "1.2.1",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "displayName": "[Preview]: Enable Monitoring in Azure Security Center",
+          "policyType": "BuiltIn",
+          "description": "Monitor all the available security recommendations in Azure Security Center. This is the default policy for Azure Security Center.",
+          "metadata": {
+            "category": "Security Center"
+          },
+          "version": "1.2.1",
+          "parameters": {},
+          "policyDefinitions": [
+            {
+              "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/a8bef009-a5c9-4d0f-90d7-6018734e8a16",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "RefId1"
+            },
+            {
+              "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/af8051bf-258b-44e2-a2bf-165330459f9d",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "RefId2"
+            },
+            {
+              "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/86b3d65f-7626-441e-b690-81a8b71cff60",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "RefId3"
+            },
+            {
+              "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/655cb504-bcee-4362-bd4c-402e6aa38759",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "RefId4"
+            },
+            {
+              "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/b0f33259-77d7-4c9e-aac6-3aabcfae693c",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "RefId5"
+            },
+            {
+              "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/47a6b606-51aa-4496-8bb7-64b11cf66adc",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "RefId6"
+            },
+            {
+              "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/44452482-524f-4bf4-b852-0bff7cc4a3ed",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "RefId7"
+            },
+            {
+              "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/e1e5fd5d-3e4c-4ce1-8661-7d1873ae6b15",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "RefId8"
+            },
+            {
+              "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/af6cd1bd-1635-48cb-bde7-5b15693900b9",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "RefId9"
+            },
+            {
+              "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/0961003e-5a0a-4549-abde-af6a37f2724d",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "RefId10"
+            }
+          ]
+        },
+        "id": "/providers/Microsoft.Authorization/policySetDefinitions/1f3afdf9-d0c9-4c3d-847f-89da613e70a8/versions/1.2.1",
+        "type": "Microsoft.Authorization/policySetDefinitions/versions",
+        "name": "1.2.1"
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/getBuiltinPolicyDefinition.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/getBuiltinPolicyDefinition.json
@@ -1,0 +1,57 @@
+{
+  "parameters": {
+    "subscriptionId": "ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "policyDefinitionName": "7433c107-6db4-4ad1-b57a-a76dce0154a1",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "mode": "All",
+          "displayName": "Allowed storage account SKUs",
+          "policyType": "BuiltIn",
+          "description": "This policy enables you to specify a set of storage account SKUs that your organization can deploy.",
+          "parameters": {
+            "listOfAllowedSKUs": {
+              "type": "Array",
+              "metadata": {
+                "description": "The list of SKUs that can be specified for storage accounts.",
+                "displayName": "Allowed SKUs",
+                "strongType": "StorageSKUs"
+              }
+            }
+          },
+          "version": "1.2.1",
+          "versions": [
+            "1.2.1",
+            "1.0.0"
+          ],
+          "policyRule": {
+            "if": {
+              "allOf": [
+                {
+                  "field": "type",
+                  "equals": "Microsoft.Storage/storageAccounts"
+                },
+                {
+                  "not": {
+                    "field": "Microsoft.Storage/storageAccounts/sku.name",
+                    "in": "[parameters('listOfAllowedSKUs')]"
+                  }
+                }
+              ]
+            },
+            "then": {
+              "effect": "Deny"
+            }
+          }
+        },
+        "id": "/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+        "type": "Microsoft.Authorization/policyDefinitions",
+        "name": "7433c107-6db4-4ad1-b57a-a76dce0154a1"
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/getBuiltinPolicyDefinitionVersion.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/getBuiltinPolicyDefinitionVersion.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "subscriptionId": "ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "policyDefinitionName": "7433c107-6db4-4ad1-b57a-a76dce0154a1",
+    "policyDefinitionVersion": "1.2.1",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "mode": "All",
+          "displayName": "Allowed storage account SKUs",
+          "policyType": "BuiltIn",
+          "description": "This policy enables you to specify a set of storage account SKUs that your organization can deploy.",
+          "parameters": {
+            "listOfAllowedSKUs": {
+              "type": "Array",
+              "metadata": {
+                "description": "The list of SKUs that can be specified for storage accounts.",
+                "displayName": "Allowed SKUs",
+                "strongType": "StorageSKUs"
+              }
+            }
+          },
+          "version": "1.2.1",
+          "policyRule": {
+            "if": {
+              "allOf": [
+                {
+                  "field": "type",
+                  "equals": "Microsoft.Storage/storageAccounts"
+                },
+                {
+                  "not": {
+                    "field": "Microsoft.Storage/storageAccounts/sku.name",
+                    "in": "[parameters('listOfAllowedSKUs')]"
+                  }
+                }
+              ]
+            },
+            "then": {
+              "effect": "Deny"
+            }
+          }
+        },
+        "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1/versions/1.2.1",
+        "type": "Microsoft.Authorization/policyDefinitions/versions",
+        "name": "1.2.1"
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/getPolicyAssignment.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/getPolicyAssignment.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "scope": "subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "policyAssignmentName": "EnforceNaming",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "displayName": "Enforce resource naming rules",
+          "description": "Force resource names to begin with given DeptA and end with -LC",
+          "metadata": {
+            "assignedBy": "Special Someone"
+          },
+          "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+          "definitionVersion": "1.*.*",
+          "notScopes": [],
+          "parameters": {
+            "prefix": {
+              "value": "DeptA"
+            },
+            "suffix": {
+              "value": "-LC"
+            }
+          },
+          "enforcementMode": "Default",
+          "scope": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+          "instanceId": "e4b0f5a6-7c8d-4e9f-8a1b-2c3d4e5f6a7b"
+        },
+        "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyAssignments/EnforceNaming",
+        "type": "Microsoft.Authorization/policyAssignments",
+        "name": "EnforceNaming"
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/getPolicyAssignmentById.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/getPolicyAssignmentById.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "policyAssignmentId": "providers/Microsoft.Management/managementGroups/MyManagementGroup/providers/Microsoft.Authorization/policyAssignments/LowCostStorage",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "displayName": "Enforce storage account SKU",
+          "description": "Allow only storage accounts of SKU Standard_GRS or Standard_LRS to be created",
+          "metadata": {
+            "assignedBy": "Cheapskate Boss"
+          },
+          "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+          "definitionVersion": "1.*.*",
+          "notScopes": [],
+          "parameters": {
+            "listOfAllowedSKUs": {
+              "value": [
+                "Standard_GRS",
+                "Standard_LRS"
+              ]
+            }
+          },
+          "enforcementMode": "Default",
+          "instanceId": "b7e0f8a9-1c2d-4e3f-8b4c-5d6e7f8a9b0c"
+        },
+        "id": "/providers/Microsoft.Management/managementGroups/MyManagementGroup/providers/Microsoft.Authorization/policyAssignments/LowCostStorage",
+        "type": "Microsoft.Authorization/policyAssignments",
+        "name": "LowCostStorage"
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/getPolicyAssignmentWithIdentity.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/getPolicyAssignmentWithIdentity.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "scope": "subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "policyAssignmentName": "EnforceNaming",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "displayName": "Enforce resource naming rules",
+          "description": "Force resource names to begin with given DeptA and end with -LC",
+          "metadata": {
+            "assignedBy": "Special Someone"
+          },
+          "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+          "definitionVersion": "1.*.*",
+          "notScopes": [],
+          "parameters": {
+            "prefix": {
+              "value": "DeptA"
+            },
+            "suffix": {
+              "value": "-LC"
+            }
+          },
+          "enforcementMode": "Default",
+          "scope": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+          "instanceId": "e4b0f5a6-7c8d-4e9f-8a1b-2c3d4e5f6a7b"
+        },
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "e6d23f8d-af97-4fbc-bda6-00604e4e3d0a",
+          "tenantId": "4bee2b8a-1bee-47c2-90e9-404241551135"
+        },
+        "location": "westus",
+        "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyAssignments/EnforceNaming",
+        "type": "Microsoft.Authorization/policyAssignments",
+        "name": "EnforceNaming"
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/getPolicyAssignmentWithIdentityById.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/getPolicyAssignmentWithIdentityById.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "policyAssignmentId": "providers/Microsoft.Management/managementGroups/MyManagementGroup/providers/Microsoft.Authorization/policyAssignments/LowCostStorage",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "displayName": "Enforce storage account SKU",
+          "description": "Allow only storage accounts of SKU Standard_GRS or Standard_LRS to be created",
+          "metadata": {
+            "assignedBy": "Cheapskate Boss"
+          },
+          "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+          "definitionVersion": "1.*.*",
+          "notScopes": [],
+          "parameters": {
+            "listOfAllowedSKUs": {
+              "value": [
+                "Standard_GRS",
+                "Standard_LRS"
+              ]
+            }
+          },
+          "enforcementMode": "Default",
+          "instanceId": "b7e0f8a9-1c2d-4e3f-8b4c-5d6e7f8a9b0c"
+        },
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "e6d23f8d-af97-4fbc-bda6-00604e4e3d0a",
+          "tenantId": "4bee2b8a-1bee-47c2-90e9-404241551135"
+        },
+        "location": "westus",
+        "id": "/providers/Microsoft.Management/managementGroups/MyManagementGroup/providers/Microsoft.Authorization/policyAssignments/LowCostStorage",
+        "type": "Microsoft.Authorization/policyAssignments",
+        "name": "LowCostStorage"
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/getPolicyAssignmentWithOverrides.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/getPolicyAssignmentWithOverrides.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "scope": "subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "policyAssignmentName": "CostManagement",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "displayName": "Limit the resource location and resource SKU",
+          "description": "Limit the resource location and resource SKU",
+          "metadata": {
+            "assignedBy": "Special Someone"
+          },
+          "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policySetDefinitions/CostManagement",
+          "definitionVersion": "1.*.*",
+          "notScopes": [],
+          "enforcementMode": "Default",
+          "scope": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+          "overrides": [
+            {
+              "kind": "policyEffect",
+              "value": "Audit",
+              "selectors": [
+                {
+                  "kind": "policyDefinitionReferenceId",
+                  "in": [
+                    "Limit_Skus",
+                    "Limit_Locations"
+                  ]
+                }
+              ]
+            }
+          ],
+          "instanceId": "d2f3a4b5-c6d7-8e9f-0a1b-2c3d4e5f6a7b"
+        },
+        "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyAssignments/CostManagement",
+        "type": "Microsoft.Authorization/policyAssignments",
+        "name": "CostManagement"
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/getPolicyAssignmentWithResourceSelectors.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/getPolicyAssignmentWithResourceSelectors.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "scope": "subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "policyAssignmentName": "CostManagement",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "displayName": "Limit the resource location and resource SKU",
+          "description": "Limit the resource location and resource SKU",
+          "metadata": {
+            "assignedBy": "Special Someone"
+          },
+          "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policySetDefinitions/CostManagement",
+          "definitionVersion": "1.*.*",
+          "notScopes": [],
+          "enforcementMode": "Default",
+          "scope": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+          "resourceSelectors": [
+            {
+              "name": "SDPRegions",
+              "selectors": [
+                {
+                  "kind": "resourceLocation",
+                  "in": [
+                    "eastus2euap",
+                    "centraluseuap"
+                  ]
+                }
+              ]
+            }
+          ],
+          "instanceId": "a3c4d5e6-f7a8-9b0c-1d2e-3f4a5b6c7d8e"
+        },
+        "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyAssignments/CostManagement",
+        "type": "Microsoft.Authorization/policyAssignments",
+        "name": "CostManagement"
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/getPolicyAssignmentWithUserAssignedIdentity.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/getPolicyAssignmentWithUserAssignedIdentity.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "scope": "subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "policyAssignmentName": "EnforceNaming",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "displayName": "Enforce resource naming rules",
+          "description": "Force resource names to begin with given DeptA and end with -LC",
+          "metadata": {
+            "assignedBy": "Special Someone"
+          },
+          "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+          "definitionVersion": "1.*.*",
+          "notScopes": [],
+          "parameters": {
+            "prefix": {
+              "value": "DeptA"
+            },
+            "suffix": {
+              "value": "-LC"
+            }
+          },
+          "enforcementMode": "Default",
+          "scope": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+          "instanceId": "e4b0f5a6-7c8d-4e9f-8a1b-2c3d4e5f6a7b"
+        },
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/resourceGroups/testResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-identity": {
+              "principalId": "e6d23f8d-af97-4fbc-bda6-00604e4e3d0a",
+              "clientId": "4bee2b8a-1bee-47c2-90e9-404241551135"
+            }
+          }
+        },
+        "location": "westus",
+        "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyAssignments/EnforceNaming",
+        "type": "Microsoft.Authorization/policyAssignments",
+        "name": "EnforceNaming"
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/getPolicyDefinition.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/getPolicyDefinition.json
@@ -1,0 +1,58 @@
+{
+  "parameters": {
+    "subscriptionId": "ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "policyDefinitionName": "ResourceNaming",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "mode": "All",
+          "displayName": "Naming Convention",
+          "description": "Force resource names to begin with 'prefix' and end with 'suffix'",
+          "metadata": {
+            "category": "Naming"
+          },
+          "version": "1.2.1",
+          "versions": [
+            "1.2.1",
+            "1.0.0"
+          ],
+          "policyRule": {
+            "if": {
+              "not": {
+                "field": "name",
+                "like": "[concat(parameters('prefix'), '*', parameters('suffix'))]"
+              }
+            },
+            "then": {
+              "effect": "deny"
+            }
+          },
+          "parameters": {
+            "prefix": {
+              "type": "String",
+              "metadata": {
+                "displayName": "Prefix",
+                "description": "Resource name prefix"
+              }
+            },
+            "suffix": {
+              "type": "String",
+              "metadata": {
+                "displayName": "Suffix",
+                "description": "Resource name suffix"
+              }
+            }
+          },
+          "policyType": "Custom"
+        },
+        "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+        "type": "Microsoft.Authorization/policyDefinitions",
+        "name": "ResourceNaming"
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/getPolicyDefinitionAtManagementGroup.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/getPolicyDefinitionAtManagementGroup.json
@@ -1,0 +1,58 @@
+{
+  "parameters": {
+    "managementGroupId": "MyManagementGroup",
+    "policyDefinitionName": "ResourceNaming",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "id": "/providers/Microsoft.Management/managementgroups/MyManagementGroup/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+        "type": "Microsoft.Authorization/policyDefinitions",
+        "name": "ResourceNaming",
+        "properties": {
+          "mode": "All",
+          "displayName": "Naming Convention",
+          "description": "Force resource names to begin with 'prefix' and end with 'suffix'",
+          "metadata": {
+            "category": "Naming"
+          },
+          "version": "1.2.1",
+          "versions": [
+            "1.2.1",
+            "1.0.0"
+          ],
+          "policyRule": {
+            "if": {
+              "not": {
+                "field": "name",
+                "like": "[concat(parameters('prefix'), '*', parameters('suffix'))]"
+              }
+            },
+            "then": {
+              "effect": "deny"
+            }
+          },
+          "parameters": {
+            "prefix": {
+              "type": "String",
+              "metadata": {
+                "displayName": "Prefix",
+                "description": "Resource name prefix"
+              }
+            },
+            "suffix": {
+              "type": "String",
+              "metadata": {
+                "displayName": "Suffix",
+                "description": "Resource name suffix"
+              }
+            }
+          },
+          "policyType": "Custom"
+        }
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/getPolicyDefinitionVersion.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/getPolicyDefinitionVersion.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "subscriptionId": "ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "policyDefinitionName": "ResourceNaming",
+    "policyDefinitionVersion": "1.2.1",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "mode": "All",
+          "displayName": "Naming Convention",
+          "description": "Force resource names to begin with 'prefix' and end with 'suffix'",
+          "metadata": {
+            "category": "Naming"
+          },
+          "version": "1.2.1",
+          "policyRule": {
+            "if": {
+              "not": {
+                "field": "name",
+                "like": "[concat(parameters('prefix'), '*', parameters('suffix'))]"
+              }
+            },
+            "then": {
+              "effect": "deny"
+            }
+          },
+          "parameters": {
+            "prefix": {
+              "type": "String",
+              "metadata": {
+                "displayName": "Prefix",
+                "description": "Resource name prefix"
+              }
+            },
+            "suffix": {
+              "type": "String",
+              "metadata": {
+                "displayName": "Suffix",
+                "description": "Resource name suffix"
+              }
+            }
+          },
+          "policyType": "Custom"
+        },
+        "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming/versions/1.2.1",
+        "type": "Microsoft.Authorization/policyDefinitions/versions",
+        "name": "1.2.1"
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/getPolicyDefinitionVersionAtManagementGroup.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/getPolicyDefinitionVersionAtManagementGroup.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "managementGroupName": "MyManagementGroup",
+    "policyDefinitionName": "ResourceNaming",
+    "policyDefinitionVersion": "1.2.1",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "id": "/providers/Microsoft.Management/managementgroups/MyManagementGroup/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming/versions/1.2.1",
+        "type": "Microsoft.Authorization/policyDefinitions/versions",
+        "name": "1.2.1",
+        "properties": {
+          "mode": "All",
+          "displayName": "Naming Convention",
+          "description": "Force resource names to begin with 'prefix' and end with 'suffix'",
+          "metadata": {
+            "category": "Naming"
+          },
+          "version": "1.2.1",
+          "policyRule": {
+            "if": {
+              "not": {
+                "field": "name",
+                "like": "[concat(parameters('prefix'), '*', parameters('suffix'))]"
+              }
+            },
+            "then": {
+              "effect": "deny"
+            }
+          },
+          "parameters": {
+            "prefix": {
+              "type": "String",
+              "metadata": {
+                "displayName": "Prefix",
+                "description": "Resource name prefix"
+              }
+            },
+            "suffix": {
+              "type": "String",
+              "metadata": {
+                "displayName": "Suffix",
+                "description": "Resource name suffix"
+              }
+            }
+          },
+          "policyType": "Custom"
+        }
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/getPolicySetDefinition.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/getPolicySetDefinition.json
@@ -1,0 +1,75 @@
+{
+  "parameters": {
+    "subscriptionId": "ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "policySetDefinitionName": "CostManagement",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policySetDefinitions/CostManagement",
+        "type": "Microsoft.Authorization/policySetDefinitions",
+        "name": "CostManagement",
+        "properties": {
+          "displayName": "Cost Management",
+          "description": "Policies to enforce low cost storage SKUs",
+          "metadata": {
+            "category": "Cost Management"
+          },
+          "version": "1.2.1",
+          "versions": [
+            "1.2.1",
+            "1.0.0"
+          ],
+          "policyDefinitionGroups": [
+            {
+              "name": "CostSaving",
+              "displayName": "Cost Management Policies",
+              "description": "Policies designed to control spend within a subscription."
+            },
+            {
+              "name": "Organizational",
+              "displayName": "Organizational Policies",
+              "description": "Policies that help enforce resource organization standards within a subscription."
+            }
+          ],
+          "policyDefinitions": [
+            {
+              "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "Limit_Skus",
+              "groupNames": [
+                "CostSaving"
+              ],
+              "parameters": {
+                "listOfAllowedSKUs": {
+                  "value": [
+                    "Standard_GRS",
+                    "Standard_LRS"
+                  ]
+                }
+              }
+            },
+            {
+              "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "Resource_Naming",
+              "groupNames": [
+                "Organizational"
+              ],
+              "parameters": {
+                "prefix": {
+                  "value": "DeptA"
+                },
+                "suffix": {
+                  "value": "-LC"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/getPolicySetDefinitionAtManagementGroup.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/getPolicySetDefinitionAtManagementGroup.json
@@ -1,0 +1,57 @@
+{
+  "parameters": {
+    "managementGroupId": "MyManagementGroup",
+    "policySetDefinitionName": "CostManagement",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "id": "/providers/Microsoft.Management/managementgroups/MyManagementGroup/providers/Microsoft.Authorization/policySetDefinitions/CostManagement",
+        "type": "Microsoft.Authorization/policySetDefinitions",
+        "name": "CostManagement",
+        "properties": {
+          "displayName": "Cost Management",
+          "description": "Policies to enforce low cost storage SKUs",
+          "metadata": {
+            "category": "Cost Management"
+          },
+          "version": "1.2.1",
+          "versions": [
+            "1.2.1",
+            "1.0.0"
+          ],
+          "policyDefinitions": [
+            {
+              "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "Limit_Skus",
+              "parameters": {
+                "listOfAllowedSKUs": {
+                  "value": [
+                    "Standard_GRS",
+                    "Standard_LRS"
+                  ]
+                }
+              }
+            },
+            {
+              "policyDefinitionId": "/providers/Microsoft.Management/managementgroups/MyManagementGroup/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "Resource_Naming",
+              "parameters": {
+                "prefix": {
+                  "value": "DeptA"
+                },
+                "suffix": {
+                  "value": "-LC"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/getPolicySetDefinitionVersion.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/getPolicySetDefinitionVersion.json
@@ -1,0 +1,72 @@
+{
+  "parameters": {
+    "subscriptionId": "ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "policySetDefinitionName": "CostManagement",
+    "policyDefinitionVersion": "1.2.1",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policySetDefinitions/CostManagement/versions/1.2.1",
+        "type": "Microsoft.Authorization/policySetDefinitions/versions",
+        "name": "1.2.1",
+        "properties": {
+          "displayName": "Cost Management",
+          "description": "Policies to enforce low cost storage SKUs",
+          "metadata": {
+            "category": "Cost Management"
+          },
+          "version": "1.2.1",
+          "policyDefinitionGroups": [
+            {
+              "name": "CostSaving",
+              "displayName": "Cost Management Policies",
+              "description": "Policies designed to control spend within a subscription."
+            },
+            {
+              "name": "Organizational",
+              "displayName": "Organizational Policies",
+              "description": "Policies that help enforce resource organization standards within a subscription."
+            }
+          ],
+          "policyDefinitions": [
+            {
+              "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "Limit_Skus",
+              "groupNames": [
+                "CostSaving"
+              ],
+              "parameters": {
+                "listOfAllowedSKUs": {
+                  "value": [
+                    "Standard_GRS",
+                    "Standard_LRS"
+                  ]
+                }
+              }
+            },
+            {
+              "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "Resource_Naming",
+              "groupNames": [
+                "Organizational"
+              ],
+              "parameters": {
+                "prefix": {
+                  "value": "DeptA"
+                },
+                "suffix": {
+                  "value": "-LC"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/getPolicySetDefinitionVersionAtManagementGroup.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/getPolicySetDefinitionVersionAtManagementGroup.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "managementGroupName": "MyManagementGroup",
+    "policySetDefinitionName": "CostManagement",
+    "policyDefinitionVersion": "1.2.1",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "id": "/providers/Microsoft.Management/managementgroups/MyManagementGroup/providers/Microsoft.Authorization/policySetDefinitions/CostManagement/versions/1.2.1",
+        "type": "Microsoft.Authorization/policySetDefinitions/versions",
+        "name": "1.2.1",
+        "properties": {
+          "displayName": "Cost Management",
+          "description": "Policies to enforce low cost storage SKUs",
+          "metadata": {
+            "category": "Cost Management"
+          },
+          "version": "1.2.1",
+          "policyDefinitions": [
+            {
+              "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "Limit_Skus",
+              "parameters": {
+                "listOfAllowedSKUs": {
+                  "value": [
+                    "Standard_GRS",
+                    "Standard_LRS"
+                  ]
+                }
+              }
+            },
+            {
+              "policyDefinitionId": "/providers/Microsoft.Management/managementgroups/MyManagementGroup/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+              "definitionVersion": "1.*.*",
+              "policyDefinitionReferenceId": "Resource_Naming",
+              "parameters": {
+                "prefix": {
+                  "value": "DeptA"
+                },
+                "suffix": {
+                  "value": "-LC"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listAllBuiltInPolicyDefinitionVersions.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listAllBuiltInPolicyDefinitionVersions.json
@@ -1,0 +1,105 @@
+{
+  "parameters": {
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "mode": "All",
+              "displayName": "Audit SQL DB Level Audit Setting",
+              "policyType": "BuiltIn",
+              "description": "Audit DB level audit setting for SQL databases",
+              "parameters": {
+                "setting": {
+                  "type": "String",
+                  "metadata": {
+                    "displayName": "Audit Setting"
+                  },
+                  "allowedValues": [
+                    "enabled",
+                    "disabled"
+                  ]
+                }
+              },
+              "version": "1.2.1",
+              "policyRule": {
+                "if": {
+                  "field": "type",
+                  "equals": "Microsoft.Sql/servers/databases"
+                },
+                "then": {
+                  "effect": "AuditIfNotExists",
+                  "details": {
+                    "type": "Microsoft.Sql/servers/databases/auditingSettings",
+                    "name": "default",
+                    "existenceCondition": {
+                      "allOf": [
+                        {
+                          "field": "Microsoft.Sql/auditingSettings.state",
+                          "equals": "[parameters('setting')]"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "id": "/providers/Microsoft.Authorization/policyDefinitions/06a78e20-9358-41c9-923c-fb736d382a12/versions/1.2.1",
+            "type": "Microsoft.Authorization/policyDefinitions/versions",
+            "name": "1.2.1"
+          },
+          {
+            "properties": {
+              "mode": "All",
+              "displayName": "Audit SQL DB Level Audit Setting",
+              "policyType": "BuiltIn",
+              "description": "Audit DB level audit setting for SQL databases",
+              "parameters": {
+                "setting": {
+                  "type": "String",
+                  "metadata": {
+                    "displayName": "Audit Setting"
+                  },
+                  "allowedValues": [
+                    "enabled",
+                    "disabled",
+                    "default"
+                  ]
+                }
+              },
+              "version": "1.0.0",
+              "policyRule": {
+                "if": {
+                  "field": "type",
+                  "equals": "Microsoft.Sql/servers/databases"
+                },
+                "then": {
+                  "effect": "AuditIfNotExists",
+                  "details": {
+                    "type": "Microsoft.Sql/servers/databases/auditingSettings",
+                    "name": "default",
+                    "existenceCondition": {
+                      "allOf": [
+                        {
+                          "field": "Microsoft.Sql/auditingSettings.state",
+                          "equals": "[parameters('setting')]"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "id": "/providers/Microsoft.Authorization/policyDefinitions/06a78e20-9358-41c9-923c-fb736d382a12/versions/1.0.0",
+            "type": "Microsoft.Authorization/policyDefinitions/versions",
+            "name": "1.0.0"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listAllBuiltInPolicySetDefinitionVersions.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listAllBuiltInPolicySetDefinitionVersions.json
@@ -1,0 +1,81 @@
+{
+  "parameters": {
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "displayName": "[Preview]: Enable Monitoring in Azure Security Center",
+              "policyType": "BuiltIn",
+              "description": "Monitor all the available security recommendations in Azure Security Center. This is the default policy for Azure Security Center.",
+              "metadata": {
+                "category": "Security Center"
+              },
+              "version": "1.2.1",
+              "parameters": {},
+              "policyDefinitions": [
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/a8bef009-a5c9-4d0f-90d7-6018734e8a16",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId1"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/af8051bf-258b-44e2-a2bf-165330459f9d",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId2"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/86b3d65f-7626-441e-b690-81a8b71cff60",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId3"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/655cb504-bcee-4362-bd4c-402e6aa38759",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId4"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/b0f33259-77d7-4c9e-aac6-3aabcfae693c",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId5"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/47a6b606-51aa-4496-8bb7-64b11cf66adc",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId6"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/44452482-524f-4bf4-b852-0bff7cc4a3ed",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId7"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/e1e5fd5d-3e4c-4ce1-8661-7d1873ae6b15",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId8"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/af6cd1bd-1635-48cb-bde7-5b15693900b9",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId9"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/0961003e-5a0a-4549-abde-af6a37f2724d",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId10"
+                }
+              ]
+            },
+            "id": "/providers/Microsoft.Authorization/policySetDefinitions/1f3afdf9-d0c9-4c3d-847f-89da613e70a8/versions/1.2.1",
+            "type": "Microsoft.Authorization/policySetDefinitions/versions",
+            "name": "1.2.1"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listAllPolicyDefinitionVersions.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listAllPolicyDefinitionVersions.json
@@ -1,0 +1,99 @@
+{
+  "parameters": {
+    "subscriptionId": "ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "mode": "All",
+              "displayName": "Naming Convention",
+              "description": "Force resource names to begin with 'prefix' and end with 'suffix'",
+              "metadata": {
+                "category": "Naming"
+              },
+              "parameters": {
+                "prefix": {
+                  "type": "String",
+                  "metadata": {
+                    "displayName": "Prefix",
+                    "description": "Resource name prefix"
+                  }
+                },
+                "suffix": {
+                  "type": "String",
+                  "metadata": {
+                    "displayName": "Suffix",
+                    "description": "Resource name suffix"
+                  }
+                }
+              },
+              "version": "1.2.1",
+              "policyRule": {
+                "if": {
+                  "not": {
+                    "field": "name",
+                    "like": "[concat(parameters('prefix'), '*', parameters('suffix'))]"
+                  }
+                },
+                "then": {
+                  "effect": "deny"
+                }
+              },
+              "policyType": "Custom"
+            },
+            "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming/versions/1.2.1",
+            "type": "Microsoft.Authorization/policyDefinitions/versions",
+            "name": "1.2.1"
+          },
+          {
+            "properties": {
+              "mode": "All",
+              "displayName": "Naming Convention",
+              "description": "Force resource names to begin with 'prefix' and end with 'suffix'",
+              "metadata": {
+                "category": "Naming"
+              },
+              "parameters": {
+                "prefix": {
+                  "type": "String",
+                  "metadata": {
+                    "displayName": "Prefix",
+                    "description": "Resource name prefix"
+                  }
+                },
+                "suffix": {
+                  "type": "String",
+                  "metadata": {
+                    "displayName": "Suffix",
+                    "description": "Resource name suffix"
+                  }
+                }
+              },
+              "version": "1.0.0",
+              "policyRule": {
+                "if": {
+                  "not": {
+                    "field": "name",
+                    "like": "[concat(parameters('prefix'), '-*', parameters('suffix'))]"
+                  }
+                },
+                "then": {
+                  "effect": "deny"
+                }
+              },
+              "policyType": "Custom"
+            },
+            "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/versions/1.0.0",
+            "type": "Microsoft.Authorization/policyDefinitions",
+            "name": "1.0.0"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listAllPolicyDefinitionVersionsByManagementGroup.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listAllPolicyDefinitionVersionsByManagementGroup.json
@@ -1,0 +1,99 @@
+{
+  "parameters": {
+    "managementGroupName": "MyManagementGroup",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Management/managementgroups/MyManagementGroup/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming/versions/1.2.1",
+            "type": "Microsoft.Authorization/policyDefinitions/versions",
+            "name": "1.2.1",
+            "properties": {
+              "mode": "All",
+              "displayName": "Naming Convention",
+              "description": "Force resource names to begin with 'prefix' and end with 'suffix'",
+              "metadata": {
+                "category": "Naming"
+              },
+              "version": "1.2.1",
+              "policyRule": {
+                "if": {
+                  "not": {
+                    "field": "name",
+                    "like": "[concat(parameters('prefix'), '*', parameters('suffix'))]"
+                  }
+                },
+                "then": {
+                  "effect": "deny"
+                }
+              },
+              "parameters": {
+                "prefix": {
+                  "type": "String",
+                  "metadata": {
+                    "displayName": "Prefix",
+                    "description": "Resource name prefix"
+                  }
+                },
+                "suffix": {
+                  "type": "String",
+                  "metadata": {
+                    "displayName": "Suffix",
+                    "description": "Resource name suffix"
+                  }
+                }
+              },
+              "policyType": "Custom"
+            }
+          },
+          {
+            "id": "/providers/Microsoft.Management/managementgroups/MyManagementGroup/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming/versions/1.0.0",
+            "type": "Microsoft.Authorization/policyDefinitions/versions",
+            "name": "1.0.0",
+            "properties": {
+              "mode": "All",
+              "displayName": "Naming Convention",
+              "description": "Force resource names to begin with 'prefix' and end with 'suffix'",
+              "metadata": {
+                "category": "Naming"
+              },
+              "version": "1.2.1",
+              "policyRule": {
+                "if": {
+                  "not": {
+                    "field": "name",
+                    "like": "[concat(parameters('prefix'), '-*', parameters('suffix'))]"
+                  }
+                },
+                "then": {
+                  "effect": "deny"
+                }
+              },
+              "parameters": {
+                "prefix": {
+                  "type": "String",
+                  "metadata": {
+                    "displayName": "Prefix",
+                    "description": "Resource name prefix"
+                  }
+                },
+                "suffix": {
+                  "type": "String",
+                  "metadata": {
+                    "displayName": "Suffix",
+                    "description": "Resource name suffix"
+                  }
+                }
+              },
+              "policyType": "Custom"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listAllPolicySetDefinitionVersions.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listAllPolicySetDefinitionVersions.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "subscriptionId": "ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policySetDefinitions/CostManagement/versions/1.2.1",
+            "type": "Microsoft.Authorization/policySetDefinitions/versions",
+            "name": "1.2.1",
+            "properties": {
+              "displayName": "Cost Management",
+              "description": "Policies to enforce low cost storage SKUs",
+              "metadata": {
+                "category": "Cost Management"
+              },
+              "version": "1.2.1",
+              "policyDefinitions": [
+                {
+                  "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "Limit_Skus",
+                  "parameters": {
+                    "listOfAllowedSKUs": {
+                      "value": [
+                        "Standard_GRS",
+                        "Standard_LRS"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "Resource_Naming",
+                  "parameters": {
+                    "prefix": {
+                      "value": "DeptA"
+                    },
+                    "suffix": {
+                      "value": "-LC"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listAllPolicySetDefinitionVersionsByManagementGroup.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listAllPolicySetDefinitionVersionsByManagementGroup.json
@@ -1,0 +1,123 @@
+{
+  "parameters": {
+    "managementGroupName": "MyManagementGroup",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "displayName": "[Preview]: Enable Monitoring in Azure Security Center",
+              "policyType": "BuiltIn",
+              "description": "Monitor all the available security recommendations in Azure Security Center. This is the default policy for Azure Security Center.",
+              "metadata": {
+                "category": "Security Center"
+              },
+              "version": "1.2.1",
+              "parameters": {},
+              "policyDefinitions": [
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/a8bef009-a5c9-4d0f-90d7-6018734e8a16",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId1"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/af8051bf-258b-44e2-a2bf-165330459f9d",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId2"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/86b3d65f-7626-441e-b690-81a8b71cff60",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId3"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/655cb504-bcee-4362-bd4c-402e6aa38759",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId4"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/b0f33259-77d7-4c9e-aac6-3aabcfae693c",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId5"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/47a6b606-51aa-4496-8bb7-64b11cf66adc",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId6"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/44452482-524f-4bf4-b852-0bff7cc4a3ed",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId7"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/e1e5fd5d-3e4c-4ce1-8661-7d1873ae6b15",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId8"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/af6cd1bd-1635-48cb-bde7-5b15693900b9",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId9"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/0961003e-5a0a-4549-abde-af6a37f2724d",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId10"
+                }
+              ]
+            },
+            "id": "/providers/Microsoft.Authorization/policySetDefinitions/1f3afdf9-d0c9-4c3d-847f-89da613e70a8/versoins/1.2.1",
+            "type": "Microsoft.Authorization/policySetDefinitions/versions",
+            "name": "1.2.1"
+          },
+          {
+            "id": "/providers/Microsoft.Management/managementgroups/MyManagementGroup/providers/Microsoft.Authorization/policySetDefinitions/CostManagement/versions/1.2.1",
+            "type": "Microsoft.Authorization/policySetDefinitions/versions",
+            "name": "1.2.1",
+            "properties": {
+              "displayName": "Cost Management",
+              "description": "Policies to enforce low cost storage SKUs",
+              "metadata": {
+                "category": "Cost Management"
+              },
+              "version": "1.2.1",
+              "policyDefinitions": [
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "Limit_Skus",
+                  "parameters": {
+                    "listOfAllowedSKUs": {
+                      "value": [
+                        "Standard_GRS",
+                        "Standard_LRS"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Management/managementgroups/MyManagementGroup/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "Resource_Naming",
+                  "parameters": {
+                    "prefix": {
+                      "value": "DeptA"
+                    },
+                    "suffix": {
+                      "value": "-LC"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listBuiltInPolicyDefinitionVersions.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listBuiltInPolicyDefinitionVersions.json
@@ -1,0 +1,106 @@
+{
+  "parameters": {
+    "policyDefinitionName": "06a78e20-9358-41c9-923c-fb736d382a12",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "mode": "All",
+              "displayName": "Audit SQL DB Level Audit Setting",
+              "policyType": "BuiltIn",
+              "description": "Audit DB level audit setting for SQL databases",
+              "parameters": {
+                "setting": {
+                  "type": "String",
+                  "metadata": {
+                    "displayName": "Audit Setting"
+                  },
+                  "allowedValues": [
+                    "enabled",
+                    "disabled"
+                  ]
+                }
+              },
+              "version": "1.2.1",
+              "policyRule": {
+                "if": {
+                  "field": "type",
+                  "equals": "Microsoft.Sql/servers/databases"
+                },
+                "then": {
+                  "effect": "AuditIfNotExists",
+                  "details": {
+                    "type": "Microsoft.Sql/servers/databases/auditingSettings",
+                    "name": "default",
+                    "existenceCondition": {
+                      "allOf": [
+                        {
+                          "field": "Microsoft.Sql/auditingSettings.state",
+                          "equals": "[parameters('setting')]"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "id": "/providers/Microsoft.Authorization/policyDefinitions/06a78e20-9358-41c9-923c-fb736d382a12/versions/1.2.1",
+            "type": "Microsoft.Authorization/policyDefinitions/versions",
+            "name": "1.2.1"
+          },
+          {
+            "properties": {
+              "mode": "All",
+              "displayName": "Audit SQL DB Level Audit Setting",
+              "policyType": "BuiltIn",
+              "description": "Audit DB level audit setting for SQL databases",
+              "parameters": {
+                "setting": {
+                  "type": "String",
+                  "metadata": {
+                    "displayName": "Audit Setting"
+                  },
+                  "allowedValues": [
+                    "enabled",
+                    "disabled",
+                    "default"
+                  ]
+                }
+              },
+              "version": "1.0.0",
+              "policyRule": {
+                "if": {
+                  "field": "type",
+                  "equals": "Microsoft.Sql/servers/databases"
+                },
+                "then": {
+                  "effect": "AuditIfNotExists",
+                  "details": {
+                    "type": "Microsoft.Sql/servers/databases/auditingSettings",
+                    "name": "default",
+                    "existenceCondition": {
+                      "allOf": [
+                        {
+                          "field": "Microsoft.Sql/auditingSettings.state",
+                          "equals": "[parameters('setting')]"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "id": "/providers/Microsoft.Authorization/policyDefinitions/06a78e20-9358-41c9-923c-fb736d382a12/versions/1.0.0",
+            "type": "Microsoft.Authorization/policyDefinitions/versions",
+            "name": "1.0.0"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listBuiltInPolicyDefinitions.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listBuiltInPolicyDefinitions.json
@@ -1,0 +1,145 @@
+{
+  "parameters": {
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "mode": "All",
+              "displayName": "Audit SQL DB Level Audit Setting",
+              "policyType": "BuiltIn",
+              "description": "Audit DB level audit setting for SQL databases",
+              "parameters": {
+                "setting": {
+                  "type": "String",
+                  "metadata": {
+                    "displayName": "Audit Setting"
+                  },
+                  "allowedValues": [
+                    "enabled",
+                    "disabled"
+                  ]
+                }
+              },
+              "version": "1.2.1",
+              "versions": [
+                "1.2.1",
+                "1.0.0"
+              ],
+              "policyRule": {
+                "if": {
+                  "field": "type",
+                  "equals": "Microsoft.Sql/servers/databases"
+                },
+                "then": {
+                  "effect": "AuditIfNotExists",
+                  "details": {
+                    "type": "Microsoft.Sql/servers/databases/auditingSettings",
+                    "name": "default",
+                    "existenceCondition": {
+                      "allOf": [
+                        {
+                          "field": "Microsoft.Sql/auditingSettings.state",
+                          "equals": "[parameters('setting')]"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "id": "/providers/Microsoft.Authorization/policyDefinitions/06a78e20-9358-41c9-923c-fb736d382a12",
+            "type": "Microsoft.Authorization/policyDefinitions",
+            "name": "06a78e20-9358-41c9-923c-fb736d382a12"
+          },
+          {
+            "properties": {
+              "mode": "All",
+              "displayName": "Allowed storage account SKUs",
+              "policyType": "Static",
+              "description": "This policy enables you to specify a set of storage account SKUs that your organization can deploy.",
+              "parameters": {
+                "listOfAllowedSKUs": {
+                  "type": "Array",
+                  "metadata": {
+                    "description": "The list of SKUs that can be specified for storage accounts.",
+                    "displayName": "Allowed SKUs",
+                    "strongType": "StorageSKUs"
+                  }
+                }
+              },
+              "version": "1.2.1",
+              "versions": [
+                "1.2.1",
+                "1.0.0"
+              ],
+              "policyRule": {
+                "if": {
+                  "allOf": [
+                    {
+                      "field": "type",
+                      "equals": "Microsoft.Storage/storageAccounts"
+                    },
+                    {
+                      "not": {
+                        "field": "Microsoft.Storage/storageAccounts/sku.name",
+                        "in": "[parameters('listOfAllowedSKUs')]"
+                      }
+                    }
+                  ]
+                },
+                "then": {
+                  "effect": "Deny"
+                }
+              }
+            },
+            "id": "/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+            "type": "Microsoft.Authorization/policyDefinitions",
+            "name": "7433c107-6db4-4ad1-b57a-a76dce0154a1"
+          },
+          {
+            "properties": {
+              "mode": "Microsoft.KeyVault.Data",
+              "displayName": "Audit KeyVault certificates that expire within specified number of days",
+              "policyType": "BuiltIn",
+              "description": "Audit certificates that are stored in Azure Key Vault, that expire within 'X' number of days.",
+              "metadata": {
+                "category": "KeyVault DataPlane"
+              },
+              "parameters": {
+                "daysToExpire": {
+                  "type": "Integer",
+                  "metadata": {
+                    "displayName": "Days to expire",
+                    "description": "The number of days for a certificate to expire."
+                  }
+                }
+              },
+              "version": "1.2.1",
+              "versions": [
+                "1.2.1",
+                "1.0.0"
+              ],
+              "policyRule": {
+                "if": {
+                  "field": "Microsoft.KeyVault.Data/vaults/certificates/attributes/expiresOn",
+                  "lessOrEquals": "[addDays(utcNow(), parameters('daysToExpire'))]"
+                },
+                "then": {
+                  "effect": "audit"
+                }
+              }
+            },
+            "id": "/providers/Microsoft.Authorization/policyDefinitions/abeed54a-73c5-441d-8a8c-6b5e7a0c299e",
+            "type": "Microsoft.Authorization/policyDefinitions",
+            "name": "abeed54a-73c5-441d-8a8c-6b5e7a0c299e"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listBuiltInPolicySetDefinitionVersions.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listBuiltInPolicySetDefinitionVersions.json
@@ -1,0 +1,82 @@
+{
+  "parameters": {
+    "policySetDefinitionName": "1f3afdf9-d0c9-4c3d-847f-89da613e70a8",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "displayName": "[Preview]: Enable Monitoring in Azure Security Center",
+              "policyType": "BuiltIn",
+              "description": "Monitor all the available security recommendations in Azure Security Center. This is the default policy for Azure Security Center.",
+              "metadata": {
+                "category": "Security Center"
+              },
+              "version": "1.2.1",
+              "parameters": {},
+              "policyDefinitions": [
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/a8bef009-a5c9-4d0f-90d7-6018734e8a16",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId1"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/af8051bf-258b-44e2-a2bf-165330459f9d",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId2"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/86b3d65f-7626-441e-b690-81a8b71cff60",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId3"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/655cb504-bcee-4362-bd4c-402e6aa38759",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId4"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/b0f33259-77d7-4c9e-aac6-3aabcfae693c",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId5"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/47a6b606-51aa-4496-8bb7-64b11cf66adc",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId6"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/44452482-524f-4bf4-b852-0bff7cc4a3ed",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId7"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/e1e5fd5d-3e4c-4ce1-8661-7d1873ae6b15",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId8"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/af6cd1bd-1635-48cb-bde7-5b15693900b9",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId9"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/0961003e-5a0a-4549-abde-af6a37f2724d",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId10"
+                }
+              ]
+            },
+            "id": "/providers/Microsoft.Authorization/policySetDefinitions/1f3afdf9-d0c9-4c3d-847f-89da613e70a8/versions/1.2.1",
+            "type": "Microsoft.Authorization/policySetDefinitions/versions",
+            "name": "1.2.1"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listBuiltInPolicySetDefinitions.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listBuiltInPolicySetDefinitions.json
@@ -1,0 +1,85 @@
+{
+  "parameters": {
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "displayName": "[Preview]: Enable Monitoring in Azure Security Center",
+              "policyType": "BuiltIn",
+              "description": "Monitor all the available security recommendations in Azure Security Center. This is the default policy for Azure Security Center.",
+              "metadata": {
+                "category": "Security Center"
+              },
+              "version": "1.2.1",
+              "versions": [
+                "1.2.1",
+                "1.0.0"
+              ],
+              "parameters": {},
+              "policyDefinitions": [
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/a8bef009-a5c9-4d0f-90d7-6018734e8a16",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId1"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/af8051bf-258b-44e2-a2bf-165330459f9d",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId2"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/86b3d65f-7626-441e-b690-81a8b71cff60",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId3"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/655cb504-bcee-4362-bd4c-402e6aa38759",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId4"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/b0f33259-77d7-4c9e-aac6-3aabcfae693c",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId5"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/47a6b606-51aa-4496-8bb7-64b11cf66adc",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId6"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/44452482-524f-4bf4-b852-0bff7cc4a3ed",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId7"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/e1e5fd5d-3e4c-4ce1-8661-7d1873ae6b15",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId8"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/af6cd1bd-1635-48cb-bde7-5b15693900b9",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId9"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/0961003e-5a0a-4549-abde-af6a37f2724d",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId10"
+                }
+              ]
+            },
+            "id": "/providers/Microsoft.Authorization/policySetDefinitions/1f3afdf9-d0c9-4c3d-847f-89da613e70a8",
+            "type": "Microsoft.Authorization/policySetDefinitions",
+            "name": "1f3afdf9-d0c9-4c3d-847f-89da613e70a8"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listPolicyAssignments.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listPolicyAssignments.json
@@ -1,0 +1,63 @@
+{
+  "parameters": {
+    "subscriptionId": "ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "api-version": "2025-03-01",
+    "$filter": "atScope()",
+    "$expand": "LatestDefinitionVersion, EffectiveDefinitionVersion"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyAssignments/CostManagement",
+            "type": "Microsoft.Authorization/policyAssignments",
+            "name": "CostManagement",
+            "location": "eastus",
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "e6d23f8d-af97-4fbc-bda6-00604e4e3d0a",
+              "tenantId": "4bee2b8a-1bee-47c2-90e9-404241551135"
+            },
+            "properties": {
+              "displayName": "Storage Cost Management",
+              "description": "Minimize the risk of accidental cost overruns",
+              "metadata": {
+                "category": "Cost Management"
+              },
+              "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/storageSkus",
+              "definitionVersion": "1.*.*",
+              "latestDefinitionVersion": "1.0.0",
+              "effectiveDefinitionVersion": "1.0.0",
+              "parameters": {
+                "allowedSkus": {
+                  "value": "Standard_A1"
+                }
+              },
+              "scope": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+              "notScopes": [],
+              "instanceId": "a3c4d5e6-f7a8-9b0c-1d2e-3f4a5b6c7d8e"
+            }
+          },
+          {
+            "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyAssignments/TagEnforcement",
+            "type": "Microsoft.Authorization/policyAssignments",
+            "name": "TagEnforcement",
+            "properties": {
+              "displayName": "Enforces a tag key and value",
+              "description": "Ensure a given tag key and value are present on all resources",
+              "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/TagKeyValue",
+              "definitionVersion": "1.*.*",
+              "latestDefinitionVersion": "1.0.0",
+              "effectiveDefinitionVersion": "1.0.0",
+              "scope": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+              "notScopes": [],
+              "instanceId": "b6d7e8f9-a0b1-2c3d-4e5f-6a7b8c9d0e1f"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listPolicyAssignmentsForManagementGroup.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listPolicyAssignmentsForManagementGroup.json
@@ -1,0 +1,63 @@
+{
+  "parameters": {
+    "managementGroupId": "TestManagementGroup",
+    "api-version": "2025-03-01",
+    "$filter": "atScope()",
+    "$expand": "LatestDefinitionVersion, EffectiveDefinitionVersion"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Management/managementGroups/TestManagementGroup/providers/Microsoft.Authorization/policyAssignments/TestCostManagement",
+            "type": "Microsoft.Authorization/policyAssignments",
+            "name": "TestCostManagement",
+            "location": "eastus",
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "e6d23f8d-af97-4fbc-bda6-00604e4e3d0a",
+              "tenantId": "4bee2b8a-1bee-47c2-90e9-404241551135"
+            },
+            "properties": {
+              "displayName": "Storage Cost Management",
+              "description": "Minimize the risk of accidental cost overruns",
+              "metadata": {
+                "category": "Cost Management"
+              },
+              "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/TestManagementGroup/providers/Microsoft.Authorization/policyDefinitions/storageSkus",
+              "definitionVersion": "1.*.*",
+              "latestDefinitionVersion": "1.0.0",
+              "effectiveDefinitionVersion": "1.0.0",
+              "parameters": {
+                "allowedSkus": {
+                  "value": "Standard_A1"
+                }
+              },
+              "scope": "/providers/Microsoft.Management/managementGroups/TestManagementGroup",
+              "notScopes": [],
+              "instanceId": "c7e8f9a0-b1c2-3d4e-5f6a-7b8c9d0e1f2a"
+            }
+          },
+          {
+            "id": "/providers/Microsoft.Management/managementGroups/TestManagementGroup/providers/Microsoft.Authorization/policyAssignments/TestTagEnforcement",
+            "type": "Microsoft.Authorization/policyAssignments",
+            "name": "TestTagEnforcement",
+            "properties": {
+              "displayName": "Enforces a tag key and value",
+              "description": "Ensure a given tag key and value are present on all resources",
+              "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/TestManagementGroup/providers/Microsoft.Authorization/policyDefinitions/TagKeyValue",
+              "definitionVersion": "1.*.*",
+              "latestDefinitionVersion": "1.0.0",
+              "effectiveDefinitionVersion": "1.0.0",
+              "scope": "/providers/Microsoft.Management/managementGroups/TestManagementGroup",
+              "notScopes": [],
+              "instanceId": "d8f9a0b1-c2d3-4e5f-6a7b-8c9d0e1f2a3b"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listPolicyAssignmentsForResource.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listPolicyAssignmentsForResource.json
@@ -1,0 +1,62 @@
+{
+  "parameters": {
+    "resourceGroupName": "TestResourceGroup",
+    "resourceProviderNamespace": "Microsoft.Compute",
+    "parentResourcePath": "virtualMachines/MyTestVm",
+    "resourceType": "domainNames",
+    "resourceName": "MyTestComputer.cloudapp.net",
+    "subscriptionId": "ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/resourceGroups/TestResourceGroup/providers/Microsoft.Authorization/policyAssignments/TestCostManagement",
+            "type": "Microsoft.Authorization/policyAssignments",
+            "name": "TestCostManagement",
+            "location": "eastus",
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "e6d23f8d-af97-4fbc-bda6-00604e4e3d0a",
+              "tenantId": "4bee2b8a-1bee-47c2-90e9-404241551135"
+            },
+            "properties": {
+              "displayName": "VM Cost Management",
+              "description": "Minimize the risk of accidental cost overruns",
+              "metadata": {
+                "category": "Cost Management"
+              },
+              "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/vmSkus",
+              "definitionVersion": "1.*.*",
+              "parameters": {
+                "allowedSkus": {
+                  "value": "Standard_A1"
+                }
+              },
+              "scope": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/resourceGroups/TestResourceGroup",
+              "notScopes": [],
+              "instanceId": "e9a0b1c2-d3e4-5f6a-7b8c-9d0e1f2a3b4c"
+            }
+          },
+          {
+            "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/resourceGroups/TestResourceGroup/providers/Microsoft.Authorization/policyAssignments/TestTagEnforcement",
+            "type": "Microsoft.Authorization/policyAssignments",
+            "name": "TestTagEnforcement",
+            "properties": {
+              "displayName": "Enforces a tag key and value",
+              "description": "Ensure a given tag key and value are present on all resources",
+              "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/TagKeyValue",
+              "definitionVersion": "1.*.*",
+              "scope": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/resourceGroups/TestResourceGroup",
+              "notScopes": [],
+              "instanceId": "f0b1c2d3-e4f5-6a7b-8c9d-0e1f2a3b4c5d"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listPolicyAssignmentsForResourceGroup.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listPolicyAssignmentsForResourceGroup.json
@@ -1,0 +1,64 @@
+{
+  "parameters": {
+    "resourceGroupName": "TestResourceGroup",
+    "subscriptionId": "ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "api-version": "2025-03-01",
+    "$filter": "atScope()",
+    "$expand": "LatestDefinitionVersion, EffectiveDefinitionVersion"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/resourceGroups/TestResourceGroup/providers/Microsoft.Authorization/policyAssignments/TestCostManagement",
+            "type": "Microsoft.Authorization/policyAssignments",
+            "name": "TestCostManagement",
+            "location": "eastus",
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "e6d23f8d-af97-4fbc-bda6-00604e4e3d0a",
+              "tenantId": "4bee2b8a-1bee-47c2-90e9-404241551135"
+            },
+            "properties": {
+              "displayName": "Storage Cost Management",
+              "description": "Minimize the risk of accidental cost overruns",
+              "metadata": {
+                "category": "Cost Management"
+              },
+              "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/storageSkus",
+              "definitionVersion": "1.*.*",
+              "latestDefinitionVersion": "1.0.0",
+              "effectiveDefinitionVersion": "1.0.0",
+              "parameters": {
+                "allowedSkus": {
+                  "value": "Standard_A1"
+                }
+              },
+              "scope": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/resourceGroups/TestResourceGroup",
+              "notScopes": [],
+              "instanceId": "a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d"
+            }
+          },
+          {
+            "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/resourceGroups/TestResourceGroup/providers/Microsoft.Authorization/policyAssignments/TestTagEnforcement",
+            "type": "Microsoft.Authorization/policyAssignments",
+            "name": "TestTagEnforcement",
+            "properties": {
+              "displayName": "Enforces a tag key and value",
+              "description": "Ensure a given tag key and value are present on all resources",
+              "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/TagKeyValue",
+              "definitionVersion": "1.*.*",
+              "latestDefinitionVersion": "1.0.0",
+              "effectiveDefinitionVersion": "1.0.0",
+              "scope": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/resourceGroups/TestResourceGroup",
+              "notScopes": [],
+              "instanceId": "f0b1c2d3-e4f5-6a7b-8c9d-0e1f2a3b4c5d"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listPolicyDefinitionVersions.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listPolicyDefinitionVersions.json
@@ -1,0 +1,100 @@
+{
+  "parameters": {
+    "subscriptionId": "ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "policyDefinitionName": "ResourceNaming",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "mode": "All",
+              "displayName": "Naming Convention",
+              "description": "Force resource names to begin with 'prefix' and end with 'suffix'",
+              "metadata": {
+                "category": "Naming"
+              },
+              "parameters": {
+                "prefix": {
+                  "type": "String",
+                  "metadata": {
+                    "displayName": "Prefix",
+                    "description": "Resource name prefix"
+                  }
+                },
+                "suffix": {
+                  "type": "String",
+                  "metadata": {
+                    "displayName": "Suffix",
+                    "description": "Resource name suffix"
+                  }
+                }
+              },
+              "version": "1.2.1",
+              "policyRule": {
+                "if": {
+                  "not": {
+                    "field": "name",
+                    "like": "[concat(parameters('prefix'), '*', parameters('suffix'))]"
+                  }
+                },
+                "then": {
+                  "effect": "deny"
+                }
+              },
+              "policyType": "Custom"
+            },
+            "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming/versions/1.2.1",
+            "type": "Microsoft.Authorization/policyDefinitions/versions",
+            "name": "1.2.1"
+          },
+          {
+            "properties": {
+              "mode": "All",
+              "displayName": "Naming Convention",
+              "description": "Force resource names to begin with 'prefix' and end with 'suffix'",
+              "metadata": {
+                "category": "Naming"
+              },
+              "parameters": {
+                "prefix": {
+                  "type": "String",
+                  "metadata": {
+                    "displayName": "Prefix",
+                    "description": "Resource name prefix"
+                  }
+                },
+                "suffix": {
+                  "type": "String",
+                  "metadata": {
+                    "displayName": "Suffix",
+                    "description": "Resource name suffix"
+                  }
+                }
+              },
+              "version": "1.0.0",
+              "policyRule": {
+                "if": {
+                  "not": {
+                    "field": "name",
+                    "like": "[concat(parameters('prefix'), '-*', parameters('suffix'))]"
+                  }
+                },
+                "then": {
+                  "effect": "deny"
+                }
+              },
+              "policyType": "Custom"
+            },
+            "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/versions/1.0.0",
+            "type": "Microsoft.Authorization/policyDefinitions",
+            "name": "1.0.0"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listPolicyDefinitionVersionsByManagementGroup.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listPolicyDefinitionVersionsByManagementGroup.json
@@ -1,0 +1,100 @@
+{
+  "parameters": {
+    "managementGroupName": "MyManagementGroup",
+    "policyDefinitionName": "ResourceNaming",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Management/managementgroups/MyManagementGroup/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming/versions/1.2.1",
+            "type": "Microsoft.Authorization/policyDefinitions/versions",
+            "name": "1.2.1",
+            "properties": {
+              "mode": "All",
+              "displayName": "Naming Convention",
+              "description": "Force resource names to begin with 'prefix' and end with 'suffix'",
+              "metadata": {
+                "category": "Naming"
+              },
+              "version": "1.2.1",
+              "policyRule": {
+                "if": {
+                  "not": {
+                    "field": "name",
+                    "like": "[concat(parameters('prefix'), '*', parameters('suffix'))]"
+                  }
+                },
+                "then": {
+                  "effect": "deny"
+                }
+              },
+              "parameters": {
+                "prefix": {
+                  "type": "String",
+                  "metadata": {
+                    "displayName": "Prefix",
+                    "description": "Resource name prefix"
+                  }
+                },
+                "suffix": {
+                  "type": "String",
+                  "metadata": {
+                    "displayName": "Suffix",
+                    "description": "Resource name suffix"
+                  }
+                }
+              },
+              "policyType": "Custom"
+            }
+          },
+          {
+            "id": "/providers/Microsoft.Management/managementgroups/MyManagementGroup/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming/versions/1.0.0",
+            "type": "Microsoft.Authorization/policyDefinitions/versions",
+            "name": "1.0.0",
+            "properties": {
+              "mode": "All",
+              "displayName": "Naming Convention",
+              "description": "Force resource names to begin with 'prefix' and end with 'suffix'",
+              "metadata": {
+                "category": "Naming"
+              },
+              "version": "1.2.1",
+              "policyRule": {
+                "if": {
+                  "not": {
+                    "field": "name",
+                    "like": "[concat(parameters('prefix'), '-*', parameters('suffix'))]"
+                  }
+                },
+                "then": {
+                  "effect": "deny"
+                }
+              },
+              "parameters": {
+                "prefix": {
+                  "type": "String",
+                  "metadata": {
+                    "displayName": "Prefix",
+                    "description": "Resource name prefix"
+                  }
+                },
+                "suffix": {
+                  "type": "String",
+                  "metadata": {
+                    "displayName": "Suffix",
+                    "description": "Resource name suffix"
+                  }
+                }
+              },
+              "policyType": "Custom"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listPolicyDefinitions.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listPolicyDefinitions.json
@@ -1,0 +1,143 @@
+{
+  "parameters": {
+    "subscriptionId": "ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "mode": "All",
+              "displayName": "Allowed storage account SKUs",
+              "policyType": "BuiltIn",
+              "description": "This policy enables you to specify a set of storage account SKUs that your organization can deploy.",
+              "parameters": {
+                "listOfAllowedSKUs": {
+                  "type": "Array",
+                  "metadata": {
+                    "description": "The list of SKUs that can be specified for storage accounts.",
+                    "displayName": "Allowed SKUs",
+                    "strongType": "StorageSKUs"
+                  }
+                }
+              },
+              "version": "1.2.1",
+              "versions": [
+                "1.2.1",
+                "1.0.0"
+              ],
+              "policyRule": {
+                "if": {
+                  "allOf": [
+                    {
+                      "field": "type",
+                      "equals": "Microsoft.Storage/storageAccounts"
+                    },
+                    {
+                      "not": {
+                        "field": "Microsoft.Storage/storageAccounts/sku.name",
+                        "in": "[parameters('listOfAllowedSKUs')]"
+                      }
+                    }
+                  ]
+                },
+                "then": {
+                  "effect": "Deny"
+                }
+              }
+            },
+            "id": "/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+            "type": "Microsoft.Authorization/policyDefinitions",
+            "name": "7433c107-6db4-4ad1-b57a-a76dce0154a1"
+          },
+          {
+            "properties": {
+              "mode": "All",
+              "displayName": "Naming Convention",
+              "description": "Force resource names to begin with 'prefix' and end with 'suffix'",
+              "metadata": {
+                "category": "Naming"
+              },
+              "parameters": {
+                "prefix": {
+                  "type": "String",
+                  "metadata": {
+                    "displayName": "Prefix",
+                    "description": "Resource name prefix"
+                  }
+                },
+                "suffix": {
+                  "type": "String",
+                  "metadata": {
+                    "displayName": "Suffix",
+                    "description": "Resource name suffix"
+                  }
+                }
+              },
+              "version": "1.2.1",
+              "versions": [
+                "1.2.1",
+                "1.0.0"
+              ],
+              "policyRule": {
+                "if": {
+                  "not": {
+                    "field": "name",
+                    "like": "[concat(parameters('prefix'), '*', parameters('suffix'))]"
+                  }
+                },
+                "then": {
+                  "effect": "deny"
+                }
+              },
+              "policyType": "Custom"
+            },
+            "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+            "type": "Microsoft.Authorization/policyDefinitions",
+            "name": "ResourceNaming"
+          },
+          {
+            "properties": {
+              "mode": "Microsoft.KeyVault.Data",
+              "displayName": "Audit KeyVault certificates that expire within specified number of days",
+              "description": "Audit certificates that are stored in Azure Key Vault, that expire within 'X' number of days.",
+              "metadata": {
+                "category": "KeyVault DataPlane"
+              },
+              "parameters": {
+                "daysToExpire": {
+                  "type": "Integer",
+                  "metadata": {
+                    "displayName": "Days to expire",
+                    "description": "The number of days for a certificate to expire."
+                  }
+                }
+              },
+              "version": "1.2.1",
+              "versions": [
+                "1.2.1",
+                "1.0.0"
+              ],
+              "policyRule": {
+                "if": {
+                  "field": "Microsoft.KeyVault.Data/vaults/certificates/attributes/expiresOn",
+                  "lessOrEquals": "[addDays(utcNow(), parameters('daysToExpire'))]"
+                },
+                "then": {
+                  "effect": "audit"
+                }
+              },
+              "policyType": "Custom"
+            },
+            "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/AuditSoonToExpireCerts",
+            "type": "Microsoft.Authorization/policyDefinitions",
+            "name": "AuditSoonToExpireCerts"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listPolicyDefinitionsByManagementGroup.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listPolicyDefinitionsByManagementGroup.json
@@ -1,0 +1,106 @@
+{
+  "parameters": {
+    "managementGroupId": "MyManagementGroup",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "mode": "All",
+              "displayName": "Allowed storage account SKUs",
+              "policyType": "BuiltIn",
+              "description": "This policy enables you to specify a set of storage account SKUs that your organization can deploy.",
+              "parameters": {
+                "listOfAllowedSKUs": {
+                  "type": "Array",
+                  "metadata": {
+                    "description": "The list of SKUs that can be specified for storage accounts.",
+                    "displayName": "Allowed SKUs",
+                    "strongType": "StorageSKUs"
+                  }
+                }
+              },
+              "version": "1.2.1",
+              "versions": [
+                "1.2.1",
+                "1.0.0"
+              ],
+              "policyRule": {
+                "if": {
+                  "allOf": [
+                    {
+                      "field": "type",
+                      "equals": "Microsoft.Storage/storageAccounts"
+                    },
+                    {
+                      "not": {
+                        "field": "Microsoft.Storage/storageAccounts/sku.name",
+                        "in": "[parameters('listOfAllowedSKUs')]"
+                      }
+                    }
+                  ]
+                },
+                "then": {
+                  "effect": "Deny"
+                }
+              }
+            },
+            "id": "/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+            "type": "Microsoft.Authorization/policyDefinitions",
+            "name": "7433c107-6db4-4ad1-b57a-a76dce0154a1"
+          },
+          {
+            "id": "/providers/Microsoft.Management/managementgroups/MyManagementGroup/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+            "type": "Microsoft.Authorization/policyDefinitions",
+            "name": "ResourceNaming",
+            "properties": {
+              "mode": "All",
+              "displayName": "Naming Convention",
+              "description": "Force resource names to begin with 'prefix' and end with 'suffix'",
+              "metadata": {
+                "category": "Naming"
+              },
+              "version": "1.2.1",
+              "versions": [
+                "1.2.1",
+                "1.0.0"
+              ],
+              "policyRule": {
+                "if": {
+                  "not": {
+                    "field": "name",
+                    "like": "[concat(parameters('prefix'), '*', parameters('suffix'))]"
+                  }
+                },
+                "then": {
+                  "effect": "deny"
+                }
+              },
+              "parameters": {
+                "prefix": {
+                  "type": "String",
+                  "metadata": {
+                    "displayName": "Prefix",
+                    "description": "Resource name prefix"
+                  }
+                },
+                "suffix": {
+                  "type": "String",
+                  "metadata": {
+                    "displayName": "Suffix",
+                    "description": "Resource name suffix"
+                  }
+                }
+              },
+              "policyType": "Custom"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listPolicySetDefinitionVersions.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listPolicySetDefinitionVersions.json
@@ -1,0 +1,57 @@
+{
+  "parameters": {
+    "subscriptionId": "ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "policySetDefinitionName": "CostManagement",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policySetDefinitions/CostManagement/versions/1.2.1",
+            "type": "Microsoft.Authorization/policySetDefinitions/versions",
+            "name": "1.2.1",
+            "properties": {
+              "displayName": "Cost Management",
+              "description": "Policies to enforce low cost storage SKUs",
+              "metadata": {
+                "category": "Cost Management"
+              },
+              "version": "1.2.1",
+              "policyDefinitions": [
+                {
+                  "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "Limit_Skus",
+                  "parameters": {
+                    "listOfAllowedSKUs": {
+                      "value": [
+                        "Standard_GRS",
+                        "Standard_LRS"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "Resource_Naming",
+                  "parameters": {
+                    "prefix": {
+                      "value": "DeptA"
+                    },
+                    "suffix": {
+                      "value": "-LC"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listPolicySetDefinitionVersionsByManagementGroup.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listPolicySetDefinitionVersionsByManagementGroup.json
@@ -1,0 +1,57 @@
+{
+  "parameters": {
+    "managementGroupName": "MyManagementGroup",
+    "policySetDefinitionName": "CostManagement",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "id": "/providers/Microsoft.Management/managementgroups/MyManagementGroup/providers/Microsoft.Authorization/policySetDefinitions/CostManagement/versions/1.2.1",
+            "type": "Microsoft.Authorization/policySetDefinitions/versions",
+            "name": "1.2.1",
+            "properties": {
+              "displayName": "Cost Management",
+              "description": "Policies to enforce low cost storage SKUs",
+              "metadata": {
+                "category": "Cost Management"
+              },
+              "version": "1.2.1",
+              "policyDefinitions": [
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "Limit_Skus",
+                  "parameters": {
+                    "listOfAllowedSKUs": {
+                      "value": [
+                        "Standard_GRS",
+                        "Standard_LRS"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Management/managementgroups/MyManagementGroup/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "Resource_Naming",
+                  "parameters": {
+                    "prefix": {
+                      "value": "DeptA"
+                    },
+                    "suffix": {
+                      "value": "-LC"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listPolicySetDefinitions.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listPolicySetDefinitions.json
@@ -1,0 +1,131 @@
+{
+  "parameters": {
+    "subscriptionId": "ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "displayName": "[Preview]: Enable Monitoring in Azure Security Center",
+              "policyType": "BuiltIn",
+              "description": "Monitor all the available security recommendations in Azure Security Center. This is the default policy for Azure Security Center.",
+              "metadata": {
+                "category": "Security Center"
+              },
+              "version": "1.2.1",
+              "versions": [
+                "1.2.1",
+                "1.0.0"
+              ],
+              "parameters": {},
+              "policyDefinitions": [
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/a8bef009-a5c9-4d0f-90d7-6018734e8a16",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId1"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/af8051bf-258b-44e2-a2bf-165330459f9d",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId2"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/86b3d65f-7626-441e-b690-81a8b71cff60",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId3"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/655cb504-bcee-4362-bd4c-402e6aa38759",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId4"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/b0f33259-77d7-4c9e-aac6-3aabcfae693c",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId5"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/47a6b606-51aa-4496-8bb7-64b11cf66adc",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId6"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/44452482-524f-4bf4-b852-0bff7cc4a3ed",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId7"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/e1e5fd5d-3e4c-4ce1-8661-7d1873ae6b15",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId8"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/af6cd1bd-1635-48cb-bde7-5b15693900b9",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId9"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/0961003e-5a0a-4549-abde-af6a37f2724d",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId10"
+                }
+              ]
+            },
+            "id": "/providers/Microsoft.Authorization/policySetDefinitions/1f3afdf9-d0c9-4c3d-847f-89da613e70a8",
+            "type": "Microsoft.Authorization/policySetDefinitions",
+            "name": "1f3afdf9-d0c9-4c3d-847f-89da613e70a8"
+          },
+          {
+            "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policySetDefinitions/CostManagement",
+            "type": "Microsoft.Authorization/policySetDefinitions",
+            "name": "CostManagement",
+            "properties": {
+              "displayName": "Cost Management",
+              "description": "Policies to enforce low cost storage SKUs",
+              "metadata": {
+                "category": "Cost Management"
+              },
+              "version": "1.2.1",
+              "versions": [
+                "1.2.1",
+                "1.0.0"
+              ],
+              "policyDefinitions": [
+                {
+                  "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "Limit_Skus",
+                  "parameters": {
+                    "listOfAllowedSKUs": {
+                      "value": [
+                        "Standard_GRS",
+                        "Standard_LRS"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "Resource_Naming",
+                  "parameters": {
+                    "prefix": {
+                      "value": "DeptA"
+                    },
+                    "suffix": {
+                      "value": "-LC"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listPolicySetDefinitionsByManagementGroup.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/listPolicySetDefinitionsByManagementGroup.json
@@ -1,0 +1,129 @@
+{
+  "parameters": {
+    "managementGroupId": "MyManagementGroup",
+    "api-version": "2025-03-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "displayName": "[Preview]: Enable Monitoring in Azure Security Center",
+              "policyType": "BuiltIn",
+              "description": "Monitor all the available security recommendations in Azure Security Center. This is the default policy for Azure Security Center.",
+              "metadata": {
+                "category": "Security Center"
+              },
+              "version": "1.2.1",
+              "versions": [
+                "1.2.1",
+                "1.0.0"
+              ],
+              "parameters": {},
+              "policyDefinitions": [
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/a8bef009-a5c9-4d0f-90d7-6018734e8a16",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId1"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/af8051bf-258b-44e2-a2bf-165330459f9d",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId2"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/86b3d65f-7626-441e-b690-81a8b71cff60",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId3"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/655cb504-bcee-4362-bd4c-402e6aa38759",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId4"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/b0f33259-77d7-4c9e-aac6-3aabcfae693c",
+                  "policyDefinitionReferenceId": "RefId5"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/47a6b606-51aa-4496-8bb7-64b11cf66adc",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId6"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/44452482-524f-4bf4-b852-0bff7cc4a3ed",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId7"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/e1e5fd5d-3e4c-4ce1-8661-7d1873ae6b15",
+                  "policyDefinitionReferenceId": "RefId8"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/af6cd1bd-1635-48cb-bde7-5b15693900b9",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId9"
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/0961003e-5a0a-4549-abde-af6a37f2724d",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "RefId10"
+                }
+              ]
+            },
+            "id": "/providers/Microsoft.Authorization/policySetDefinitions/1f3afdf9-d0c9-4c3d-847f-89da613e70a8",
+            "type": "Microsoft.Authorization/policySetDefinitions",
+            "name": "1f3afdf9-d0c9-4c3d-847f-89da613e70a8"
+          },
+          {
+            "id": "/providers/Microsoft.Management/managementgroups/MyManagementGroup/providers/Microsoft.Authorization/policySetDefinitions/CostManagement",
+            "type": "Microsoft.Authorization/policySetDefinitions",
+            "name": "CostManagement",
+            "properties": {
+              "displayName": "Cost Management",
+              "description": "Policies to enforce low cost storage SKUs",
+              "metadata": {
+                "category": "Cost Management"
+              },
+              "version": "1.2.1",
+              "versions": [
+                "1.2.1",
+                "1.0.0"
+              ],
+              "policyDefinitions": [
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "Limit_Skus",
+                  "parameters": {
+                    "listOfAllowedSKUs": {
+                      "value": [
+                        "Standard_GRS",
+                        "Standard_LRS"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "policyDefinitionId": "/providers/Microsoft.Management/managementgroups/MyManagementGroup/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+                  "definitionVersion": "1.*.*",
+                  "policyDefinitionReferenceId": "Resource_Naming",
+                  "parameters": {
+                    "prefix": {
+                      "value": "DeptA"
+                    },
+                    "suffix": {
+                      "value": "-LC"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/updatePolicyAssignmentWithIdentity.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/updatePolicyAssignmentWithIdentity.json
@@ -1,0 +1,50 @@
+{
+  "parameters": {
+    "scope": "subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "policyAssignmentName": "EnforceNaming",
+    "api-version": "2025-03-01",
+    "parameters": {
+      "location": "eastus",
+      "identity": {
+        "type": "SystemAssigned"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "displayName": "Enforce resource naming rules",
+          "description": "Force resource names to begin with given DeptA and end with -LC",
+          "metadata": {
+            "assignedBy": "Special Someone"
+          },
+          "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+          "definitionVersion": "1.*.*",
+          "notScopes": [],
+          "parameters": {
+            "prefix": {
+              "value": "DeptA"
+            },
+            "suffix": {
+              "value": "-LC"
+            }
+          },
+          "enforcementMode": "Default",
+          "scope": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+          "instanceId": "e4b0f5a6-7c8d-4e9f-8a1b-2c3d4e5f6a7b"
+        },
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "e6d23f8d-af97-4fbc-bda6-00604e4e3d0a",
+          "tenantId": "4bee2b8a-1bee-47c2-90e9-404241551135"
+        },
+        "location": "eastus",
+        "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyAssignments/EnforceNaming",
+        "type": "Microsoft.Authorization/policyAssignments",
+        "name": "EnforceNaming"
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/updatePolicyAssignmentWithIdentityById.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/updatePolicyAssignmentWithIdentityById.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "policyAssignmentId": "providers/Microsoft.Management/managementGroups/MyManagementGroup/providers/Microsoft.Authorization/policyAssignments/LowCostStorage",
+    "api-version": "2025-03-01",
+    "parameters": {
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "location": "eastus"
+    }
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "displayName": "Enforce storage account SKU",
+          "description": "Allow only storage accounts of SKU Standard_GRS or Standard_LRS to be created",
+          "metadata": {
+            "assignedBy": "Cheapskate Boss"
+          },
+          "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/7433c107-6db4-4ad1-b57a-a76dce0154a1",
+          "definitionVersion": "1.*.*",
+          "notScopes": [],
+          "parameters": {
+            "listOfAllowedSKUs": {
+              "value": [
+                "Standard_GRS",
+                "Standard_LRS"
+              ]
+            }
+          },
+          "enforcementMode": "Default",
+          "instanceId": "b7e0f8a9-1c2d-4e3f-8b4c-5d6e7f8a9b0c"
+        },
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "e6d23f8d-af97-4fbc-bda6-00604e4e3d0a",
+          "tenantId": "4bee2b8a-1bee-47c2-90e9-404241551135"
+        },
+        "location": "eastus",
+        "id": "/providers/Microsoft.Management/managementGroups/MyManagementGroup/providers/Microsoft.Authorization/policyAssignments/LowCostStorage",
+        "type": "Microsoft.Authorization/policyAssignments",
+        "name": "LowCostStorage"
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/updatePolicyAssignmentWithOverrides.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/updatePolicyAssignmentWithOverrides.json
@@ -1,0 +1,64 @@
+{
+  "parameters": {
+    "scope": "subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "policyAssignmentName": "CostManagement",
+    "api-version": "2025-03-01",
+    "parameters": {
+      "properties": {
+        "overrides": [
+          {
+            "kind": "policyEffect",
+            "value": "Audit",
+            "selectors": [
+              {
+                "kind": "policyDefinitionReferenceId",
+                "in": [
+                  "Limit_Skus",
+                  "Limit_Locations"
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "displayName": "Limit the resource location and resource SKU",
+          "description": "Limit the resource location and resource SKU",
+          "metadata": {
+            "assignedBy": "Special Someone"
+          },
+          "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policySetDefinitions/CostManagement",
+          "definitionVersion": "1.*.*",
+          "notScopes": [],
+          "enforcementMode": "Default",
+          "scope": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+          "overrides": [
+            {
+              "kind": "policyEffect",
+              "value": "Audit",
+              "selectors": [
+                {
+                  "kind": "policyDefinitionReferenceId",
+                  "in": [
+                    "Limit_Skus",
+                    "Limit_Locations"
+                  ]
+                }
+              ]
+            }
+          ],
+          "instanceId": "a3c4d5e6-f7a8-9b0c-1d2e-3f4a5b6c7d8e"
+        },
+        "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyAssignments/CostManagement",
+        "type": "Microsoft.Authorization/policyAssignments",
+        "name": "CostManagement"
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/updatePolicyAssignmentWithResourceSelectors.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/updatePolicyAssignmentWithResourceSelectors.json
@@ -1,0 +1,62 @@
+{
+  "parameters": {
+    "scope": "subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "policyAssignmentName": "CostManagement",
+    "api-version": "2025-03-01",
+    "parameters": {
+      "properties": {
+        "resourceSelectors": [
+          {
+            "name": "SDPRegions",
+            "selectors": [
+              {
+                "kind": "resourceLocation",
+                "in": [
+                  "eastus2euap",
+                  "centraluseuap"
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "displayName": "Limit the resource location and resource SKU",
+          "description": "Limit the resource location and resource SKU",
+          "metadata": {
+            "assignedBy": "Special Someone"
+          },
+          "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policySetDefinitions/CostManagement",
+          "definitionVersion": "1.*.*",
+          "notScopes": [],
+          "enforcementMode": "Default",
+          "scope": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+          "resourceSelectors": [
+            {
+              "name": "SDPRegions",
+              "selectors": [
+                {
+                  "kind": "resourceLocation",
+                  "in": [
+                    "eastus2euap",
+                    "centraluseuap"
+                  ]
+                }
+              ]
+            }
+          ],
+          "instanceId": "a3c4d5e6-f7a8-9b0c-1d2e-3f4a5b6c7d8e"
+        },
+        "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyAssignments/CostManagement",
+        "type": "Microsoft.Authorization/policyAssignments",
+        "name": "CostManagement"
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/updatePolicyAssignmentWithUserAssignedIdentity.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/examples/updatePolicyAssignmentWithUserAssignedIdentity.json
@@ -1,0 +1,57 @@
+{
+  "parameters": {
+    "scope": "subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+    "policyAssignmentName": "EnforceNaming",
+    "api-version": "2025-03-01",
+    "parameters": {
+      "location": "eastus",
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/resourceGroups/testResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-identity": {}
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "properties": {
+          "displayName": "Enforce resource naming rules",
+          "description": "Force resource names to begin with given DeptA and end with -LC",
+          "metadata": {
+            "assignedBy": "Special Someone"
+          },
+          "policyDefinitionId": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyDefinitions/ResourceNaming",
+          "definitionVersion": "1.*.*",
+          "notScopes": [],
+          "parameters": {
+            "prefix": {
+              "value": "DeptA"
+            },
+            "suffix": {
+              "value": "-LC"
+            }
+          },
+          "enforcementMode": "Default",
+          "scope": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2",
+          "instanceId": "e4b0f5a6-7c8d-4e9f-8a1b-2c3d4e5f6a7b"
+        },
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/resourceGroups/testResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-identity": {
+              "principalId": "e6d23f8d-af97-4fbc-bda6-00604e4e3d0a",
+              "clientId": "4bee2b8a-1bee-47c2-90e9-404241551135"
+            }
+          }
+        },
+        "location": "eastus",
+        "id": "/subscriptions/ae640e6b-ba3e-4256-9d62-2993eecfa6f2/providers/Microsoft.Authorization/policyAssignments/EnforceNaming",
+        "type": "Microsoft.Authorization/policyAssignments",
+        "name": "EnforceNaming"
+      }
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/policyAssignments.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/policyAssignments.json
@@ -1,0 +1,1099 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "PolicyClient",
+    "version": "2025-03-01",
+    "description": "To manage and control access to your resources, you can define customized policies and assign them at a scope."
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/{scope}/providers/Microsoft.Authorization/policyAssignments/{policyAssignmentName}": {
+      "delete": {
+        "tags": [
+          "PolicyAssignments"
+        ],
+        "operationId": "PolicyAssignments_Delete",
+        "summary": "Deletes a policy assignment.",
+        "description": "This operation deletes a policy assignment, given its name and the scope it was created in. The scope of a policy assignment is the part of its ID preceding '/providers/Microsoft.Authorization/policyAssignments/{policyAssignmentName}'.",
+        "x-ms-examples": {
+          "Delete a policy assignment": {
+            "$ref": "./examples/deletePolicyAssignment.json"
+          }
+        },
+        "parameters": [
+          {
+            "name": "scope",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The scope of the policy assignment. Valid scopes are: management group (format: '/providers/Microsoft.Management/managementGroups/{managementGroup}'), subscription (format: '/subscriptions/{subscriptionId}'), resource group (format: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}', or resource (format: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/[{parentResourcePath}/]{resourceType}/{resourceName}'",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "name": "policyAssignmentName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": "^[^<>*%&:\\?.+/]*[^<>*%&:\\?.+/ ]+$",
+            "description": "The name of the policy assignment to delete."
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns information about the deleted assignment.",
+            "schema": {
+              "$ref": "#/definitions/PolicyAssignment"
+            }
+          },
+          "204": {
+            "description": "No Content - the policy assignment doesn't exist."
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "PolicyAssignments"
+        ],
+        "operationId": "PolicyAssignments_Create",
+        "summary": "Creates or updates a policy assignment.",
+        "description": " This operation creates or updates a policy assignment with the given scope and name. Policy assignments apply to all resources contained within their scope. For example, when you assign a policy at resource group scope, that policy applies to all resources in the group.",
+        "x-ms-examples": {
+          "Create or update a policy assignment": {
+            "$ref": "./examples/createPolicyAssignment.json"
+          },
+          "Create or update a policy assignment with multiple non-compliance messages": {
+            "$ref": "./examples/createPolicyAssignmentNonComplianceMessages.json"
+          },
+          "Create or update a policy assignment with a system assigned identity": {
+            "$ref": "./examples/createPolicyAssignmentWithIdentity.json"
+          },
+          "Create or update a policy assignment with a user assigned identity": {
+            "$ref": "./examples/createPolicyAssignmentWithUserAssignedIdentity.json"
+          },
+          "Create or update a policy assignment without enforcing policy effect during resource creation or update.": {
+            "$ref": "./examples/createPolicyAssignmentWithoutEnforcement.json"
+          },
+          "Create or update a policy assignment to enforce policy effect only on enrolled resources during resource creation or update.": {
+            "$ref": "./examples/createPolicyAssignmentWithEnrollEnforcement.json"
+          },
+          "Create or update a policy assignment with resource selectors": {
+            "$ref": "./examples/createPolicyAssignmentWithResourceSelectors.json"
+          },
+          "Create or update a policy assignment with overrides": {
+            "$ref": "./examples/createPolicyAssignmentWithOverrides.json"
+          }
+        },
+        "parameters": [
+          {
+            "name": "scope",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The scope of the policy assignment. Valid scopes are: management group (format: '/providers/Microsoft.Management/managementGroups/{managementGroup}'), subscription (format: '/subscriptions/{subscriptionId}'), resource group (format: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}', or resource (format: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/[{parentResourcePath}/]{resourceType}/{resourceName}'",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "name": "policyAssignmentName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": "^[^<>*%&:\\?.+/]*[^<>*%&:\\?.+/ ]+$",
+            "description": "The name of the policy assignment."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PolicyAssignment"
+            },
+            "description": "Parameters for the policy assignment."
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created - Returns information about the new policy assignment.",
+            "schema": {
+              "$ref": "#/definitions/PolicyAssignment"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "PolicyAssignments"
+        ],
+        "operationId": "PolicyAssignments_Get",
+        "summary": "Retrieves a policy assignment.",
+        "description": "This operation retrieves a single policy assignment, given its name and the scope it was created at.",
+        "x-ms-examples": {
+          "Retrieve a policy assignment": {
+            "$ref": "./examples/getPolicyAssignment.json"
+          },
+          "Retrieve a policy assignment with a system assigned identity": {
+            "$ref": "./examples/getPolicyAssignmentWithIdentity.json"
+          },
+          "Retrieve a policy assignment with a user assigned identity": {
+            "$ref": "./examples/getPolicyAssignmentWithUserAssignedIdentity.json"
+          },
+          "Retrieve a policy assignment with resource selectors": {
+            "$ref": "./examples/getPolicyAssignmentWithResourceSelectors.json"
+          },
+          "Retrieve a policy assignment with overrides": {
+            "$ref": "./examples/getPolicyAssignmentWithOverrides.json"
+          }
+        },
+        "parameters": [
+          {
+            "name": "scope",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The scope of the policy assignment. Valid scopes are: management group (format: '/providers/Microsoft.Management/managementGroups/{managementGroup}'), subscription (format: '/subscriptions/{subscriptionId}'), resource group (format: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}', or resource (format: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/[{parentResourcePath}/]{resourceType}/{resourceName}'",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "name": "policyAssignmentName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": "^[^<>*%&:\\?.+/]*[^<>*%&:\\?.+/ ]+$",
+            "description": "The name of the policy assignment to get."
+          },
+          {
+            "$ref": "#/parameters/PolicyAssignmentExpandParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns information about the policy assignment.",
+            "schema": {
+              "$ref": "#/definitions/PolicyAssignment"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "PolicyAssignments"
+        ],
+        "operationId": "PolicyAssignments_Update",
+        "summary": "Updates a policy assignment.",
+        "description": " This operation updates a policy assignment with the given scope and name. Policy assignments apply to all resources contained within their scope. For example, when you assign a policy at resource group scope, that policy applies to all resources in the group.",
+        "x-ms-examples": {
+          "Update a policy assignment with a system assigned identity": {
+            "$ref": "./examples/updatePolicyAssignmentWithIdentity.json"
+          },
+          "Update a policy assignment with a user assigned identity": {
+            "$ref": "./examples/updatePolicyAssignmentWithUserAssignedIdentity.json"
+          },
+          "Update a policy assignment with resource selectors": {
+            "$ref": "./examples/updatePolicyAssignmentWithResourceSelectors.json"
+          },
+          "Update a policy assignment with overrides": {
+            "$ref": "./examples/updatePolicyAssignmentWithOverrides.json"
+          }
+        },
+        "parameters": [
+          {
+            "name": "scope",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The scope of the policy assignment. Valid scopes are: management group (format: '/providers/Microsoft.Management/managementGroups/{managementGroup}'), subscription (format: '/subscriptions/{subscriptionId}'), resource group (format: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}', or resource (format: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/[{parentResourcePath}/]{resourceType}/{resourceName}'",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "name": "policyAssignmentName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": "^[^<>*%&:\\?.+/]*[^<>*%&:\\?.+/ ]+$",
+            "description": "The name of the policy assignment."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PolicyAssignmentUpdate"
+            },
+            "description": "Parameters for policy assignment patch request."
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns information about the policy assignment.",
+            "schema": {
+              "$ref": "#/definitions/PolicyAssignment"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Authorization/policyAssignments": {
+      "get": {
+        "tags": [
+          "PolicyAssignments"
+        ],
+        "operationId": "PolicyAssignments_ListForResourceGroup",
+        "summary": "Retrieves all policy assignments that apply to a resource group.",
+        "description": "This operation retrieves the list of all policy assignments associated with the given resource group in the given subscription that match the optional given $filter. Valid values for $filter are: 'atScope()', 'atExactScope()' or 'policyDefinitionId eq '{value}''. If $filter is not provided, the unfiltered list includes all policy assignments associated with the resource group, including those that apply directly or apply from containing scopes, as well as any applied to resources contained within the resource group. If $filter=atScope() is provided, the returned list includes all policy assignments that apply to the resource group, which is everything in the unfiltered list except those applied to resources contained within the resource group. If $filter=atExactScope() is provided, the returned list only includes all policy assignments that at the resource group. If $filter=policyDefinitionId eq '{value}' is provided, the returned list includes all policy assignments of the policy definition whose id is {value} that apply to the resource group.",
+        "x-ms-examples": {
+          "List policy assignments that apply to a resource group": {
+            "$ref": "./examples/listPolicyAssignmentsForResourceGroup.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group that contains policy assignments.",
+            "pattern": "^[-\\w\\._\\(\\)]+$",
+            "minLength": 1,
+            "maxLength": 90
+          },
+          {
+            "$ref": "#/parameters/PolicyAssignmentsFilterParameter"
+          },
+          {
+            "$ref": "#/parameters/PolicyAssignmentExpandParameter"
+          },
+          {
+            "$ref": "#/parameters/TopParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns an array of policy assignments.",
+            "schema": {
+              "$ref": "#/definitions/PolicyAssignmentListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{parentResourcePath}/{resourceType}/{resourceName}/providers/Microsoft.Authorization/policyAssignments": {
+      "get": {
+        "tags": [
+          "PolicyAssignments"
+        ],
+        "operationId": "PolicyAssignments_ListForResource",
+        "summary": "Retrieves all policy assignments that apply to a resource.",
+        "description": "This operation retrieves the list of all policy assignments associated with the specified resource in the given resource group and subscription that match the optional given $filter. Valid values for $filter are: 'atScope()', 'atExactScope()' or 'policyDefinitionId eq '{value}''. If $filter is not provided, the unfiltered list includes all policy assignments associated with the resource, including those that apply directly or from all containing scopes, as well as any applied to resources contained within the resource. If $filter=atScope() is provided, the returned list includes all policy assignments that apply to the resource, which is everything in the unfiltered list except those applied to resources contained within the resource. If $filter=atExactScope() is provided, the returned list only includes all policy assignments that at the resource level. If $filter=policyDefinitionId eq '{value}' is provided, the returned list includes all policy assignments of the policy definition whose id is {value} that apply to the resource. Three parameters plus the resource name are used to identify a specific resource. If the resource is not part of a parent resource (the more common case), the parent resource path should not be provided (or provided as ''). For example a web app could be specified as ({resourceProviderNamespace} == 'Microsoft.Web', {parentResourcePath} == '', {resourceType} == 'sites', {resourceName} == 'MyWebApp'). If the resource is part of a parent resource, then all parameters should be provided. For example a virtual machine DNS name could be specified as ({resourceProviderNamespace} == 'Microsoft.Compute', {parentResourcePath} == 'virtualMachines/MyVirtualMachine', {resourceType} == 'domainNames', {resourceName} == 'MyComputerName'). A convenient alternative to providing the namespace and type name separately is to provide both in the {resourceType} parameter, format: ({resourceProviderNamespace} == '', {parentResourcePath} == '', {resourceType} == 'Microsoft.Web/sites', {resourceName} == 'MyWebApp').",
+        "deprecated": false,
+        "x-ms-examples": {
+          "List all policy assignments that apply to a resource": {
+            "$ref": "./examples/listPolicyAssignmentsForResource.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group containing the resource.",
+            "pattern": "^[-\\w\\._\\(\\)]+$",
+            "minLength": 1,
+            "maxLength": 90
+          },
+          {
+            "name": "resourceProviderNamespace",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The namespace of the resource provider. For example, the namespace of a virtual machine is Microsoft.Compute (from Microsoft.Compute/virtualMachines)"
+          },
+          {
+            "name": "parentResourcePath",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The parent resource path. Use empty string if there is none.",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "name": "resourceType",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The resource type name. For example the type name of a web app is 'sites' (from Microsoft.Web/sites).",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": "^.+$",
+            "description": "The name of the resource."
+          },
+          {
+            "$ref": "#/parameters/PolicyAssignmentsFilterParameter"
+          },
+          {
+            "$ref": "#/parameters/PolicyAssignmentExpandParameter"
+          },
+          {
+            "$ref": "#/parameters/TopParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns an array of policy assignments.",
+            "schema": {
+              "$ref": "#/definitions/PolicyAssignmentListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-odata": "#/definitions/PolicyAssignment"
+      }
+    },
+    "/providers/Microsoft.Management/managementGroups/{managementGroupId}/providers/Microsoft.Authorization/policyAssignments": {
+      "get": {
+        "tags": [
+          "PolicyAssignments"
+        ],
+        "operationId": "PolicyAssignments_ListForManagementGroup",
+        "summary": "Retrieves all policy assignments that apply to a management group.",
+        "description": "This operation retrieves the list of all policy assignments applicable to the management group that match the given $filter. Valid values for $filter are: 'atScope()', 'atExactScope()' or 'policyDefinitionId eq '{value}''. If $filter=atScope() is provided, the returned list includes all policy assignments that are assigned to the management group or the management group's ancestors. If $filter=atExactScope() is provided, the returned list only includes all policy assignments that at the management group. If $filter=policyDefinitionId eq '{value}' is provided, the returned list includes all policy assignments of the policy definition whose id is {value} that apply to the management group.",
+        "x-ms-examples": {
+          "List policy assignments that apply to a management group": {
+            "$ref": "./examples/listPolicyAssignmentsForManagementGroup.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/ManagementGroupIdParameter"
+          },
+          {
+            "$ref": "#/parameters/PolicyAssignmentsFilterParameter"
+          },
+          {
+            "$ref": "#/parameters/PolicyAssignmentExpandParameter"
+          },
+          {
+            "$ref": "#/parameters/TopParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns an array of policy assignments.",
+            "schema": {
+              "$ref": "#/definitions/PolicyAssignmentListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Authorization/policyAssignments": {
+      "get": {
+        "tags": [
+          "PolicyAssignments"
+        ],
+        "operationId": "PolicyAssignments_List",
+        "summary": "Retrieves all policy assignments that apply to a subscription.",
+        "description": "This operation retrieves the list of all policy assignments associated with the given subscription that match the optional given $filter. Valid values for $filter are: 'atScope()', 'atExactScope()' or 'policyDefinitionId eq '{value}''. If $filter is not provided, the unfiltered list includes all policy assignments associated with the subscription, including those that apply directly or from management groups that contain the given subscription, as well as any applied to objects contained within the subscription. If $filter=atScope() is provided, the returned list includes all policy assignments that apply to the subscription, which is everything in the unfiltered list except those applied to objects contained within the subscription. If $filter=atExactScope() is provided, the returned list only includes all policy assignments that at the subscription. If $filter=policyDefinitionId eq '{value}' is provided, the returned list includes all policy assignments of the policy definition whose id is {value}.",
+        "x-ms-examples": {
+          "List policy assignments that apply to a subscription": {
+            "$ref": "./examples/listPolicyAssignments.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/PolicyAssignmentsFilterParameter"
+          },
+          {
+            "$ref": "#/parameters/PolicyAssignmentExpandParameter"
+          },
+          {
+            "$ref": "#/parameters/TopParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns an array of policy assignments.",
+            "schema": {
+              "$ref": "#/definitions/PolicyAssignmentListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-odata": "#/definitions/PolicyAssignment"
+      }
+    },
+    "/{policyAssignmentId}": {
+      "delete": {
+        "tags": [
+          "PolicyAssignments"
+        ],
+        "operationId": "PolicyAssignments_DeleteById",
+        "summary": "Deletes a policy assignment.",
+        "description": "This operation deletes the policy with the given ID. Policy assignment IDs have this format: '{scope}/providers/Microsoft.Authorization/policyAssignments/{policyAssignmentName}'. Valid formats for {scope} are: '/providers/Microsoft.Management/managementGroups/{managementGroup}' (management group), '/subscriptions/{subscriptionId}' (subscription), '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}' (resource group), or '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/[{parentResourcePath}/]{resourceType}/{resourceName}' (resource).",
+        "x-ms-examples": {
+          "Delete a policy assignment by ID": {
+            "$ref": "./examples/deletePolicyAssignmentById.json"
+          }
+        },
+        "parameters": [
+          {
+            "name": "policyAssignmentId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The ID of the policy assignment to delete. Use the format '{scope}/providers/Microsoft.Authorization/policyAssignments/{policyAssignmentName}'.",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns information about the policy assignment.",
+            "schema": {
+              "$ref": "#/definitions/PolicyAssignment"
+            }
+          },
+          "204": {
+            "description": "No Content - the policy assignment doesn't exist."
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "PolicyAssignments"
+        ],
+        "operationId": "PolicyAssignments_CreateById",
+        "summary": "Creates or updates a policy assignment.",
+        "description": "This operation creates or updates the policy assignment with the given ID. Policy assignments made on a scope apply to all resources contained in that scope. For example, when you assign a policy to a resource group that policy applies to all resources in the group. Policy assignment IDs have this format: '{scope}/providers/Microsoft.Authorization/policyAssignments/{policyAssignmentName}'. Valid scopes are: management group (format: '/providers/Microsoft.Management/managementGroups/{managementGroup}'), subscription (format: '/subscriptions/{subscriptionId}'), resource group (format: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}', or resource (format: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/[{parentResourcePath}/]{resourceType}/{resourceName}'.",
+        "x-ms-examples": {
+          "Create or update policy assignment by ID": {
+            "$ref": "./examples/createPolicyAssignmentById.json"
+          },
+          "Create or update policy assignment with a managed identity by ID": {
+            "$ref": "./examples/createPolicyAssignmentWithIdentityById.json"
+          }
+        },
+        "parameters": [
+          {
+            "name": "policyAssignmentId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The ID of the policy assignment to create. Use the format '{scope}/providers/Microsoft.Authorization/policyAssignments/{policyAssignmentName}'.",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PolicyAssignment"
+            },
+            "description": "Parameters for policy assignment."
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created - Returns information about the policy assignment.",
+            "schema": {
+              "$ref": "#/definitions/PolicyAssignment"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "PolicyAssignments"
+        ],
+        "operationId": "PolicyAssignments_GetById",
+        "summary": "Retrieves the policy assignment with the given ID.",
+        "description": "The operation retrieves the policy assignment with the given ID. Policy assignment IDs have this format: '{scope}/providers/Microsoft.Authorization/policyAssignments/{policyAssignmentName}'. Valid scopes are: management group (format: '/providers/Microsoft.Management/managementGroups/{managementGroup}'), subscription (format: '/subscriptions/{subscriptionId}'), resource group (format: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}', or resource (format: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/[{parentResourcePath}/]{resourceType}/{resourceName}'.",
+        "x-ms-examples": {
+          "Retrieve a policy assignment by ID": {
+            "$ref": "./examples/getPolicyAssignmentById.json"
+          },
+          "Retrieve a policy assignment with a managed identity by ID": {
+            "$ref": "./examples/getPolicyAssignmentWithIdentityById.json"
+          }
+        },
+        "parameters": [
+          {
+            "name": "policyAssignmentId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The ID of the policy assignment to get. Use the format '{scope}/providers/Microsoft.Authorization/policyAssignments/{policyAssignmentName}'.",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns information about the policy assignment.",
+            "schema": {
+              "$ref": "#/definitions/PolicyAssignment"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "PolicyAssignments"
+        ],
+        "operationId": "PolicyAssignments_UpdateById",
+        "summary": "Updates a policy assignment.",
+        "description": "This operation updates the policy assignment with the given ID. Policy assignments made on a scope apply to all resources contained in that scope. For example, when you assign a policy to a resource group that policy applies to all resources in the group. Policy assignment IDs have this format: '{scope}/providers/Microsoft.Authorization/policyAssignments/{policyAssignmentName}'. Valid scopes are: management group (format: '/providers/Microsoft.Management/managementGroups/{managementGroup}'), subscription (format: '/subscriptions/{subscriptionId}'), resource group (format: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}', or resource (format: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/[{parentResourcePath}/]{resourceType}/{resourceName}'.",
+        "x-ms-examples": {
+          "Update policy assignment with a managed identity by ID": {
+            "$ref": "./examples/updatePolicyAssignmentWithIdentityById.json"
+          }
+        },
+        "parameters": [
+          {
+            "name": "policyAssignmentId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The ID of the policy assignment to update. Use the format '{scope}/providers/Microsoft.Authorization/policyAssignments/{policyAssignmentName}'.",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PolicyAssignmentUpdate"
+            },
+            "description": "Parameters for policy assignment patch request."
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns information about the policy assignment.",
+            "schema": {
+              "$ref": "#/definitions/PolicyAssignment"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "PolicyAssignmentProperties": {
+      "type": "object",
+      "properties": {
+        "displayName": {
+          "type": "string",
+          "description": "The display name of the policy assignment."
+        },
+        "policyDefinitionId": {
+          "type": "string",
+          "description": "The ID of the policy definition or policy set definition being assigned."
+        },
+        "definitionVersion": {
+          "type": "string",
+          "description": "The version of the policy definition to use."
+        },
+        "latestDefinitionVersion": {
+          "type": "string",
+          "description": "The latest version of the policy definition available. This is only present if requested via the $expand query parameter.",
+          "readOnly": true
+        },
+        "effectiveDefinitionVersion": {
+          "type": "string",
+          "description": "The effective version of the policy definition in use. This is only present if requested via the $expand query parameter.",
+          "readOnly": true
+        },
+        "scope": {
+          "type": "string",
+          "description": "The scope for the policy assignment.",
+          "readOnly": true
+        },
+        "notScopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The policy's excluded scopes."
+        },
+        "parameters": {
+          "description": "The parameter values for the assigned policy rule. The keys are the parameter names.",
+          "$ref": "#/definitions/ParameterValues"
+        },
+        "description": {
+          "type": "string",
+          "description": "This message will be part of response in case of policy violation."
+        },
+        "metadata": {
+          "type": "object",
+          "description": "The policy assignment metadata. Metadata is an open ended object and is typically a collection of key value pairs."
+        },
+        "enforcementMode": {
+          "type": "string",
+          "description": "The policy assignment enforcement mode. Possible values are Default, DoNotEnforce, and Enroll",
+          "enum": [
+            "Default",
+            "DoNotEnforce",
+            "Enroll"
+          ],
+          "x-ms-enum": {
+            "name": "enforcementMode",
+            "modelAsString": true,
+            "values": [
+              {
+                "value": "Default",
+                "description": "The policy effect is enforced during resource creation or update."
+              },
+              {
+                "value": "DoNotEnforce",
+                "description": "The policy effect is not enforced during resource creation or update."
+              },
+              {
+                "value": "Enroll",
+                "description": "The policy effect is not enforced during resource creation or update until the resource or scope of the resource is enrolled to the assignment instance. Enrollment occurs upon deployment of the policy enrollment resource."
+              }
+            ]
+          },
+          "default": "Default"
+        },
+        "nonComplianceMessages": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NonComplianceMessage"
+          },
+          "x-ms-identifiers": [
+            "message",
+            "policyDefinitionReferenceId"
+          ],
+          "description": "The messages that describe why a resource is non-compliant with the policy."
+        },
+        "resourceSelectors": {
+          "type": "array",
+          "items": {
+            "$ref": "../../common/v2/types.json#/definitions/ResourceSelector"
+          },
+          "x-ms-identifiers": [],
+          "description": "The resource selector list to filter policies by resource properties."
+        },
+        "overrides": {
+          "type": "array",
+          "items": {
+            "$ref": "../../common/v2/types.json#/definitions/Override"
+          },
+          "x-ms-identifiers": [],
+          "description": "The policy property value override."
+        },
+        "assignmentType": {
+          "type": "string",
+          "description": "The type of policy assignment. Possible values are NotSpecified, System, SystemHidden, and Custom. Immutable.",
+          "enum": [
+            "NotSpecified",
+            "System",
+            "SystemHidden",
+            "Custom"
+          ],
+          "x-ms-enum": {
+            "name": "assignmentType",
+            "modelAsString": true
+          }
+        },
+        "instanceId": {
+          "type": "string",
+          "description": "The instance ID of the policy assignment. This ID only and always changes when the assignment is deleted and recreated.",
+          "readOnly": true
+        }
+      },
+      "description": "The policy assignment properties."
+    },
+    "NonComplianceMessage": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string",
+          "description": "A message that describes why a resource is non-compliant with the policy. This is shown in 'deny' error messages and on resource's non-compliant compliance results."
+        },
+        "policyDefinitionReferenceId": {
+          "type": "string",
+          "description": "The policy definition reference ID within a policy set definition the message is intended for. This is only applicable if the policy assignment assigns a policy set definition. If this is not provided the message applies to all policies assigned by this policy assignment."
+        }
+      },
+      "required": [
+        "message"
+      ],
+      "description": "A message that describes why a resource is non-compliant with the policy. This is shown in 'deny' error messages and on resource's non-compliant compliance results."
+    },
+    "ParameterValues": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/ParameterValuesValue"
+      },
+      "description": "The parameter values for the policy rule. The keys are the parameter names."
+    },
+    "ParameterValuesValue": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "The value of the parameter.",
+          "type": "object"
+        }
+      },
+      "description": "The value of a parameter."
+    },
+    "PolicyAssignment": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/PolicyAssignmentProperties",
+          "description": "Properties for the policy assignment."
+        },
+        "id": {
+          "type": "string",
+          "description": "The ID of the policy assignment.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of the policy assignment.",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the policy assignment.",
+          "readOnly": true
+        },
+        "location": {
+          "type": "string",
+          "description": "The location of the policy assignment. Only required when utilizing managed identity."
+        },
+        "identity": {
+          "$ref": "#/definitions/Identity",
+          "description": "The managed identity associated with the policy assignment."
+        },
+        "systemData": {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/systemData",
+          "readOnly": true,
+          "description": "The system metadata relating to this resource."
+        }
+      },
+      "description": "The policy assignment.",
+      "x-ms-azure-resource": true
+    },
+    "PolicyAssignmentListResult": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PolicyAssignment"
+          },
+          "x-ms-identifiers": [],
+          "description": "An array of policy assignments."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to use for getting the next set of results."
+        }
+      },
+      "description": "List of policy assignments."
+    },
+    "Identity": {
+      "type": "object",
+      "properties": {
+        "principalId": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The principal ID of the resource identity.  This property will only be provided for a system assigned identity"
+        },
+        "tenantId": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The tenant ID of the resource identity.  This property will only be provided for a system assigned identity"
+        },
+        "type": {
+          "type": "string",
+          "description": "The identity type. This is the only required field when adding a system or user assigned identity to a resource.",
+          "enum": [
+            "SystemAssigned",
+            "UserAssigned",
+            "None"
+          ],
+          "x-ms-enum": {
+            "name": "ResourceIdentityType",
+            "modelAsString": false,
+            "values": [
+              {
+                "value": "SystemAssigned",
+                "description": "Indicates that a system assigned identity is associated with the resource."
+              },
+              {
+                "value": "UserAssigned",
+                "description": "Indicates that a system assigned identity is associated with the resource."
+              },
+              {
+                "value": "None",
+                "description": "Indicates that no identity is associated with the resource or that the existing identity should be removed."
+              }
+            ]
+          }
+        },
+        "userAssignedIdentities": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "x-ms-client-name": "userAssignedIdentitiesValue",
+            "properties": {
+              "principalId": {
+                "readOnly": true,
+                "type": "string",
+                "description": "The principal id of user assigned identity."
+              },
+              "clientId": {
+                "readOnly": true,
+                "type": "string",
+                "description": "The client id of user assigned identity."
+              }
+            }
+          },
+          "description": "The user identity associated with the policy. The user identity dictionary key references will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'."
+        }
+      },
+      "description": "Identity for the resource.  Policy assignments support a maximum of one identity.  That is either a system assigned identity or a single user assigned identity."
+    },
+    "PolicyAssignmentUpdateProperties": {
+      "type": "object",
+      "properties": {
+        "resourceSelectors": {
+          "type": "array",
+          "items": {
+            "$ref": "../../common/v2/types.json#/definitions/ResourceSelector"
+          },
+          "x-ms-identifiers": [],
+          "description": "The resource selector list to filter policies by resource properties."
+        },
+        "overrides": {
+          "type": "array",
+          "items": {
+            "$ref": "../../common/v2/types.json#/definitions/Override"
+          },
+          "x-ms-identifiers": [],
+          "description": "The policy property value override."
+        }
+      },
+      "description": "The policy assignment properties for Patch request."
+    },
+    "PolicyAssignmentUpdate": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/PolicyAssignmentUpdateProperties",
+          "description": "The policy assignment properties for Patch request."
+        },
+        "location": {
+          "type": "string",
+          "description": "The location of the policy assignment. Only required when utilizing managed identity."
+        },
+        "identity": {
+          "$ref": "#/definitions/Identity",
+          "description": "The managed identity associated with the policy assignment."
+        }
+      },
+      "description": "The policy assignment for Patch request."
+    }
+  },
+  "parameters": {
+    "ManagementGroupIdParameter": {
+      "name": "managementGroupId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The ID of the management group.",
+      "x-ms-parameter-location": "method"
+    },
+    "PolicyAssignmentsFilterParameter": {
+      "name": "$filter",
+      "in": "query",
+      "required": false,
+      "type": "string",
+      "description": "The filter to apply on the operation. Valid values for $filter are: 'atScope()', 'atExactScope()' or 'policyDefinitionId eq '{value}''. If $filter is not provided, no filtering is performed. If $filter=atScope() is provided, the returned list only includes all policy assignments that apply to the scope, which is everything in the unfiltered list except those applied to sub scopes contained within the given scope. If $filter=atExactScope() is provided, the returned list only includes all policy assignments that at the given scope. If $filter=policyDefinitionId eq '{value}' is provided, the returned list includes all policy assignments of the policy definition whose id is {value}.",
+      "x-ms-skip-url-encoding": true,
+      "x-ms-parameter-location": "method"
+    },
+    "PolicyAssignmentExpandParameter": {
+      "name": "$expand",
+      "in": "query",
+      "required": false,
+      "type": "string",
+      "description": "Comma-separated list of additional properties to be included in the response. Supported values are 'LatestDefinitionVersion, EffectiveDefinitionVersion'.",
+      "x-ms-parameter-location": "method"
+    },
+    "TopParameter": {
+      "name": "$top",
+      "in": "query",
+      "required": false,
+      "type": "integer",
+      "format": "int32",
+      "minimum": 1,
+      "maximum": 1000,
+      "description": "Maximum number of records to return. When the $top filter is not provided, it will return 500 records.",
+      "x-ms-parameter-location": "method"
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/policyDefinitionVersions.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/policyDefinitionVersions.json
@@ -1,0 +1,856 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "PolicyClient",
+    "version": "2025-03-01",
+    "description": "To manage and control access to your resources, you can define customized policies and assign them at a scope."
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/providers/Microsoft.Authorization/listPolicyDefinitionVersions": {
+      "post": {
+        "tags": [
+          "PolicyDefinitionVersions"
+        ],
+        "operationId": "PolicyDefinitionVersions_ListAllBuiltins",
+        "summary": "Lists all built-in policy definition versions.",
+        "description": "This operation lists all the built-in policy definition versions for all built-in policy definitions.",
+        "x-ms-examples": {
+          "List all built-in policy definition versions": {
+            "$ref": "./examples/listAllBuiltInPolicyDefinitionVersions.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns an array of policy definition versions.",
+            "schema": {
+              "$ref": "#/definitions/PolicyDefinitionVersionListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/providers/Microsoft.Management/managementGroups/{managementGroupName}/providers/Microsoft.Authorization/listPolicyDefinitionVersions": {
+      "post": {
+        "tags": [
+          "PolicyDefinitionVersions"
+        ],
+        "operationId": "PolicyDefinitionVersions_ListAllAtManagementGroup",
+        "summary": "Lists all policy definition versions at management group scope.",
+        "description": "This operation lists all the policy definition versions for all policy definitions at the management group scope.",
+        "x-ms-examples": {
+          "List all policy definition versions at management group": {
+            "$ref": "./examples/listAllPolicyDefinitionVersionsByManagementGroup.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ManagementGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns an array of policy definition versions.",
+            "schema": {
+              "$ref": "#/definitions/PolicyDefinitionVersionListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Authorization/listPolicyDefinitionVersions": {
+      "post": {
+        "tags": [
+          "PolicyDefinitionVersions"
+        ],
+        "operationId": "PolicyDefinitionVersions_ListAll",
+        "summary": "Lists all policy definition versions within a subscription.",
+        "description": "This operation lists all the policy definition versions for all policy definitions within a subscription.",
+        "x-ms-examples": {
+          "List all policy definition versions at subscription": {
+            "$ref": "./examples/listAllPolicyDefinitionVersions.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns an array of policy definition versions.",
+            "schema": {
+              "$ref": "#/definitions/PolicyDefinitionVersionListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Authorization/policyDefinitions/{policyDefinitionName}/versions/{policyDefinitionVersion}": {
+      "put": {
+        "tags": [
+          "PolicyDefinitionVersions"
+        ],
+        "operationId": "PolicyDefinitionVersions_CreateOrUpdate",
+        "summary": "Creates or updates a policy definition in a subscription.",
+        "description": "This operation creates or updates a policy definition in the given subscription with the given name.",
+        "x-ms-examples": {
+          "Create or update a policy definition version": {
+            "$ref": "./examples/createOrUpdatePolicyDefinitionVersion.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/PolicyDefinitionName"
+          },
+          {
+            "$ref": "#/parameters/PolicyDefinitionVersion"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PolicyDefinitionVersion"
+            },
+            "description": "The policy definition properties."
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created - Returns information about the policy definition version.",
+            "schema": {
+              "$ref": "#/definitions/PolicyDefinitionVersion"
+            }
+          },
+          "200": {
+            "description": "OK - Successfully updated policy definition version.",
+            "schema": {
+              "$ref": "#/definitions/PolicyDefinitionVersion"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "PolicyDefinitionVersions"
+        ],
+        "operationId": "PolicyDefinitionVersions_Delete",
+        "summary": "Deletes a policy definition version in a subscription.",
+        "description": "This operation deletes the policy definition version in the given subscription with the given name.",
+        "x-ms-examples": {
+          "Delete a policy definition version": {
+            "$ref": "./examples/deletePolicyDefinitionVersion.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/PolicyDefinitionName"
+          },
+          {
+            "$ref": "#/parameters/PolicyDefinitionVersion"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "200": {
+            "description": "OK"
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "PolicyDefinitionVersions"
+        ],
+        "operationId": "PolicyDefinitionVersions_Get",
+        "summary": "Retrieves a policy definition version in a subscription.",
+        "description": "This operation retrieves the policy definition version in the given subscription with the given name.",
+        "x-ms-examples": {
+          "Retrieve a policy definition version": {
+            "$ref": "./examples/getPolicyDefinitionVersion.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/PolicyDefinitionName"
+          },
+          {
+            "$ref": "#/parameters/PolicyDefinitionVersion"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns information about the policy definition.",
+            "schema": {
+              "$ref": "#/definitions/PolicyDefinitionVersion"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/providers/Microsoft.Authorization/policyDefinitions/{policyDefinitionName}/versions/{policyDefinitionVersion}": {
+      "get": {
+        "tags": [
+          "PolicyDefinitionVersions"
+        ],
+        "operationId": "PolicyDefinitionVersions_GetBuiltIn",
+        "summary": "Retrieves a built-in policy definition version.",
+        "description": "This operation retrieves the built-in policy definition version with the given name.",
+        "x-ms-examples": {
+          "Retrieve a built-in policy definition version": {
+            "$ref": "./examples/getBuiltinPolicyDefinitionVersion.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/PolicyDefinitionName"
+          },
+          {
+            "$ref": "#/parameters/PolicyDefinitionVersion"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns information about the built-in policy definition.",
+            "schema": {
+              "$ref": "#/definitions/PolicyDefinitionVersion"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/providers/Microsoft.Management/managementGroups/{managementGroupName}/providers/Microsoft.Authorization/policyDefinitions/{policyDefinitionName}/versions/{policyDefinitionVersion}": {
+      "put": {
+        "tags": [
+          "PolicyDefinitionVersions"
+        ],
+        "operationId": "PolicyDefinitionVersions_CreateOrUpdateAtManagementGroup",
+        "summary": "Creates or updates a policy definition version in a management group.",
+        "description": "This operation creates or updates a policy definition version in the given management group with the given name.",
+        "x-ms-examples": {
+          "Create or update a policy definition version at management group level": {
+            "$ref": "./examples/createOrUpdatePolicyDefinitionVersionAtManagementGroup.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ManagementGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/PolicyDefinitionName"
+          },
+          {
+            "$ref": "#/parameters/PolicyDefinitionVersion"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PolicyDefinitionVersion"
+            },
+            "description": "The policy definition properties."
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created - Returns information about the policy definition version.",
+            "schema": {
+              "$ref": "#/definitions/PolicyDefinitionVersion"
+            }
+          },
+          "200": {
+            "description": "OK - Successfully updated policy definition version.",
+            "schema": {
+              "$ref": "#/definitions/PolicyDefinitionVersion"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "PolicyDefinitionVersions"
+        ],
+        "operationId": "PolicyDefinitionVersions_DeleteAtManagementGroup",
+        "summary": "Deletes a policy definition in a management group.",
+        "description": "This operation deletes the policy definition in the given management group with the given name.",
+        "x-ms-examples": {
+          "Delete a policy definition version at management group level": {
+            "$ref": "./examples/deletePolicyDefinitionVersionAtManagementGroup.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ManagementGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/PolicyDefinitionName"
+          },
+          {
+            "$ref": "#/parameters/PolicyDefinitionVersion"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "200": {
+            "description": "OK"
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "PolicyDefinitionVersions"
+        ],
+        "operationId": "PolicyDefinitionVersions_GetAtManagementGroup",
+        "summary": "Retrieve a policy definition version in a management group.",
+        "description": "This operation retrieves the policy definition version in the given management group with the given name.",
+        "x-ms-examples": {
+          "Retrieve a policy definition version at management group level": {
+            "$ref": "./examples/getPolicyDefinitionVersionAtManagementGroup.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ManagementGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/PolicyDefinitionName"
+          },
+          {
+            "$ref": "#/parameters/PolicyDefinitionVersion"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns information about the policy definition.",
+            "schema": {
+              "$ref": "#/definitions/PolicyDefinitionVersion"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Authorization/policyDefinitions/{policyDefinitionName}/versions": {
+      "get": {
+        "tags": [
+          "PolicyDefinitionVersions"
+        ],
+        "operationId": "PolicyDefinitionVersions_List",
+        "summary": "Retrieves policy definition versions for a given policy definition in a subscription",
+        "description": "This operation retrieves a list of all the policy definition versions for the given policy definition.",
+        "x-ms-examples": {
+          "List policy definition versions by subscription": {
+            "$ref": "./examples/listPolicyDefinitionVersions.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/PolicyDefinitionName"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/TopParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns an array of policy definition versions.",
+            "schema": {
+              "$ref": "#/definitions/PolicyDefinitionVersionListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/providers/Microsoft.Authorization/policyDefinitions/{policyDefinitionName}/versions": {
+      "get": {
+        "tags": [
+          "PolicyDefinitionVersions"
+        ],
+        "operationId": "PolicyDefinitionVersions_ListBuiltIn",
+        "summary": "Retrieve built-in policy definition versions",
+        "description": "This operation retrieves a list of all the built-in policy definition versions for the given policy definition.",
+        "x-ms-examples": {
+          "List built-in policy definition versions": {
+            "$ref": "./examples/listBuiltInPolicyDefinitionVersions.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/PolicyDefinitionName"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/TopParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns an array of built-in policy definition versions.",
+            "schema": {
+              "$ref": "#/definitions/PolicyDefinitionVersionListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/providers/Microsoft.Management/managementGroups/{managementGroupName}/providers/Microsoft.Authorization/policyDefinitions/{policyDefinitionName}/versions": {
+      "get": {
+        "tags": [
+          "PolicyDefinitionVersions"
+        ],
+        "operationId": "PolicyDefinitionVersions_ListByManagementGroup",
+        "summary": "Retrieve policy definition versions in a management group policy definition.",
+        "description": "This operation retrieves a list of all the policy definition versions for the given policy definition in the given management group.",
+        "x-ms-examples": {
+          "List policy definition versions by management group": {
+            "$ref": "./examples/listPolicyDefinitionVersionsByManagementGroup.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ManagementGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/PolicyDefinitionName"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/TopParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns an array of policy definition versions.",
+            "schema": {
+              "$ref": "#/definitions/PolicyDefinitionVersionListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "PolicyDefinitionVersionProperties": {
+      "type": "object",
+      "properties": {
+        "policyType": {
+          "type": "string",
+          "description": "The type of policy definition. Possible values are NotSpecified, BuiltIn, Custom, and Static.",
+          "enum": [
+            "NotSpecified",
+            "BuiltIn",
+            "Custom",
+            "Static"
+          ],
+          "x-ms-enum": {
+            "name": "policyType",
+            "modelAsString": true
+          }
+        },
+        "mode": {
+          "type": "string",
+          "description": "The policy definition mode. Some examples are All, Indexed, Microsoft.KeyVault.Data.",
+          "default": "Indexed"
+        },
+        "displayName": {
+          "type": "string",
+          "description": "The display name of the policy definition."
+        },
+        "description": {
+          "type": "string",
+          "description": "The policy definition description."
+        },
+        "policyRule": {
+          "type": "object",
+          "description": "The policy rule."
+        },
+        "metadata": {
+          "type": "object",
+          "description": "The policy definition metadata.  Metadata is an open ended object and is typically a collection of key value pairs."
+        },
+        "parameters": {
+          "description": "The parameter definitions for parameters used in the policy rule. The keys are the parameter names.",
+          "$ref": "#/definitions/ParameterDefinitions"
+        },
+        "version": {
+          "type": "string",
+          "description": "The policy definition version in #.#.# format."
+        },
+        "externalEvaluationEnforcementSettings": {
+          "description": "The details of the source of external evaluation results required by the policy during enforcement evaluation.",
+          "$ref": "#/definitions/ExternalEvaluationEnforcementSettings"
+        }
+      },
+      "description": "The policy definition properties."
+    },
+    "ParameterDefinitionsValue": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "The data type of the parameter.",
+          "type": "string",
+          "enum": [
+            "String",
+            "Array",
+            "Object",
+            "Boolean",
+            "Integer",
+            "Float",
+            "DateTime"
+          ],
+          "x-ms-enum": {
+            "name": "parameterType",
+            "modelAsString": true
+          }
+        },
+        "allowedValues": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          },
+          "x-ms-identifiers": [],
+          "description": "The allowed values for the parameter."
+        },
+        "defaultValue": {
+          "type": "object",
+          "description": "The default value for the parameter if no value is provided."
+        },
+        "schema": {
+          "type": "object",
+          "description": "Provides validation of parameter inputs during assignment using a self-defined JSON schema. This property is only supported for object-type parameters and follows the Json.NET Schema 2019-09 implementation. You can learn more about using schemas at https://json-schema.org/ and test draft schemas at https://www.jsonschemavalidator.net/."
+        },
+        "metadata": {
+          "type": "object",
+          "properties": {
+            "displayName": {
+              "type": "string",
+              "description": "The display name for the parameter."
+            },
+            "description": {
+              "type": "string",
+              "description": "The description of the parameter."
+            },
+            "strongType": {
+              "type": "string",
+              "description": "Used when assigning the policy definition through the portal. Provides a context aware list of values for the user to choose from."
+            },
+            "assignPermissions": {
+              "type": "boolean",
+              "description": "Set to true to have Azure portal create role assignments on the resource ID or resource scope value of this parameter during policy assignment. This property is useful in case you wish to assign permissions outside the assignment scope."
+            }
+          },
+          "additionalProperties": {
+            "type": "object"
+          },
+          "description": "General metadata for the parameter."
+        }
+      },
+      "description": "The definition of a parameter that can be provided to the policy."
+    },
+    "ParameterDefinitions": {
+      "description": "The parameter definitions for parameters used in the policy. The keys are the parameter names.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/ParameterDefinitionsValue"
+      }
+    },
+    "PolicyDefinitionVersion": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/PolicyDefinitionVersionProperties",
+          "description": "The policy definition version properties."
+        },
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The ID of the policy definition version."
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The name of the policy definition version."
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The type of the resource (Microsoft.Authorization/policyDefinitions/versions)."
+        },
+        "systemData": {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/systemData",
+          "readOnly": true,
+          "description": "The system metadata relating to this resource."
+        }
+      },
+      "description": "The ID of the policy definition version.",
+      "x-ms-azure-resource": true
+    },
+    "PolicyDefinitionVersionListResult": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PolicyDefinitionVersion"
+          },
+          "description": "An array of policy definitions versions."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to use for getting the next set of results."
+        }
+      },
+      "description": "List of policy definition versions."
+    },
+    "ExternalEvaluationEnforcementSettings": {
+      "type": "object",
+      "properties": {
+        "missingTokenAction": {
+          "type": "string",
+          "description": "What to do when evaluating an enforcement policy that requires an external evaluation and the token is missing. Possible values are Audit and Deny."
+        },
+        "resultLifespan": {
+          "type": "string",
+          "description": "The lifespan of the endpoint invocation result after which it's no longer valid. Value is expected to follow the ISO 8601 duration format.",
+          "pattern": "^P(\\d+Y)?(\\d+M)?(\\d+D)?(T(\\d+H)?(\\d+M)?(\\d+(\\.\\d+)?S)?)?$"
+        },
+        "endpointSettings": {
+          "description": "The settings of an external endpoint providing evaluation results.",
+          "$ref": "#/definitions/ExternalEvaluationEndpointSettings"
+        },
+        "roleDefinitionIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "An array of the role definition Ids the assignment's MSI will need in order to invoke the endpoint."
+        }
+      },
+      "description": "The details of the source of external evaluation results required by the policy during enforcement evaluation."
+    },
+    "ExternalEvaluationEndpointSettings": {
+      "type": "object",
+      "properties": {
+        "kind": {
+          "type": "string",
+          "description": "The kind of the endpoint."
+        },
+        "details": {
+          "type": "object",
+          "description": "The details of the endpoint."
+        }
+      },
+      "description": "The settings of an external endpoint providing evaluation results."
+    }
+  },
+  "parameters": {
+    "PolicyDefinitionName": {
+      "name": "policyDefinitionName",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "pattern": "^[^<>*%&:\\?.+/]*[^<>*%&:\\?.+/ ]+$",
+      "description": "The name of the policy definition.",
+      "x-ms-parameter-location": "method"
+    },
+    "PolicyDefinitionVersion": {
+      "name": "policyDefinitionVersion",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "description": "The policy definition version.  The format is x.y.z where x is the major version number, y is the minor version number, and z is the patch number",
+      "x-ms-parameter-location": "method"
+    },
+    "PolicyDefinitionsFilterParameter": {
+      "name": "$filter",
+      "in": "query",
+      "required": false,
+      "type": "string",
+      "description": "The filter to apply on the operation. Valid values for $filter are: 'atExactScope()', 'policyType -eq {value}' or 'category eq '{value}''. If $filter is not provided, no filtering is performed. If $filter=atExactScope() is provided, the returned list only includes all policy definitions that at the given scope. If $filter='policyType -eq {value}' is provided, the returned list only includes all policy definitions whose type match the {value}. Possible policyType values are NotSpecified, BuiltIn, Custom, and Static. If $filter='category -eq {value}' is provided, the returned list only includes all policy definitions whose category match the {value}.",
+      "x-ms-skip-url-encoding": true,
+      "x-ms-parameter-location": "method"
+    },
+    "TopParameter": {
+      "name": "$top",
+      "in": "query",
+      "required": false,
+      "type": "integer",
+      "format": "int32",
+      "minimum": 1,
+      "maximum": 1000,
+      "description": "Maximum number of records to return. When the $top filter is not provided, it will return 500 records.",
+      "x-ms-parameter-location": "method"
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/policyDefinitions.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/policyDefinitions.json
@@ -1,0 +1,753 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "PolicyClient",
+    "version": "2025-03-01",
+    "description": "To manage and control access to your resources, you can define customized policies and assign them at a scope."
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Authorization/policyDefinitions/{policyDefinitionName}": {
+      "put": {
+        "tags": [
+          "PolicyDefinitions"
+        ],
+        "operationId": "PolicyDefinitions_CreateOrUpdate",
+        "summary": "Creates or updates a policy definition in a subscription.",
+        "description": "This operation creates or updates a policy definition in the given subscription with the given name.",
+        "x-ms-examples": {
+          "Create or update a policy definition": {
+            "$ref": "./examples/createOrUpdatePolicyDefinition.json"
+          },
+          "Create or update a policy definition with advanced parameters": {
+            "$ref": "./examples/createOrUpdatePolicyDefinitionAdvancedParams.json"
+          },
+          "Create or update a policy definition with external evaluation enforcement settings": {
+            "$ref": "./examples/createOrUpdatePolicyDefinitionExternalEvaluationEnforcementSettings.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "policyDefinitionName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": "^[^<>*%&:\\?.+/]*[^<>*%&:\\?.+/ ]+$",
+            "description": "The name of the policy definition to create."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PolicyDefinition"
+            },
+            "description": "The policy definition properties."
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created - Returns information about the policy definition.",
+            "schema": {
+              "$ref": "#/definitions/PolicyDefinition"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "PolicyDefinitions"
+        ],
+        "operationId": "PolicyDefinitions_Delete",
+        "summary": "Deletes a policy definition in a subscription.",
+        "description": "This operation deletes the policy definition in the given subscription with the given name.",
+        "x-ms-examples": {
+          "Delete a policy definition": {
+            "$ref": "./examples/deletePolicyDefinition.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "policyDefinitionName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": "^[^<>*%&:\\?.+/]*[^<>*%&:\\?.+/ ]+$",
+            "description": "The name of the policy definition to delete."
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "200": {
+            "description": "OK"
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "PolicyDefinitions"
+        ],
+        "operationId": "PolicyDefinitions_Get",
+        "summary": "Retrieves a policy definition in a subscription.",
+        "description": "This operation retrieves the policy definition in the given subscription with the given name.",
+        "x-ms-examples": {
+          "Retrieve a policy definition": {
+            "$ref": "./examples/getPolicyDefinition.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "policyDefinitionName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": "^[^<>*%&:\\?.+/]*[^<>*%&:\\?.+/ ]+$",
+            "description": "The name of the policy definition to get."
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns information about the policy definition.",
+            "schema": {
+              "$ref": "#/definitions/PolicyDefinition"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/providers/Microsoft.Authorization/policyDefinitions/{policyDefinitionName}": {
+      "get": {
+        "tags": [
+          "PolicyDefinitions"
+        ],
+        "operationId": "PolicyDefinitions_GetBuiltIn",
+        "summary": "Retrieves a built-in policy definition.",
+        "description": "This operation retrieves the built-in policy definition with the given name.",
+        "x-ms-examples": {
+          "Retrieve a built-in policy definition": {
+            "$ref": "./examples/getBuiltinPolicyDefinition.json"
+          }
+        },
+        "parameters": [
+          {
+            "name": "policyDefinitionName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": "^[^<>*%&:\\?.+/]*[^<>*%&:\\?.+/ ]+$",
+            "description": "The name of the built-in policy definition to get."
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns information about the built-in policy definition.",
+            "schema": {
+              "$ref": "#/definitions/PolicyDefinition"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/providers/Microsoft.Management/managementGroups/{managementGroupId}/providers/Microsoft.Authorization/policyDefinitions/{policyDefinitionName}": {
+      "put": {
+        "tags": [
+          "PolicyDefinitions"
+        ],
+        "operationId": "PolicyDefinitions_CreateOrUpdateAtManagementGroup",
+        "summary": "Creates or updates a policy definition in a management group.",
+        "description": "This operation creates or updates a policy definition in the given management group with the given name.",
+        "x-ms-examples": {
+          "Create or update a policy definition at management group level": {
+            "$ref": "./examples/createOrUpdatePolicyDefinitionAtManagementGroup.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/ManagementGroupIdParameter"
+          },
+          {
+            "name": "policyDefinitionName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": "^[^<>*%&:\\?.+/]*[^<>*%&:\\?.+/ ]+$",
+            "description": "The name of the policy definition to create."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PolicyDefinition"
+            },
+            "description": "The policy definition properties."
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created - Returns information about the policy definition.",
+            "schema": {
+              "$ref": "#/definitions/PolicyDefinition"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "PolicyDefinitions"
+        ],
+        "operationId": "PolicyDefinitions_DeleteAtManagementGroup",
+        "summary": "Deletes a policy definition in a management group.",
+        "description": "This operation deletes the policy definition in the given management group with the given name.",
+        "x-ms-examples": {
+          "Delete a policy definition at management group level": {
+            "$ref": "./examples/deletePolicyDefinitionAtManagementGroup.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/ManagementGroupIdParameter"
+          },
+          {
+            "name": "policyDefinitionName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": "^[^<>*%&:\\?.+/]*[^<>*%&:\\?.+/ ]+$",
+            "description": "The name of the policy definition to delete."
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "200": {
+            "description": "OK"
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "PolicyDefinitions"
+        ],
+        "operationId": "PolicyDefinitions_GetAtManagementGroup",
+        "summary": "Retrieve a policy definition in a management group.",
+        "description": "This operation retrieves the policy definition in the given management group with the given name.",
+        "x-ms-examples": {
+          "Retrieve a policy definition at management group level": {
+            "$ref": "./examples/getPolicyDefinitionAtManagementGroup.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/ManagementGroupIdParameter"
+          },
+          {
+            "name": "policyDefinitionName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": "^[^<>*%&:\\?.+/]*[^<>*%&:\\?.+/ ]+$",
+            "description": "The name of the policy definition to get."
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns information about the policy definition.",
+            "schema": {
+              "$ref": "#/definitions/PolicyDefinition"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Authorization/policyDefinitions": {
+      "get": {
+        "tags": [
+          "PolicyDefinitions"
+        ],
+        "operationId": "PolicyDefinitions_List",
+        "summary": "Retrieves policy definitions in a subscription",
+        "description": "This operation retrieves a list of all the policy definitions in a given subscription that match the optional given $filter. Valid values for $filter are: 'atExactScope()', 'policyType -eq {value}' or 'category eq '{value}''. If $filter is not provided, the unfiltered list includes all policy definitions associated with the subscription, including those that apply directly or from management groups that contain the given subscription. If $filter=atExactScope() is provided, the returned list only includes all policy definitions that at the given subscription. If $filter='policyType -eq {value}' is provided, the returned list only includes all policy definitions whose type match the {value}. Possible policyType values are NotSpecified, BuiltIn, Custom, and Static. If $filter='category -eq {value}' is provided, the returned list only includes all policy definitions whose category match the {value}.",
+        "x-ms-examples": {
+          "List policy definitions by subscription": {
+            "$ref": "./examples/listPolicyDefinitions.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/PolicyDefinitionsFilterParameter"
+          },
+          {
+            "$ref": "#/parameters/TopParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns an array of policy definitions.",
+            "schema": {
+              "$ref": "#/definitions/PolicyDefinitionListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/providers/Microsoft.Authorization/policyDefinitions": {
+      "get": {
+        "tags": [
+          "PolicyDefinitions"
+        ],
+        "operationId": "PolicyDefinitions_ListBuiltIn",
+        "summary": "Retrieve built-in policy definitions",
+        "description": "This operation retrieves a list of all the built-in policy definitions that match the optional given $filter. If $filter='policyType -eq {value}' is provided, the returned list only includes all built-in policy definitions whose type match the {value}. Possible policyType values are NotSpecified, BuiltIn, Custom, and Static. If $filter='category -eq {value}' is provided, the returned list only includes all built-in policy definitions whose category match the {value}.",
+        "x-ms-examples": {
+          "List built-in policy definitions": {
+            "$ref": "./examples/listBuiltInPolicyDefinitions.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/PolicyDefinitionsFilterParameter"
+          },
+          {
+            "$ref": "#/parameters/TopParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns an array of built-in policy definitions.",
+            "schema": {
+              "$ref": "#/definitions/PolicyDefinitionListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/providers/Microsoft.Management/managementGroups/{managementGroupId}/providers/Microsoft.Authorization/policyDefinitions": {
+      "get": {
+        "tags": [
+          "PolicyDefinitions"
+        ],
+        "operationId": "PolicyDefinitions_ListByManagementGroup",
+        "summary": "Retrieve policy definitions in a management group",
+        "description": "This operation retrieves a list of all the policy definitions in a given management group that match the optional given $filter. Valid values for $filter are: 'atExactScope()', 'policyType -eq {value}' or 'category eq '{value}''. If $filter is not provided, the unfiltered list includes all policy definitions associated with the management group, including those that apply directly or from management groups that contain the given management group. If $filter=atExactScope() is provided, the returned list only includes all policy definitions that at the given management group. If $filter='policyType -eq {value}' is provided, the returned list only includes all policy definitions whose type match the {value}. Possible policyType values are NotSpecified, BuiltIn, Custom, and Static. If $filter='category -eq {value}' is provided, the returned list only includes all policy definitions whose category match the {value}.",
+        "x-ms-examples": {
+          "List policy definitions by management group": {
+            "$ref": "./examples/listPolicyDefinitionsByManagementGroup.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/ManagementGroupIdParameter"
+          },
+          {
+            "$ref": "#/parameters/PolicyDefinitionsFilterParameter"
+          },
+          {
+            "$ref": "#/parameters/TopParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns an array of policy definitions.",
+            "schema": {
+              "$ref": "#/definitions/PolicyDefinitionListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "PolicyDefinitionProperties": {
+      "type": "object",
+      "properties": {
+        "policyType": {
+          "type": "string",
+          "description": "The type of policy definition. Possible values are NotSpecified, BuiltIn, Custom, and Static.",
+          "enum": [
+            "NotSpecified",
+            "BuiltIn",
+            "Custom",
+            "Static"
+          ],
+          "x-ms-enum": {
+            "name": "policyType",
+            "modelAsString": true
+          }
+        },
+        "mode": {
+          "type": "string",
+          "description": "The policy definition mode. Some examples are All, Indexed, Microsoft.KeyVault.Data.",
+          "default": "Indexed"
+        },
+        "displayName": {
+          "type": "string",
+          "description": "The display name of the policy definition."
+        },
+        "description": {
+          "type": "string",
+          "description": "The policy definition description."
+        },
+        "policyRule": {
+          "type": "object",
+          "description": "The policy rule."
+        },
+        "metadata": {
+          "type": "object",
+          "description": "The policy definition metadata.  Metadata is an open ended object and is typically a collection of key value pairs."
+        },
+        "parameters": {
+          "description": "The parameter definitions for parameters used in the policy rule. The keys are the parameter names.",
+          "$ref": "#/definitions/ParameterDefinitions"
+        },
+        "version": {
+          "type": "string",
+          "description": "The policy definition version in #.#.# format."
+        },
+        "versions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "A list of available versions for this policy definition."
+        },
+        "externalEvaluationEnforcementSettings": {
+          "description": "The details of the source of external evaluation results required by the policy during enforcement evaluation.",
+          "$ref": "#/definitions/ExternalEvaluationEnforcementSettings"
+        }
+      },
+      "description": "The policy definition properties."
+    },
+    "ParameterDefinitionsValue": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "The data type of the parameter.",
+          "type": "string",
+          "enum": [
+            "String",
+            "Array",
+            "Object",
+            "Boolean",
+            "Integer",
+            "Float",
+            "DateTime"
+          ],
+          "x-ms-enum": {
+            "name": "parameterType",
+            "modelAsString": true
+          }
+        },
+        "allowedValues": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          },
+          "x-ms-identifiers": [],
+          "description": "The allowed values for the parameter."
+        },
+        "defaultValue": {
+          "type": "object",
+          "description": "The default value for the parameter if no value is provided."
+        },
+        "schema": {
+          "type": "object",
+          "description": "Provides validation of parameter inputs during assignment using a self-defined JSON schema. This property is only supported for object-type parameters and follows the Json.NET Schema 2019-09 implementation. You can learn more about using schemas at https://json-schema.org/ and test draft schemas at https://www.jsonschemavalidator.net/."
+        },
+        "metadata": {
+          "type": "object",
+          "properties": {
+            "displayName": {
+              "type": "string",
+              "description": "The display name for the parameter."
+            },
+            "description": {
+              "type": "string",
+              "description": "The description of the parameter."
+            },
+            "strongType": {
+              "type": "string",
+              "description": "Used when assigning the policy definition through the portal. Provides a context aware list of values for the user to choose from."
+            },
+            "assignPermissions": {
+              "type": "boolean",
+              "description": "Set to true to have Azure portal create role assignments on the resource ID or resource scope value of this parameter during policy assignment. This property is useful in case you wish to assign permissions outside the assignment scope."
+            }
+          },
+          "additionalProperties": {
+            "type": "object"
+          },
+          "description": "General metadata for the parameter."
+        }
+      },
+      "description": "The definition of a parameter that can be provided to the policy."
+    },
+    "ParameterDefinitions": {
+      "description": "The parameter definitions for parameters used in the policy. The keys are the parameter names.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/ParameterDefinitionsValue"
+      }
+    },
+    "PolicyDefinition": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/PolicyDefinitionProperties",
+          "description": "The policy definition properties."
+        },
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The ID of the policy definition."
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The name of the policy definition."
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The type of the resource (Microsoft.Authorization/policyDefinitions)."
+        },
+        "systemData": {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/systemData",
+          "readOnly": true,
+          "description": "The system metadata relating to this resource."
+        }
+      },
+      "description": "The policy definition.",
+      "x-ms-azure-resource": true
+    },
+    "PolicyDefinitionListResult": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PolicyDefinition"
+          },
+          "description": "An array of policy definitions."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to use for getting the next set of results."
+        }
+      },
+      "description": "List of policy definitions."
+    },
+    "ExternalEvaluationEnforcementSettings": {
+      "type": "object",
+      "properties": {
+        "missingTokenAction": {
+          "type": "string",
+          "description": "What to do when evaluating an enforcement policy that requires an external evaluation and the token is missing. Possible values are Audit and Deny."
+        },
+        "resultLifespan": {
+          "type": "string",
+          "description": "The lifespan of the endpoint invocation result after which it's no longer valid. Value is expected to follow the ISO 8601 duration format.",
+          "pattern": "^P(\\d+Y)?(\\d+M)?(\\d+D)?(T(\\d+H)?(\\d+M)?(\\d+(\\.\\d+)?S)?)?$"
+        },
+        "endpointSettings": {
+          "description": "The settings of an external endpoint providing evaluation results.",
+          "$ref": "#/definitions/ExternalEvaluationEndpointSettings"
+        },
+        "roleDefinitionIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "An array of the role definition Ids the assignment's MSI will need in order to invoke the endpoint."
+        }
+      },
+      "description": "The details of the source of external evaluation results required by the policy during enforcement evaluation."
+    },
+    "ExternalEvaluationEndpointSettings": {
+      "type": "object",
+      "properties": {
+        "kind": {
+          "type": "string",
+          "description": "The kind of the endpoint."
+        },
+        "details": {
+          "type": "object",
+          "description": "The details of the endpoint."
+        }
+      },
+      "description": "The settings of an external endpoint providing evaluation results."
+    }
+  },
+  "parameters": {
+    "ManagementGroupIdParameter": {
+      "name": "managementGroupId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The ID of the management group.",
+      "x-ms-parameter-location": "method"
+    },
+    "PolicyDefinitionsFilterParameter": {
+      "name": "$filter",
+      "in": "query",
+      "required": false,
+      "type": "string",
+      "description": "The filter to apply on the operation. Valid values for $filter are: 'atExactScope()', 'policyType -eq {value}' or 'category eq '{value}''. If $filter is not provided, no filtering is performed. If $filter=atExactScope() is provided, the returned list only includes all policy definitions that at the given scope. If $filter='policyType -eq {value}' is provided, the returned list only includes all policy definitions whose type match the {value}. Possible policyType values are NotSpecified, BuiltIn, Custom, and Static. If $filter='category -eq {value}' is provided, the returned list only includes all policy definitions whose category match the {value}.",
+      "x-ms-skip-url-encoding": true,
+      "x-ms-parameter-location": "method"
+    },
+    "TopParameter": {
+      "name": "$top",
+      "in": "query",
+      "required": false,
+      "type": "integer",
+      "format": "int32",
+      "minimum": 1,
+      "maximum": 1000,
+      "description": "Maximum number of records to return. When the $top filter is not provided, it will return 500 records.",
+      "x-ms-parameter-location": "method"
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/policySetDefinitionVersions.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/policySetDefinitionVersions.json
@@ -1,0 +1,852 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "PolicyClient",
+    "version": "2025-03-01",
+    "description": "To manage and control access to your resources, you can define customized policies and assign them at a scope."
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/providers/Microsoft.Authorization/listPolicySetDefinitionVersions": {
+      "post": {
+        "tags": [
+          "PolicySetDefinitionVersions"
+        ],
+        "operationId": "PolicySetDefinitionVersions_ListAllBuiltins",
+        "summary": "Lists all built-in policy set definition versions.",
+        "description": "This operation lists all the built-in policy set definition versions for all built-in policy set definitions.",
+        "x-ms-examples": {
+          "List all built-in policy definition versions": {
+            "$ref": "./examples/listAllBuiltInPolicySetDefinitionVersions.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns an array of policy set definition versions.",
+            "schema": {
+              "$ref": "#/definitions/PolicySetDefinitionVersionListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/providers/Microsoft.Management/managementGroups/{managementGroupName}/providers/Microsoft.Authorization/listPolicySetDefinitionVersions": {
+      "post": {
+        "tags": [
+          "PolicySetDefinitionVersions"
+        ],
+        "operationId": "PolicySetDefinitionVersions_ListAllAtManagementGroup",
+        "summary": "Lists all policy set definition versions at management group scope.",
+        "description": "This operation lists all the policy set definition versions for all policy set definitions at the management group scope.",
+        "x-ms-examples": {
+          "List all policy definition versions at management group": {
+            "$ref": "./examples/listAllPolicySetDefinitionVersionsByManagementGroup.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ManagementGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns an array of policy set definition versions.",
+            "schema": {
+              "$ref": "#/definitions/PolicySetDefinitionVersionListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Authorization/listPolicySetDefinitionVersions": {
+      "post": {
+        "tags": [
+          "PolicySetDefinitionVersions"
+        ],
+        "operationId": "PolicySetDefinitionVersions_ListAll",
+        "summary": "Lists all policy set definition versions within a subscription.",
+        "description": "This operation lists all the policy set definition versions for all policy set definitions within a subscription.",
+        "x-ms-examples": {
+          "List all policy definition versions at subscription": {
+            "$ref": "./examples/listAllPolicySetDefinitionVersions.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns an array of policy set definition versions.",
+            "schema": {
+              "$ref": "#/definitions/PolicySetDefinitionVersionListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Authorization/policySetDefinitions/{policySetDefinitionName}/versions/{policyDefinitionVersion}": {
+      "put": {
+        "tags": [
+          "PolicySetDefinitionVersions"
+        ],
+        "operationId": "PolicySetDefinitionVersions_CreateOrUpdate",
+        "summary": "Creates or updates a policy set definition version.",
+        "description": "This operation creates or updates a policy set definition version in the given subscription with the given name and version.",
+        "x-ms-examples": {
+          "Create or update a policy set definition version": {
+            "$ref": "./examples/createOrUpdatePolicySetDefinitionVersion.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/PolicySetDefinitionName"
+          },
+          {
+            "$ref": "#/parameters/PolicySetDefinitionVersion"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PolicySetDefinitionVersion"
+            },
+            "description": "The policy set definition properties."
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created - Returns information about the policy set definition version.",
+            "schema": {
+              "$ref": "#/definitions/PolicySetDefinitionVersion"
+            }
+          },
+          "200": {
+            "description": "OK - Successfully updated policy set definition version.",
+            "schema": {
+              "$ref": "#/definitions/PolicySetDefinitionVersion"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "PolicySetDefinitionVersions"
+        ],
+        "operationId": "PolicySetDefinitionVersions_Delete",
+        "summary": "Deletes a policy set definition version.",
+        "description": "This operation deletes the policy set definition version in the given subscription with the given name and version.",
+        "x-ms-examples": {
+          "Delete a policy set definition version": {
+            "$ref": "./examples/deletePolicySetDefinitionVersion.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/PolicySetDefinitionName"
+          },
+          {
+            "$ref": "#/parameters/PolicySetDefinitionVersion"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content - the policy set definition doesn't exist in the subscription."
+          },
+          "200": {
+            "description": "OK"
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "PolicySetDefinitionVersions"
+        ],
+        "operationId": "PolicySetDefinitionVersions_Get",
+        "summary": "Retrieves a policy set definition version.",
+        "description": "This operation retrieves the policy set definition version in the given subscription with the given name and version.",
+        "x-ms-examples": {
+          "Retrieve a policy set definition version": {
+            "$ref": "./examples/getPolicySetDefinitionVersion.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/PolicySetDefinitionName"
+          },
+          {
+            "$ref": "#/parameters/PolicySetDefinitionVersion"
+          },
+          {
+            "$ref": "#/parameters/PolicySetDefinitionsExpandParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns information about the policy set definition version.",
+            "schema": {
+              "$ref": "#/definitions/PolicySetDefinitionVersion"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/providers/Microsoft.Authorization/policySetDefinitions/{policySetDefinitionName}/versions/{policyDefinitionVersion}": {
+      "get": {
+        "tags": [
+          "PolicySetDefinitionVersions"
+        ],
+        "operationId": "PolicySetDefinitionVersions_GetBuiltIn",
+        "summary": "Retrieves a built in policy set definition version.",
+        "description": "This operation retrieves the built-in policy set definition version with the given name and version.",
+        "x-ms-examples": {
+          "Retrieve a built-in policy set definition version": {
+            "$ref": "./examples/getBuiltInPolicySetDefinitionVersion.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/PolicySetDefinitionName"
+          },
+          {
+            "$ref": "#/parameters/PolicySetDefinitionVersion"
+          },
+          {
+            "$ref": "#/parameters/PolicySetDefinitionsExpandParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns information about the built in policy set definition version.",
+            "schema": {
+              "$ref": "#/definitions/PolicySetDefinitionVersion"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Authorization/policySetDefinitions/{policySetDefinitionName}/versions": {
+      "get": {
+        "tags": [
+          "PolicySetDefinitionVersions"
+        ],
+        "operationId": "PolicySetDefinitionVersions_List",
+        "summary": "Retrieves the policy set definition versions for a given policy set definition in a subscription.",
+        "description": "This operation retrieves a list of all the policy set definition versions for the given policy set definition.",
+        "x-ms-examples": {
+          "List policy set definitions": {
+            "$ref": "./examples/listPolicySetDefinitionVersions.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/PolicySetDefinitionName"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/PolicySetDefinitionsExpandParameter"
+          },
+          {
+            "$ref": "#/parameters/TopParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns an array of policy set definition versions.",
+            "schema": {
+              "$ref": "#/definitions/PolicySetDefinitionVersionListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/providers/Microsoft.Authorization/policySetDefinitions/{policySetDefinitionName}/versions": {
+      "get": {
+        "tags": [
+          "PolicySetDefinitionVersions"
+        ],
+        "operationId": "PolicySetDefinitionVersions_ListBuiltIn",
+        "summary": "Retrieves built-in policy set definition versions.",
+        "description": "This operation retrieves a list of all the built-in policy set definition versions for the given built-in policy set definition.",
+        "x-ms-examples": {
+          "List built-in policy set definitions": {
+            "$ref": "./examples/listBuiltInPolicySetDefinitionVersions.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/PolicySetDefinitionName"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/PolicySetDefinitionsExpandParameter"
+          },
+          {
+            "$ref": "#/parameters/TopParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns an array of built in policy set definition versions.",
+            "schema": {
+              "$ref": "#/definitions/PolicySetDefinitionVersionListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/providers/Microsoft.Management/managementGroups/{managementGroupName}/providers/Microsoft.Authorization/policySetDefinitions/{policySetDefinitionName}/versions/{policyDefinitionVersion}": {
+      "put": {
+        "tags": [
+          "PolicySetDefinitionVersions"
+        ],
+        "operationId": "PolicySetDefinitionVersions_CreateOrUpdateAtManagementGroup",
+        "summary": "Creates or updates a policy set definition version.",
+        "description": "This operation creates or updates a policy set definition version in the given management group with the given name and version.",
+        "x-ms-examples": {
+          "Create or update a policy set definition version at management group level": {
+            "$ref": "./examples/createOrUpdatePolicySetDefinitionVersionAtManagementGroup.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ManagementGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/PolicySetDefinitionName"
+          },
+          {
+            "$ref": "#/parameters/PolicySetDefinitionVersion"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PolicySetDefinitionVersion"
+            },
+            "description": "The policy set definition version properties."
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created - Returns information about the policy set definition version.",
+            "schema": {
+              "$ref": "#/definitions/PolicySetDefinitionVersion"
+            }
+          },
+          "200": {
+            "description": "OK - Successfully updated policy set definition version.",
+            "schema": {
+              "$ref": "#/definitions/PolicySetDefinitionVersion"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "PolicySetDefinitionVersions"
+        ],
+        "operationId": "PolicySetDefinitionVersions_DeleteAtManagementGroup",
+        "summary": "Deletes a policy set definition version.",
+        "description": "This operation deletes the policy set definition version in the given management group with the given name and version.",
+        "x-ms-examples": {
+          "Delete a policy set definition version at management group level": {
+            "$ref": "./examples/deletePolicySetDefinitionVersionAtManagementGroup.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ManagementGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/PolicySetDefinitionName"
+          },
+          {
+            "$ref": "#/parameters/PolicySetDefinitionVersion"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content - the policy set definition doesn't exist in the subscription."
+          },
+          "200": {
+            "description": "OK"
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "PolicySetDefinitionVersions"
+        ],
+        "operationId": "PolicySetDefinitionVersions_GetAtManagementGroup",
+        "summary": "Retrieves a policy set definition version.",
+        "description": "This operation retrieves the policy set definition version in the given management group with the given name and version.",
+        "x-ms-examples": {
+          "Retrieve a policy set definition version at management group level": {
+            "$ref": "./examples/getPolicySetDefinitionVersionAtManagementGroup.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ManagementGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/PolicySetDefinitionName"
+          },
+          {
+            "$ref": "#/parameters/PolicySetDefinitionVersion"
+          },
+          {
+            "$ref": "#/parameters/PolicySetDefinitionsExpandParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns information about the policy set definition version.",
+            "schema": {
+              "$ref": "#/definitions/PolicySetDefinitionVersion"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/providers/Microsoft.Management/managementGroups/{managementGroupName}/providers/Microsoft.Authorization/policySetDefinitions/{policySetDefinitionName}/versions": {
+      "get": {
+        "tags": [
+          "PolicySetDefinitionVersions"
+        ],
+        "operationId": "PolicySetDefinitionVersions_ListByManagementGroup",
+        "summary": "Retrieves all policy set definition versions for a given policy set definition in a management group.",
+        "description": "This operation retrieves a list of all the policy set definition versions for the given policy set definition in a given management group.",
+        "x-ms-examples": {
+          "List policy set definitions at management group level": {
+            "$ref": "./examples/listPolicySetDefinitionVersionsByManagementGroup.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ManagementGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/PolicySetDefinitionName"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/PolicySetDefinitionsExpandParameter"
+          },
+          {
+            "$ref": "#/parameters/TopParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns an array of policy set definition versions.",
+            "schema": {
+              "$ref": "#/definitions/PolicySetDefinitionVersionListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "PolicySetDefinitionVersionProperties": {
+      "type": "object",
+      "properties": {
+        "policyType": {
+          "type": "string",
+          "description": "The type of policy definition. Possible values are NotSpecified, BuiltIn, Custom, and Static.",
+          "enum": [
+            "NotSpecified",
+            "BuiltIn",
+            "Custom",
+            "Static"
+          ],
+          "x-ms-enum": {
+            "name": "policyType",
+            "modelAsString": true
+          }
+        },
+        "displayName": {
+          "type": "string",
+          "description": "The display name of the policy set definition."
+        },
+        "description": {
+          "type": "string",
+          "description": "The policy set definition description."
+        },
+        "metadata": {
+          "type": "object",
+          "description": "The policy set definition metadata.  Metadata is an open ended object and is typically a collection of key value pairs."
+        },
+        "parameters": {
+          "description": "The policy set definition parameters that can be used in policy definition references.",
+          "$ref": "./policyDefinitions.json#/definitions/ParameterDefinitions"
+        },
+        "policyDefinitions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PolicyDefinitionReference"
+          },
+          "x-ms-identifiers": [
+            "policyDefinitionReferenceId"
+          ],
+          "description": "An array of policy definition references."
+        },
+        "policyDefinitionGroups": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PolicyDefinitionGroup"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ],
+          "description": "The metadata describing groups of policy definition references within the policy set definition."
+        },
+        "version": {
+          "type": "string",
+          "description": "The policy set definition version in #.#.# format."
+        }
+      },
+      "required": [
+        "policyDefinitions"
+      ],
+      "description": "The policy set definition properties."
+    },
+    "PolicyDefinitionReference": {
+      "type": "object",
+      "properties": {
+        "policyDefinitionId": {
+          "type": "string",
+          "description": "The ID of the policy definition or policy set definition."
+        },
+        "definitionVersion": {
+          "type": "string",
+          "description": "The version of the policy definition to use."
+        },
+        "latestDefinitionVersion": {
+          "type": "string",
+          "description": "The latest version of the policy definition available. This is only present if requested via the $expand query parameter.",
+          "readOnly": true
+        },
+        "effectiveDefinitionVersion": {
+          "type": "string",
+          "description": "The effective version of the policy definition in use. This is only present if requested via the $expand query parameter.",
+          "readOnly": true
+        },
+        "parameters": {
+          "description": "The parameter values for the referenced policy rule. The keys are the parameter names.",
+          "$ref": "./policyAssignments.json#/definitions/ParameterValues"
+        },
+        "policyDefinitionReferenceId": {
+          "type": "string",
+          "description": "A unique id (within the policy set definition) for this policy definition reference."
+        },
+        "groupNames": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The name of the groups that this policy definition reference belongs to."
+        }
+      },
+      "required": [
+        "policyDefinitionId"
+      ],
+      "description": "The policy definition reference."
+    },
+    "PolicyDefinitionGroup": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the group."
+        },
+        "displayName": {
+          "type": "string",
+          "description": "The group's display name."
+        },
+        "category": {
+          "type": "string",
+          "description": "The group's category."
+        },
+        "description": {
+          "type": "string",
+          "description": "The group's description."
+        },
+        "additionalMetadataId": {
+          "type": "string",
+          "description": "A resource ID of a resource that contains additional metadata about the group."
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "description": "The policy definition group."
+    },
+    "PolicySetDefinitionVersion": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/PolicySetDefinitionVersionProperties",
+          "description": "The policy set definition version properties."
+        },
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The ID of the policy set definition version."
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The name of the policy set definition version."
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The type of the resource (Microsoft.Authorization/policySetDefinitions/versions)."
+        },
+        "systemData": {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/systemData",
+          "readOnly": true,
+          "description": "The system metadata relating to this resource."
+        }
+      },
+      "description": "The policy set definition version.",
+      "x-ms-azure-resource": true
+    },
+    "PolicySetDefinitionVersionListResult": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PolicySetDefinitionVersion"
+          },
+          "description": "An array of policy set definition versions."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to use for getting the next set of results."
+        }
+      },
+      "description": "List of policy set definition versions."
+    }
+  },
+  "parameters": {
+    "PolicySetDefinitionName": {
+      "name": "policySetDefinitionName",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "pattern": "^[^<>*%&:\\?.+/]*[^<>*%&:\\?.+/ ]+$",
+      "description": "The name of the policy set definition.",
+      "x-ms-parameter-location": "method"
+    },
+    "PolicySetDefinitionVersion": {
+      "name": "policyDefinitionVersion",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "description": "The policy set definition version.  The format is x.y.z where x is the major version number, y is the minor version number, and z is the patch number",
+      "x-ms-parameter-location": "method"
+    },
+    "PolicySetDefinitionsFilterParameter": {
+      "name": "$filter",
+      "in": "query",
+      "required": false,
+      "type": "string",
+      "description": "The filter to apply on the operation. Valid values for $filter are: 'atExactScope()', 'policyType -eq {value}' or 'category eq '{value}''. If $filter is not provided, no filtering is performed. If $filter=atExactScope() is provided, the returned list only includes all policy set definitions that at the given scope. If $filter='policyType -eq {value}' is provided, the returned list only includes all policy set definitions whose type match the {value}. Possible policyType values are NotSpecified, BuiltIn, Custom, and Static. If $filter='category -eq {value}' is provided, the returned list only includes all policy set definitions whose category match the {value}.",
+      "x-ms-skip-url-encoding": true,
+      "x-ms-parameter-location": "method"
+    },
+    "PolicySetDefinitionsExpandParameter": {
+      "name": "$expand",
+      "in": "query",
+      "required": false,
+      "type": "string",
+      "description": "Comma-separated list of additional properties to be included in the response. Supported values are 'LatestDefinitionVersion, EffectiveDefinitionVersion'.",
+      "x-ms-parameter-location": "method"
+    },
+    "TopParameter": {
+      "name": "$top",
+      "in": "query",
+      "required": false,
+      "type": "integer",
+      "format": "int32",
+      "minimum": 1,
+      "maximum": 1000,
+      "description": "Maximum number of records to return. When the $top filter is not provided, it will return 500 records.",
+      "x-ms-parameter-location": "method"
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/policySetDefinitions.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/policySetDefinitions.json
@@ -1,0 +1,761 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "PolicyClient",
+    "version": "2025-03-01",
+    "description": "To manage and control access to your resources, you can define customized policies and assign them at a scope."
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Authorization/policySetDefinitions/{policySetDefinitionName}": {
+      "put": {
+        "tags": [
+          "PolicySetDefinitions"
+        ],
+        "operationId": "PolicySetDefinitions_CreateOrUpdate",
+        "summary": "Creates or updates a policy set definition.",
+        "description": "This operation creates or updates a policy set definition in the given subscription with the given name.",
+        "x-ms-examples": {
+          "Create or update a policy set definition": {
+            "$ref": "./examples/createOrUpdatePolicySetDefinition.json"
+          },
+          "Create or update a policy set definition with groups": {
+            "$ref": "./examples/createOrUpdatePolicySetDefinitionWithGroups.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "policySetDefinitionName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": "^[^<>*%&:\\?.+/]*[^<>*%&:\\?.+/ ]+$",
+            "description": "The name of the policy set definition to create."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PolicySetDefinition"
+            },
+            "description": "The policy set definition properties."
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created - Returns information about the policy set definition.",
+            "schema": {
+              "$ref": "#/definitions/PolicySetDefinition"
+            }
+          },
+          "200": {
+            "description": "OK - Returns information about the policy set definition.",
+            "schema": {
+              "$ref": "#/definitions/PolicySetDefinition"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "PolicySetDefinitions"
+        ],
+        "operationId": "PolicySetDefinitions_Delete",
+        "summary": "Deletes a policy set definition.",
+        "description": "This operation deletes the policy set definition in the given subscription with the given name.",
+        "x-ms-examples": {
+          "Delete a policy set definition": {
+            "$ref": "./examples/deletePolicySetDefinition.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "policySetDefinitionName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": "^[^<>*%&:\\?.+/]*[^<>*%&:\\?.+/ ]+$",
+            "description": "The name of the policy set definition to delete."
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content - the policy set definition doesn't exist in the subscription."
+          },
+          "200": {
+            "description": "OK"
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "PolicySetDefinitions"
+        ],
+        "operationId": "PolicySetDefinitions_Get",
+        "summary": "Retrieves a policy set definition.",
+        "description": "This operation retrieves the policy set definition in the given subscription with the given name.",
+        "x-ms-examples": {
+          "Retrieve a policy set definition": {
+            "$ref": "./examples/getPolicySetDefinition.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "policySetDefinitionName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": "^[^<>*%&:\\?.+/]*[^<>*%&:\\?.+/ ]+$",
+            "description": "The name of the policy set definition to get."
+          },
+          {
+            "$ref": "#/parameters/PolicySetDefinitionsExpandParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns information about the policy set definition.",
+            "schema": {
+              "$ref": "#/definitions/PolicySetDefinition"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/providers/Microsoft.Authorization/policySetDefinitions/{policySetDefinitionName}": {
+      "get": {
+        "tags": [
+          "PolicySetDefinitions"
+        ],
+        "operationId": "PolicySetDefinitions_GetBuiltIn",
+        "summary": "Retrieves a built in policy set definition.",
+        "description": "This operation retrieves the built-in policy set definition with the given name.",
+        "x-ms-examples": {
+          "Retrieve a built-in policy set definition": {
+            "$ref": "./examples/getBuiltInPolicySetDefinition.json"
+          }
+        },
+        "parameters": [
+          {
+            "name": "policySetDefinitionName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": "^[^<>*%&:\\?.+/]*[^<>*%&:\\?.+/ ]+$",
+            "description": "The name of the policy set definition to get."
+          },
+          {
+            "$ref": "#/parameters/PolicySetDefinitionsExpandParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns information about the built in policy set definition.",
+            "schema": {
+              "$ref": "#/definitions/PolicySetDefinition"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Authorization/policySetDefinitions": {
+      "get": {
+        "tags": [
+          "PolicySetDefinitions"
+        ],
+        "operationId": "PolicySetDefinitions_List",
+        "summary": "Retrieves the policy set definitions for a subscription.",
+        "description": "This operation retrieves a list of all the policy set definitions in a given subscription that match the optional given $filter. Valid values for $filter are: 'atExactScope()', 'policyType -eq {value}' or 'category eq '{value}''. If $filter is not provided, the unfiltered list includes all policy set definitions associated with the subscription, including those that apply directly or from management groups that contain the given subscription. If $filter=atExactScope() is provided, the returned list only includes all policy set definitions that at the given subscription. If $filter='policyType -eq {value}' is provided, the returned list only includes all policy set definitions whose type match the {value}. Possible policyType values are NotSpecified, BuiltIn and Custom. If $filter='category -eq {value}' is provided, the returned list only includes all policy set definitions whose category match the {value}.",
+        "x-ms-examples": {
+          "List policy set definitions": {
+            "$ref": "./examples/listPolicySetDefinitions.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/PolicySetDefinitionsFilterParameter"
+          },
+          {
+            "$ref": "#/parameters/PolicySetDefinitionsExpandParameter"
+          },
+          {
+            "$ref": "#/parameters/TopParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns an array of policy set definitions.",
+            "schema": {
+              "$ref": "#/definitions/PolicySetDefinitionListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/providers/Microsoft.Authorization/policySetDefinitions": {
+      "get": {
+        "tags": [
+          "PolicySetDefinitions"
+        ],
+        "operationId": "PolicySetDefinitions_ListBuiltIn",
+        "summary": "Retrieves built-in policy set definitions.",
+        "description": "This operation retrieves a list of all the built-in policy set definitions that match the optional given $filter. If $filter='category -eq {value}' is provided, the returned list only includes all built-in policy set definitions whose category match the {value}.",
+        "x-ms-examples": {
+          "List built-in policy set definitions": {
+            "$ref": "./examples/listBuiltInPolicySetDefinitions.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/PolicySetDefinitionsFilterParameter"
+          },
+          {
+            "$ref": "#/parameters/PolicySetDefinitionsExpandParameter"
+          },
+          {
+            "$ref": "#/parameters/TopParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns an array of built in policy set definitions.",
+            "schema": {
+              "$ref": "#/definitions/PolicySetDefinitionListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/providers/Microsoft.Management/managementGroups/{managementGroupId}/providers/Microsoft.Authorization/policySetDefinitions/{policySetDefinitionName}": {
+      "put": {
+        "tags": [
+          "PolicySetDefinitions"
+        ],
+        "operationId": "PolicySetDefinitions_CreateOrUpdateAtManagementGroup",
+        "summary": "Creates or updates a policy set definition.",
+        "description": "This operation creates or updates a policy set definition in the given management group with the given name.",
+        "x-ms-examples": {
+          "Create or update a policy set definition at management group level": {
+            "$ref": "./examples/createOrUpdatePolicySetDefinitionAtManagementGroup.json"
+          },
+          "Create or update a policy set definition with groups at management group level": {
+            "$ref": "./examples/createOrUpdatePolicySetDefinitionWithGroupsAtManagementGroup.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/ManagementGroupIdParameter"
+          },
+          {
+            "name": "policySetDefinitionName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": "^[^<>*%&:\\?.+/]*[^<>*%&:\\?.+/ ]+$",
+            "description": "The name of the policy set definition to create."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PolicySetDefinition"
+            },
+            "description": "The policy set definition properties."
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created - Returns information about the policy set definition.",
+            "schema": {
+              "$ref": "#/definitions/PolicySetDefinition"
+            }
+          },
+          "200": {
+            "description": "OK - Returns information about the policy set definition.",
+            "schema": {
+              "$ref": "#/definitions/PolicySetDefinition"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "PolicySetDefinitions"
+        ],
+        "operationId": "PolicySetDefinitions_DeleteAtManagementGroup",
+        "summary": "Deletes a policy set definition.",
+        "description": "This operation deletes the policy set definition in the given management group with the given name.",
+        "x-ms-examples": {
+          "Delete a policy set definition at management group level": {
+            "$ref": "./examples/deletePolicySetDefinitionAtManagementGroup.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/ManagementGroupIdParameter"
+          },
+          {
+            "name": "policySetDefinitionName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": "^[^<>*%&:\\?.+/]*[^<>*%&:\\?.+/ ]+$",
+            "description": "The name of the policy set definition to delete."
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content - the policy set definition doesn't exist in the subscription."
+          },
+          "200": {
+            "description": "OK"
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "PolicySetDefinitions"
+        ],
+        "operationId": "PolicySetDefinitions_GetAtManagementGroup",
+        "summary": "Retrieves a policy set definition.",
+        "description": "This operation retrieves the policy set definition in the given management group with the given name.",
+        "x-ms-examples": {
+          "Retrieve a policy set definition at management group level": {
+            "$ref": "./examples/getPolicySetDefinitionAtManagementGroup.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/ManagementGroupIdParameter"
+          },
+          {
+            "name": "policySetDefinitionName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": "^[^<>*%&:\\?.+/]*[^<>*%&:\\?.+/ ]+$",
+            "description": "The name of the policy set definition to get."
+          },
+          {
+            "$ref": "#/parameters/PolicySetDefinitionsExpandParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns information about the policy set definition.",
+            "schema": {
+              "$ref": "#/definitions/PolicySetDefinition"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/providers/Microsoft.Management/managementGroups/{managementGroupId}/providers/Microsoft.Authorization/policySetDefinitions": {
+      "get": {
+        "tags": [
+          "PolicySetDefinitions"
+        ],
+        "operationId": "PolicySetDefinitions_ListByManagementGroup",
+        "summary": "Retrieves all policy set definitions in management group.",
+        "description": "This operation retrieves a list of all the policy set definitions in a given management group that match the optional given $filter. Valid values for $filter are: 'atExactScope()', 'policyType -eq {value}' or 'category eq '{value}''. If $filter is not provided, the unfiltered list includes all policy set definitions associated with the management group, including those that apply directly or from management groups that contain the given management group. If $filter=atExactScope() is provided, the returned list only includes all policy set definitions that at the given management group. If $filter='policyType -eq {value}' is provided, the returned list only includes all policy set definitions whose type match the {value}. Possible policyType values are NotSpecified, BuiltIn and Custom. If $filter='category -eq {value}' is provided, the returned list only includes all policy set definitions whose category match the {value}.",
+        "x-ms-examples": {
+          "List policy set definitions at management group level": {
+            "$ref": "./examples/listPolicySetDefinitionsByManagementGroup.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/ManagementGroupIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/PolicySetDefinitionsFilterParameter"
+          },
+          {
+            "$ref": "#/parameters/PolicySetDefinitionsExpandParameter"
+          },
+          {
+            "$ref": "#/parameters/TopParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Returns an array of policy set definitions.",
+            "schema": {
+              "$ref": "#/definitions/PolicySetDefinitionListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "PolicySetDefinitionProperties": {
+      "type": "object",
+      "properties": {
+        "policyType": {
+          "type": "string",
+          "description": "The type of policy set definition. Possible values are NotSpecified, BuiltIn, Custom, and Static.",
+          "enum": [
+            "NotSpecified",
+            "BuiltIn",
+            "Custom",
+            "Static"
+          ],
+          "x-ms-enum": {
+            "name": "policyType",
+            "modelAsString": true
+          }
+        },
+        "displayName": {
+          "type": "string",
+          "description": "The display name of the policy set definition."
+        },
+        "description": {
+          "type": "string",
+          "description": "The policy set definition description."
+        },
+        "metadata": {
+          "type": "object",
+          "description": "The policy set definition metadata.  Metadata is an open ended object and is typically a collection of key value pairs."
+        },
+        "parameters": {
+          "description": "The policy set definition parameters that can be used in policy definition references.",
+          "$ref": "./policyDefinitions.json#/definitions/ParameterDefinitions"
+        },
+        "policyDefinitions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PolicyDefinitionReference"
+          },
+          "x-ms-identifiers": [
+            "policyDefinitionReferenceId"
+          ],
+          "description": "An array of policy definition references."
+        },
+        "policyDefinitionGroups": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PolicyDefinitionGroup"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ],
+          "description": "The metadata describing groups of policy definition references within the policy set definition."
+        },
+        "version": {
+          "type": "string",
+          "description": "The policy set definition version in #.#.# format."
+        },
+        "versions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "A list of available versions for this policy set definition."
+        }
+      },
+      "required": [
+        "policyDefinitions"
+      ],
+      "description": "The policy set definition properties."
+    },
+    "PolicyDefinitionReference": {
+      "type": "object",
+      "properties": {
+        "policyDefinitionId": {
+          "type": "string",
+          "description": "The ID of the policy definition or policy set definition."
+        },
+        "definitionVersion": {
+          "type": "string",
+          "description": "The version of the policy definition to use."
+        },
+        "latestDefinitionVersion": {
+          "type": "string",
+          "description": "The latest version of the policy definition available. This is only present if requested via the $expand query parameter.",
+          "readOnly": true
+        },
+        "effectiveDefinitionVersion": {
+          "type": "string",
+          "description": "The effective version of the policy definition in use. This is only present if requested via the $expand query parameter.",
+          "readOnly": true
+        },
+        "parameters": {
+          "description": "The parameter values for the referenced policy rule. The keys are the parameter names.",
+          "$ref": "./policyAssignments.json#/definitions/ParameterValues"
+        },
+        "policyDefinitionReferenceId": {
+          "type": "string",
+          "description": "A unique id (within the policy set definition) for this policy definition reference."
+        },
+        "groupNames": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The name of the groups that this policy definition reference belongs to."
+        }
+      },
+      "required": [
+        "policyDefinitionId"
+      ],
+      "description": "The policy definition reference."
+    },
+    "PolicyDefinitionGroup": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the group."
+        },
+        "displayName": {
+          "type": "string",
+          "description": "The group's display name."
+        },
+        "category": {
+          "type": "string",
+          "description": "The group's category."
+        },
+        "description": {
+          "type": "string",
+          "description": "The group's description."
+        },
+        "additionalMetadataId": {
+          "type": "string",
+          "description": "A resource ID of a resource that contains additional metadata about the group."
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "description": "The policy definition group."
+    },
+    "PolicySetDefinition": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/PolicySetDefinitionProperties",
+          "description": "The policy set definition properties."
+        },
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The ID of the policy set definition."
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The name of the policy set definition."
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The type of the resource (Microsoft.Authorization/policySetDefinitions)."
+        },
+        "systemData": {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/systemData",
+          "readOnly": true,
+          "description": "The system metadata relating to this resource."
+        }
+      },
+      "description": "The policy set definition.",
+      "x-ms-azure-resource": true
+    },
+    "PolicySetDefinitionListResult": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PolicySetDefinition"
+          },
+          "description": "An array of policy set definitions."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to use for getting the next set of results."
+        }
+      },
+      "description": "List of policy set definitions."
+    }
+  },
+  "parameters": {
+    "ManagementGroupIdParameter": {
+      "name": "managementGroupId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The ID of the management group.",
+      "x-ms-parameter-location": "method"
+    },
+    "PolicySetDefinitionsFilterParameter": {
+      "name": "$filter",
+      "in": "query",
+      "required": false,
+      "type": "string",
+      "description": "The filter to apply on the operation. Valid values for $filter are: 'atExactScope()', 'policyType -eq {value}' or 'category eq '{value}''. If $filter is not provided, no filtering is performed. If $filter=atExactScope() is provided, the returned list only includes all policy set definitions that at the given scope. If $filter='policyType -eq {value}' is provided, the returned list only includes all policy set definitions whose type match the {value}. Possible policyType values are NotSpecified, BuiltIn, Custom, and Static. If $filter='category -eq {value}' is provided, the returned list only includes all policy set definitions whose category match the {value}.",
+      "x-ms-skip-url-encoding": true,
+      "x-ms-parameter-location": "method"
+    },
+    "PolicySetDefinitionsExpandParameter": {
+      "name": "$expand",
+      "in": "query",
+      "required": false,
+      "type": "string",
+      "description": "Comma-separated list of additional properties to be included in the response. Supported values are 'LatestDefinitionVersion, EffectiveDefinitionVersion'.",
+      "x-ms-parameter-location": "method"
+    },
+    "TopParameter": {
+      "name": "$top",
+      "in": "query",
+      "required": false,
+      "type": "integer",
+      "format": "int32",
+      "minimum": 1,
+      "maximum": 1000,
+      "description": "Maximum number of records to return. When the $top filter is not provided, it will return 500 records.",
+      "x-ms-parameter-location": "method"
+    }
+  }
+}

--- a/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/policyTokens.json
+++ b/specification/resources/resource-manager/Microsoft.Authorization/stable/2025-03-01/policyTokens.json
@@ -1,0 +1,312 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "PolicyClient",
+    "version": "2025-03-01",
+    "description": "Allows resource operations to call external endpoints, issuing tokens upon validation."
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Authorization/acquirePolicyToken": {
+      "post": {
+        "tags": [
+          "PolicyTokens"
+        ],
+        "operationId": "PolicyTokens_Acquire",
+        "summary": "Acquires a policy token.",
+        "description": "This operation acquires a policy token in the given subscription for the given request body.",
+        "x-ms-examples": {
+          "Acquire a policy token": {
+            "$ref": "./examples/acquirePolicyToken.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PolicyTokenRequest"
+            },
+            "description": "The policy token properties."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully acquired the policy token.",
+            "schema": {
+              "$ref": "#/definitions/PolicyTokenResponse"
+            }
+          },
+          "202": {
+            "description": "Accepted and the request for acquiring the policy token is being processed asynchronously."
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "PolicyTokenRequest": {
+      "type": "object",
+      "properties": {
+        "operation": {
+          "description": "The resource operation to acquire a token for.",
+          "$ref": "#/definitions/PolicyTokenOperation"
+        },
+        "changeReference": {
+          "type": "string",
+          "description": "The change reference."
+        }
+      },
+      "description": "The policy token request properties."
+    },
+    "PolicyTokenResponse": {
+      "type": "object",
+      "properties": {
+        "result": {
+          "type": "string",
+          "description": "The result of the completed token acquisition operation. Possible values are Succeeded and Failed.",
+          "enum": [
+            "Succeeded",
+            "Failed"
+          ],
+          "x-ms-enum": {
+            "name": "policyTokenResult",
+            "modelAsString": true
+          }
+        },
+        "message": {
+          "type": "string",
+          "description": "Status message with additional details about the token acquisition operation result."
+        },
+        "retryAfter": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date and time after which the client can try to acquire a token again in the case of retry-able failures."
+        },
+        "results": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ExternalEvaluationEndpointInvocationResult"
+          },
+          "description": "An array of external evaluation endpoint invocation results."
+        },
+        "changeReference": {
+          "type": "string",
+          "description": "The change reference associated with the operation for which the token is acquired."
+        },
+        "token": {
+          "type": "string",
+          "description": "The issued policy token."
+        },
+        "tokenId": {
+          "type": "string",
+          "description": "The unique Id assigned to the policy token."
+        },
+        "expiration": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The expiration of the policy token."
+        }
+      },
+      "description": "The policy token response properties."
+    },
+    "PolicyTokenOperation": {
+      "type": "object",
+      "properties": {
+        "uri": {
+          "type": "string",
+          "description": "The request URI of the resource operation."
+        },
+        "httpMethod": {
+          "type": "string",
+          "description": "The http method of the resource operation."
+        },
+        "content": {
+          "type": "object",
+          "description": "The payload of the resource operation."
+        }
+      },
+      "description": "The resource operation to acquire a token for."
+    },
+    "ExternalEvaluationEndpointInvocationResult": {
+      "type": "object",
+      "properties": {
+        "policyInfo": {
+          "description": "The details of the policy requiring the external endpoint invocation.",
+          "$ref": "#/definitions/PolicyLogInfo"
+        },
+        "result": {
+          "type": "string",
+          "description": "The result of the external endpoint. Possible values are Succeeded and Failed.",
+          "enum": [
+            "Succeeded",
+            "Failed"
+          ],
+          "x-ms-enum": {
+            "name": "externalEndpointResult",
+            "modelAsString": true
+          }
+        },
+        "message": {
+          "type": "string",
+          "description": "The status message with additional details about the invocation result."
+        },
+        "retryAfter": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date and time after which a failed endpoint invocation can be retried."
+        },
+        "claims": {
+          "type": "object",
+          "description": "The set of claims that will be attached to the policy token as an attestation for the result of the endpoint invocation."
+        },
+        "expiration": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The expiration of the results."
+        }
+      },
+      "description": "The external evaluation endpoint invocation results."
+    },
+    "PolicyLogInfo": {
+      "type": "object",
+      "properties": {
+        "policyDefinitionId": {
+          "type": "string",
+          "description": "The policy definition Id."
+        },
+        "policySetDefinitionId": {
+          "type": "string",
+          "description": "The policy set definition Id."
+        },
+        "policyDefinitionReferenceId": {
+          "type": "string",
+          "description": "The policy definition instance Id inside a policy set."
+        },
+        "policySetDefinitionName": {
+          "type": "string",
+          "description": "The policy set definition name."
+        },
+        "policySetDefinitionDisplayName": {
+          "type": "string",
+          "description": "The policy set definition display name."
+        },
+        "policySetDefinitionVersion": {
+          "type": "string",
+          "description": "The policy set definition version."
+        },
+        "policySetDefinitionCategory": {
+          "type": "string",
+          "description": "The policy set definition category."
+        },
+        "policyDefinitionName": {
+          "type": "string",
+          "description": "The policy definition name."
+        },
+        "policyDefinitionDisplayName": {
+          "type": "string",
+          "description": "The policy definition display name."
+        },
+        "policyDefinitionVersion": {
+          "type": "string",
+          "description": "The policy definition version."
+        },
+        "policyDefinitionEffect": {
+          "type": "string",
+          "description": "The policy definition action."
+        },
+        "policyDefinitionGroupNames": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "An array of policy definition group names."
+        },
+        "policyAssignmentId": {
+          "type": "string",
+          "description": "The policy assignment Id."
+        },
+        "policyAssignmentName": {
+          "type": "string",
+          "description": "The policy assignment name."
+        },
+        "policyAssignmentDisplayName": {
+          "type": "string",
+          "description": "The policy assignment display name."
+        },
+        "policyAssignmentVersion": {
+          "type": "string",
+          "description": "The policy assignment version."
+        },
+        "policyAssignmentScope": {
+          "type": "string",
+          "description": "The policy assignment scope."
+        },
+        "resourceLocation": {
+          "type": "string",
+          "description": "The resource location."
+        },
+        "ancestors": {
+          "type": "string",
+          "description": "The management group ancestors."
+        },
+        "complianceReasonCode": {
+          "type": "string",
+          "description": "The policy compliance reason code."
+        },
+        "policyExemptionIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "An array of policy exemption Ids."
+        }
+      },
+      "description": "The policy log info."
+    }
+  }
+}

--- a/specification/resources/resource-manager/readme.md
+++ b/specification/resources/resource-manager/readme.md
@@ -42,7 +42,7 @@ tag: package-locks-2020-05
 ```
 
 ``` yaml $(package-policy)
-tag: package-policy-2025-01-stable
+tag: package-policy-2025-03-stable
 ```
 
 ``` yaml $(package-databoundaries)
@@ -97,11 +97,29 @@ tag: package-snapshots-2022-11
 tag: package-bicep-2023-11
 ```
 
-### Tag: package-policy-2025-01-stable
+### Tag: package-policy-2025-03-stable
 
-These settings apply only when `--tag=package-policy-2025-01-stable` is specified on the command line.
+These settings apply only when `--tag=package-2025-03-01` is specified on the command line.
 
-```yaml $(tag) == 'package-policy-2025-01-stable'
+```yaml $(tag) == 'package-policy-2025-03-stable'
+input-file:
+  - Microsoft.Authorization/stable/2025-03-01/policyAssignments.json
+  - Microsoft.Authorization/stable/2025-03-01/policyDefinitions.json
+  - Microsoft.Authorization/stable/2025-03-01/policyDefinitionVersions.json
+  - Microsoft.Authorization/stable/2025-03-01/policySetDefinitions.json
+  - Microsoft.Authorization/stable/2025-03-01/policySetDefinitionVersions.json
+  - Microsoft.Authorization/stable/2025-03-01/policyTokens.json
+
+# Needed when there is more than one input file
+override-info:
+  title: PolicyClient
+```
+
+### Tag: package-policy-2025-01
+
+These settings apply only when `--tag=package-policy-2025-01` is specified on the command line.
+
+```yaml $(tag) == 'package-policy-2025-01'
 input-file:
 - Microsoft.Authorization/stable/2025-01-01/policyDefinitions.json
 - Microsoft.Authorization/stable/2025-01-01/policyDefinitionVersions.json

--- a/specification/resources/resource-manager/sdk-suppressions.yaml
+++ b/specification/resources/resource-manager/sdk-suppressions.yaml
@@ -106,3 +106,8 @@ suppressions:
         - Removed Enum KnownExemptionCategory
         - Removed operation group DataPolicyManifests
         - Removed operation group PolicyExemptions
+        - Interface ErrorResponse no longer has parameter additionalInfo
+        - Interface ErrorResponse no longer has parameter code
+        - Interface ErrorResponse no longer has parameter details
+        - Interface ErrorResponse no longer has parameter message
+        - Interface ErrorResponse no longer has parameter target

--- a/specification/synapse/data-plane/Microsoft.Synapse/stable/2020-12-01/entityTypes/LinkedService.json
+++ b/specification/synapse/data-plane/Microsoft.Synapse/stable/2020-12-01/entityTypes/LinkedService.json
@@ -1509,10 +1509,7 @@
           "type": "object",
           "description": "The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager. Type: string (or Expression with resultType string)."
         }
-      },
-      "required": [
-        "connectionString"
-      ]
+      }
     },
     "AmazonRdsForOracleLinkedService": {
       "x-ms-discriminator-value": "AmazonRdsForOracle",

--- a/specification/web/resource-manager/Microsoft.Web/stable/2015-08-01/service.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2015-08-01/service.json
@@ -18363,7 +18363,7 @@
           "type": "string"
         },
         "issuer": {
-          "description": "Gets or sets the OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\r\n            When using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://sts.windows.net/{tenant-guid}/.\r\n            This URI is a case-sensitive identifier for the token issuer.\r\n            More information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+          "description": "Gets or sets the OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\r\n            When using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://sts.windows.net/{tenant-guid}/`.\r\n            This URI is a case-sensitive identifier for the token issuer.\r\n            More information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
           "type": "string"
         },
         "allowedAudiences": {
@@ -18523,7 +18523,7 @@
           "type": "number"
         },
         "changeDecisionCallbackUrl": {
-          "description": "Custom decision algorithm can be provided in TiPCallback site extension which Url can be specified. See TiPCallback site extension for the scaffold and contracts.\r\n            https://www.siteextensions.net/packages/TiPCallback/",
+          "description": "Custom decision algorithm can be provided in TiPCallback site extension which Url can be specified.",
           "type": "string"
         },
         "name": {

--- a/specification/web/resource-manager/Microsoft.Web/stable/2016-03-01/CommonDefinitions.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2016-03-01/CommonDefinitions.json
@@ -1391,7 +1391,7 @@
           "type": "number"
         },
         "changeDecisionCallbackUrl": {
-          "description": "Custom decision algorithm can be provided in TiPCallback site extension which URL can be specified. See TiPCallback site extension for the scaffold and contracts.\nhttps://www.siteextensions.net/packages/TiPCallback/",
+          "description": "Custom decision algorithm can be provided in TiPCallback site extension which URL can be specified.",
           "type": "string"
         },
         "name": {

--- a/specification/web/resource-manager/Microsoft.Web/stable/2016-08-01/WebApps.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2016-08-01/WebApps.json
@@ -16996,7 +16996,7 @@
               "type": "string"
             },
             "issuer": {
-              "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://sts.windows.net/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+              "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://sts.windows.net/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
               "type": "string"
             },
             "allowedAudiences": {

--- a/specification/web/resource-manager/Microsoft.Web/stable/2018-02-01/CommonDefinitions.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2018-02-01/CommonDefinitions.json
@@ -1629,7 +1629,7 @@
           "type": "number"
         },
         "changeDecisionCallbackUrl": {
-          "description": "Custom decision algorithm can be provided in TiPCallback site extension which URL can be specified. See TiPCallback site extension for the scaffold and contracts.\nhttps://www.siteextensions.net/packages/TiPCallback/",
+          "description": "Custom decision algorithm can be provided in TiPCallback site extension which URL can be specified.",
           "type": "string"
         },
         "name": {

--- a/specification/web/resource-manager/Microsoft.Web/stable/2018-02-01/WebApps.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2018-02-01/WebApps.json
@@ -21199,7 +21199,7 @@
               "type": "string"
             },
             "issuer": {
-              "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://sts.windows.net/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+              "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://sts.windows.net/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
               "type": "string"
             },
             "validateIssuer": {

--- a/specification/web/resource-manager/Microsoft.Web/stable/2018-11-01/WebApps.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2018-11-01/WebApps.json
@@ -20269,7 +20269,7 @@
               "type": "string"
             },
             "issuer": {
-              "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://sts.windows.net/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+              "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://sts.windows.net/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
               "type": "string"
             },
             "validateIssuer": {

--- a/specification/web/resource-manager/Microsoft.Web/stable/2019-08-01/CommonDefinitions.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2019-08-01/CommonDefinitions.json
@@ -1556,7 +1556,7 @@
           "type": "number"
         },
         "changeDecisionCallbackUrl": {
-          "description": "Custom decision algorithm can be provided in TiPCallback site extension which URL can be specified. See TiPCallback site extension for the scaffold and contracts.\nhttps://www.siteextensions.net/packages/TiPCallback/",
+          "description": "Custom decision algorithm can be provided in TiPCallback site extension which URL can be specified.",
           "type": "string"
         },
         "name": {

--- a/specification/web/resource-manager/Microsoft.Web/stable/2019-08-01/WebApps.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2019-08-01/WebApps.json
@@ -22966,7 +22966,7 @@
               "type": "string"
             },
             "issuer": {
-              "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://sts.windows.net/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+              "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://sts.windows.net/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
               "type": "string"
             },
             "validateIssuer": {

--- a/specification/web/resource-manager/Microsoft.Web/stable/2020-06-01/CommonDefinitions.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2020-06-01/CommonDefinitions.json
@@ -1577,7 +1577,7 @@
           "type": "number"
         },
         "changeDecisionCallbackUrl": {
-          "description": "Custom decision algorithm can be provided in TiPCallback site extension which URL can be specified. See TiPCallback site extension for the scaffold and contracts.\nhttps://www.siteextensions.net/packages/TiPCallback/",
+          "description": "Custom decision algorithm can be provided in TiPCallback site extension which URL can be specified.",
           "type": "string"
         },
         "name": {

--- a/specification/web/resource-manager/Microsoft.Web/stable/2020-06-01/WebApps.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2020-06-01/WebApps.json
@@ -23648,7 +23648,7 @@
               "type": "string"
             },
             "issuer": {
-              "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://sts.windows.net/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+              "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://sts.windows.net/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
               "type": "string"
             },
             "validateIssuer": {

--- a/specification/web/resource-manager/Microsoft.Web/stable/2020-09-01/CommonDefinitions.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2020-09-01/CommonDefinitions.json
@@ -1581,7 +1581,7 @@
           "type": "number"
         },
         "changeDecisionCallbackUrl": {
-          "description": "Custom decision algorithm can be provided in TiPCallback site extension which URL can be specified. See TiPCallback site extension for the scaffold and contracts.\nhttps://www.siteextensions.net/packages/TiPCallback/",
+          "description": "Custom decision algorithm can be provided in TiPCallback site extension which URL can be specified.",
           "type": "string"
         },
         "name": {

--- a/specification/web/resource-manager/Microsoft.Web/stable/2020-09-01/WebApps.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2020-09-01/WebApps.json
@@ -23648,7 +23648,7 @@
               "type": "string"
             },
             "issuer": {
-              "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://sts.windows.net/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+              "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://sts.windows.net/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
               "type": "string"
             },
             "validateIssuer": {

--- a/specification/web/resource-manager/Microsoft.Web/stable/2020-10-01/CommonDefinitions.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2020-10-01/CommonDefinitions.json
@@ -1581,7 +1581,7 @@
           "type": "number"
         },
         "changeDecisionCallbackUrl": {
-          "description": "Custom decision algorithm can be provided in TiPCallback site extension which URL can be specified. See TiPCallback site extension for the scaffold and contracts.\nhttps://www.siteextensions.net/packages/TiPCallback/",
+          "description": "Custom decision algorithm can be provided in TiPCallback site extension which URL can be specified.",
           "type": "string"
         },
         "name": {

--- a/specification/web/resource-manager/Microsoft.Web/stable/2020-10-01/WebApps.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2020-10-01/WebApps.json
@@ -23648,7 +23648,7 @@
               "type": "string"
             },
             "issuer": {
-              "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://sts.windows.net/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+              "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://sts.windows.net/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
               "type": "string"
             },
             "validateIssuer": {

--- a/specification/web/resource-manager/Microsoft.Web/stable/2020-12-01/CommonDefinitions.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2020-12-01/CommonDefinitions.json
@@ -1905,7 +1905,7 @@
           "type": "number"
         },
         "changeDecisionCallbackUrl": {
-          "description": "Custom decision algorithm can be provided in TiPCallback site extension which URL can be specified. See TiPCallback site extension for the scaffold and contracts.\nhttps://www.siteextensions.net/packages/TiPCallback/",
+          "description": "Custom decision algorithm can be provided in TiPCallback site extension which URL can be specified.",
           "type": "string"
         },
         "name": {

--- a/specification/web/resource-manager/Microsoft.Web/stable/2020-12-01/WebApps.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2020-12-01/WebApps.json
@@ -21145,7 +21145,7 @@
       "type": "object",
       "properties": {
         "openIdIssuer": {
-          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://login.microsoftonline.com/v2.0/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://login.microsoftonline.com/v2.0/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
           "type": "string"
         },
         "clientId": {
@@ -24240,7 +24240,7 @@
               "type": "string"
             },
             "issuer": {
-              "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://sts.windows.net/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+              "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://sts.windows.net/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
               "type": "string"
             },
             "validateIssuer": {

--- a/specification/web/resource-manager/Microsoft.Web/stable/2021-01-01/CommonDefinitions.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2021-01-01/CommonDefinitions.json
@@ -1926,7 +1926,7 @@
           "type": "number"
         },
         "changeDecisionCallbackUrl": {
-          "description": "Custom decision algorithm can be provided in TiPCallback site extension which URL can be specified. See TiPCallback site extension for the scaffold and contracts.\nhttps://www.siteextensions.net/packages/TiPCallback/",
+          "description": "Custom decision algorithm can be provided in TiPCallback site extension which URL can be specified.",
           "type": "string"
         },
         "name": {

--- a/specification/web/resource-manager/Microsoft.Web/stable/2021-01-01/WebApps.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2021-01-01/WebApps.json
@@ -21145,7 +21145,7 @@
       "type": "object",
       "properties": {
         "openIdIssuer": {
-          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://login.microsoftonline.com/v2.0/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://login.microsoftonline.com/v2.0/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
           "type": "string"
         },
         "clientId": {
@@ -24240,7 +24240,7 @@
               "type": "string"
             },
             "issuer": {
-              "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://sts.windows.net/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+              "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://sts.windows.net/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
               "type": "string"
             },
             "validateIssuer": {

--- a/specification/web/resource-manager/Microsoft.Web/stable/2021-01-15/CommonDefinitions.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2021-01-15/CommonDefinitions.json
@@ -1927,7 +1927,7 @@
           "type": "number"
         },
         "changeDecisionCallbackUrl": {
-          "description": "Custom decision algorithm can be provided in TiPCallback site extension which URL can be specified. See TiPCallback site extension for the scaffold and contracts.\nhttps://www.siteextensions.net/packages/TiPCallback/",
+          "description": "Custom decision algorithm can be provided in TiPCallback site extension which URL can be specified.",
           "type": "string"
         },
         "name": {

--- a/specification/web/resource-manager/Microsoft.Web/stable/2021-01-15/WebApps.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2021-01-15/WebApps.json
@@ -21401,7 +21401,7 @@
       "type": "object",
       "properties": {
         "openIdIssuer": {
-          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://login.microsoftonline.com/v2.0/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://login.microsoftonline.com/v2.0/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
           "type": "string"
         },
         "clientId": {
@@ -24513,7 +24513,7 @@
               "type": "string"
             },
             "issuer": {
-              "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://sts.windows.net/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+              "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://sts.windows.net/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
               "type": "string"
             },
             "validateIssuer": {

--- a/specification/web/resource-manager/Microsoft.Web/stable/2021-02-01/CommonDefinitions.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2021-02-01/CommonDefinitions.json
@@ -1946,7 +1946,7 @@
           "type": "number"
         },
         "changeDecisionCallbackUrl": {
-          "description": "Custom decision algorithm can be provided in TiPCallback site extension which URL can be specified. See TiPCallback site extension for the scaffold and contracts.\nhttps://www.siteextensions.net/packages/TiPCallback/",
+          "description": "Custom decision algorithm can be provided in TiPCallback site extension which URL can be specified.",
           "type": "string"
         },
         "name": {

--- a/specification/web/resource-manager/Microsoft.Web/stable/2021-02-01/WebApps.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2021-02-01/WebApps.json
@@ -21421,7 +21421,7 @@
       "type": "object",
       "properties": {
         "openIdIssuer": {
-          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://login.microsoftonline.com/v2.0/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://login.microsoftonline.com/v2.0/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
           "type": "string"
         },
         "clientId": {
@@ -24554,7 +24554,7 @@
               "type": "string"
             },
             "issuer": {
-              "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://sts.windows.net/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+              "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://sts.windows.net/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
               "type": "string"
             },
             "validateIssuer": {

--- a/specification/web/resource-manager/Microsoft.Web/stable/2021-03-01/CommonDefinitions.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2021-03-01/CommonDefinitions.json
@@ -2352,7 +2352,7 @@
           "type": "number"
         },
         "changeDecisionCallbackUrl": {
-          "description": "Custom decision algorithm can be provided in TiPCallback site extension which URL can be specified. See TiPCallback site extension for the scaffold and contracts.\nhttps://www.siteextensions.net/packages/TiPCallback/",
+          "description": "Custom decision algorithm can be provided in TiPCallback site extension which URL can be specified.",
           "type": "string"
         },
         "name": {

--- a/specification/web/resource-manager/Microsoft.Web/stable/2021-03-01/WebApps.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2021-03-01/WebApps.json
@@ -21589,7 +21589,7 @@
       "type": "object",
       "properties": {
         "openIdIssuer": {
-          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://login.microsoftonline.com/v2.0/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://login.microsoftonline.com/v2.0/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
           "type": "string"
         },
         "clientId": {
@@ -24743,7 +24743,7 @@
               "type": "string"
             },
             "issuer": {
-              "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://sts.windows.net/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+              "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://sts.windows.net/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
               "type": "string"
             },
             "validateIssuer": {

--- a/specification/web/resource-manager/Microsoft.Web/stable/2022-03-01/CommonDefinitions.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2022-03-01/CommonDefinitions.json
@@ -2530,7 +2530,7 @@
           "type": "number"
         },
         "changeDecisionCallbackUrl": {
-          "description": "Custom decision algorithm can be provided in TiPCallback site extension which URL can be specified. See TiPCallback site extension for the scaffold and contracts.\nhttps://www.siteextensions.net/packages/TiPCallback/",
+          "description": "Custom decision algorithm can be provided in TiPCallback site extension which URL can be specified.",
           "type": "string"
         },
         "name": {

--- a/specification/web/resource-manager/Microsoft.Web/stable/2022-03-01/WebApps.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2022-03-01/WebApps.json
@@ -23417,7 +23417,7 @@
       "type": "object",
       "properties": {
         "openIdIssuer": {
-          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://login.microsoftonline.com/v2.0/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://login.microsoftonline.com/v2.0/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
           "type": "string"
         },
         "clientId": {
@@ -27458,7 +27458,7 @@
               "type": "string"
             },
             "issuer": {
-              "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://sts.windows.net/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+              "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://sts.windows.net/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
               "type": "string"
             },
             "validateIssuer": {

--- a/specification/web/resource-manager/Microsoft.Web/stable/2022-09-01/CommonDefinitions.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2022-09-01/CommonDefinitions.json
@@ -2530,7 +2530,7 @@
           "type": "number"
         },
         "changeDecisionCallbackUrl": {
-          "description": "Custom decision algorithm can be provided in TiPCallback site extension which URL can be specified. See TiPCallback site extension for the scaffold and contracts.\nhttps://www.siteextensions.net/packages/TiPCallback/",
+          "description": "Custom decision algorithm can be provided in TiPCallback site extension which URL can be specified.",
           "type": "string"
         },
         "name": {

--- a/specification/web/resource-manager/Microsoft.Web/stable/2022-09-01/WebApps.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2022-09-01/WebApps.json
@@ -23917,7 +23917,7 @@
       "type": "object",
       "properties": {
         "openIdIssuer": {
-          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://login.microsoftonline.com/v2.0/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://login.microsoftonline.com/v2.0/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
           "type": "string"
         },
         "clientId": {
@@ -27958,7 +27958,7 @@
               "type": "string"
             },
             "issuer": {
-              "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://sts.windows.net/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+              "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://sts.windows.net/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
               "type": "string"
             },
             "validateIssuer": {

--- a/specification/web/resource-manager/Microsoft.Web/stable/2023-01-01/CommonDefinitions.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2023-01-01/CommonDefinitions.json
@@ -2530,7 +2530,7 @@
           "type": "number"
         },
         "changeDecisionCallbackUrl": {
-          "description": "Custom decision algorithm can be provided in TiPCallback site extension which URL can be specified. See TiPCallback site extension for the scaffold and contracts.\nhttps://www.siteextensions.net/packages/TiPCallback/",
+          "description": "Custom decision algorithm can be provided in TiPCallback site extension which URL can be specified.",
           "type": "string"
         },
         "name": {

--- a/specification/web/resource-manager/Microsoft.Web/stable/2023-01-01/WebApps.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2023-01-01/WebApps.json
@@ -23917,7 +23917,7 @@
       "type": "object",
       "properties": {
         "openIdIssuer": {
-          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://login.microsoftonline.com/v2.0/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://login.microsoftonline.com/v2.0/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
           "type": "string"
         },
         "clientId": {
@@ -27958,7 +27958,7 @@
               "type": "string"
             },
             "issuer": {
-              "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://sts.windows.net/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+              "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://sts.windows.net/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
               "type": "string"
             },
             "validateIssuer": {

--- a/specification/web/resource-manager/Microsoft.Web/stable/2023-12-01/CommonDefinitions.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2023-12-01/CommonDefinitions.json
@@ -2543,7 +2543,7 @@
           "type": "number"
         },
         "changeDecisionCallbackUrl": {
-          "description": "Custom decision algorithm can be provided in TiPCallback site extension which URL can be specified. See TiPCallback site extension for the scaffold and contracts.\nhttps://www.siteextensions.net/packages/TiPCallback/",
+          "description": "Custom decision algorithm can be provided in TiPCallback site extension which URL can be specified.",
           "type": "string"
         },
         "name": {

--- a/specification/web/resource-manager/Microsoft.Web/stable/2023-12-01/WebApps.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2023-12-01/WebApps.json
@@ -24355,7 +24355,7 @@
       "type": "object",
       "properties": {
         "openIdIssuer": {
-          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://login.microsoftonline.com/v2.0/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://login.microsoftonline.com/v2.0/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
           "type": "string"
         },
         "clientId": {
@@ -28413,7 +28413,7 @@
               "type": "string"
             },
             "issuer": {
-              "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://sts.windows.net/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+              "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://sts.windows.net/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
               "type": "string"
             },
             "validateIssuer": {

--- a/specification/web/resource-manager/Microsoft.Web/stable/2024-04-01/CommonDefinitions.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2024-04-01/CommonDefinitions.json
@@ -2556,7 +2556,7 @@
           "type": "number"
         },
         "changeDecisionCallbackUrl": {
-          "description": "Custom decision algorithm can be provided in TiPCallback site extension which URL can be specified. See TiPCallback site extension for the scaffold and contracts.\nhttps://www.siteextensions.net/packages/TiPCallback/",
+          "description": "Custom decision algorithm can be provided in TiPCallback site extension which URL can be specified.",
           "type": "string"
         },
         "name": {

--- a/specification/web/resource-manager/Microsoft.Web/stable/2024-04-01/WebApps.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2024-04-01/WebApps.json
@@ -24401,7 +24401,7 @@
       "type": "object",
       "properties": {
         "openIdIssuer": {
-          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://login.microsoftonline.com/v2.0/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://login.microsoftonline.com/v2.0/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
           "type": "string"
         },
         "clientId": {
@@ -28459,7 +28459,7 @@
               "type": "string"
             },
             "issuer": {
-              "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://sts.windows.net/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+              "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://sts.windows.net/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
               "type": "string"
             },
             "validateIssuer": {

--- a/specification/web/resource-manager/Microsoft.Web/stable/2024-11-01/CommonDefinitions.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2024-11-01/CommonDefinitions.json
@@ -2879,7 +2879,7 @@
           "type": "number"
         },
         "changeDecisionCallbackUrl": {
-          "description": "Custom decision algorithm can be provided in TiPCallback site extension which URL can be specified. See TiPCallback site extension for the scaffold and contracts.\nhttps://www.siteextensions.net/packages/TiPCallback/",
+          "description": "Custom decision algorithm can be provided in TiPCallback site extension which URL can be specified.",
           "type": "string"
         },
         "name": {

--- a/specification/web/resource-manager/Microsoft.Web/stable/2024-11-01/WebApps.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2024-11-01/WebApps.json
@@ -24401,7 +24401,7 @@
       "type": "object",
       "properties": {
         "openIdIssuer": {
-          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://login.microsoftonline.com/v2.0/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://login.microsoftonline.com/v2.0/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
           "type": "string"
         },
         "clientId": {
@@ -28482,7 +28482,7 @@
               "type": "string"
             },
             "issuer": {
-              "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://sts.windows.net/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
+              "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. `https://sts.windows.net/{tenant-guid}/`.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html",
               "type": "string"
             },
             "validateIssuer": {


### PR DESCRIPTION
@naveedaz

(cherry-picking the commit from main to sync up)

This is a bulk edit of existing Microsoft.Web API specs to fix broken links. They fall into the following categories:

https://www.siteextensions.net/packages/TiPCallback/ -> defunct link. delete
[https://sts.windows.net/{tenant-guid}/](https://sts.windows.net/%7Btenant-guid%7D/) -> use back ticks to change link formatting into code formatting.
[https://login.microsoftonline.com/v2.0/{tenant-guid}/](https://login.microsoftonline.com/v2.0/%7Btenant-guid%7D/) -> use back ticks to change link formatting into code formatting.