### PR TITLE
Add API key auth via the header `Authorization: Bearer <key>`

### DIFF
--- a/specification/ai/Azure.AI.Projects/assistants/files/routes.tsp
+++ b/specification/ai/Azure.AI.Projects/assistants/files/routes.tsp
@@ -58,10 +58,10 @@ op uploadFile is Azure.Core.Foundations.Operation<
       @doc("The file data, in bytes.")
       @clientName("Data", "csharp")
       file: HttpPart<File>;
-  
+
       @doc("The intended purpose of the uploaded file. Use `assistants` for Agents and Message files, `vision` for Agents image file inputs, `batch` for Batch API, and `fine-tune` for Fine-tuning.")
       purpose: HttpPart<FilePurpose>;
-  
+
       /*
        * Spec note: filename is not documented as a distinct option but functionally should be one. The value is encoded
        *            in the multipart Content-Disposition header for the data section and can be provided independently of

--- a/specification/ai/Azure.AI.Projects/common/models.tsp
+++ b/specification/ai/Azure.AI.Projects/common/models.tsp
@@ -5,9 +5,6 @@ import "@azure-tools/typespec-azure-resource-manager";
 import "../credentials/models.tsp";
 
 using TypeSpec.Http;
-using TypeSpec.Versioning;
-using Azure.ResourceManager;
-using Azure.ResourceManager.Foundations;
 
 namespace Azure.AI.Projects;
 

--- a/specification/ai/Azure.AI.Projects/connections/models.tsp
+++ b/specification/ai/Azure.AI.Projects/connections/models.tsp
@@ -6,12 +6,7 @@ import "@typespec/openapi";
 import "@typespec/versioning";
 import "../credentials/models.tsp";
 
-using TypeSpec.OpenAPI;
-using TypeSpec.Http;
 using TypeSpec.Rest;
-using TypeSpec.Versioning;
-using Azure.Core;
-using Azure.Core.Traits;
 
 namespace Azure.AI.Projects;
 

--- a/specification/ai/Azure.AI.Projects/connections/routes.tsp
+++ b/specification/ai/Azure.AI.Projects/connections/routes.tsp
@@ -5,11 +5,8 @@ import "@azure-tools/typespec-azure-core";
 import "./models.tsp";
 
 using TypeSpec.Http;
-using TypeSpec.Rest;
-using TypeSpec.Versioning;
 using Azure.Core;
 using Azure.Core.Traits;
-using Azure.Core.Foundations;
 
 namespace Azure.AI.Projects;
 

--- a/specification/ai/Azure.AI.Projects/credentials/models.tsp
+++ b/specification/ai/Azure.AI.Projects/credentials/models.tsp
@@ -4,13 +4,6 @@ import "@typespec/versioning";
 import "@azure-tools/typespec-azure-core";
 import "@typespec/openapi";
 
-using TypeSpec.OpenAPI;
-using TypeSpec.Http;
-using TypeSpec.Rest;
-using TypeSpec.Versioning;
-using Azure.Core;
-using Azure.Core.Traits;
-
 namespace Azure.AI.Projects;
 
 @doc("The different Credential types")

--- a/specification/ai/Azure.AI.Projects/datasets/models.tsp
+++ b/specification/ai/Azure.AI.Projects/datasets/models.tsp
@@ -7,13 +7,6 @@ import "../main.tsp";
 import "@typespec/openapi";
 import "@typespec/versioning";
 
-using TypeSpec.OpenAPI;
-using TypeSpec.Http;
-using TypeSpec.Rest;
-using TypeSpec.Versioning;
-using Azure.Core;
-using Azure.Core.Traits;
-
 namespace Azure.AI.Projects;
 
 @doc("Enum to determine the type of data.")

--- a/specification/ai/Azure.AI.Projects/datasets/routes.tsp
+++ b/specification/ai/Azure.AI.Projects/datasets/routes.tsp
@@ -8,11 +8,6 @@ import "./models.tsp";
 import "../servicepatterns.tsp";
 
 using TypeSpec.Http;
-using TypeSpec.Rest;
-using TypeSpec.Versioning;
-using Azure.Core;
-using Azure.Core.Traits;
-using Azure.Core.Foundations;
 
 namespace Azure.AI.Projects;
 

--- a/specification/ai/Azure.AI.Projects/deployments/models.tsp
+++ b/specification/ai/Azure.AI.Projects/deployments/models.tsp
@@ -6,12 +6,7 @@ import "../main.tsp";
 import "../common/models.tsp";
 import "@typespec/openapi";
 
-using TypeSpec.OpenAPI;
-using TypeSpec.Http;
 using TypeSpec.Rest;
-using TypeSpec.Versioning;
-using Azure.Core;
-using Azure.Core.Traits;
 
 namespace Azure.AI.Projects;
 

--- a/specification/ai/Azure.AI.Projects/deployments/routes.tsp
+++ b/specification/ai/Azure.AI.Projects/deployments/routes.tsp
@@ -5,11 +5,8 @@ import "@azure-tools/typespec-azure-core";
 import "./models.tsp";
 
 using TypeSpec.Http;
-using TypeSpec.Rest;
-using TypeSpec.Versioning;
 using Azure.Core;
 using Azure.Core.Traits;
-using Azure.Core.Foundations;
 
 namespace Azure.AI.Projects;
 

--- a/specification/ai/Azure.AI.Projects/evaluations/models.tsp
+++ b/specification/ai/Azure.AI.Projects/evaluations/models.tsp
@@ -7,12 +7,7 @@ import "../common/models.tsp";
 import "../main.tsp";
 import "@typespec/openapi";
 
-using TypeSpec.OpenAPI;
-using TypeSpec.Http;
 using TypeSpec.Rest;
-using TypeSpec.Versioning;
-using Azure.Core;
-using Azure.Core.Traits;
 
 namespace Azure.AI.Projects;
 

--- a/specification/ai/Azure.AI.Projects/evaluations/routes.tsp
+++ b/specification/ai/Azure.AI.Projects/evaluations/routes.tsp
@@ -5,11 +5,8 @@ import "@azure-tools/typespec-azure-core";
 import "./models.tsp";
 
 using TypeSpec.Http;
-using TypeSpec.Rest;
-using TypeSpec.Versioning;
 using Azure.Core;
 using Azure.Core.Traits;
-using Azure.Core.Foundations;
 
 namespace Azure.AI.Projects;
 

--- a/specification/ai/Azure.AI.Projects/indexes/models.tsp
+++ b/specification/ai/Azure.AI.Projects/indexes/models.tsp
@@ -5,13 +5,6 @@ import "@azure-tools/typespec-azure-core";
 import "../common/models.tsp";
 import "../main.tsp";
 
-using TypeSpec.OpenAPI;
-using TypeSpec.Http;
-using TypeSpec.Rest;
-using TypeSpec.Versioning;
-using Azure.Core;
-using Azure.Core.Traits;
-
 namespace Azure.AI.Projects;
 
 @doc("Index resource Definition")

--- a/specification/ai/Azure.AI.Projects/indexes/routes.tsp
+++ b/specification/ai/Azure.AI.Projects/indexes/routes.tsp
@@ -7,11 +7,6 @@ import "../servicepatterns.tsp";
 import "../common/models.tsp";
 
 using TypeSpec.Http;
-using TypeSpec.Rest;
-using TypeSpec.Versioning;
-using Azure.Core;
-using Azure.Core.Traits;
-using Azure.Core.Foundations;
 
 namespace Azure.AI.Projects;
 

--- a/specification/ai/Azure.AI.Projects/main.tsp
+++ b/specification/ai/Azure.AI.Projects/main.tsp
@@ -20,20 +20,16 @@ import "./indexes/routes.tsp";
 import "./deployments/routes.tsp";
 
 using TypeSpec.Http;
-using TypeSpec.Rest;
-using Azure.ResourceManager;
-using Azure.ResourceManager.Foundations;
 using TypeSpec.Versioning;
-using Azure.Core;
-using Azure.Core.Traits;
 
 #suppress "@azure-tools/typespec-azure-core/casing-style"
 namespace Azure.AI {
 
 }
 
+#suppress "@azure-tools/typespec-autorest/unsupported-http-auth-scheme"
 @useAuth(
-  OAuth2Auth<[
+  BearerAuth | OAuth2Auth<[
     {
       type: OAuth2FlowType.implicit,
       authorizationUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",

--- a/specification/ai/data-plane/Azure.AI.Projects/preview/2025-05-01-preview/azure-ai-projects-1dp.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/preview/2025-05-01-preview/azure-ai-projects-1dp.json
@@ -222,11 +222,7 @@
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
           },
           {
-            "name": "assistantId",
-            "in": "path",
-            "description": "Identifier of the agent.",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/Assistants.GetAgentOptions"
           }
         ],
         "responses": {
@@ -298,11 +294,7 @@
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
           },
           {
-            "name": "assistantId",
-            "in": "path",
-            "description": "Identifier of the agent.",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/Assistants.DeleteAgentOptions"
           }
         ],
         "responses": {
@@ -4178,6 +4170,41 @@
         "referenceType"
       ]
     },
+    "Assistants.AISearchIndexResource": {
+      "type": "object",
+      "description": "A AI Search Index resource.",
+      "properties": {
+        "index_connection_id": {
+          "type": "string",
+          "description": "An index connection id in an IndexResource attached to this agent.",
+          "x-ms-client-name": "indexConnectionId"
+        },
+        "index_name": {
+          "type": "string",
+          "description": "The name of an index in an IndexResource attached to this agent.",
+          "x-ms-client-name": "indexName"
+        },
+        "query_type": {
+          "$ref": "#/definitions/Assistants.AzureAISearchQueryType",
+          "description": "Type of query in an AIIndexResource attached to this agent.",
+          "x-ms-client-name": "queryType"
+        },
+        "top_k": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of documents to retrieve from search and present to the model.",
+          "x-ms-client-name": "topK"
+        },
+        "filter": {
+          "type": "string",
+          "description": "Odata filter string for search resource."
+        }
+      },
+      "required": [
+        "index_connection_id",
+        "index_name"
+      ]
+    },
     "Assistants.Agent": {
       "type": "object",
       "description": "Represents an agent that can call the model and use tools.",
@@ -4668,7 +4695,7 @@
         "code_interpreter",
         "file_search",
         "bing_grounding",
-        "fabric_aiskill",
+        "fabric_dataagent",
         "sharepoint_grounding",
         "azure_ai_search"
       ],
@@ -4698,8 +4725,8 @@
           },
           {
             "name": "microsoftFabric",
-            "value": "fabric_aiskill",
-            "description": "Tool type `fabric_aiskill`"
+            "value": "fabric_dataagent",
+            "description": "Tool type `fabric_dataagent`"
           },
           {
             "name": "sharepoint",
@@ -4714,6 +4741,48 @@
         ]
       }
     },
+    "Assistants.AzureAISearchQueryType": {
+      "type": "string",
+      "description": "Available query types for Azure AI Search tool.",
+      "enum": [
+        "simple",
+        "semantic",
+        "vector",
+        "vector_simple_hybrid",
+        "vector_semantic_hybrid"
+      ],
+      "x-ms-enum": {
+        "name": "AzureAISearchQueryType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "simple",
+            "value": "simple",
+            "description": "Query type `simple`"
+          },
+          {
+            "name": "semantic",
+            "value": "semantic",
+            "description": "Query type `semantic`"
+          },
+          {
+            "name": "vector",
+            "value": "vector",
+            "description": "Query type `vector`"
+          },
+          {
+            "name": "vector_simple_hybrid",
+            "value": "vector_simple_hybrid",
+            "description": "Query type `vector_simple_hybrid`"
+          },
+          {
+            "name": "vector_semantic_hybrid",
+            "value": "vector_semantic_hybrid",
+            "description": "Query type `vector_semantic_hybrid`"
+          }
+        ]
+      }
+    },
     "Assistants.AzureAISearchResource": {
       "type": "object",
       "description": "A set of index resources used by the `azure_ai_search` tool.",
@@ -4723,7 +4792,7 @@
           "description": "The indices attached to this agent. There can be a maximum of 1 index\nresource attached to the agent.",
           "maxItems": 1,
           "items": {
-            "$ref": "#/definitions/Assistants.IndexResource"
+            "$ref": "#/definitions/Assistants.AISearchIndexResource"
           },
           "x-ms-client-name": "indexList",
           "x-ms-identifiers": []
@@ -5994,19 +6063,54 @@
         }
       }
     },
+    "Assistants.MessageDeltaTextUrlCitationAnnotation": {
+      "type": "object",
+      "description": "A citation within the message that points to a specific URL associated with the message. Generated when the agent uses tools such as 'bing_grounding' to search the Internet.",
+      "properties": {
+        "url_citation": {
+          "$ref": "#/definitions/Assistants.MessageDeltaTextUrlCitationDetails",
+          "description": "The details of the URL citation.",
+          "x-ms-client-name": "urlCitation"
+        },
+        "start_index": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The first text index associated with this text annotation.",
+          "x-ms-client-name": "startIndex"
+        },
+        "end_index": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The last text index associated with this text annotation.",
+          "x-ms-client-name": "endIndex"
+        }
+      },
+      "required": [
+        "url_citation"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/Assistants.MessageDeltaTextAnnotation"
+        }
+      ],
+      "x-ms-discriminator-value": "url_citation"
+    },
     "Assistants.MessageDeltaTextUrlCitationDetails": {
       "type": "object",
-      "description": "A representation of the URL used for the text citation.",
+      "description": "A representation of a URL citation, as used in text thread message content.",
       "properties": {
         "url": {
           "type": "string",
-          "description": "The URL where the citation is from."
+          "description": "The URL associated with this citation."
         },
         "title": {
           "type": "string",
           "description": "The title of the URL."
         }
-      }
+      },
+      "required": [
+        "url"
+      ]
     },
     "Assistants.MessageImageFileContent": {
       "type": "object",
@@ -6350,24 +6454,73 @@
         "file_id"
       ]
     },
+    "Assistants.MessageTextUrlCitationAnnotation": {
+      "type": "object",
+      "description": "A citation within the message that points to a specific URL associated with the message. Generated when the agent uses tools such as 'bing_grounding' to search the Internet.",
+      "properties": {
+        "url_citation": {
+          "$ref": "#/definitions/Assistants.MessageTextUrlCitationDetails",
+          "description": "The details of the URL citation.",
+          "x-ms-client-name": "urlCitation"
+        },
+        "start_index": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The first text index associated with this text annotation.",
+          "x-ms-client-name": "startIndex"
+        },
+        "end_index": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The last text index associated with this text annotation.",
+          "x-ms-client-name": "endIndex"
+        }
+      },
+      "required": [
+        "url_citation"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/Assistants.MessageTextAnnotation"
+        }
+      ],
+      "x-ms-discriminator-value": "url_citation"
+    },
+    "Assistants.MessageTextUrlCitationDetails": {
+      "type": "object",
+      "description": "A representation of a URL citation, as used in text thread message content.",
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "The URL associated with this citation."
+        },
+        "title": {
+          "type": "string",
+          "description": "The title of the URL."
+        }
+      },
+      "required": [
+        "url"
+      ]
+    },
     "Assistants.MicrosoftFabricToolDefinition": {
       "type": "object",
       "description": "The input definition information for a Microsoft Fabric tool as used to configure an agent.",
       "properties": {
-        "fabric_aiskill": {
+        "fabric_dataagent": {
           "$ref": "#/definitions/Assistants.ToolConnectionList",
           "description": "The list of connections used by the Microsoft Fabric tool."
         }
       },
       "required": [
-        "fabric_aiskill"
+        "fabric_dataagent"
       ],
       "allOf": [
         {
           "$ref": "#/definitions/Assistants.ToolDefinition"
         }
       ],
-      "x-ms-discriminator-value": "fabric_aiskill"
+      "x-ms-discriminator-value": "fabric_dataagent"
     },
     "Assistants.OpenAIFile": {
       "type": "object",
@@ -7318,11 +7471,8 @@
       "description": "Represents a file search tool call within a streaming run step's tool call details.",
       "properties": {
         "file_search": {
-          "type": "object",
+          "$ref": "#/definitions/Assistants.RunStepFileSearchToolCallResults",
           "description": "Reserved for future use.",
-          "additionalProperties": {
-            "type": "string"
-          },
           "x-ms-client-name": "fileSearch"
         }
       },
@@ -7661,7 +7811,7 @@
       "type": "object",
       "description": "A record of a call to a Microsoft Fabric tool, issued by the model in evaluation of a defined tool, that represents\nexecuted Microsoft Fabric operations.",
       "properties": {
-        "fabric_aiskill": {
+        "fabric_dataagent": {
           "type": "object",
           "description": "Reserved for future use.",
           "additionalProperties": {
@@ -7671,14 +7821,14 @@
         }
       },
       "required": [
-        "fabric_aiskill"
+        "fabric_dataagent"
       ],
       "allOf": [
         {
           "$ref": "#/definitions/Assistants.RunStepToolCall"
         }
       ],
-      "x-ms-discriminator-value": "fabric_aiskill"
+      "x-ms-discriminator-value": "fabric_dataagent"
     },
     "Assistants.RunStepSharepointToolCall": {
       "type": "object",
@@ -8443,7 +8593,7 @@
     },
     "Assistants.ToolConnectionList": {
       "type": "object",
-      "description": "A set of connection resources currently used by either the `bing_grounding`, `fabric_aiskill`, or `sharepoint_grounding` tools.",
+      "description": "A set of connection resources currently used by either the `bing_grounding`, `fabric_dataagent`, or `sharepoint_grounding` tools.",
       "properties": {
         "connections": {
           "type": "array",
@@ -10774,6 +10924,22 @@
     }
   },
   "parameters": {
+    "Assistants.DeleteAgentOptions": {
+      "name": "assistantId",
+      "in": "path",
+      "description": "Identifier of the agent.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "Assistants.GetAgentOptions": {
+      "name": "assistantId",
+      "in": "path",
+      "description": "Identifier of the agent.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
     "Assistants.UpdateAgentOptions.assistantId": {
       "name": "assistantId",
       "in": "path",


### PR DESCRIPTION
See file `specification/ai/Azure.AI.Projects/main.tsp` for that change.

Also remove unused `using` statements.

Tested using the emitted Python SDK. Example of a list deployments call made by the SDK shows the Authorization header with my api-key:

```text
List all deployments:
Request URL: 'https://ninhu-m84wmi4e-germanywestcentra.services.ai.azure.com/projects/123/deployments?api-version=2025-05-01-preview'
Request method: 'GET'
Request headers:
    'Accept': 'application/json'
    'x-ms-client-request-id': '1e404a3f-0a7e-11f0-b1f4-f46b8c824a55'
    'User-Agent': 'azsdk-python-ai-projects-dp1/1.0.0b1 Python/3.12.9 (Windows-11-10.0.26100-SP0)'
    'Authorization': 'Bearer my-api-key'
```text