### PR TITLE
FIX: OpenAI `ChatCompletions` and `Completions` `usage` field is optional

### DIFF
--- a/specification/cognitiveservices/OpenAI.Inference/models/completions/chat_completions.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/completions/chat_completions.tsp
@@ -535,7 +535,7 @@ model ChatCompletions {
   @doc("""
     Usage information for tokens processed and generated as part of this completions operation.
     """)
-  usage: CompletionsUsage;
+  usage?: CompletionsUsage;
 }
 
 @added(ServiceApiVersions.v2024_02_15_Preview)

--- a/specification/cognitiveservices/OpenAI.Inference/models/completions/completions_create.tsp
+++ b/specification/cognitiveservices/OpenAI.Inference/models/completions/completions_create.tsp
@@ -192,7 +192,7 @@ model Completions {
   @doc("""
     Usage information for tokens processed and generated as part of this completions operation.
     """)
-  usage: CompletionsUsage;
+  usage?: CompletionsUsage;
 
   /**
    * This fingerprint represents the backend configuration that the model runs with.

--- a/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2023-06-01-preview/generated.json
+++ b/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2023-06-01-preview/generated.json
@@ -505,8 +505,7 @@
       "required": [
         "id",
         "created",
-        "choices",
-        "usage"
+        "choices"
       ]
     },
     "ChatCompletionsOptions": {
@@ -805,8 +804,7 @@
       "required": [
         "id",
         "created",
-        "choices",
-        "usage"
+        "choices"
       ]
     },
     "CompletionsFinishReason": {

--- a/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2023-07-01-preview/generated.json
+++ b/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2023-07-01-preview/generated.json
@@ -505,8 +505,7 @@
       "required": [
         "id",
         "created",
-        "choices",
-        "usage"
+        "choices"
       ]
     },
     "ChatCompletionsOptions": {
@@ -858,8 +857,7 @@
       "required": [
         "id",
         "created",
-        "choices",
-        "usage"
+        "choices"
       ]
     },
     "CompletionsFinishReason": {

--- a/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-02-15-preview/generated.json
+++ b/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-02-15-preview/generated.json
@@ -2065,8 +2065,7 @@
       "required": [
         "id",
         "created",
-        "choices",
-        "usage"
+        "choices"
       ]
     },
     "ChatCompletionsFunctionToolCall": {
@@ -2701,8 +2700,7 @@
       "required": [
         "id",
         "created",
-        "choices",
-        "usage"
+        "choices"
       ]
     },
     "CompletionsFinishReason": {

--- a/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-03-01-preview/generated.json
+++ b/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-03-01-preview/generated.json
@@ -2065,8 +2065,7 @@
       "required": [
         "id",
         "created",
-        "choices",
-        "usage"
+        "choices"
       ]
     },
     "ChatCompletionsFunctionToolCall": {
@@ -2701,8 +2700,7 @@
       "required": [
         "id",
         "created",
-        "choices",
-        "usage"
+        "choices"
       ]
     },
     "CompletionsFinishReason": {

--- a/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-04-01-preview/generated.json
+++ b/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-04-01-preview/generated.json
@@ -2201,8 +2201,7 @@
       "required": [
         "id",
         "created",
-        "choices",
-        "usage"
+        "choices"
       ]
     },
     "ChatCompletionsFunctionToolCall": {
@@ -2837,8 +2836,7 @@
       "required": [
         "id",
         "created",
-        "choices",
-        "usage"
+        "choices"
       ]
     },
     "CompletionsFinishReason": {

--- a/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-05-01-preview/generated.json
+++ b/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-05-01-preview/generated.json
@@ -2355,8 +2355,7 @@
       "required": [
         "id",
         "created",
-        "choices",
-        "usage"
+        "choices"
       ]
     },
     "ChatCompletionsFunctionToolCall": {
@@ -2991,8 +2990,7 @@
       "required": [
         "id",
         "created",
-        "choices",
-        "usage"
+        "choices"
       ]
     },
     "CompletionsFinishReason": {

--- a/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-07-01-preview/generated.json
+++ b/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-07-01-preview/generated.json
@@ -3046,8 +3046,7 @@
       "required": [
         "id",
         "created",
-        "choices",
-        "usage"
+        "choices"
       ]
     },
     "ChatCompletionsFunctionToolCall": {
@@ -3668,8 +3667,7 @@
       "required": [
         "id",
         "created",
-        "choices",
-        "usage"
+        "choices"
       ]
     },
     "CompletionsFinishReason": {

--- a/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-08-01-preview/generated.json
+++ b/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-08-01-preview/generated.json
@@ -3096,8 +3096,7 @@
       "required": [
         "id",
         "created",
-        "choices",
-        "usage"
+        "choices"
       ]
     },
     "ChatCompletionsFunctionToolCall": {
@@ -3805,8 +3804,7 @@
       "required": [
         "id",
         "created",
-        "choices",
-        "usage"
+        "choices"
       ]
     },
     "CompletionsFinishReason": {

--- a/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-09-01-preview/generated.json
+++ b/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-09-01-preview/generated.json
@@ -3107,8 +3107,7 @@
       "required": [
         "id",
         "created",
-        "choices",
-        "usage"
+        "choices"
       ]
     },
     "ChatCompletionsFunctionToolCall": {
@@ -3839,8 +3838,7 @@
       "required": [
         "id",
         "created",
-        "choices",
-        "usage"
+        "choices"
       ]
     },
     "CompletionsFinishReason": {

--- a/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-10-01-preview/generated.json
+++ b/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-10-01-preview/generated.json
@@ -3107,8 +3107,7 @@
       "required": [
         "id",
         "created",
-        "choices",
-        "usage"
+        "choices"
       ]
     },
     "ChatCompletionsFunctionToolCall": {
@@ -3839,8 +3838,7 @@
       "required": [
         "id",
         "created",
-        "choices",
-        "usage"
+        "choices"
       ]
     },
     "CompletionsFinishReason": {

--- a/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2025-01-01-preview/generated.json
+++ b/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2025-01-01-preview/generated.json
@@ -3184,8 +3184,7 @@
       "required": [
         "id",
         "created",
-        "choices",
-        "usage"
+        "choices"
       ]
     },
     "ChatCompletionsFunctionToolCall": {
@@ -4014,8 +4013,7 @@
       "required": [
         "id",
         "created",
-        "choices",
-        "usage"
+        "choices"
       ]
     },
     "CompletionsFinishReason": {

--- a/specification/cognitiveservices/data-plane/AzureOpenAI/inference/stable/2022-12-01/generated.json
+++ b/specification/cognitiveservices/data-plane/AzureOpenAI/inference/stable/2022-12-01/generated.json
@@ -280,8 +280,7 @@
       "required": [
         "id",
         "created",
-        "choices",
-        "usage"
+        "choices"
       ]
     },
     "CompletionsFinishReason": {

--- a/specification/cognitiveservices/data-plane/AzureOpenAI/inference/stable/2023-05-15/generated.json
+++ b/specification/cognitiveservices/data-plane/AzureOpenAI/inference/stable/2023-05-15/generated.json
@@ -322,8 +322,7 @@
       "required": [
         "id",
         "created",
-        "choices",
-        "usage"
+        "choices"
       ]
     },
     "ChatCompletionsOptions": {
@@ -608,8 +607,7 @@
       "required": [
         "id",
         "created",
-        "choices",
-        "usage"
+        "choices"
       ]
     },
     "CompletionsFinishReason": {

--- a/specification/cognitiveservices/data-plane/AzureOpenAI/inference/stable/2024-02-01/generated.json
+++ b/specification/cognitiveservices/data-plane/AzureOpenAI/inference/stable/2024-02-01/generated.json
@@ -505,8 +505,7 @@
       "required": [
         "id",
         "created",
-        "choices",
-        "usage"
+        "choices"
       ]
     },
     "ChatCompletionsOptions": {
@@ -858,8 +857,7 @@
       "required": [
         "id",
         "created",
-        "choices",
-        "usage"
+        "choices"
       ]
     },
     "CompletionsFinishReason": {

--- a/specification/cognitiveservices/data-plane/AzureOpenAI/inference/stable/2024-06-01/generated.json
+++ b/specification/cognitiveservices/data-plane/AzureOpenAI/inference/stable/2024-06-01/generated.json
@@ -2355,8 +2355,7 @@
       "required": [
         "id",
         "created",
-        "choices",
-        "usage"
+        "choices"
       ]
     },
     "ChatCompletionsFunctionToolCall": {
@@ -2991,8 +2990,7 @@
       "required": [
         "id",
         "created",
-        "choices",
-        "usage"
+        "choices"
       ]
     },
     "CompletionsFinishReason": {


### PR DESCRIPTION
Customer reported issues: https://github.com/Azure/azure-sdk-for-java/issues/44412

Making `ChatCompletions::usage` and `Completions::usage` optional and therefore comforming to the spec. Links to latest supported Azure OpenAI and non-Azure OpenAI specs:

- [ChatCompletions OpenAI](https://github.com/openai/openai-openapi/blob/ec54f8876168475efa70effa31d4e6cff122c053/openapi.yaml#L17402-L17407)
- [Completions OpenAI](https://github.com/openai/openai-openapi/blob/ec54f8876168475efa70effa31d4e6cff122c053/openapi.yaml#L17935-L17940)
- [ChatCompletions Azure OpenAI](https://github.com/Azure/azure-rest-api-specs/blob/d0c47feadfc8fa6a2d195b4a82f51551ab7f890f/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2025-01-01-preview/inference.yaml#L4232-L4237C12)
- [Completions Azure OpenAI](https://github.com/Azure/azure-rest-api-specs/blob/d0c47feadfc8fa6a2d195b4a82f51551ab7f890f/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2025-01-01-preview/inference.yaml#L2520-L2525)

The field is confirmed to be optional since the beginning, as far as I was able to tell.