### PR TITLE
[.github] Add "cwd" (current working directory) to options bags

### DIFF
--- a/.github/src/changed-files.js
+++ b/.github/src/changed-files.js
@@ -7,7 +7,7 @@ import { diff } from "./git.js";
  * @param {string} [options.baseCommitish] Defaults to "HEAD^"
  * @param {string} [options.headCommitish] Defaults to "HEAD"
  * @param {import('./types.js').ILogger} [options.logger]
- * @returns {Promise<string[]>} List of changed files, relative to the repo root.  Example: ["specification/foo/Microsoft.Foo/main.tsp"]
+ * @returns {Promise<string[]>} List of changed files, using platform-specific absolute paths. Example: ["/home/user/specs/specification/foo/Microsoft.Foo/main.tsp"].
  */
 export async function getChangedFiles(options = {}) {
   const { baseCommitish = "HEAD^", headCommitish = "HEAD", logger } = options;

--- a/.github/src/exec.js
+++ b/.github/src/exec.js
@@ -2,26 +2,29 @@
 
 import child_process from "child_process";
 import { promisify } from "util";
-const exec = promisify(child_process.exec);
+const execImpl = promisify(child_process.exec);
 
 /**
  * @param {string} command
  * @param {Object} [options]
+ * @param {string} [options.cwd] Current working directory.  Default is process.env.GITHUB_WORKSPACE or process.cwd().
  * @param {import('./types.js').ILogger} [options.logger]
  * @param {number} [options.maxBuffer]
  */
-export async function execRoot(command, options = {}) {
-  // Node default is 1024 * 1024, which is too small for some git commands returning many entities or large file content.
-  // To support "git show", should be larger than the largest swagger file in the repo (2.5 MB as of 2/28/2025).
-  const defaultMaxBuffer = 16 * 1024 * 1024;
+export async function exec(command, options = {}) {
+  const {
+    cwd = process.env.GITHUB_WORKSPACE,
+    logger,
+    // Node default is 1024 * 1024, which is too small for some git commands returning many entities or large file content.
+    // To support "git show", should be larger than the largest swagger file in the repo (2.5 MB as of 2/28/2025).
+    maxBuffer = 16 * 1024 * 1024,
+  } = options;
 
-  const { logger, maxBuffer = defaultMaxBuffer } = options;
-
-  logger?.info(`execRoot("${command}")`);
+  logger?.info(`exec("${command}")`);
 
   // TODO: Handle errors
-  const result = await exec(command, {
-    cwd: process.env.GITHUB_WORKSPACE,
+  const result = await execImpl(command, {
+    cwd,
     maxBuffer,
   });
 

--- a/.github/src/git.js
+++ b/.github/src/git.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { buildCmd, execRoot } from "./exec.js";
+import { buildCmd, exec } from "./exec.js";
 
 /**
  * @typedef {import('./types.js').ILogger} ILogger
@@ -11,17 +11,16 @@ import { buildCmd, execRoot } from "./exec.js";
  * @param {string} headCommitish
  * @param {Object} [options]
  * @param {string} [options.args]
+ * @param {string} [options.cwd] Current working directory.  Default is process.env.GITHUB_WORKSPACE or process.cwd().
  * @param {ILogger} [options.logger]
  * @returns {Promise<string>}
  */
 export async function diff(baseCommitish, headCommitish, options = {}) {
-  const { args, logger } = options;
+  const { args, cwd, logger } = options;
 
   const cmd = buildCmd("diff", args, baseCommitish, headCommitish);
 
-  return await execGit(cmd, {
-    logger: logger,
-  });
+  return await execGit(cmd, { cwd, logger });
 }
 
 /**
@@ -29,17 +28,16 @@ export async function diff(baseCommitish, headCommitish, options = {}) {
  * @param {string} path
  * @param {Object} [options]
  * @param {string} [options.args]
+ * @param {string} [options.cwd] Current working directory.  Default is process.env.GITHUB_WORKSPACE or process.cwd().
  * @param {ILogger} [options.logger]
  * @returns {Promise<string>}
  */
 export async function lsTree(treeIsh, path, options = {}) {
-  const { args, logger } = options;
+  const { args, cwd, logger } = options;
 
   const cmd = buildCmd("ls-tree", args, treeIsh, path);
 
-  return await execGit(cmd, {
-    logger: logger,
-  });
+  return await execGit(cmd, { cwd, logger });
 }
 
 /**
@@ -47,28 +45,32 @@ export async function lsTree(treeIsh, path, options = {}) {
  * @param {string} path
  * @param {Object} [options]
  * @param {string} [options.args]
+ * @param {string} [options.cwd] Current working directory.  Default is process.env.GITHUB_WORKSPACE or process.cwd().
  * @param {ILogger} [options.logger]
  * @returns {Promise<string>}
  */
 export async function show(treeIsh, path, options = {}) {
-  const { args, logger } = options;
+  const { args, cwd, logger } = options;
 
   const cmd = buildCmd("show", args, `${treeIsh}:${path}`);
 
-  return await execGit(cmd, { logger: logger });
+  return await execGit(cmd, { cwd, logger });
 }
 
 /**
  * @param {string} args
  * @param {Object} [options]
+ * @param {string} [options.cwd] Current working directory.  Default is process.env.GITHUB_WORKSPACE or process.cwd().
  * @param {ILogger} [options.logger]
  * @returns {Promise<string>}
  */
-async function execGit(args, options) {
+async function execGit(args, options = {}) {
+  const { cwd, logger } = options;
+
   // Ensure that git displays filenames as they are (without escaping)
   const defaultConfig = "-c core.quotepath=off";
 
   const cmd = buildCmd("git", defaultConfig, args);
 
-  return await execRoot(cmd, options);
+  return await exec(cmd, { cwd, logger });
 }

--- a/.github/test/exec.test.js
+++ b/.github/test/exec.test.js
@@ -1,6 +1,6 @@
 import { EOL } from "os";
 import { describe, expect, it } from "vitest";
-import { buildCmd, execRoot } from "../src/exec.js";
+import { buildCmd, exec } from "../src/exec.js";
 import { createMockLogger } from "./mocks.js";
 
 describe("exec", () => {
@@ -9,21 +9,21 @@ describe("exec", () => {
   const expected = `${str}${EOL}`;
 
   it.each([{}, { logger: createMockLogger() }])(
-    "execRoot succeeds with default buffer (options: %o)",
+    "exec succeeds with default buffer (options: %o)",
     async (options) => {
-      await expect(execRoot(cmd, options)).resolves.toEqual(expected);
+      await expect(exec(cmd, options)).resolves.toEqual(expected);
     },
   );
 
-  it("execRoot succeeds with exact-sized buffer", async () => {
-    await expect(
-      execRoot(cmd, { maxBuffer: expected.length }),
-    ).resolves.toEqual(expected);
+  it("exec succeeds with exact-sized buffer", async () => {
+    await expect(exec(cmd, { maxBuffer: expected.length })).resolves.toEqual(
+      expected,
+    );
   });
 
-  it("execRoot fails with too-small buffer", async () => {
+  it("exec fails with too-small buffer", async () => {
     await expect(
-      execRoot(cmd, { maxBuffer: expected.length - 1 }),
+      exec(cmd, { maxBuffer: expected.length - 1 }),
     ).rejects.toThrowError(
       expect.objectContaining({ code: "ERR_CHILD_PROCESS_STDIO_MAXBUFFER" }),
     );

--- a/.github/test/git.test.js
+++ b/.github/test/git.test.js
@@ -28,43 +28,37 @@ describe("git", () => {
 
   describe("mocked", () => {
     it("diff", async () => {
-      const execRootSpy = vi
-        .spyOn(exec, "execRoot")
-        .mockResolvedValue("test diff");
+      const execSpy = vi.spyOn(exec, "exec").mockResolvedValue("test diff");
 
       await expect(diff("HEAD^", "HEAD")).resolves.toBe("test diff");
 
-      expect(execRootSpy).toBeCalledWith(
+      expect(execSpy).toBeCalledWith(
         "git -c core.quotepath=off diff HEAD^ HEAD",
         expect.anything(),
       );
     });
 
     it("lsTree", async () => {
-      const execRootSpy = vi
-        .spyOn(exec, "execRoot")
-        .mockResolvedValue("test lstree");
+      const execSpy = vi.spyOn(exec, "exec").mockResolvedValue("test lstree");
 
       await expect(
         lsTree("HEAD", "specification/contosowidgetmanager"),
       ).resolves.toBe("test lstree");
 
-      expect(execRootSpy).toBeCalledWith(
+      expect(execSpy).toBeCalledWith(
         "git -c core.quotepath=off ls-tree HEAD specification/contosowidgetmanager",
         expect.anything(),
       );
     });
 
     it("show", async () => {
-      const execRootSpy = vi
-        .spyOn(exec, "execRoot")
-        .mockResolvedValue("test show");
+      const execSpy = vi.spyOn(exec, "exec").mockResolvedValue("test show");
 
       await expect(
         show("HEAD", "specification/contosowidgetmanager/cspell.yaml"),
       ).resolves.toBe("test show");
 
-      expect(execRootSpy).toBeCalledWith(
+      expect(execSpy).toBeCalledWith(
         "git -c core.quotepath=off show HEAD:specification/contosowidgetmanager/cspell.yaml",
         expect.anything(),
       );


### PR DESCRIPTION
- Keep defaulting to GITHUB_WORKSPACE if available, else process.cwd()
- Fixes #33284