### PR TITLE
Update property names in `Deployment` TypeSpec model

### DIFF
--- a/specification/ai/Azure.AI.Projects/deployments/models.tsp
+++ b/specification/ai/Azure.AI.Projects/deployments/models.tsp
@@ -21,7 +21,7 @@ model Deployment {
   @doc("Name of the deployment")
   @visibility("read")
   @key("name")
-  name: string;
+  deploymentName: string;
 
   @doc("Publisher-specific name of the deployed model")
   @visibility("read")
@@ -31,9 +31,9 @@ model Deployment {
   @visibility("read")
   modelVersion: string;
 
-  @doc("Name of the deployed model's publisher")
+  @doc("The publisher of the deployed model")
   @visibility("read")
-  modelPublisher: string;
+  publisher: string;
 
   @doc("Capabilities of deployed model")
   @visibility("read")

--- a/specification/ai/data-plane/Azure.AI.Projects/preview/2025-05-01-preview/azure-ai-projects-1dp.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/preview/2025-05-01-preview/azure-ai-projects-1dp.json
@@ -9851,7 +9851,7 @@
       "type": "object",
       "description": "Model Deployment Definition",
       "properties": {
-        "name": {
+        "deploymentName": {
           "type": "string",
           "description": "Name of the deployment",
           "readOnly": true
@@ -9866,9 +9866,9 @@
           "description": "Publisher-specific version of the deployed model",
           "readOnly": true
         },
-        "modelPublisher": {
+        "publisher": {
           "type": "string",
-          "description": "Name of the deployed model's publisher",
+          "description": "The publisher of the deployed model",
           "readOnly": true
         },
         "capabilities": {
@@ -9891,10 +9891,10 @@
         }
       },
       "required": [
-        "name",
+        "deploymentName",
         "modelName",
         "modelVersion",
-        "modelPublisher",
+        "publisher",
         "capabilities",
         "sku"
       ]


### PR DESCRIPTION
Update property names in `Deployment` TypeSpec model to match what I see on the wire

Dump of service response I see when listing deployments, for one model:

```json
{
    "deploymentName": "DeepSeek-R1",
    "modelName": "DeepSeek-R1",
    "modelVersion": "1",
    "publisher": "DeepSeek",
    "capabilities":
    {
        "chat_completion": "true"
    },
    "sku":
    {
        "name": "GlobalStandard",
        "capacity": 1
    },
    "systemData":
    {
        "createdBy": "ninhu@microsoft.com",
        "createdByType": "User",
        "createdAt": "2025-03-12T18:32:40.8445656Z",
        "lastModifiedBy": "ninhu@microsoft.com",
        "lastModifiedByType": "User",
        "lastModifiedAt": "2025-03-12T18:32:40.8445656Z"
    }
}
```
Corresponding Python "Deployment" object properties, using currently emitted code (notice the missing publisher and  name)"

```text
capabilities: {'chat_completion': 'true'}
connection_name: None
model_name: DeepSeek-R1
model_publisher: None
model_version: 1
name: None
sku: {'name': 'GlobalStandard', 'capacity': 1}
    capacity: 1
    family: None
    name: GlobalStandard
    size: None
    tier: None
```
	
This PR makes the following TypeSpec changes to match what I see on the wire:
* Rename `name` to `deploymentName`
* Rename `modelPublisher` to `publisher`


