### PR TITLE
Set pipeline variables used to create SDK PR and refactored loading execution report

### DIFF
--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -54,7 +54,6 @@ extends:
           outputs:
             - output: pipelineArtifact
               displayName: Publish logs to Pipeline Artifacts
-              condition: ne(variables['ValidationResult'], '')
               artifactName: "spec-gen-sdk-logs"
               targetPath: "$(System.DefaultWorkingDirectory)/out/logs"
 

--- a/eng/tools/spec-gen-sdk-runner/eslint.config.js
+++ b/eng/tools/spec-gen-sdk-runner/eslint.config.js
@@ -74,6 +74,8 @@ const config = tseslint.config(
       "@typescript-eslint/no-inferrable-types": "off",
       "@typescript-eslint/no-dynamic-delete": "off",
       "@typescript-eslint/no-unsafe-member-access": "off",
+      "@typescript-eslint/no-unsafe-call": "off",
+      "@typescript-eslint/no-unsafe-return": "off",
       "@typescript-eslint/no-explicit-any": "off",
 
       // We want more flexibility with file names.

--- a/eng/tools/spec-gen-sdk-runner/eslint.config.js
+++ b/eng/tools/spec-gen-sdk-runner/eslint.config.js
@@ -74,8 +74,6 @@ const config = tseslint.config(
       "@typescript-eslint/no-inferrable-types": "off",
       "@typescript-eslint/no-dynamic-delete": "off",
       "@typescript-eslint/no-unsafe-member-access": "off",
-      "@typescript-eslint/no-unsafe-call": "off",
-      "@typescript-eslint/no-unsafe-return": "off",
       "@typescript-eslint/no-explicit-any": "off",
 
       // We want more flexibility with file names.

--- a/eng/tools/spec-gen-sdk-runner/src/commands.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/commands.ts
@@ -56,11 +56,12 @@ export async function generateSdkForSingleSpec(): Promise<number> {
 
   if (statusCode === 0) {
     // Set the pipeline variables for the SDK pull request
-    const packageName =
+    let packageName =
       executionReport.packages[0]?.packageName ??
       commandInput.tspConfigPath ??
       commandInput.readmePath ??
       "missing-package-name";
+    packageName = packageName.replace("/", "-");
     const installationInstructions = executionReport.packages[0]?.installationInstructions;
     setPipelineVariables(packageName, installationInstructions);
   }

--- a/eng/tools/spec-gen-sdk-runner/src/commands.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/commands.ts
@@ -20,6 +20,11 @@ import {
 import { SpecGenSdkCmdInput, VsoLogs } from "./types.js";
 import { detectChangedSpecConfigFiles } from "./change-files.js";
 
+/**
+ * Generate SDK for a single spec.
+ * This is for the SDK release scenario.
+ * @returns the run status code.
+ */
 export async function generateSdkForSingleSpec(): Promise<number> {
   // Parse the arguments
   const commandInput: SpecGenSdkCmdInput = parseArguments();
@@ -38,23 +43,28 @@ export async function generateSdkForSingleSpec(): Promise<number> {
     statusCode = 1;
   }
 
-  // Read the execution report to determine if the generation was successful
-  const executionReportPath = path.join(
-    commandInput.workingFolder,
-    `${commandInput.sdkRepoName}_tmp/execution-report.json`,
-  );
   let executionReport;
   try {
-    executionReport = JSON.parse(fs.readFileSync(executionReportPath, "utf8"));
+    // Read the execution report to determine if the generation was successful
+    executionReport = getExecutionReport(commandInput);
     const executionResult = executionReport.executionResult;
     logMessage(`Runner command execution result:${executionResult}`);
   } catch (error) {
-    logMessage(
-      `Runner: error reading execution report at ${executionReportPath}:${error}`,
-      LogLevel.Error,
-    );
+    logMessage(`Runner: error reading execution-report.json:${error}`, LogLevel.Error);
     statusCode = 1;
   }
+
+  if (statusCode === 0) {
+    // Set the pipeline variables for the SDK pull request
+    const packageName =
+      executionReport.packages[0]?.packageName ??
+      commandInput.tspConfigPath ??
+      commandInput.readmePath ??
+      "missing-package-name";
+    const installationInstructions = executionReport.packages[0]?.installationInstructions;
+    setPipelineVariables(packageName, installationInstructions);
+  }
+
   logMessage("ending group logging", LogLevel.EndGroup);
   logIssuesToPipeline(executionReport.vsoLogPath, specConfigPathText);
 
@@ -105,22 +115,15 @@ export async function generateSdkForSpecPr(): Promise<number> {
     for (let index = 0; index < pushedSpecConfigCount * 2; index++) {
       specGenSdkCommand.pop();
     }
-    // Read the execution report to determine if the generation was successful
-    const executionReportPath = path.join(
-      commandInput.workingFolder,
-      `${commandInput.sdkRepoName}_tmp/execution-report.json`,
-    );
 
     try {
-      executionReport = JSON.parse(fs.readFileSync(executionReportPath, "utf8"));
+      // Read the execution report to determine if the generation was successful
+      executionReport = getExecutionReport(commandInput);
       const executionResult = executionReport.executionResult;
       [shouldLabelBreakingChange, breakingChangeLabel] = getBreakingChangeInfo(executionReport);
       logMessage(`Runner command execution result:${executionResult}`);
     } catch (error) {
-      logMessage(
-        `Runner: error reading execution report at ${executionReportPath}:${error}`,
-        LogLevel.Error,
-      );
+      logMessage(`Runner: error reading execution-report.json:${error}`, LogLevel.Error);
       statusCode = 1;
     }
     logMessage("ending group logging", LogLevel.EndGroup);
@@ -179,13 +182,10 @@ export async function generateSdkForBatchSpecs(runMode: string): Promise<number>
     // Pop the spec config path from the command
     specGenSdkCommand.pop();
     specGenSdkCommand.pop();
-    // Read the execution report to determine if the generation was successful
-    const executionReportPath = path.join(
-      commandInput.workingFolder,
-      `${commandInput.sdkRepoName}_tmp/execution-report.json`,
-    );
+
     try {
-      executionReport = JSON.parse(fs.readFileSync(executionReportPath, "utf8"));
+      // Read the execution report to determine if the generation was successful
+      executionReport = getExecutionReport(commandInput);
       const executionResult = executionReport.executionResult;
       logMessage(`Runner: command execution result:${executionResult}`);
 
@@ -200,10 +200,7 @@ export async function generateSdkForBatchSpecs(runMode: string): Promise<number>
         failedCount++;
       }
     } catch (error) {
-      logMessage(
-        `Runner: error reading execution report at ${executionReportPath}:${error}`,
-        LogLevel.Error,
-      );
+      logMessage(`Runner: error reading execution-report.json:${error}`, LogLevel.Error);
       statusCode = 1;
     }
     logMessage("ending group logging", LogLevel.EndGroup);
@@ -241,6 +238,33 @@ export async function generateSdkForBatchSpecs(runMode: string): Promise<number>
   return statusCode;
 }
 
+/**
+ * Load execution-report.json.
+ * @param commandInput - The command input.
+ * @returns the execution report JSON
+ */
+function getExecutionReport(commandInput: SpecGenSdkCmdInput): any {
+  // Read the execution report to determine if the generation was successful
+  const executionReportPath = path.join(
+    commandInput.workingFolder,
+    `${commandInput.sdkRepoName}_tmp/execution-report.json`,
+  );
+  return JSON.parse(fs.readFileSync(executionReportPath, "utf8"));
+}
+
+/**
+ * Set the pipeline variables for the SDK pull request.
+ * @param packageName - The package name.
+ * @param installationInstructions - The installation instructions.
+ */
+function setPipelineVariables(packageName: string, installationInstructions: string = ""): void {
+  const branchName = `sdkauto/${packageName?.replace("/", "_")}`;
+  const prTitle = `[AutoPR ${packageName}]`;
+  const prBody = installationInstructions;
+  setVsoVariable("PrBranch", branchName);
+  setVsoVariable("PrTitle", prTitle);
+  setVsoVariable("PrBody", prBody);
+}
 /**
  * Parse the arguments.
  * @returns The spec-gen-sdk command input.

--- a/eng/tools/spec-gen-sdk-runner/src/commands.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/commands.ts
@@ -56,7 +56,7 @@ export async function generateSdkForSingleSpec(): Promise<number> {
 
   if (statusCode === 0) {
     // Set the pipeline variables for the SDK pull request
-    let packageName =
+    let packageName: string =
       executionReport.packages[0]?.packageName ??
       commandInput.tspConfigPath ??
       commandInput.readmePath ??

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "azure-rest-api-specs",
       "devDependencies": {
         "@autorest/openapi-to-typespec": "0.10.13",
-        "@azure-tools/spec-gen-sdk": "^0.3.0",
+        "@azure-tools/spec-gen-sdk": "^0.3.1",
         "@azure-tools/typespec-apiview": "0.6.0",
         "@azure-tools/typespec-autorest": "0.53.0",
         "@azure-tools/typespec-azure-core": "0.53.0",
@@ -848,9 +848,9 @@
       "link": true
     },
     "node_modules/@azure-tools/spec-gen-sdk": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/spec-gen-sdk/-/spec-gen-sdk-0.3.0.tgz",
-      "integrity": "sha512-g/UiXY+ChSdSDMdYcgijtAmc0+c0hGoY4LbZsodH7d61HcMcdO8smVYXdIIC3fIXevW65cmaEQGDfM5dw3w1ZA==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@azure-tools/spec-gen-sdk/-/spec-gen-sdk-0.3.1.tgz",
+      "integrity": "sha512-8nP7btsuCDUwE7FGlDor8UVn9qCqPsiY4CET1TFCgwKhFkmqBy8KQbRKG5PiMsIweu37nsLyKqk8Vp+fghQ0oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "azure-rest-api-specs",
   "devDependencies": {
-    "@azure-tools/spec-gen-sdk": "^0.3.0",
+    "@azure-tools/spec-gen-sdk": "^0.3.1",
     "@azure-tools/typespec-apiview": "0.6.0",
     "@azure-tools/typespec-autorest": "0.53.0",
     "@azure-tools/typespec-azure-core": "0.53.0",


### PR DESCRIPTION
- Introduced the `getExecutionReport` function to simplify the code and reduces redundancy
- Added the `setPipelineVariables` function to set pipeline variables for SDK pull requests, these variables have been removed from setting by `spec-gen-sdk` tool
- Removed the condition on publishing logs to pipeline artifacts, ensuring logs are always published
