### PR TITLE
Removed dispatch trigger and minor log fix

### DIFF
--- a/.github/workflows/sdk-breaking-change-labels.yaml
+++ b/.github/workflows/sdk-breaking-change-labels.yaml
@@ -3,19 +3,13 @@ name: SDK Breaking Change Labels (Preview)
 on:
   check_run:
     types: [completed]
-  workflow_dispatch:
-    inputs:
-      check_run_id:
-        description: 'Check run ID to process'
-        required: false
-        type: string
 
 permissions:
   contents: read
 
 jobs:
   sdk-breaking-change-labels:
-    if: ${{ contains(github.event.check_run.name, '(SDK Generation Job)') && github.event.check_run.check_suite.app.name == 'Azure Pipelines'}}
+    if: ${{ contains(github.event.check_run.name, 'SDK Generation') && github.event.check_run.check_suite.app.name == 'Azure Pipelines'}}
     name: SDK Breaking Change Labels (Preview)
     runs-on: ubuntu-24.04
     steps:
@@ -32,8 +26,6 @@ jobs:
             const { getLabelAndAction } =
               await import('${{ github.workspace }}/.github/workflows/src/sdk-breaking-change-labels.js');
             return await getLabelAndAction({ github, context, core });
-        env:
-          CHECK_RUN_ID: ${{ inputs.check_run_id }}
 
       - if: |
           (fromJson(steps.get-label-and-action.outputs.result).labelAction == 'add' ||

--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -174,14 +174,14 @@ extends:
 
               if [ "${{ parameters.SpecBatchTypes }}" != "" ]; then
                 optional_params="$optional_params --rm ${{ parameters.SpecBatchTypes }}"
-                sdk_gen_info="$sdk_gen_info, SpecBatchTypes: ${{ parameters.SpecBatchTypes }}"
+                sdk_gen_info="$sdk_gen_info SpecBatchTypes: ${{ parameters.SpecBatchTypes }},"
               fi
 
               if [ "${{ parameters.ApiVersion }}" != "" ]; then
                 optional_params="$optional_params --api-version ${{ parameters.ApiVersion }} --sdk-release-type ${{ parameters.SdkReleaseType }}"
-                sdk_gen_info="$sdk_gen_info API Version: ${{ parameters.ApiVersion }}, SDK Release Type: ${{ parameters.SdkReleaseType }}"
+                sdk_gen_info="$sdk_gen_info API Version: ${{ parameters.ApiVersion }}, SDK Release Type: ${{ parameters.SdkReleaseType }},"
               fi
-              sdk_gen_info="$sdk_gen_info and CommitSHA: '$(SpecRepoCommit)', in SpecRepo: '${{ parameters.SpecRepoUrl }}'"
+              sdk_gen_info="$sdk_gen_info and CommitSHA: '$(SpecRepoCommit)' in SpecRepo: '${{ parameters.SpecRepoUrl }}'"
               echo "##vso[task.setvariable variable=GeneratedSDKInformation]$sdk_gen_info"
               echo "$sdk_gen_info"
 


### PR DESCRIPTION
* [`.github/workflows/sdk-breaking-change-labels.yaml`]: 
  - Removed the `workflow_dispatch` inputs
  - Updated the `if` condition to check for 'SDK Generation' instead of '(SDK Generation Job)'
  - Removed the `CHECK_RUN_ID` environment variable from the `get-label-and-action` step.

* [`eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml`]: Modified the `sdk_gen_info` variable formatting to include commas after `SpecBatchTypes`, `API Version`, and `SDK Release Type` parameters, and adjusted the placement of the `CommitSHA` information.