### PR TITLE
[lint-diff] Only import necessary shared JS files

### DIFF
--- a/eng/tools/lint-diff/tsconfig.json
+++ b/eng/tools/lint-diff/tsconfig.json
@@ -7,7 +7,10 @@
     "allowJs": true
   },
   "include": [
-    "../../../.github/src/*",
+    "../../../.github/src/changed-files.js",
+    "../../../.github/src/exec.js",
+    "../../../.github/src/git.js",
+    "../../../.github/src/types.js",
     "**/src/*"
   ],
   "exclude": [


### PR DESCRIPTION
- Fixes build break in typespec-next
- Long-term fix: #33540
