### PR TITLE
[LintDiff] Remove test concurrency

### DIFF
--- a/eng/tools/lint-diff/test/generateReport.test.ts
+++ b/eng/tools/lint-diff/test/generateReport.test.ts
@@ -22,7 +22,7 @@ describe("iconFor", () => {
 });
 
 describe("getLine", () => {
-  test.concurrent("returns the line number", ({ expect }) => {
+  test("returns the line number", () => {
     const violation = {
       level: "fatal",
       code: "SomeCode1",
@@ -35,7 +35,7 @@ describe("getLine", () => {
     expect(actual).toEqual(1);
   });
 
-  test.concurrent("returns undefined when source is empty array", ({ expect }) => {
+  test("returns undefined when source is empty array", () => {
     const violation = {
       level: "fatal",
       code: "SomeCode1",
@@ -48,7 +48,7 @@ describe("getLine", () => {
     expect(actual).toEqual(undefined);
   });
 
-  test.concurrent("returns undefined when source position is empty", ({ expect }) => {
+  test("returns undefined when source position is empty", () => {
     const violation = {
       level: "fatal",
       code: "SomeCode1",
@@ -61,7 +61,7 @@ describe("getLine", () => {
     expect(actual).toEqual(undefined);
   });
 
-  test.concurrent("returns 0 when source position is 0", ({ expect }) => {
+  test("returns 0 when source position is 0", () => {
     const violation = {
       level: "fatal",
       code: "SomeCode1",
@@ -76,7 +76,7 @@ describe("getLine", () => {
 });
 
 describe("getFile", () => {
-  test.concurrent("returns the file name", ({ expect }) => {
+  test("returns the file name", () => {
     const violation = {
       level: "fatal",
       code: "SomeCode1",
@@ -89,7 +89,7 @@ describe("getFile", () => {
     expect(actual).toEqual("path/to/document1.json");
   });
 
-  test.concurrent("returns empty string when source is empty array", ({ expect }) => {
+  test("returns empty string when source is empty array", () => {
     const violation = {
       level: "fatal",
       code: "SomeCode1",
@@ -104,27 +104,27 @@ describe("getFile", () => {
 });
 
 describe("getDocUrl", () => {
-  test.concurrent("returns a pointer to a kebab-cased markdown file", ({ expect }) => {
+  test("returns a pointer to a kebab-cased markdown file", () => {
     expect(getDocUrl("TestViolation")).toEqual(
       "https://github.com/Azure/azure-openapi-validator/blob/main/docs/test-violation.md",
     );
   });
 
-  test.concurrent("returns N/A when code is FATAL", ({ expect }) => {
+  test("returns N/A when code is FATAL", () => {
     expect(getDocUrl("FATAL")).toEqual("N/A");
   });
 });
 
 describe("getFileLink", () => {
-  test.concurrent("does not include #L if line is null", ({ expect }) => {
+  test("does not include #L if line is null", () => {
     expect(getFileLink("abc123", "file.json", null)).not.toContain("#L");
   });
 
-  test.concurrent("includes #L if line is not null", ({ expect }) => {
+  test("includes #L if line is not null", () => {
     expect(getFileLink("abc123", "file.json", 1)).toContain("#L1");
   });
 
-  test.concurrent("returns the correct link with preceeding forward slash", ({ expect }) => {
+  test("returns the correct link with preceeding forward slash", () => {
     expect(getFileLink("abc123", "/file.json", 1)).toEqual(
       "https://github.com/Azure/azure-rest-api-specs/blob/abc123/file.json#L1",
     );
@@ -132,7 +132,7 @@ describe("getFileLink", () => {
 });
 
 describe("getPathSegment", () => {
-  test.concurrent("returns trailing segments of a path", ({ expect }) => {
+  test("returns trailing segments of a path", () => {
     expect(
       getPathSegment(
         "/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/stable/2025-01-01/service.json",
@@ -142,7 +142,7 @@ describe("getPathSegment", () => {
 });
 
 describe("compareLintDiffViolations", () => {
-  test.concurrent("returns 0 if equal", ({ expect }) => {
+  test("returns 0 if equal", () => {
     const a: LintDiffViolation = {
       level: "error",
       code: "SomeCode1",
@@ -156,7 +156,7 @@ describe("compareLintDiffViolations", () => {
     expect(actual).toEqual(0);
   });
 
-  test.concurrent("returns 0 if a and b are equal and don't have lines", ({ expect }) => {
+  test("returns 0 if a and b are equal and don't have lines", () => {
     const a: LintDiffViolation = {
       level: "warning",
       code: "SomeCode1",
@@ -173,7 +173,7 @@ describe("compareLintDiffViolations", () => {
     expect(actual).toEqual(0);
   });
 
-  test.concurrent("returns -1 if a level is less than b's level", ({ expect }) => {
+  test("returns -1 if a level is less than b's level", () => {
     const a: LintDiffViolation = {
       level: "error",
       code: "SomeCode1",
@@ -187,7 +187,7 @@ describe("compareLintDiffViolations", () => {
     expect(actual).toEqual(-1);
   });
 
-  test.concurrent("returns 1 if a level is greater than b's level", ({ expect }) => {
+  test("returns 1 if a level is greater than b's level", () => {
     const a: LintDiffViolation = {
       level: "warning",
       code: "SomeCode1",
@@ -201,7 +201,7 @@ describe("compareLintDiffViolations", () => {
     expect(actual).toEqual(1);
   });
 
-  test.concurrent("returns -1 if a's file is less than b's file", ({ expect }) => {
+  test("returns -1 if a's file is less than b's file", () => {
     const a: LintDiffViolation = {
       level: "warning",
       code: "SomeCode1",
@@ -218,7 +218,7 @@ describe("compareLintDiffViolations", () => {
     expect(actual).toEqual(-1);
   });
 
-  test.concurrent("returns 1 if a's file is greater than b's file", ({ expect }) => {
+  test("returns 1 if a's file is greater than b's file", () => {
     const a: LintDiffViolation = {
       level: "warning",
       code: "SomeCode1",
@@ -235,7 +235,7 @@ describe("compareLintDiffViolations", () => {
     expect(actual).toEqual(1);
   });
 
-  test.concurrent("returns -1 if a's line is less than b's line", ({ expect }) => {
+  test("returns -1 if a's line is less than b's line", () => {
     const a: LintDiffViolation = {
       level: "warning",
       code: "SomeCode1",
@@ -252,7 +252,7 @@ describe("compareLintDiffViolations", () => {
     expect(actual).toEqual(-1);
   });
 
-  test.concurrent("returns 1 if a's line is greater than b's line", ({ expect }) => {
+  test("returns 1 if a's line is greater than b's line", () => {
     const a: LintDiffViolation = {
       level: "warning",
       code: "SomeCode1",

--- a/eng/tools/lint-diff/test/lint-diff.test.ts
+++ b/eng/tools/lint-diff/test/lint-diff.test.ts
@@ -3,8 +3,16 @@ import { test, describe } from "vitest";
 
 // TODO: Actual tests
 describe("e2e", () => {
-  test.concurrent("Executes", async ({ expect }) => {
-    const { exitCode } = await execa("npm", ["exec", "--no", "--", "lint-diff"], { reject: false });
-    expect(exitCode).toBe(1);
+  test.sequential("Executes", async ({ expect }) => {
+    const output = await execa("npm", ["exec", "--no", "--", "lint-diff"], { reject: false });
+
+    try {
+      expect(output.exitCode).toBe(1);
+    } catch (error) {
+      console.log(`stdout: ${output.stdout}`);
+      console.log(`stderr: ${output.stderr}`);
+      console.error("Error:", error);
+      throw error;
+    }
   });
 });

--- a/eng/tools/lint-diff/test/lint-diff.test.ts
+++ b/eng/tools/lint-diff/test/lint-diff.test.ts
@@ -1,9 +1,9 @@
 import { execa } from "execa";
-import { test, describe } from "vitest";
+import { test, describe, expect } from "vitest";
 
 // TODO: Actual tests
-describe("e2e", async () => {
-  test.sequential("Executes", async ({ expect }) => {
+describe("e2e", () => {
+  test("Executes", async () => {
     const output = await execa("npm", ["exec", "--no", "--", "lint-diff"], { reject: false });
 
     try {

--- a/eng/tools/lint-diff/test/lint-diff.test.ts
+++ b/eng/tools/lint-diff/test/lint-diff.test.ts
@@ -2,7 +2,7 @@ import { execa } from "execa";
 import { test, describe } from "vitest";
 
 // TODO: Actual tests
-describe("e2e", () => {
+describe("e2e", async () => {
   test.sequential("Executes", async ({ expect }) => {
     const output = await execa("npm", ["exec", "--no", "--", "lint-diff"], { reject: false });
 

--- a/eng/tools/lint-diff/test/markdown-utils.test.ts
+++ b/eng/tools/lint-diff/test/markdown-utils.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, test, describe, vi, Mock } from "vitest";
+import { beforeEach, test, describe, vi, Mock, expect } from "vitest";
 import { readFile } from "fs/promises";
 import { join } from "node:path";
 
@@ -25,7 +25,7 @@ describe("deduplicateTags", () => {
   // Original comment describing deduplicateTags
   // if one tag 'A' 's input files contains all the input files of Tag 'B' , then B tag will be de-duplicated
 
-  test.concurrent("deduplicates tags", async ({ expect }) => {
+  test("deduplicates tags", () => {
     const tags = [
       { tagName: "tag1", inputFiles: ["file1", "file2"] },
       { tagName: "tag2", inputFiles: ["file1"] }, // Covered in tag1
@@ -39,7 +39,7 @@ describe("deduplicateTags", () => {
 });
 
 describe("getInputFiles", () => {
-  test.concurrent("returns input files for a readme content's tag", async ({ expect }) => {
+  test("returns input files for a readme content's tag", async () => {
     const readmeContent = await readFile(join(__dirname, "fixtures/getInputFiles/readme.md"), {
       encoding: "utf-8",
     });
@@ -49,7 +49,7 @@ describe("getInputFiles", () => {
     expect(inputFiles).toEqual(["Azure.Contoso.WidgetManager/stable/2022-12-01/widgets.json"]);
   });
 
-  test.concurrent("returns empty array when no input files are found", async ({ expect }) => {
+  test("returns empty array when no input files are found", async () => {
     const readmeContent = await readFile(join(__dirname, "fixtures/getInputFiles/readme.md"), {
       encoding: "utf-8",
     });
@@ -60,8 +60,8 @@ describe("getInputFiles", () => {
   });
 });
 
-describe("getDocRawUrl", async () => {
-  test.concurrent("returns the expected doc url", async ({ expect }) => {
+describe("getDocRawUrl", () => {
+  test("returns the expected doc url", () => {
     const docUrl = getDocRawUrl("Post201Response");
 
     expect(docUrl).toEqual(
@@ -69,48 +69,42 @@ describe("getDocRawUrl", async () => {
     );
   });
 
-  test.concurrent("returns N/A on FATAL", async ({ expect }) => {
+  test("returns N/A on FATAL", () => {
     const docUrl = getDocRawUrl("FATAL");
 
     expect(docUrl).toEqual("N/A");
   });
 });
 
-describe("getDefaultTag", async () => {
-  test.concurrent(
-    "returns default tag when there is a Basic Information header",
-    async ({ expect }) => {
-      const readmeContent = await readFile(
-        join(__dirname, "fixtures/getDefaultTag/hasBasicInformation.md"),
-        {
-          encoding: "utf-8",
-        },
-      );
-      6;
+describe("getDefaultTag", () => {
+  test("returns default tag when there is a Basic Information header", async () => {
+    const readmeContent = await readFile(
+      join(__dirname, "fixtures/getDefaultTag/hasBasicInformation.md"),
+      {
+        encoding: "utf-8",
+      },
+    );
+    6;
 
-      const defaultTag = getDefaultTag(readmeContent);
+    const defaultTag = getDefaultTag(readmeContent);
 
-      expect(defaultTag).toEqual("package-2022-12-01");
-    },
-  );
+    expect(defaultTag).toEqual("package-2022-12-01");
+  });
 
-  test.concurrent(
-    "returns default tag when there is no Basic Information header",
-    async ({ expect }) => {
-      const readmeContent = await readFile(
-        join(__dirname, "fixtures/getDefaultTag/noBasicInformation.md"),
-        {
-          encoding: "utf-8",
-        },
-      );
+  test("returns default tag when there is no Basic Information header", async () => {
+    const readmeContent = await readFile(
+      join(__dirname, "fixtures/getDefaultTag/noBasicInformation.md"),
+      {
+        encoding: "utf-8",
+      },
+    );
 
-      const defaultTag = getDefaultTag(readmeContent);
+    const defaultTag = getDefaultTag(readmeContent);
 
-      expect(defaultTag).toEqual("package-2023-07-preview");
-    },
-  );
+    expect(defaultTag).toEqual("package-2023-07-preview");
+  });
 
-  test.concurrent("returns empty string when there is no default tag", async ({ expect }) => {
+  test("returns empty string when there is no default tag", async () => {
     const readmeContent = await readFile(
       join(__dirname, "fixtures/getDefaultTag/noDefaultTag.md"),
       {
@@ -124,8 +118,8 @@ describe("getDefaultTag", async () => {
   });
 });
 
-describe("getAllTags", async () => {
-  test.concurrent("returns all tags", async ({ expect }) => {
+describe("getAllTags", () => {
+  test("returns all tags", async () => {
     const readmeContent = await readFile(join(__dirname, "fixtures/getAllTags/readme.md"), {
       encoding: "utf-8",
     });
@@ -154,16 +148,15 @@ describe("getAllTags", async () => {
   });
 });
 
-describe("getOpenapiType", async () => {
-  test.concurrent("openapi-type found and valid", async ({ expect }) => {
+describe("getOpenapiType", () => {
+  test("openapi-type found and valid", async () => {
     const markdownFile = join(__dirname, "fixtures/getOpenapiType/type-found-and-valid.md");
     const openapiType = await getOpenapiType(markdownFile);
 
     expect(openapiType).toEqual("data-plane");
   });
 
-  test.skipIf(isWindows)
-  .concurrent("openapi-type found but not valid", async ({ expect }) => {
+  test.skipIf(isWindows)("openapi-type found but not valid", async () => {
     const markdownFile = join(
       __dirname,
       "fixtures/getOpenapiType/specification/service1/data-plane/type-found-not-valid-readme.md",
@@ -173,8 +166,7 @@ describe("getOpenapiType", async () => {
     expect(openapiType).toEqual("data-plane");
   });
 
-  test.skipIf(isWindows)
-  .concurrent("openapi-type not found, type arm", async ({ expect }) => {
+  test.skipIf(isWindows)("openapi-type not found, type arm", async () => {
     const markdownFile = join(
       __dirname,
       "fixtures/getOpenapiType/specification/service1/resource-manager/inferred-resource-manager-readme.md",
@@ -182,8 +174,7 @@ describe("getOpenapiType", async () => {
     const openApiType = await getOpenapiType(markdownFile);
     expect(openApiType).toEqual("arm");
   });
-  test.skipIf(isWindows)
-  .concurrent("openapi-type not found, type data-plane", async ({ expect }) => {
+  test.skipIf(isWindows)("openapi-type not found, type data-plane", async () => {
     const markdownFile = join(
       __dirname,
       "fixtures/getOpenapiType/specification/service1/data-plane/inferred-data-plane-readme.md",
@@ -192,15 +183,15 @@ describe("getOpenapiType", async () => {
     expect(openApiType).toEqual("data-plane");
   });
 
-  test.concurrent("openapi-type not found, type default", async ({ expect }) => {
+  test("openapi-type not found, type default", async () => {
     const markdownFile = join(__dirname, "fixtures/getOpenapiType/default.md");
     const openApiType = await getOpenapiType(markdownFile);
     expect(openApiType).toEqual("default");
   });
 });
 
-describe("getTagsAndInputFiles", async () => {
-  test.concurrent("gets accurate input files for tag", async ({ expect }) => {
+describe("getTagsAndInputFiles", () => {
+  test("gets accurate input files for tag", async () => {
     const readmeContent = await readFile(
       join(__dirname, "fixtures/getTagsAndInputFiles/readme.md"),
       { encoding: "utf-8" },
@@ -217,7 +208,7 @@ describe("getTagsAndInputFiles", async () => {
   });
 });
 
-describe("getRelatedArmRpcFromDoc", async () => {
+describe("getRelatedArmRpcFromDoc", () => {
   // Tests are run sequentially to avoid concurrency issues with axios mocking
   beforeEach(() => {
     (axios.get as Mock).mockReset();
@@ -233,13 +224,13 @@ describe("getRelatedArmRpcFromDoc", async () => {
     });
   }
 
-  test.sequential("returns empty array on FATAL", async ({ expect }) => {
+  test("returns empty array on FATAL", async () => {
     const rule = await getRelatedArmRpcFromDoc("FATAL");
 
     expect(rule).toEqual([]);
   });
 
-  test.sequential("returns a rule from the cache", async ({ expect }) => {
+  test("returns a rule from the cache", async () => {
     await mockResponseFile("lro-patch202.md");
 
     await getRelatedArmRpcFromDoc("LroPatch202");
@@ -248,34 +239,34 @@ describe("getRelatedArmRpcFromDoc", async () => {
     expect((axios.get as Mock).mock.calls.length).toBe(1);
   });
 
-  test.sequential("returns an empty array when no rules are found", async ({ expect }) => {
+  test("returns an empty array when no rules are found", async () => {
     await mockResponseFile("api-host.md");
     const rules = await getRelatedArmRpcFromDoc("ApiHost");
     expect(rules).toEqual([]);
   });
 
-  test.sequential("returns rules when a list is found", async ({ expect }) => {
+  test("returns rules when a list is found", async () => {
     await mockResponseFile("system-data-definitions-common-types.md");
     const rules = await getRelatedArmRpcFromDoc("SystemDataDefinitionsCommonTypes");
 
     expect(rules).toEqual(["RPC-SystemData-V1-01", "RPC-SystemData-V1-02"]);
   });
 
-  test.sequential("returns rules when a list with commas is found", async ({ expect }) => {
+  test("returns rules when a list with commas is found", async () => {
     await mockResponseFile("lro-patch202.md");
     const rules = await getRelatedArmRpcFromDoc("LroPatch202");
 
     expect(rules).toEqual(["RPC-Patch-V1-06", "RPC-Async-V1-08"]);
   });
 
-  test.sequential("returns an empty set when the docUrl is not found", async ({ expect }) => {
+  test("returns an empty set when the docUrl is not found", async () => {
     (axios.get as Mock).mockRejectedValue(new Error("404 Not Found"));
     const rules = await getRelatedArmRpcFromDoc("DoesNotExist");
 
     expect(rules).toEqual([]);
   });
 
-  test.sequential("does not throw on axios errors", async ({ expect }) => {
+  test("does not throw on axios errors", () => {
     (axios.get as Mock).mockRejectedValue(new Error("404 Not Found"));
 
     expect(async () => await getRelatedArmRpcFromDoc("DoesNotExist")).not.toThrow();

--- a/eng/tools/lint-diff/test/processChanges.fs.test.ts
+++ b/eng/tools/lint-diff/test/processChanges.fs.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, vi, test, describe } from "vitest";
+import { beforeEach, vi, test, describe, expect } from "vitest";
 import { vol } from "memfs";
 
 import { getAffectedReadmes, readFileList } from "../src/processChanges.js";
@@ -25,8 +25,7 @@ describe("getAffectedReadmes", () => {
     vol.reset();
   });
 
-  test.skipIf(isWindows)
-  .concurrent("includes expected changed file", async ({ expect }) => {
+  test.skipIf(isWindows)("includes expected changed file", async () => {
     const files = {
       "./specification/a/readme.md": "a",
       "./specification/b/readme.md": "b",
@@ -38,7 +37,7 @@ describe("getAffectedReadmes", () => {
     expect(affectedReadmes).toEqual(["specification/a/readme.md"]);
   });
 
-  test.concurrent("excludes non-changed file outside of scope", async ({ expect }) => {
+  test("excludes non-changed file outside of scope", async () => {
     const files = {
       "./specification/a/readme.md": "a",
       "./specification/b/readme.md": "b",
@@ -50,8 +49,7 @@ describe("getAffectedReadmes", () => {
     expect(affectedReadmes).not.toContain(["specification/b/readme.md"]);
   });
 
-  test.skipIf(isWindows)
-  .concurrent("includes files up the heirarchy", async ({ expect }) => {
+  test.skipIf(isWindows)("includes files up the heirarchy", async () => {
     const files = {
       "./specification/a/readme.md": "a",
       "./specification/a/b/c/readme.md": "c",
@@ -63,26 +61,21 @@ describe("getAffectedReadmes", () => {
     expect(affectedReadmes).toEqual(["specification/a/b/c/readme.md", "specification/a/readme.md"]);
   });
 
-  test.skipIf(isWindows)
-  .concurrent(
-    "lists reademe files in folders with affected swagger files",
-    async ({ expect }) => {
-      const files = {
-        "./specification/service1/readme.md": "a",
-        "./specification/service1/b/c/swagger.json": "{}",
-        "./specification/service2/readme.md": "b",
-        "./specification/service2/swagger.json": "{}",
-      };
-      vol.fromJSON(files, ".");
+  test.skipIf(isWindows)("lists reademe files in folders with affected swagger files", async () => {
+    const files = {
+      "./specification/service1/readme.md": "a",
+      "./specification/service1/b/c/swagger.json": "{}",
+      "./specification/service2/readme.md": "b",
+      "./specification/service2/swagger.json": "{}",
+    };
+    vol.fromJSON(files, ".");
 
-      const changedFiles = ["specification/service1/b/c/swagger.json"];
-      const affectedReadmes = await getAffectedReadmes(changedFiles, ".");
-      expect(affectedReadmes).toEqual(["specification/service1/readme.md"]);
-    },
-  );
+    const changedFiles = ["specification/service1/b/c/swagger.json"];
+    const affectedReadmes = await getAffectedReadmes(changedFiles, ".");
+    expect(affectedReadmes).toEqual(["specification/service1/readme.md"]);
+  });
 
-  test.skipIf(isWindows)
-  .concurrent("excludes files outside of specification/", async ({ expect }) => {
+  test.skipIf(isWindows)("excludes files outside of specification/", async () => {
     const files = {
       "./repo-root/specification/a/readme.md": "a",
       "./repo-root/specification/b/readme.md": "b",
@@ -97,12 +90,12 @@ describe("getAffectedReadmes", () => {
   });
 });
 
-describe("readFileList", async () => {
+describe("readFileList", () => {
   afterEach(() => {
     vol.reset();
   });
 
-  test.concurrent("returns a list of items", async ({ expect }) => {
+  test("returns a list of items", async () => {
     // Using test1.txt because somehow another test affects the
     // value of test.txt in this context.
     const files = {
@@ -114,7 +107,7 @@ describe("readFileList", async () => {
     expect(fileList).toEqual(["line1", "line2"]);
   });
 
-  test.concurrent("returns an empty list if the file is empty", async ({ expect }) => {
+  test("returns an empty list if the file is empty", async () => {
     const files = {
       "./test.txt": "",
     };

--- a/eng/tools/lint-diff/test/processChanges.test.ts
+++ b/eng/tools/lint-diff/test/processChanges.test.ts
@@ -1,4 +1,4 @@
-import { test, describe } from "vitest";
+import { test, describe, expect } from "vitest";
 import { join } from "node:path";
 
 import {
@@ -12,8 +12,7 @@ import {
 import { isWindows } from "./test-util.js";
 
 describe("getSwaggerDependenciesMap", () => {
-  test.skipIf(isWindows)
-  .concurrent("empty set on no .json files", async ({ expect }) => {
+  test("empty set on no .json files", async () => {
     const __dirname = new URL(".", import.meta.url).pathname;
     console.log("dirname", __dirname);
     const dependencyMap = await getSwaggerDependenciesMap(
@@ -24,8 +23,7 @@ describe("getSwaggerDependenciesMap", () => {
     expect(dependencyMap.size).toEqual(0);
   });
 
-  test.skipIf(isWindows)
-  .concurrent("d has no dependencies", async ({ expect }) => {
+  test("d has no dependencies", async () => {
     const __dirname = new URL(".", import.meta.url).pathname;
     const dependencyMap = await getSwaggerDependenciesMap(
       join(__dirname, "fixtures/getSwaggerDependenciesMap"),
@@ -36,8 +34,7 @@ describe("getSwaggerDependenciesMap", () => {
     expect(dependencyMap.get("specification/1/d.json")).toEqual(new Set<string>());
   });
 
-  test.skipIf(isWindows)
-  .concurrent("a depends on b and c (and d transitively)", async ({ expect }) => {
+  test("a depends on b and c (and d transitively)", async () => {
     const __dirname = new URL(".", import.meta.url).pathname;
     const dependencyMap = await getSwaggerDependenciesMap(
       join(__dirname, "fixtures/getSwaggerDependenciesMap"),
@@ -55,8 +52,7 @@ describe("getSwaggerDependenciesMap", () => {
     );
   });
 
-  test.skipIf(isWindows)
-  .concurrent("b depends on c and d", async ({ expect }) => {
+  test("b depends on c and d", async () => {
     const __dirname = new URL(".", import.meta.url).pathname;
     const dependencyMap = await getSwaggerDependenciesMap(
       join(__dirname, "fixtures/getSwaggerDependenciesMap"),
@@ -71,8 +67,7 @@ describe("getSwaggerDependenciesMap", () => {
 });
 
 describe("getAffectedSwaggers", () => {
-  test.skipIf(isWindows)
-  .concurrent("a affects only a", async ({ expect }) => {
+  test("a affects only a", async () => {
     const __dirname = new URL(".", import.meta.url).pathname;
     const dependencyMap = await getSwaggerDependenciesMap(
       join(__dirname, "fixtures/getSwaggerDependenciesMap"),
@@ -84,8 +79,7 @@ describe("getAffectedSwaggers", () => {
     expect(affectedSwaggers).toEqual(["specification/1/a.json"]);
   });
 
-  test.skipIf(isWindows)
-  .concurrent("b affects a and b", async ({ expect }) => {
+  test("b affects a and b", async () => {
     const __dirname = new URL(".", import.meta.url).pathname;
     const dependencyMap = await getSwaggerDependenciesMap(
       join(__dirname, "fixtures/getSwaggerDependenciesMap"),
@@ -97,8 +91,7 @@ describe("getAffectedSwaggers", () => {
     expect(affectedSwaggers).toEqual(["specification/1/nesting/b.json", "specification/1/a.json"]);
   });
 
-  test.skipIf(isWindows)
-  .concurrent("c affects a, b, c", async ({ expect }) => {
+  test("c affects a, b, c", async () => {
     const __dirname = new URL(".", import.meta.url).pathname;
     const dependencyMap = await getSwaggerDependenciesMap(
       join(__dirname, "fixtures/getSwaggerDependenciesMap"),
@@ -114,8 +107,7 @@ describe("getAffectedSwaggers", () => {
     ]);
   });
 
-  test.skipIf(isWindows)
-  .concurrent("d affects a, b, d", async ({ expect }) => {
+  test("d affects a, b, d", async () => {
     const __dirname = new URL(".", import.meta.url).pathname;
     const dependencyMap = await getSwaggerDependenciesMap(
       join(__dirname, "fixtures/getSwaggerDependenciesMap"),
@@ -131,8 +123,7 @@ describe("getAffectedSwaggers", () => {
     ]);
   });
 
-  test.skipIf(isWindows)
-  .concurrent("d, c affects a, b, c, d", async ({ expect }) => {
+  test("d, c affects a, b, c, d", async () => {
     const __dirname = new URL(".", import.meta.url).pathname;
     const dependencyMap = await getSwaggerDependenciesMap(
       join(__dirname, "fixtures/getSwaggerDependenciesMap"),
@@ -154,16 +145,14 @@ describe("getAffectedSwaggers", () => {
 });
 
 describe("getAffectedServices", () => {
-  test.skipIf(isWindows)
-  .concurrent("returns single service with multiple files", async ({ expect }) => {
+  test("returns single service with multiple files", async () => {
     const changedFiles = ["specification/service1/file1.json", "specification/service1/file2.json"];
     const affectedServices = await getAffectedServices(changedFiles);
 
     expect(affectedServices).toEqual(new Set<string>(["specification/service1"]));
   });
 
-  test.skipIf(isWindows)
-  .concurrent("returns multiple services", async ({ expect }) => {
+  test("returns multiple services", async () => {
     const changedFiles = [
       "specification/service1/file1.json",
       "specification/service1/file2.json",
@@ -178,50 +167,39 @@ describe("getAffectedServices", () => {
 });
 
 describe("getService", () => {
-  test.skipIf(isWindows)
-  .concurrent("returns service name from file path", async ({ expect }) => {
+  test("returns service name from file path", async () => {
     const filePath = "specification/service1/file1.json";
     const serviceName = await getService(filePath);
 
     expect(serviceName).toEqual("specification/service1");
   });
 
-  test.skipIf(isWindows)
-  .concurrent(
-    "returns service name from file path with leading separator",
-    async ({ expect }) => {
-      const filePath = "/specification/service1/file1.json";
-      const serviceName = await getService(filePath);
+  test.skipIf(isWindows)("returns service name from file path with leading separator", async () => {
+    const filePath = "/specification/service1/file1.json";
+    const serviceName = await getService(filePath);
 
-      expect(serviceName).toEqual("specification/service1");
-    },
-  );
+    expect(serviceName).toEqual("specification/service1");
+  });
 
-  test.concurrent(
-    "throws when file path does not contain enough pieces to assemble a service name",
-    async ({ expect }) => {
-      const filePath = "file1.json";
-      await expect(() => getService(filePath)).toThrow("Could not find service for file path");
-    },
-  );
+  test("throws when file path does not contain enough pieces to assemble a service name", async () => {
+    const filePath = "file1.json";
+    await expect(() => getService(filePath)).toThrow("Could not find service for file path");
+  });
 });
 
 describe("reconcileChangedFilesAndTags", () => {
-  test.concurrent(
-    "if a tag is deleted in after and exists in before, remove the tag from before",
-    ({ expect }) => {
-      const before = new Map<string, string[]>([["specification/1/readme.md", ["tag1", "tag2"]]]);
-      const after = new Map<string, string[]>([["specification/1/readme.md", ["tag1"]]]);
+  test("if a tag is deleted in after and exists in before, remove the tag from before", () => {
+    const before = new Map<string, string[]>([["specification/1/readme.md", ["tag1", "tag2"]]]);
+    const after = new Map<string, string[]>([["specification/1/readme.md", ["tag1"]]]);
 
-      const [beforeFinal, afterFinal] = reconcileChangedFilesAndTags(before, after);
-      expect(beforeFinal).toEqual(
-        new Map<string, string[]>([["specification/1/readme.md", ["tag1"]]]),
-      );
-      expect(afterFinal).toEqual(after);
-    },
-  );
+    const [beforeFinal, afterFinal] = reconcileChangedFilesAndTags(before, after);
+    expect(beforeFinal).toEqual(
+      new Map<string, string[]>([["specification/1/readme.md", ["tag1"]]]),
+    );
+    expect(afterFinal).toEqual(after);
+  });
 
-  test.concurrent("does not change if there is no change", ({ expect }) => {
+  test("does not change if there is no change", () => {
     const before = new Map<string, string[]>([["specification/1/readme.md", ["tag1", "tag2"]]]);
     const after = new Map<string, string[]>([["specification/1/readme.md", ["tag1", "tag2"]]]);
 
@@ -231,7 +209,7 @@ describe("reconcileChangedFilesAndTags", () => {
   });
 
   // TODO: Test this and ensure the behavior matches
-  test.concurrent("keeps a specification in before if it is deleted in after", ({ expect }) => {
+  test("keeps a specification in before if it is deleted in after", () => {
     const before = new Map<string, string[]>([["specification/1/readme.md", ["tag1", "tag2"]]]);
     const after = new Map<string, string[]>();
 

--- a/eng/tools/lint-diff/test/processChanges.test.ts
+++ b/eng/tools/lint-diff/test/processChanges.test.ts
@@ -1,5 +1,6 @@
 import { test, describe, expect } from "vitest";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import {
   getSwaggerDependenciesMap,
@@ -13,7 +14,7 @@ import { isWindows } from "./test-util.js";
 
 describe("getSwaggerDependenciesMap", () => {
   test("empty set on no .json files", async () => {
-    const __dirname = new URL(".", import.meta.url).pathname;
+    const __dirname = dirname(fileURLToPath(import.meta.url));
     console.log("dirname", __dirname);
     const dependencyMap = await getSwaggerDependenciesMap(
       join(__dirname, "fixtures/getSwaggerDependenciesMap"),
@@ -23,23 +24,28 @@ describe("getSwaggerDependenciesMap", () => {
     expect(dependencyMap.size).toEqual(0);
   });
 
-  test("d has no dependencies", async () => {
-    const __dirname = new URL(".", import.meta.url).pathname;
+  test.skipIf(isWindows)("d has no dependencies", async () => {
+    const __dirname = dirname(fileURLToPath(import.meta.url));
+    console.log("dirname", __dirname);
     const dependencyMap = await getSwaggerDependenciesMap(
       join(__dirname, "fixtures/getSwaggerDependenciesMap"),
       "specification/1",
     );
+
+    console.log(dependencyMap);
 
     expect(dependencyMap.has("specification/1/d.json")).toEqual(true);
     expect(dependencyMap.get("specification/1/d.json")).toEqual(new Set<string>());
   });
 
-  test("a depends on b and c (and d transitively)", async () => {
-    const __dirname = new URL(".", import.meta.url).pathname;
+  test.skipIf(isWindows)("a depends on b and c (and d transitively)", async () => {
+    const __dirname = dirname(fileURLToPath(import.meta.url));
     const dependencyMap = await getSwaggerDependenciesMap(
       join(__dirname, "fixtures/getSwaggerDependenciesMap"),
       "specification/1",
     );
+
+    console.log(dependencyMap);
 
     expect(dependencyMap.has("specification/1/a.json")).toEqual(true);
     expect(dependencyMap.get("specification/1/a.json")).toEqual(
@@ -52,12 +58,14 @@ describe("getSwaggerDependenciesMap", () => {
     );
   });
 
-  test("b depends on c and d", async () => {
-    const __dirname = new URL(".", import.meta.url).pathname;
+  test.skipIf(isWindows)("b depends on c and d", async () => {
+    const __dirname = dirname(fileURLToPath(import.meta.url));
     const dependencyMap = await getSwaggerDependenciesMap(
       join(__dirname, "fixtures/getSwaggerDependenciesMap"),
       "specification/1",
     );
+
+    console.log(dependencyMap);
 
     expect(dependencyMap.has("specification/1/nesting/b.json")).toEqual(true);
     expect(dependencyMap.get("specification/1/nesting/b.json")).toEqual(
@@ -68,7 +76,7 @@ describe("getSwaggerDependenciesMap", () => {
 
 describe("getAffectedSwaggers", () => {
   test("a affects only a", async () => {
-    const __dirname = new URL(".", import.meta.url).pathname;
+    const __dirname = dirname(fileURLToPath(import.meta.url));
     const dependencyMap = await getSwaggerDependenciesMap(
       join(__dirname, "fixtures/getSwaggerDependenciesMap"),
       "specification/1",
@@ -79,20 +87,22 @@ describe("getAffectedSwaggers", () => {
     expect(affectedSwaggers).toEqual(["specification/1/a.json"]);
   });
 
-  test("b affects a and b", async () => {
-    const __dirname = new URL(".", import.meta.url).pathname;
+  test.skipIf(isWindows)("b affects a and b", async () => {
+    const __dirname = dirname(fileURLToPath(import.meta.url));
     const dependencyMap = await getSwaggerDependenciesMap(
       join(__dirname, "fixtures/getSwaggerDependenciesMap"),
       "specification/1",
     );
+
+    console.log(dependencyMap);
 
     const affectedSwaggers = getAffectedSwaggers(["specification/1/nesting/b.json"], dependencyMap);
 
     expect(affectedSwaggers).toEqual(["specification/1/nesting/b.json", "specification/1/a.json"]);
   });
 
-  test("c affects a, b, c", async () => {
-    const __dirname = new URL(".", import.meta.url).pathname;
+  test.skipIf(isWindows)("c affects a, b, c", async () => {
+    const __dirname = dirname(fileURLToPath(import.meta.url));
     const dependencyMap = await getSwaggerDependenciesMap(
       join(__dirname, "fixtures/getSwaggerDependenciesMap"),
       "specification/1",
@@ -107,8 +117,8 @@ describe("getAffectedSwaggers", () => {
     ]);
   });
 
-  test("d affects a, b, d", async () => {
-    const __dirname = new URL(".", import.meta.url).pathname;
+  test.skipIf(isWindows)("d affects a, b, d", async () => {
+    const __dirname = dirname(fileURLToPath(import.meta.url));
     const dependencyMap = await getSwaggerDependenciesMap(
       join(__dirname, "fixtures/getSwaggerDependenciesMap"),
       "specification/1",
@@ -123,8 +133,8 @@ describe("getAffectedSwaggers", () => {
     ]);
   });
 
-  test("d, c affects a, b, c, d", async () => {
-    const __dirname = new URL(".", import.meta.url).pathname;
+  test.skipIf(isWindows)("d, c affects a, b, c, d", async () => {
+    const __dirname = dirname(fileURLToPath(import.meta.url));
     const dependencyMap = await getSwaggerDependenciesMap(
       join(__dirname, "fixtures/getSwaggerDependenciesMap"),
       "specification/1",
@@ -145,14 +155,14 @@ describe("getAffectedSwaggers", () => {
 });
 
 describe("getAffectedServices", () => {
-  test("returns single service with multiple files", async () => {
+  test.skipIf(isWindows)("returns single service with multiple files", async () => {
     const changedFiles = ["specification/service1/file1.json", "specification/service1/file2.json"];
     const affectedServices = await getAffectedServices(changedFiles);
 
     expect(affectedServices).toEqual(new Set<string>(["specification/service1"]));
   });
 
-  test("returns multiple services", async () => {
+  test.skipIf(isWindows)("returns multiple services", async () => {
     const changedFiles = [
       "specification/service1/file1.json",
       "specification/service1/file2.json",
@@ -167,7 +177,7 @@ describe("getAffectedServices", () => {
 });
 
 describe("getService", () => {
-  test("returns service name from file path", async () => {
+  test.skipIf(isWindows)("returns service name from file path", async () => {
     const filePath = "specification/service1/file1.json";
     const serviceName = await getService(filePath);
 

--- a/eng/tools/lint-diff/test/util.test.ts
+++ b/eng/tools/lint-diff/test/util.test.ts
@@ -1,4 +1,4 @@
-import { test, describe, vi } from "vitest";
+import { test, describe, vi, expect } from "vitest";
 import { vol } from "memfs";
 import { pathExists } from "../src/util.js";
 import { beforeEach } from "node:test";
@@ -15,7 +15,7 @@ describe("pathExists", () => {
     vol.reset();
   });
 
-  test.concurrent("returns true for existing path", async ({ expect }) => {
+  test("returns true for existing path", async () => {
     const files = {
       "./file-exists": "a",
     };
@@ -26,7 +26,7 @@ describe("pathExists", () => {
     expect(exists).toEqual(true);
   });
 
-  test.concurrent("returns false for non-existing path", async ({ expect }) => {
+  test("returns false for non-existing path", async () => {
     const files = {
       "./file-exists": "a",
     };


### PR DESCRIPTION
Should fix windows intermittent failures. The only intermittent failure was observed in `lint-diff.ts` but removing unnecessary concurrency in other places. 

Execution time for `npm run test:ci` in actions: 

| OS | Time |
| -- | ---- | 
| Windows | 9s | 
| Linux | 5s | 

This change in concurrency is pretty low cost. 

Fixes #33678