### PR TITLE
Use original file name when searching files

### DIFF
--- a/eng/tools/spec-gen-sdk-runner/src/commands.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/commands.ts
@@ -9,7 +9,14 @@ import {
   resetGitRepo,
   objectToMap,
 } from "./utils.js";
-import { LogLevel, logMessage, setVsoVariable, vsoAddAttachment, vsoLogIssue } from "./log.js";
+import {
+  LogIssueType,
+  LogLevel,
+  logMessage,
+  setVsoVariable,
+  vsoAddAttachment,
+  vsoLogIssue,
+} from "./log.js";
 import { SpecGenSdkCmdInput, VsoLogs } from "./types.js";
 import { detectChangedSpecConfigFiles } from "./change-files.js";
 
@@ -375,7 +382,7 @@ function logIssuesToPipeline(logPath: string, specConfigDisplayText: string): vo
       const warningTitle = `Warnings occurred while generating SDK from ${specConfigDisplayText}`;
       logMessage(warningTitle, LogLevel.Group);
       const warningsWithTitle = [warningTitle, ...warnings];
-      vsoLogIssue(warningsWithTitle.join("%0D%0A"));
+      vsoLogIssue(warningsWithTitle.join("%0D%0A"), LogIssueType.Warning);
       logMessage("ending group logging", LogLevel.EndGroup);
     }
   }

--- a/eng/tools/spec-gen-sdk-runner/src/log.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/log.ts
@@ -7,6 +7,11 @@ export enum LogLevel {
   EndGroup = "endgroup",
 }
 
+export enum LogIssueType {
+  Error = "error",
+  Warning = "warning",
+}
+
 /**
  * Logs a message to the console with a specified log level. *
  * @param message The message to log.
@@ -45,7 +50,7 @@ export function vsoAddAttachment(name: string, path: string): void {
   console.log(`##vso[task.addattachment type=Distributedtask.Core.Summary;name=${name};]${path}`);
 }
 
-export function vsoLogIssue(message: string, type = "error"): void {
+export function vsoLogIssue(message: string, type: LogIssueType = LogIssueType.Error): void {
   console.log(`##vso[task.logissue type=${type}]${message}`);
 }
 

--- a/eng/tools/spec-gen-sdk-runner/src/utils.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/utils.ts
@@ -178,7 +178,7 @@ export function findParentWithFile(
     try {
       const absolutePath = path.resolve(specRepoFolder, currentPath);
       const files = fs.readdirSync(absolutePath);
-      if (files.some((file) => searchFile.test(file.toLowerCase()))) {
+      if (files.some((file) => searchFile.test(file))) {
         return currentPath;
       }
     } catch (error) {


### PR DESCRIPTION
- There are some services under specification folder adding `README.md` to describe its service. This would be mistakenly considered as 'readme.md' to be used for SDK generation. This PR changes the file comparison code to use the original file name when searching files.
Here is an example README.md:
https://github.com/Azure/azure-rest-api-specs/blob/main/specification/communication/Communication.JobRouter/README.md

- Log warning issues in pipeline result.
