### PR TITLE
Add galleryScriptReferenceId parameter to runCommand.json

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2025-04-01/runCommand.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2025-04-01/runCommand.json
@@ -1189,15 +1189,27 @@
         },
         "commandId": {
           "type": "string",
-          "description": "Specifies a commandId of predefined built-in script."
+          "description": "Specifies a commandId of predefined built-in script. commandIds available for Linux listed at https://aka.ms/RunCommandManagedLinux#available-commands, Windows at https://aka.ms/RunCommandManagedWindows#available-commands"
         },
         "scriptUriManagedIdentity": {
           "$ref": "#/definitions/RunCommandManagedIdentity",
           "description": "User-assigned managed identity that has access to scriptUri in case of Azure storage blob. Use an empty object in case of system-assigned identity. Make sure the Azure storage blob exists, and managed identity has been given access to blob's container with 'Storage Blob Data Reader' role assignment. In case of user-assigned identity, make sure you add it under VM's identity. For more info on managed identity and Run Command, refer https://aka.ms/ManagedIdentity and https://aka.ms/RunCommandManaged."
+        },
+        "scriptShell": {
+          "type": "string",
+          "description": "Optional. Specify which shell to use for running the script. These values must match those expected by the extension. Currently supported only for Windows VMs, script uses Powershell 7 when specified. Powershell 7 must be already installed on the machine to use Powershell7 parameter value.",
+          "enum": [
+            "Default",
+            "Powershell7"
+          ]
+        },
+        "galleryScriptReferenceId": {
+          "type": "string",
+          "description": "The resource Id of a Gallery Script version that needs to be executed. Example Id looks like /subscriptions/{subId}/resourceGroups/{rgName}/providers/Microsoft.Compute/galleries/{galleryName}/scripts/{scriptName}/versions/{version}."
         }
       },
       "type": "object",
-      "description": "Describes the script sources for run command. Use only one of script, scriptUri, commandId."
+      "description": "Describes the script sources for run command. Use only one these script sources: script, scriptUri, commandId, galleryScriptReferenceId."
     },
     "VirtualMachineRunCommandProperties": {
       "properties": {

--- a/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2025-04-01/runCommand.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2025-04-01/runCommand.json
@@ -103,7 +103,7 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The command id."
+            "description": "Specifies a commandId of predefined built-in script. Command IDs available for Linux are listed at https://aka.ms/RunCommandManagedLinux#available-commands, Windows at https://aka.ms/RunCommandManagedWindows#available-commands."
           },
           {
             "$ref": "../../../common-types/v1/common.json#/parameters/ApiVersionParameter"
@@ -946,7 +946,7 @@
       "properties": {
         "commandId": {
           "type": "string",
-          "description": "The run command id."
+          "description": "Specifies a commandId of predefined built-in script. Command IDs available for Linux are listed at https://aka.ms/RunCommandManagedLinux#available-commands, Windows at https://aka.ms/RunCommandManagedWindows#available-commands."
         },
         "script": {
           "type": "array",
@@ -1189,7 +1189,7 @@
         },
         "commandId": {
           "type": "string",
-          "description": "Specifies a commandId of predefined built-in script. Command Ids available for Linux are listed at https://aka.ms/RunCommandManagedLinux#available-commands, Windows at https://aka.ms/RunCommandManagedWindows#available-commands"
+          "description": "Specifies a commandId of predefined built-in script. Command IDs available for Linux are listed at https://aka.ms/RunCommandManagedLinux#available-commands, Windows at https://aka.ms/RunCommandManagedWindows#available-commands"
         },
         "scriptUriManagedIdentity": {
           "$ref": "#/definitions/RunCommandManagedIdentity",
@@ -1209,7 +1209,7 @@
         },
         "galleryScriptReferenceId": {
           "type": "string",
-          "description": "The resource Id of a Gallery Script version that needs to be executed. Example Id looks like /subscriptions/{subId}/resourceGroups/{rgName}/providers/Microsoft.Compute/galleries/{galleryName}/scripts/{scriptName}/versions/{version}."
+          "description": "The resource ID of a Gallery Script version that needs to be executed. Example ID looks like /subscriptions/{subId}/resourceGroups/{rgName}/providers/Microsoft.Compute/galleries/{galleryName}/scripts/{scriptName}/versions/{version}."
         }
       },
       "type": "object",

--- a/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2025-04-01/runCommand.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2025-04-01/runCommand.json
@@ -1189,7 +1189,7 @@
         },
         "commandId": {
           "type": "string",
-          "description": "Specifies a commandId of predefined built-in script. commandIds available for Linux listed at https://aka.ms/RunCommandManagedLinux#available-commands, Windows at https://aka.ms/RunCommandManagedWindows#available-commands"
+          "description": "Specifies a commandId of predefined built-in script. Command Ids available for Linux are listed at https://aka.ms/RunCommandManagedLinux#available-commands, Windows at https://aka.ms/RunCommandManagedWindows#available-commands"
         },
         "scriptUriManagedIdentity": {
           "$ref": "#/definitions/RunCommandManagedIdentity",
@@ -1201,7 +1201,11 @@
           "enum": [
             "Default",
             "Powershell7"
-          ]
+          ],
+          "x-ms-enum": {
+            "name": "ScriptShellTypes",
+            "modelAsString": true
+          }
         },
         "galleryScriptReferenceId": {
           "type": "string",
@@ -1209,7 +1213,7 @@
         }
       },
       "type": "object",
-      "description": "Describes the script sources for run command. Use only one these script sources: script, scriptUri, commandId, galleryScriptReferenceId."
+      "description": "Describes the script sources for run command. Use only one of these script sources: script, scriptUri, commandId, galleryScriptReferenceId."
     },
     "VirtualMachineRunCommandProperties": {
       "properties": {


### PR DESCRIPTION
- This is releated to PR https://github.com/Azure/azure-rest-api-specs/pull/33511 [Compute] Add Gallery scripts specs
- Gallery Scripts helps store user's commonly used scripts in gallery and make them shareable, reusable.
API design doc: https://microsoft.sharepoint.com/:w:/t/ComputeVM/ER0OOJwCfPtCtOp_0yrkXmQBmniHv1liTdsHSJGtFDQCWw?e=r1a539
=================
# Choose a PR Template

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.
