### PR TITLE
Gate updates for the fleet-2025-04-01-preview API

### DIFF
--- a/specification/containerservice/Fleet.Management/examples/2025-04-01-preview/Gates_Get.json
+++ b/specification/containerservice/Fleet.Management/examples/2025-04-01-preview/Gates_Get.json
@@ -32,14 +32,11 @@
           "displayName": "Perform health checks after Group 1",
           "target": {
             "id": "/subscriptions/subid1/resourcegroups/rg1/providers/Microsoft.ContainerService/fleets/fleet-1/updateRuns/run1",
-            "type": "UpdateRun",
-            "properties": {
-              "updateRun": {
-                "name": "run1",
-                "stage": "stage1",
-                "group": "group1",
-                "timing": "After"
-              }
+            "updateRunProperties": {
+              "name": "run1",
+              "stage": "stage1",
+              "group": "group1",
+              "timing": "After"
             }
           },
           "gateType": "Approval",

--- a/specification/containerservice/Fleet.Management/examples/2025-04-01-preview/Gates_ListByFleet.json
+++ b/specification/containerservice/Fleet.Management/examples/2025-04-01-preview/Gates_ListByFleet.json
@@ -30,14 +30,11 @@
               "displayName": "Perform health checks after Group 1",
               "target": {
                 "id": "/subscriptions/subid1/resourcegroups/rg1/providers/Microsoft.ContainerService/fleets/fleet-1/updateRuns/run1",
-                "type": "UpdateRun",
-                "properties": {
-                  "updateRun": {
-                    "name": "run1",
-                    "stage": "stage1",
-                    "group": "group1",
-                    "timing": "After"
-                  }
+                "updateRunProperties": {
+                  "name": "run1",
+                  "stage": "stage1",
+                  "group": "group1",
+                  "timing": "After"
                 }
               },
               "gateType": "Approval",

--- a/specification/containerservice/Fleet.Management/examples/2025-04-01-preview/Gates_Update.json
+++ b/specification/containerservice/Fleet.Management/examples/2025-04-01-preview/Gates_Update.json
@@ -38,14 +38,11 @@
           "displayName": "Perform health checks after Group 1",
           "target": {
             "id": "/subscriptions/subid1/resourcegroups/rg1/providers/Microsoft.ContainerService/fleets/fleet-1/updateRuns/run1",
-            "type": "UpdateRun",
-            "properties": {
-              "updateRun": {
-                "name": "run1",
-                "stage": "stage1",
-                "group": "group1",
-                "timing": "After"
-              }
+            "updateRunProperties": {
+              "name": "run1",
+              "stage": "stage1",
+              "group": "group1",
+              "timing": "After"
             }
           },
           "gateType": "Approval",

--- a/specification/containerservice/Fleet.Management/gate.tsp
+++ b/specification/containerservice/Fleet.Management/gate.tsp
@@ -66,13 +66,13 @@ model GateProperties {
   @maxLength(100)
   displayName?: string;
 
-  @doc("The target that the Gate is controlling, e.g. an Update Run.")
-  @visibility(Lifecycle.Create, Lifecycle.Read)
-  target: GateTarget;
-
   @doc("The type of the Gate determines how it is completed.")
   @visibility(Lifecycle.Create, Lifecycle.Read)
   gateType: GateType;
+
+  @doc("The target that the Gate is controlling, e.g. an Update Run.")
+  @visibility(Lifecycle.Create, Lifecycle.Read)
+  target: GateTarget;
 
   @doc("The state of the Gate.")
   @visibility(Lifecycle.Create, Lifecycle.Update, Lifecycle.Read)

--- a/specification/containerservice/Fleet.Management/gate.tsp
+++ b/specification/containerservice/Fleet.Management/gate.tsp
@@ -89,25 +89,9 @@ union GateTargetType {
   UpdateRun: "UpdateRun",
 }
 
-@doc("The type of staged rollout that the Gate is targeting.")
-@added(Versions.v2025_04_01_preview)
-union GateTargetProperties {
-  @doc("The Gate is controlling the staged rollout of an Update Run.")
-  updateRunProperties: UpdateRunGateTargetProperties,
-}
-
-// A wrapper is needed because the union does not create one itself. Without it, properties of
-// all different types would end up in a single `properties` model.
-@doc("Wrapper object around the Update Run Gate Target Properties.")
+@doc("The properties of the Update Run that the Gate is targeting.")
 @added(Versions.v2025_04_01_preview)
 model UpdateRunGateTargetProperties {
-  @doc("Properties specific to the Update Run.")
-  updateRun: UpdateRunGateTarget;
-}
-
-@doc("The Gate is targeting an Update Run staged rollout.")
-@added(Versions.v2025_04_01_preview)
-model UpdateRunGateTarget {
   @doc("The name of the Update Run.")
   @visibility(Lifecycle.Read)
   @pattern("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
@@ -160,20 +144,16 @@ union GateTargetId {
   updateRun: UpdateRunResourceId,
 }
 
-@doc("The target that the Gate is controlling, e.g. an Update Run.")
+@doc("The target that the Gate is controlling, e.g. an Update Run. Exactly one of the properties objects will be set.")
 @added(Versions.v2025_04_01_preview)
 model GateTarget {
   @doc("The resource id that the Gate is controlling the rollout of.")
   @visibility(Lifecycle.Create, Lifecycle.Read)
   id: GateTargetId;
 
-  @doc("The type of the resource being targeted by this Gate.")
+  @doc("The properties of the Update Run that the Gate is targeting.")
   @visibility(Lifecycle.Create, Lifecycle.Read)
-  type: GateTargetType;
-
-  @doc("Properties specific to the target of this Gate.")
-  @visibility(Lifecycle.Create, Lifecycle.Read)
-  properties: GateTargetProperties;
+  updateRunProperties?: UpdateRunGateTargetProperties;
 }
 
 @doc("The provisioning state of the Gate resource.")

--- a/specification/containerservice/Fleet.Management/gate.tsp
+++ b/specification/containerservice/Fleet.Management/gate.tsp
@@ -45,6 +45,9 @@ union GateState {
   @doc("A Pending Gate will continue to block the staged rollout process it is controlling.")
   Pending: "Pending",
 
+  @doc("A Skipped Gate means that the staged rollout process it is controlling was skipped.")
+  Skipped: "Skipped",
+
   @doc("An Completed Gate allows the staged rollout process to continue.")
   Completed: "Completed",
 }

--- a/specification/containerservice/Fleet.Management/gate.tsp
+++ b/specification/containerservice/Fleet.Management/gate.tsp
@@ -62,7 +62,6 @@ model GateProperties {
 
   @doc("The human-readable display name of the Gate.")
   @visibility(Lifecycle.Create, Lifecycle.Read)
-  @pattern("^[A-Za-z0-9].*$")
   @minLength(1)
   @maxLength(100)
   displayName?: string;

--- a/specification/containerservice/Fleet.Management/update/common.tsp
+++ b/specification/containerservice/Fleet.Management/update/common.tsp
@@ -37,12 +37,12 @@ model UpdateStage {
 
   @doc("A list of Gates that will be created before this Stage is executed.")
   @added(Versions.v2025_04_01_preview)
-  @extension("x-ms-identifiers", ["displayName"])
+  @extension("x-ms-identifiers", #["displayName"])
   beforeGates?: GateConfiguration[];
 
   @doc("A list of Gates that will be created after this Stage is executed.")
   @added(Versions.v2025_04_01_preview)
-  @extension("x-ms-identifiers", ["displayName"])
+  @extension("x-ms-identifiers", #["displayName"])
   afterGates?: GateConfiguration[];
 }
 
@@ -59,12 +59,12 @@ model UpdateGroup {
 
   @doc("A list of Gates that will be created before this Group is executed.")
   @added(Versions.v2025_04_01_preview)
-  @extension("x-ms-identifiers", ["displayName"])
+  @extension("x-ms-identifiers", #["displayName"])
   beforeGates?: GateConfiguration[];
 
   @doc("A list of Gates that will be created after this Group is executed.")
   @added(Versions.v2025_04_01_preview)
-  @extension("x-ms-identifiers", ["displayName"])
+  @extension("x-ms-identifiers", #["displayName"])
   afterGates?: GateConfiguration[];
 }
 

--- a/specification/containerservice/Fleet.Management/update/common.tsp
+++ b/specification/containerservice/Fleet.Management/update/common.tsp
@@ -37,12 +37,12 @@ model UpdateStage {
 
   @doc("A list of Gates that will be created before this Stage is executed.")
   @added(Versions.v2025_04_01_preview)
-  @extension("x-ms-identifiers", #["displayName"])
+  @extension("x-ms-identifiers", #[])
   beforeGates?: GateConfiguration[];
 
   @doc("A list of Gates that will be created after this Stage is executed.")
   @added(Versions.v2025_04_01_preview)
-  @extension("x-ms-identifiers", #["displayName"])
+  @extension("x-ms-identifiers", #[])
   afterGates?: GateConfiguration[];
 }
 
@@ -59,12 +59,12 @@ model UpdateGroup {
 
   @doc("A list of Gates that will be created before this Group is executed.")
   @added(Versions.v2025_04_01_preview)
-  @extension("x-ms-identifiers", #["displayName"])
+  @extension("x-ms-identifiers", #[])
   beforeGates?: GateConfiguration[];
 
   @doc("A list of Gates that will be created after this Group is executed.")
   @added(Versions.v2025_04_01_preview)
-  @extension("x-ms-identifiers", #["displayName"])
+  @extension("x-ms-identifiers", #[])
   afterGates?: GateConfiguration[];
 }
 

--- a/specification/containerservice/Fleet.Management/update/common.tsp
+++ b/specification/containerservice/Fleet.Management/update/common.tsp
@@ -72,7 +72,6 @@ model UpdateGroup {
 @added(Versions.v2025_04_01_preview)
 model GateConfiguration {
   @doc("The human-readable display name of the Gate.")
-  @pattern("^[A-Za-z0-9].*$")
   @minLength(1)
   @maxLength(100)
   displayName?: string;

--- a/specification/containerservice/Fleet.Management/update/run.tsp
+++ b/specification/containerservice/Fleet.Management/update/run.tsp
@@ -265,13 +265,13 @@ model UpdateStageStatus {
   groups?: UpdateGroupStatus[];
 
   @visibility(Lifecycle.Read)
-  @extension("x-ms-identifiers", ["displayName"])
+  @extension("x-ms-identifiers", #["displayName"])
   @doc("The list of Gates that will run before this UpdateStage.")
   @added(Versions.v2025_04_01_preview)
   beforeGates?: UpdateRunGateStatus[];
 
   @visibility(Lifecycle.Read)
-  @extension("x-ms-identifiers", ["displayName"])
+  @extension("x-ms-identifiers", #["displayName"])
   @doc("The list of Gates that will run after this UpdateStage.")
   @added(Versions.v2025_04_01_preview)
   afterGates?: UpdateRunGateStatus[];
@@ -297,13 +297,13 @@ model UpdateGroupStatus {
   members?: MemberUpdateStatus[];
 
   @visibility(Lifecycle.Read)
-  @extension("x-ms-identifiers", ["displayName"])
+  @extension("x-ms-identifiers", #["displayName"])
   @doc("The list of Gates that will run before this UpdateGroup.")
   @added(Versions.v2025_04_01_preview)
   beforeGates?: UpdateRunGateStatus[];
 
   @visibility(Lifecycle.Read)
-  @extension("x-ms-identifiers", ["displayName"])
+  @extension("x-ms-identifiers", #["displayName"])
   @doc("The list of Gates that will run after this UpdateGroup.")
   @added(Versions.v2025_04_01_preview)
   afterGates?: UpdateRunGateStatus[];

--- a/specification/containerservice/Fleet.Management/update/run.tsp
+++ b/specification/containerservice/Fleet.Management/update/run.tsp
@@ -325,7 +325,6 @@ model WaitStatus {
 model UpdateRunGateStatus {
   @doc("The human-readable display name of the Gate.")
   @visibility(Lifecycle.Read)
-  @pattern("^[A-Za-z0-9].*$")
   @minLength(1)
   @maxLength(100)
   displayName?: string;

--- a/specification/containerservice/Fleet.Management/update/run.tsp
+++ b/specification/containerservice/Fleet.Management/update/run.tsp
@@ -265,13 +265,13 @@ model UpdateStageStatus {
   groups?: UpdateGroupStatus[];
 
   @visibility(Lifecycle.Read)
-  @extension("x-ms-identifiers", #["displayName"])
+  @extension("x-ms-identifiers", #[])
   @doc("The list of Gates that will run before this UpdateStage.")
   @added(Versions.v2025_04_01_preview)
   beforeGates?: UpdateRunGateStatus[];
 
   @visibility(Lifecycle.Read)
-  @extension("x-ms-identifiers", #["displayName"])
+  @extension("x-ms-identifiers", #[])
   @doc("The list of Gates that will run after this UpdateStage.")
   @added(Versions.v2025_04_01_preview)
   afterGates?: UpdateRunGateStatus[];
@@ -297,13 +297,13 @@ model UpdateGroupStatus {
   members?: MemberUpdateStatus[];
 
   @visibility(Lifecycle.Read)
-  @extension("x-ms-identifiers", #["displayName"])
+  @extension("x-ms-identifiers", #[])
   @doc("The list of Gates that will run before this UpdateGroup.")
   @added(Versions.v2025_04_01_preview)
   beforeGates?: UpdateRunGateStatus[];
 
   @visibility(Lifecycle.Read)
-  @extension("x-ms-identifiers", #["displayName"])
+  @extension("x-ms-identifiers", #[])
   @doc("The list of Gates that will run after this UpdateGroup.")
   @added(Versions.v2025_04_01_preview)
   afterGates?: UpdateRunGateStatus[];

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2025-04-01-preview/examples/Gates_Get.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2025-04-01-preview/examples/Gates_Get.json
@@ -32,14 +32,11 @@
           "displayName": "Perform health checks after Group 1",
           "target": {
             "id": "/subscriptions/subid1/resourcegroups/rg1/providers/Microsoft.ContainerService/fleets/fleet-1/updateRuns/run1",
-            "type": "UpdateRun",
-            "properties": {
-              "updateRun": {
-                "name": "run1",
-                "stage": "stage1",
-                "group": "group1",
-                "timing": "After"
-              }
+            "updateRunProperties": {
+              "name": "run1",
+              "stage": "stage1",
+              "group": "group1",
+              "timing": "After"
             }
           },
           "gateType": "Approval",

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2025-04-01-preview/examples/Gates_ListByFleet.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2025-04-01-preview/examples/Gates_ListByFleet.json
@@ -30,14 +30,11 @@
               "displayName": "Perform health checks after Group 1",
               "target": {
                 "id": "/subscriptions/subid1/resourcegroups/rg1/providers/Microsoft.ContainerService/fleets/fleet-1/updateRuns/run1",
-                "type": "UpdateRun",
-                "properties": {
-                  "updateRun": {
-                    "name": "run1",
-                    "stage": "stage1",
-                    "group": "group1",
-                    "timing": "After"
-                  }
+                "updateRunProperties": {
+                  "name": "run1",
+                  "stage": "stage1",
+                  "group": "group1",
+                  "timing": "After"
                 }
               },
               "gateType": "Approval",

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2025-04-01-preview/examples/Gates_Update.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2025-04-01-preview/examples/Gates_Update.json
@@ -38,14 +38,11 @@
           "displayName": "Perform health checks after Group 1",
           "target": {
             "id": "/subscriptions/subid1/resourcegroups/rg1/providers/Microsoft.ContainerService/fleets/fleet-1/updateRuns/run1",
-            "type": "UpdateRun",
-            "properties": {
-              "updateRun": {
-                "name": "run1",
-                "stage": "stage1",
-                "group": "group1",
-                "timing": "After"
-              }
+            "updateRunProperties": {
+              "name": "run1",
+              "stage": "stage1",
+              "group": "group1",
+              "timing": "After"
             }
           },
           "gateType": "Approval",

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2025-04-01-preview/fleets.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2025-04-01-preview/fleets.json
@@ -3403,6 +3403,7 @@
       "description": "The state of the Gate.",
       "enum": [
         "Pending",
+        "Skipped",
         "Completed"
       ],
       "x-ms-enum": {
@@ -3413,6 +3414,11 @@
             "name": "Pending",
             "value": "Pending",
             "description": "A Pending Gate will continue to block the staged rollout process it is controlling."
+          },
+          {
+            "name": "Skipped",
+            "value": "Skipped",
+            "description": "A Skipped Gate means that the staged rollout process it is controlling was skipped."
           },
           {
             "name": "Completed",

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2025-04-01-preview/fleets.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2025-04-01-preview/fleets.json
@@ -3257,8 +3257,7 @@
           "type": "string",
           "description": "The human-readable display name of the Gate.",
           "minLength": 1,
-          "maxLength": 100,
-          "pattern": "^[A-Za-z0-9].*$"
+          "maxLength": 100
         },
         "type": {
           "$ref": "#/definitions/GateType",
@@ -3304,7 +3303,6 @@
           "description": "The human-readable display name of the Gate.",
           "minLength": 1,
           "maxLength": 100,
-          "pattern": "^[A-Za-z0-9].*$",
           "x-ms-mutability": [
             "read",
             "create"
@@ -3913,7 +3911,6 @@
           "description": "The human-readable display name of the Gate.",
           "minLength": 1,
           "maxLength": 100,
-          "pattern": "^[A-Za-z0-9].*$",
           "readOnly": true
         },
         "gateId": {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2025-04-01-preview/fleets.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2025-04-01-preview/fleets.json
@@ -3308,17 +3308,17 @@
             "create"
           ]
         },
-        "target": {
-          "$ref": "#/definitions/GateTarget",
-          "description": "The target that the Gate is controlling, e.g. an Update Run.",
+        "gateType": {
+          "$ref": "#/definitions/GateType",
+          "description": "The type of the Gate determines how it is completed.",
           "x-ms-mutability": [
             "read",
             "create"
           ]
         },
-        "gateType": {
-          "$ref": "#/definitions/GateType",
-          "description": "The type of the Gate determines how it is completed.",
+        "target": {
+          "$ref": "#/definitions/GateTarget",
+          "description": "The target that the Gate is controlling, e.g. an Update Run.",
           "x-ms-mutability": [
             "read",
             "create"
@@ -3335,8 +3335,8 @@
         }
       },
       "required": [
-        "target",
         "gateType",
+        "target",
         "state"
       ]
     },
@@ -3813,9 +3813,7 @@
           "items": {
             "$ref": "#/definitions/GateConfiguration"
           },
-          "x-ms-identifiers": [
-            "displayName"
-          ]
+          "x-ms-identifiers": []
         },
         "afterGates": {
           "type": "array",
@@ -3823,9 +3821,7 @@
           "items": {
             "$ref": "#/definitions/GateConfiguration"
           },
-          "x-ms-identifiers": [
-            "displayName"
-          ]
+          "x-ms-identifiers": []
         }
       },
       "required": [
@@ -3864,9 +3860,7 @@
             "$ref": "#/definitions/UpdateRunGateStatus"
           },
           "readOnly": true,
-          "x-ms-identifiers": [
-            "displayName"
-          ]
+          "x-ms-identifiers": []
         },
         "afterGates": {
           "type": "array",
@@ -3875,9 +3869,7 @@
             "$ref": "#/definitions/UpdateRunGateStatus"
           },
           "readOnly": true,
-          "x-ms-identifiers": [
-            "displayName"
-          ]
+          "x-ms-identifiers": []
         }
       }
     },
@@ -4145,9 +4137,7 @@
           "items": {
             "$ref": "#/definitions/GateConfiguration"
           },
-          "x-ms-identifiers": [
-            "displayName"
-          ]
+          "x-ms-identifiers": []
         },
         "afterGates": {
           "type": "array",
@@ -4155,9 +4145,7 @@
           "items": {
             "$ref": "#/definitions/GateConfiguration"
           },
-          "x-ms-identifiers": [
-            "displayName"
-          ]
+          "x-ms-identifiers": []
         }
       },
       "required": [
@@ -4196,9 +4184,7 @@
             "$ref": "#/definitions/UpdateRunGateStatus"
           },
           "readOnly": true,
-          "x-ms-identifiers": [
-            "displayName"
-          ]
+          "x-ms-identifiers": []
         },
         "afterGates": {
           "type": "array",
@@ -4207,9 +4193,7 @@
             "$ref": "#/definitions/UpdateRunGateStatus"
           },
           "readOnly": true,
-          "x-ms-identifiers": [
-            "displayName"
-          ]
+          "x-ms-identifiers": []
         },
         "afterStageWaitStatus": {
           "$ref": "#/definitions/WaitStatus",

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2025-04-01-preview/fleets.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2025-04-01-preview/fleets.json
@@ -3426,7 +3426,7 @@
     },
     "GateTarget": {
       "type": "object",
-      "description": "The target that the Gate is controlling, e.g. an Update Run.",
+      "description": "The target that the Gate is controlling, e.g. an Update Run. Exactly one of the properties objects will be set.",
       "properties": {
         "id": {
           "$ref": "#/definitions/GateTargetId",
@@ -3436,17 +3436,9 @@
             "create"
           ]
         },
-        "type": {
-          "$ref": "#/definitions/GateTargetType",
-          "description": "The type of the resource being targeted by this Gate.",
-          "x-ms-mutability": [
-            "read",
-            "create"
-          ]
-        },
-        "properties": {
-          "$ref": "#/definitions/GateTargetProperties",
-          "description": "Properties specific to the target of this Gate.",
+        "updateRunProperties": {
+          "$ref": "#/definitions/UpdateRunGateTargetProperties",
+          "description": "The properties of the Update Run that the Gate is targeting.",
           "x-ms-mutability": [
             "read",
             "create"
@@ -3454,41 +3446,12 @@
         }
       },
       "required": [
-        "id",
-        "type",
-        "properties"
+        "id"
       ]
     },
     "GateTargetId": {
       "$ref": "#/definitions/UpdateRunResourceId",
       "x-nullable": false
-    },
-    "GateTargetProperties": {
-      "type": "object",
-      "x-nullable": false,
-      "allOf": [
-        {
-          "$ref": "#/definitions/UpdateRunGateTargetProperties"
-        }
-      ]
-    },
-    "GateTargetType": {
-      "type": "string",
-      "description": "The type of the Gate target.",
-      "enum": [
-        "UpdateRun"
-      ],
-      "x-ms-enum": {
-        "name": "GateTargetType",
-        "modelAsString": true,
-        "values": [
-          {
-            "name": "UpdateRun",
-            "value": "UpdateRun",
-            "description": "The Gate targets an Update Run."
-          }
-        ]
-      }
     },
     "GateType": {
       "type": "string",
@@ -3965,9 +3928,9 @@
         }
       }
     },
-    "UpdateRunGateTarget": {
+    "UpdateRunGateTargetProperties": {
       "type": "object",
-      "description": "The Gate is targeting an Update Run staged rollout.",
+      "description": "The properties of the Update Run that the Gate is targeting.",
       "properties": {
         "name": {
           "type": "string",
@@ -4005,19 +3968,6 @@
       "required": [
         "name",
         "timing"
-      ]
-    },
-    "UpdateRunGateTargetProperties": {
-      "type": "object",
-      "description": "Wrapper object around the Update Run Gate Target Properties.",
-      "properties": {
-        "updateRun": {
-          "$ref": "#/definitions/UpdateRunGateTarget",
-          "description": "Properties specific to the Update Run."
-        }
-      },
-      "required": [
-        "updateRun"
       ]
     },
     "UpdateRunListResult": {


### PR DESCRIPTION
* Remove GateTargetType and the matching union.
  * Using the @disciminated annotation (https://typespec.io/docs/standard-library/discriminated-types) did not work once I added a second type to the union (gave warning and did not generate any swagger output for the type).
  * Instead, I've just put the updateRun target properties directly on GateTarget, making the oneof implicit.
* Remove the regex pattern from the displayName property in GateProperties.
