### PR TITLE
Update maximum number of container groups in standbyContainerGroupPool to 10000

### DIFF
--- a/specification/standbypool/StandbyPool.Management/standbyContainerGroupPool.tsp
+++ b/specification/standbypool/StandbyPool.Management/standbyContainerGroupPool.tsp
@@ -54,7 +54,7 @@ model StandbyContainerGroupPoolResourceProperties {
 @doc("Specifies the elasticity profile of the standby container group pools.")
 model StandbyContainerGroupPoolElasticityProfile {
   @doc("Specifies maximum number of standby container groups in the standby pool.")
-  @maxValue(2000)
+  @maxValue(1000)
   @minValue(0)
   maxReadyCapacity: int64;
 

--- a/specification/standbypool/StandbyPool.Management/standbyContainerGroupPool.tsp
+++ b/specification/standbypool/StandbyPool.Management/standbyContainerGroupPool.tsp
@@ -54,7 +54,7 @@ model StandbyContainerGroupPoolResourceProperties {
 @doc("Specifies the elasticity profile of the standby container group pools.")
 model StandbyContainerGroupPoolElasticityProfile {
   @doc("Specifies maximum number of standby container groups in the standby pool.")
-  @maxValue(1000)
+  @maxValue(10000)
   @minValue(0)
   maxReadyCapacity: int64;
 


### PR DESCRIPTION
Update maximum number of container groups in StandbyContainerGroupPool to 10000 

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
