### PR TITLE
Make sure this TypeSpec PR is green with regards to Python SDK emitter

### DIFF
--- a/specification/ai/Azure.AI.Projects/tspconfig.yaml
+++ b/specification/ai/Azure.AI.Projects/tspconfig.yaml
@@ -11,13 +11,13 @@ options:
     output-file: "{azure-resource-provider-folder}/{service-name}/{version-status}/{version}/azure-ai-projects-1dp.json"
   "@azure-tools/typespec-python":
     package-mode: "dataplane"
-    package-dir: "azure-ai-projects-dp1"
+    package-dir: "azure-ai-projects-onedp"
     package-name: "{package-dir}"
-    namespace: "azure.ai.projects"
+    namespace: "azure.ai.projects.onedp"
     api-version: "2025-05-15-preview"
     flavor: azure
-    generate-test: false
-    generate-sample: false
+    generate-test: true
+    generate-sample: true
   "@azure-tools/typespec-csharp":
     package-mode: "dataplane"
     package-dir: "Azure.AI.Projects.1DP"

--- a/specification/ai/cspell.yaml
+++ b/specification/ai/cspell.yaml
@@ -44,6 +44,7 @@ words:
   - wordprocessingml
   - azureai
   - atbash
+  - onedp
 overrides:
   - filename: >-
       **/specification/ai/data-plane/DocumentIntelligence/**/DocumentIntelligence.json


### PR DESCRIPTION
To make the TypeSpec PR green with regards to Python emitter, so we are ready for REST API review next week, I need to:
- Update the package name since digits are not allowed. Use "-onedp" instead of "-1dp".
- Add "onedp" to the speller.
- Turn on samples and test generation. This will NOT override the tests and samples folder we added manually (if any), so it's safe to always have this on.