### PR TITLE
Fix for C# emitter crash

### DIFF
--- a/specification/ai/Azure.AI.Projects/tspconfig.yaml
+++ b/specification/ai/Azure.AI.Projects/tspconfig.yaml
@@ -18,8 +18,8 @@ options:
     generate-sample: false
   "@azure-tools/typespec-csharp":
     package-mode: "dataplane"
-    package-dir: "Azure.AI.Projects.1DP"
-    namespace: "Azure.AI.Projects.1DP"
+    package-dir: "Azure.AI.Projects1DP"
+    namespace: "Azure.AI.Projects1DP"
     package-name: "{package-dir}"
     model-namespace: false
     flavor: azure


### PR DESCRIPTION
Update namespace for C# to prevent crash in emitter