### PR TITLE
Fix startPendingUploadAutoIncrement

### DIFF
--- a/specification/ai/Azure.AI.Projects/datasets/routes.tsp
+++ b/specification/ai/Azure.AI.Projects/datasets/routes.tsp
@@ -47,7 +47,7 @@ interface Datasets
   @Rest.actionSeparator("/")
   @Rest.action("startPendingUpload")
   @Http.post
-  startPendingUploadAutoIncrement is ServicePatterns.BuildingBlocks.RepeatableCoreOps.ResourceAction<
+  startPendingUploadAutoIncrement is ServicePatterns.UnversionedResourceAction<
     DatasetVersion,
     PendingUploadRequest,
     PendingUploadResponse

--- a/specification/ai/Azure.AI.Projects/servicepatterns.tsp
+++ b/specification/ai/Azure.AI.Projects/servicepatterns.tsp
@@ -114,6 +114,21 @@ namespace Azure.AI.Projects.ServicePatterns {
     TResponse
   >;
 
+  @Rest.action
+  op UnversionedResourceAction<
+    TEntityType extends Reflection.Model,
+    TParams,
+    TResponse
+  > is Azure.Core.Foundations.ResourceOperation<
+    TEntityType,
+    {
+      @doc("Parameters for the action")
+      @Http.bodyRoot
+      body: TParams;
+    },
+    TResponse
+  >;
+
   namespace BuildingBlocks {
     alias CoreOps = Azure.Core.StandardResourceOperations;
     alias RepeatableCoreOps = Azure.Core.ResourceOperations<Azure.Core.Traits.SupportsRepeatableRequests &

--- a/specification/ai/cspell.yaml
+++ b/specification/ai/cspell.yaml
@@ -38,6 +38,7 @@ words:
   - tyrer
   - ubinary
   - umls
+  - unversioned
   - upca
   - upce
   - wordprocessingml

--- a/specification/ai/data-plane/Azure.AI.Projects/preview/2025-05-01-preview/azure-ai-projects-1dp.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/preview/2025-05-01-preview/azure-ai-projects-1dp.json
@@ -582,17 +582,9 @@
             "type": "string"
           },
           {
-            "$ref": "#/parameters/Azure.Core.RepeatabilityRequestHeaders.repeatabilityRequestId"
-          },
-          {
-            "$ref": "#/parameters/Azure.Core.RepeatabilityRequestHeaders.repeatabilityFirstSent"
-          },
-          {
-            "$ref": "#/parameters/Azure.Core.ClientRequestIdHeader"
-          },
-          {
             "name": "body",
             "in": "body",
+            "description": "Parameters for the action",
             "required": true,
             "schema": {
               "$ref": "#/definitions/PendingUploadRequest"
@@ -604,37 +596,6 @@
             "description": "The request has succeeded.",
             "schema": {
               "$ref": "#/definitions/PendingUploadResponse"
-            },
-            "headers": {
-              "Repeatability-Result": {
-                "type": "string",
-                "description": "Indicates whether the repeatable request was accepted or rejected.",
-                "enum": [
-                  "accepted",
-                  "rejected"
-                ],
-                "x-ms-enum": {
-                  "name": "RepeatabilityResult",
-                  "modelAsString": false,
-                  "values": [
-                    {
-                      "name": "accepted",
-                      "value": "accepted",
-                      "description": "If the request was accepted and the server guarantees that the server state reflects a single execution of the operation."
-                    },
-                    {
-                      "name": "rejected",
-                      "value": "rejected",
-                      "description": "If the request was rejected because the combination of Repeatability-First-Sent and Repeatability-Request-ID were invalid\nor because the Repeatability-First-Sent value was outside the range of values held by the server."
-                    }
-                  ]
-                }
-              },
-              "x-ms-client-request-id": {
-                "type": "string",
-                "format": "uuid",
-                "description": "An opaque, globally-unique, client-generated string identifier for the request."
-              }
             }
           },
           "default": {


### PR DESCRIPTION
Before this change, looking at Python emitted code, I see that `start_pending_upload_auto_increment` is not using `body: _models.PendingUploadRequest`, but instead has all its three fields spread out individually:

```python
   def start_pending_upload(
        self,
        name: str,
        version: str,
        body: _models.PendingUploadRequest,
        *,
        content_type: str = "application/json",
        **kwargs: Any
    ) -> _models.PendingUploadResponse:

    def start_pending_upload_auto_increment(
        self,
        name: str,
        *,
        pending_upload_type: Literal[PendingUploadType.TEMPORARY_BLOB_REFERENCE],
        content_type: str = "application/json",
        pending_upload_id: Optional[str] = None,
        connection_name: Optional[str] = None,
        **kwargs: Any
    ) -> _models.PendingUploadResponse:
```

Can we fix this in TypeSpec? This is my attempt to "fix" and make the 2nd method look like the first one, just without the input "version". I confirmed that Python code emitted from this PR does that. But I may be missing something here related to why a particular TypeSpec template was used for this operator.