### PR TITLE
[.github] Change git.lsTree() to return paths relative to repo root

### DIFF
--- a/.github/src/git.js
+++ b/.github/src/git.js
@@ -35,7 +35,7 @@ export async function diff(baseCommitish, headCommitish, options = {}) {
 export async function lsTree(treeIsh, path, options = {}) {
   const { args, logger } = options;
 
-  const cmd = buildCmd("ls-tree", args, `${treeIsh}:${path}`);
+  const cmd = buildCmd("ls-tree", args, treeIsh, path);
 
   return await execGit(cmd, {
     logger: logger,

--- a/.github/test/git.test.js
+++ b/.github/test/git.test.js
@@ -26,7 +26,7 @@ describe("git", () => {
     ).resolves.toBe("test lstree");
 
     expect(execRootSpy).toBeCalledWith(
-      "git -c core.quotepath=off ls-tree HEAD:specification/contosowidgetmanager",
+      "git -c core.quotepath=off ls-tree HEAD specification/contosowidgetmanager",
       expect.anything(),
     );
   });


### PR DESCRIPTION
- Fixes #33328
- Previous code had bug, returning child paths relative to the path argument
