### PR TITLE
{Devcenter} Adjust service name for `devcenter` dataplane

### DIFF
--- a/specification/devcenter/DevCenter/DevBox/models.tsp
+++ b/specification/devcenter/DevCenter/DevBox/models.tsp
@@ -7,7 +7,7 @@ using TypeSpec.Rest;
 using TypeSpec.Http;
 using TypeSpec.Versioning;
 
-namespace DevCenterService;
+namespace Microsoft.DevCenter;
 
 @doc("The operating system type.")
 union OsType {

--- a/specification/devcenter/DevCenter/DevBox/parameters.tsp
+++ b/specification/devcenter/DevCenter/DevBox/parameters.tsp
@@ -7,7 +7,7 @@ using TypeSpec.Rest;
 using TypeSpec.Http;
 using TypeSpec.Versioning;
 
-namespace DevCenterService;
+namespace Microsoft.DevCenter;
 
 @doc("The snapshot id query parameter.")
 model SnapshotIdQueryParameter {

--- a/specification/devcenter/DevCenter/DevBox/routes.tsp
+++ b/specification/devcenter/DevCenter/DevBox/routes.tsp
@@ -11,7 +11,7 @@ using TypeSpec.Rest;
 using TypeSpec.Http;
 using TypeSpec.Versioning;
 
-namespace DevCenterService;
+namespace Microsoft.DevCenter;
 
 alias DevCenterOps = DevCenterResourceOperations<Traits.NoConditionalRequests &
   Traits.NoRepeatableRequests &

--- a/specification/devcenter/DevCenter/DevCenter/models.tsp
+++ b/specification/devcenter/DevCenter/DevCenter/models.tsp
@@ -6,7 +6,7 @@ import "../shared/models.tsp";
 using TypeSpec.Versioning;
 using TypeSpec.Rest;
 
-namespace DevCenterService;
+namespace Microsoft.DevCenter;
 
 @doc("A pending approval.")
 @resource("approvals")

--- a/specification/devcenter/DevCenter/DevCenter/routes.tsp
+++ b/specification/devcenter/DevCenter/DevCenter/routes.tsp
@@ -10,7 +10,7 @@ using TypeSpec.Rest;
 using TypeSpec.Http;
 using TypeSpec.Versioning;
 
-namespace DevCenterService;
+namespace Microsoft.DevCenter;
 
 interface DevCenter {
   @doc("Lists all projects.")

--- a/specification/devcenter/DevCenter/Environments/models.tsp
+++ b/specification/devcenter/DevCenter/Environments/models.tsp
@@ -7,7 +7,7 @@ using TypeSpec.Versioning;
 using TypeSpec.Rest;
 using TypeSpec.Http;
 
-namespace DevCenterService;
+namespace Microsoft.DevCenter;
 
 @doc("Type of the output value.")
 @added(APIVersions.v2024_02_01)

--- a/specification/devcenter/DevCenter/Environments/parameters.tsp
+++ b/specification/devcenter/DevCenter/Environments/parameters.tsp
@@ -7,7 +7,7 @@ using TypeSpec.Rest;
 using TypeSpec.Http;
 using TypeSpec.Versioning;
 
-namespace DevCenterService;
+namespace Microsoft.DevCenter;
 
 @doc("The force delete environment query parameter.")
 model ForceDeleteEnvironmentQueryParameter {

--- a/specification/devcenter/DevCenter/Environments/routes.tsp
+++ b/specification/devcenter/DevCenter/Environments/routes.tsp
@@ -10,7 +10,7 @@ using TypeSpec.Versioning;
 using TypeSpec.Rest;
 using TypeSpec.Http;
 
-namespace DevCenterService;
+namespace Microsoft.DevCenter;
 
 interface Environments {
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Does not fit any standard operation pattern since Environment has a different path"

--- a/specification/devcenter/DevCenter/main.tsp
+++ b/specification/devcenter/DevCenter/main.tsp
@@ -30,7 +30,7 @@ using TypeSpec.Http;
 )
 @doc("DevCenter service")
 @versioned(APIVersions)
-namespace DevCenterService;
+namespace Microsoft.DevCenter;
 
 @doc("DevCenter API versions")
 enum APIVersions {

--- a/specification/devcenter/DevCenter/shared/models.tsp
+++ b/specification/devcenter/DevCenter/shared/models.tsp
@@ -1,14 +1,13 @@
 import "@typespec/rest";
 import "@typespec/http";
 import "@azure-tools/typespec-azure-core";
-import "../main.tsp";
 
 using Azure.Core;
 using TypeSpec.Rest;
 using TypeSpec.Http;
 using TypeSpec.Versioning;
 
-namespace DevCenterService;
+namespace Microsoft.DevCenter;
 
 @doc("The current status of an async operation.")
 @resource("operationstatuses")

--- a/specification/devcenter/DevCenter/shared/parameters.tsp
+++ b/specification/devcenter/DevCenter/shared/parameters.tsp
@@ -7,7 +7,7 @@ using TypeSpec.Rest;
 using TypeSpec.Http;
 using TypeSpec.Versioning;
 
-namespace DevCenterService;
+namespace Microsoft.DevCenter;
 
 @doc("The project name path parameter.")
 model ProjectNameParameter {

--- a/specification/devcenter/DevCenter/shared/routes.tsp
+++ b/specification/devcenter/DevCenter/shared/routes.tsp
@@ -7,7 +7,7 @@ using Azure.Core;
 using TypeSpec.Rest;
 using TypeSpec.Http;
 
-namespace DevCenterService;
+namespace Microsoft.DevCenter;
 
 interface OperationStatuses {
   @doc("Get the status of an operation.")

--- a/specification/devcenter/DevCenter/shared/templates.tsp
+++ b/specification/devcenter/DevCenter/shared/templates.tsp
@@ -5,7 +5,7 @@ using Azure.Core;
 using TypeSpec.Rest;
 using TypeSpec.Http;
 
-namespace DevCenterService;
+namespace Microsoft.DevCenter;
 
 /**
  * Interface containing common resource operations.

--- a/specification/devcenter/DevCenter/tspconfig.yaml
+++ b/specification/devcenter/DevCenter/tspconfig.yaml
@@ -10,7 +10,7 @@ options:
     azure-resource-provider-folder: "data-plane"
     emit-lro-options: "none"
     emitter-output-dir: "{project-root}/.."
-    output-file: "{azure-resource-provider-folder}/Microsoft.DevCenter/{version-status}/{version}/devcenter.json"
+    output-file: "{azure-resource-provider-folder}/{service-name}/{version-status}/{version}/devcenter.json"
     omit-unreachable-types: true
   "@azure-tools/typespec-csharp":
     package-dir: "Azure.Developer.DevCenter"

--- a/specification/devcenter/DevCenter/tspconfig.yaml
+++ b/specification/devcenter/DevCenter/tspconfig.yaml
@@ -10,7 +10,7 @@ options:
     azure-resource-provider-folder: "data-plane"
     emit-lro-options: "none"
     emitter-output-dir: "{project-root}/.."
-    output-file: "{azure-resource-provider-folder}/{service-name}/{version-status}/{version}/devcenter.json"
+    output-file: "{azure-resource-provider-folder}/{service-name}/{version-status}/{version}/{service-name}.json"
     omit-unreachable-types: true
   "@azure-tools/typespec-csharp":
     package-dir: "Azure.Developer.DevCenter"

--- a/specification/devcenter/DevCenter/tspconfig.yaml
+++ b/specification/devcenter/DevCenter/tspconfig.yaml
@@ -10,7 +10,7 @@ options:
     azure-resource-provider-folder: "data-plane"
     emit-lro-options: "none"
     emitter-output-dir: "{project-root}/.."
-    output-file: "{azure-resource-provider-folder}/{service-name}/{version-status}/{version}/{service-name}.json"
+    output-file: "{azure-resource-provider-folder}/{service-name}/{version-status}/{version}/devcenter.json"
     omit-unreachable-types: true
   "@azure-tools/typespec-csharp":
     package-dir: "Azure.Developer.DevCenter"


### PR DESCRIPTION
All service teams use resource provider name as its service name and generate swagger file with `service-name` configured for its `output-file` in its `@azure-tools/typespec-autorest` emitter options, as below:

```
  "@azure-tools/typespec-autorest":
    azure-resource-provider-folder: "data-plane"
    emit-lro-options: "none"
    emitter-output-dir: "{project-root}/.."
    output-file: "{azure-resource-provider-folder}/{service-name}/{version-status}/{version}/{service-name}.json"
    omit-unreachable-types: true
```
The directory structure for `dev-center` data-plane looks like follow:
```
specification
-->devcenter
---->data-plane
------>Microsoft.Devcenter
......
---->resource-manager
------>Microsoft.Devcenter

```
For cli autogen tool, we use the folder name under `data-plane` as its namespace for swagger api (and it is for previous data-plane apis) and store our generated model under this namespace. 

If the namespace from tsp api become something nonsense or different, then, we will treat this data-plane api from tsp as a different namespaced api. We can still generate our model, but that would break our model inheritance. 

Can we keep this consistent with previous and all other services? Thanks.

And also I think the different namespace from tsp does not make any sense either, if possible, tsp compiler linter rule should give a hint on this part, to avoid random namespaces from api developers, in my view.


# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
