### PR TITLE
[.github] Add dependency @apidevtools/json-schema-ref-parser

### DIFF
--- a/.github/package-lock.json
+++ b/.github/package-lock.json
@@ -5,14 +5,16 @@
   "packages": {
     "": {
       "dependencies": {
-        "marked": "^15.0.7",
-        "yaml": "^2.7.0"
+        "@apidevtools/json-schema-ref-parser": "^11.9.3",
+        "js-yaml": "^4.1.0",
+        "marked": "^15.0.7"
       },
       "devDependencies": {
         "@eslint/js": "^9.22.0",
         "@octokit/webhooks-types": "^7.5.1",
         "@tsconfig/node20": "^20.1.4",
         "@types/github-script": "github:actions/github-script",
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^20.0.0",
         "@vitest/coverage-v8": "^3.0.7",
         "eslint": "^9.22.0",
@@ -97,6 +99,23 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "11.9.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.9.3.tgz",
+      "integrity": "sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -892,6 +911,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "license": "MIT"
+    },
     "node_modules/@octokit/auth-token": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
@@ -1428,11 +1453,17 @@
         "node": ">=20.0.0 <21.0.0"
       }
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -1664,7 +1695,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/assertion-error": {
@@ -2452,7 +2482,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -3595,7 +3624,10 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
       "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+      "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/.github/package.json
+++ b/.github/package.json
@@ -4,14 +4,16 @@
     "dependencies": "Runtime dependencies must be kept to an absolute minimum for performance, ideally with no transitive dependencies"
   },
   "dependencies": {
-    "marked": "^15.0.7",
-    "yaml": "^2.7.0"
+    "@apidevtools/json-schema-ref-parser": "^11.9.3",
+    "js-yaml": "^4.1.0",
+    "marked": "^15.0.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.22.0",
     "@octokit/webhooks-types": "^7.5.1",
     "@tsconfig/node20": "^20.1.4",
     "@types/github-script": "github:actions/github-script",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.0.0",
     "@vitest/coverage-v8": "^3.0.7",
     "eslint": "^9.22.0",

--- a/.github/src/readme.js
+++ b/.github/src/readme.js
@@ -1,7 +1,7 @@
 // @ts-check
 
+import yaml from "js-yaml";
 import { marked } from "marked";
-import yaml from "yaml";
 
 /**
  * @param {string} markdown
@@ -24,7 +24,7 @@ export async function getInputFiles(markdown, options = {}) {
     const tag =
       block.lang?.match(/yaml \$\(tag\) == '([^']*)'/)?.[1] || "default";
 
-    const obj = yaml.parse(block.text);
+    const obj = /** @type {any} */ (yaml.load(block.text));
     const blockFiles = /** @type string[] */ (obj["input-file"] || []);
 
     logger?.info(`Input files for tag '${tag}': ${JSON.stringify(blockFiles)}`);


### PR DESCRIPTION
- Fixes #33475
- Replace "yaml" with "js-yaml", since the latter is a dep of "@apidevtools/json-schema-ref-parser"

Small size increase, but reasonable for the added feature(s):

- Before: 2 packages, 338k compressed, 2.4M uncompressed
- After: 6 packages, 434k compressed, 2.7M uncompressed