### PR TITLE
Suppress exit error msg

### DIFF
--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -197,7 +197,7 @@ extends:
                 --commit $(SpecRepoCommit) \
                 --spec-repo-url ${{ parameters.SpecRepoUrl }} \
                 --tr true \
-                $optional_params
+                $optional_params || true # return true always to suppress exit error logging
             displayName: 'Generate SDK'
 
           - task: Powershell@2

--- a/eng/tools/spec-gen-sdk-runner/src/index.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/index.ts
@@ -21,5 +21,8 @@ export async function main() {
   } else {
     statusCode = await generateSdkForSingleSpec();
   }
+  if (statusCode !== 0) {
+    console.log("##vso[task.complete result=Failed;]");
+  }
   exit(statusCode);
 }


### PR DESCRIPTION
* [`eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml`]: Added `|| true` to the command line to always return true, suppressing exit error logging.
* [`eng/tools/spec-gen-sdk-runner/src/index.ts`]: Added a check for a non-zero status code and logged a failure message using `##vso[task.complete result=Failed;]` if the SDK generation fails.

[Test run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4715569&view=results)