### PR TITLE
fix up the spec for typespec 0.67.1

### DIFF
--- a/specification/ai/ModelClient/main.tsp
+++ b/specification/ai/ModelClient/main.tsp
@@ -18,9 +18,7 @@ using Azure.Core;
     }
   ]>
 )
-@service({
-  title: "AI Model Inference",
-})
+@service(#{ title: "AI Model Inference" })
 @versioned(AI.Model.Versions)
 namespace AI.Model;
 


### PR DESCRIPTION
We have updated to typespec 0.67.1, and quite a few usages in our new specs on this branch are no longer supported therefore the current spec will not compile in the latest version.
This PR fixes those issues