### PR TITLE
Ensure PostAPIView workflow works

### DIFF
--- a/.github/workflows/post-apiview.yml
+++ b/.github/workflows/post-apiview.yml
@@ -15,7 +15,8 @@ jobs:
     if: |
       github.event.check_run.check_suite.app.name == 'Azure Pipelines' && (
       contains(github.event.check_run.name, 'APIView') ||
-      contains(github.event.check_run.name, 'SDK Generation') )
+      contains(github.event.check_run.name, 'SDK Generation') ||
+      contains(github.event.check_run.name, 'SDK azure-sdk-for-') )
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/eng/pipelines/swagger-apiview.yml
+++ b/eng/pipelines/swagger-apiview.yml
@@ -62,6 +62,6 @@ jobs:
         -RepoName $(Build.Repository.Name) `
         -PullRequestNumber $(System.PullRequest.PullRequestNumber)`
         -Language 'Swagger' `
-        -CommitSha $(Build.SourceVersion)
+        -CommitSha $(System.PullRequest.SourceCommitId)
     displayName: Create Swagger APIView
     condition: and(succeeded(), ne(variables['Agent.JobStatus'], 'SucceededWithIssues'))

--- a/eng/pipelines/typespec-apiview.yml
+++ b/eng/pipelines/typespec-apiview.yml
@@ -53,6 +53,6 @@ jobs:
         -RepoName $(Build.Repository.Name) `
         -PullRequestNumber $(System.PullRequest.PullRequestNumber)`
         -Language 'TypeSpec' `
-        -CommitSha $(Build.SourceVersion)
+        -CommitSha $(System.PullRequest.SourceCommitId)
     displayName: Create TypeSpec APIView
     condition: and(succeeded(), ne(variables['Agent.JobStatus'], 'SucceededWithIssues'))

--- a/eng/scripts/Create-APIView.ps1
+++ b/eng/scripts/Create-APIView.ps1
@@ -550,7 +550,7 @@ function New-RestSpecsAPIViewReviews {
     $query.Add('pullRequestNumber', $PullRequestNumber)
     $query.Add('packageName', $_.BaseName)
     $query.Add('language', $Language)
-    $query.Add('commentOnPR', $true)
+    $query.Add('commentOnPR', $false)
 
     $uri = [System.UriBuilder]$APIViewUri
     $uri.Query = $query.ToString()


### PR DESCRIPTION
- Disable commenting on PRs from APIView
- Enables `post-apiview` workflow on check_runs containing `SDK azure-sdk-for-`
- Ensure APIView uses the HEAD commit of the pull request.

Should merge after  https://github.com/Azure/azure-rest-api-specs/pull/33144
