### PR TITLE
Add retries and filter on specific ado project for the check run

### DIFF
--- a/.github/workflows/sdk-breaking-change-labels.yaml
+++ b/.github/workflows/sdk-breaking-change-labels.yaml
@@ -9,7 +9,11 @@ permissions:
 
 jobs:
   sdk-breaking-change-labels:
-    if: ${{ contains(github.event.check_run.name, 'SDK Generation') && github.event.check_run.check_suite.app.name == 'Azure Pipelines'}}
+    # Only run this job when the check run is from Azure Pipelines SDK Generation job in the azure-sdk/public project
+    if: |
+      github.event.check_run.check_suite.app.name == 'Azure Pipelines' &&
+      contains(github.event.check_run.name, 'SDK Generation') &&
+      endsWith(github.event.check_run.external_id, '29ec6040-b234-4e31-b139-33dc4287b756')
     name: SDK Breaking Change Labels (Preview)
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/sdk-breaking-change-labels.yaml
+++ b/.github/workflows/sdk-breaking-change-labels.yaml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   sdk-breaking-change-labels:
-    # Only run this job when the check run is from Azure Pipelines SDK Generation job in the azure-sdk/public project
+    # Only run this job when the check run is from Azure Pipelines SDK Generation job in the azure-sdk/public(id: 29ec6040-b234-4e31-b139-33dc4287b756) project
     if: |
       github.event.check_run.check_suite.app.name == 'Azure Pipelines' &&
       contains(github.event.check_run.name, 'SDK Generation') &&

--- a/.github/workflows/sdk-breaking-change-labels.yaml
+++ b/.github/workflows/sdk-breaking-change-labels.yaml
@@ -27,12 +27,6 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            console.log('GitHub Event Payload (context.payload):');
-            console.log(JSON.stringify(context.payload, null, 2));
-
-            console.log('GitHub Event Payload (github.event):');
-            console.log(JSON.stringify(github.event, null, 2));
-
             const { getLabelAndAction } =
               await import('${{ github.workspace }}/.github/workflows/src/sdk-breaking-change-labels.js');
             return await getLabelAndAction({ github, context, core });

--- a/.github/workflows/sdk-breaking-change-labels.yaml
+++ b/.github/workflows/sdk-breaking-change-labels.yaml
@@ -23,6 +23,12 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            console.log('GitHub Event Payload (context.payload):');
+            console.log(JSON.stringify(context.payload, null, 2));
+
+            console.log('GitHub Event Payload (github.event):');
+            console.log(JSON.stringify(github.event, null, 2));
+
             const { getLabelAndAction } =
               await import('${{ github.workspace }}/.github/workflows/src/sdk-breaking-change-labels.js');
             return await getLabelAndAction({ github, context, core });

--- a/.github/workflows/src/retries.js
+++ b/.github/workflows/src/retries.js
@@ -1,0 +1,46 @@
+/**
+ * Retry a function with exponential backoff
+ * @param {Function} fn - Function to retry
+ * @param {Object} options - Retry options
+ * @param {number} [options.maxRetries=3] - Maximum number of retries
+ * @param {number} [options.initialDelayMs=1000] - Initial delay in milliseconds
+ * @param {number} [options.maxDelayMs=10000] - Maximum delay in milliseconds
+ * @param {Function} [options.logger] - Logger function
+ * @returns {Promise<any>} - Result of the function
+ */
+export async function retry(fn, { maxRetries = 3, initialDelayMs = 1000, maxDelayMs = 10000, logger = console.log } = {}) {
+  let lastError;
+
+  for (let attempt = 0; attempt < maxRetries + 1; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+
+      if (attempt < maxRetries) {
+        const delayMs = Math.min(initialDelayMs * Math.pow(2, attempt), maxDelayMs);
+        logger(`Request failed, retrying in ${delayMs}ms... (${attempt + 1}/${maxRetries})`);
+        if (error instanceof Error) {
+          logger(`Error: ${error.message}`);
+        }
+        await new Promise(resolve => setTimeout(resolve, delayMs));
+      }
+    }
+  }
+
+  throw lastError;
+}
+
+/**
+ * Fetch with retry functionality
+ * @param {string} url - URL to fetch
+ * @param {Object} [options] - Fetch options
+ * @param {Object} [retryOptions] - Retry options
+ * @returns {Promise<Response>} - Fetch response
+ */
+export async function fetchWithRetry(url, options = {}, retryOptions = {}) {
+  return retry(
+    () => fetch(url, options),
+    retryOptions
+  );
+}

--- a/.github/workflows/src/retries.js
+++ b/.github/workflows/src/retries.js
@@ -8,7 +8,15 @@
  * @param {Function} [options.logger] - Logger function
  * @returns {Promise<any>} - Result of the function
  */
-export async function retry(fn, { maxRetries = 3, initialDelayMs = 1000, maxDelayMs = 10000, logger = console.log } = {}) {
+export async function retry(
+  fn,
+  {
+    maxRetries = 3,
+    initialDelayMs = 1000,
+    maxDelayMs = 10000,
+    logger = console.log,
+  } = {},
+) {
   let lastError;
 
   for (let attempt = 0; attempt < maxRetries + 1; attempt++) {
@@ -18,12 +26,17 @@ export async function retry(fn, { maxRetries = 3, initialDelayMs = 1000, maxDela
       lastError = error;
 
       if (attempt < maxRetries) {
-        const delayMs = Math.min(initialDelayMs * Math.pow(2, attempt), maxDelayMs);
-        logger(`Request failed, retrying in ${delayMs}ms... (${attempt + 1}/${maxRetries})`);
+        const delayMs = Math.min(
+          initialDelayMs * Math.pow(2, attempt),
+          maxDelayMs,
+        );
+        logger(
+          `Request failed, retrying in ${delayMs}ms... (${attempt + 1}/${maxRetries})`,
+        );
         if (error instanceof Error) {
           logger(`Error: ${error.message}`);
         }
-        await new Promise(resolve => setTimeout(resolve, delayMs));
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
       }
     }
   }
@@ -39,8 +52,5 @@ export async function retry(fn, { maxRetries = 3, initialDelayMs = 1000, maxDela
  * @returns {Promise<Response>} - Fetch response
  */
 export async function fetchWithRetry(url, options = {}, retryOptions = {}) {
-  return retry(
-    () => fetch(url, options),
-    retryOptions
-  );
+  return retry(() => fetch(url, options), retryOptions);
 }

--- a/.github/workflows/src/sdk-breaking-change-labels.js
+++ b/.github/workflows/src/sdk-breaking-change-labels.js
@@ -71,7 +71,7 @@ export async function getLabelAndActionImpl({
         "Content-Type": "application/json",
       },
     },
-    { logger: core.info }
+    { logger: core.info },
   );
 
   if (response.status === 404) {
@@ -99,7 +99,11 @@ export async function getLabelAndActionImpl({
     core.info(`Downloading artifact from: ${downloadUrl}`);
 
     // Step 2: Fetch Artifact Content (as a Buffer) with retry
-    const artifactResponse = await fetchWithRetry(downloadUrl, {}, { logger: core.info });
+    const artifactResponse = await fetchWithRetry(
+      downloadUrl,
+      {},
+      { logger: core.info },
+    );
     if (!artifactResponse.ok) {
       throw new Error(
         `Failed to fetch artifact: ${artifactResponse.statusText}`,

--- a/.github/workflows/src/sdk-breaking-change-labels.js
+++ b/.github/workflows/src/sdk-breaking-change-labels.js
@@ -3,51 +3,7 @@ import { sdkLabels } from "../../src/sdk-types.js";
 import { LabelAction } from "./label.js";
 import { extractInputs } from "./context.js";
 import { getIssueNumber } from "./issues.js";
-
-/**
- * Retry a function with exponential backoff
- * @param {Function} fn - Function to retry
- * @param {Object} options - Retry options
- * @param {number} [options.maxRetries=3] - Maximum number of retries
- * @param {number} [options.initialDelayMs=1000] - Initial delay in milliseconds
- * @param {number} [options.maxDelayMs=10000] - Maximum delay in milliseconds
- * @param {Function} [options.logger] - Logger function
- * @returns {Promise<any>} - Result of the function
- */
-async function retry(fn, { maxRetries = 3, initialDelayMs = 1000, maxDelayMs = 10000, logger = console.log } = {}) {
-  let lastError;
-
-  for (let attempt = 0; attempt < maxRetries + 1; attempt++) {
-    try {
-      return await fn();
-    } catch (error) {
-      lastError = error;
-
-      if (attempt < maxRetries) {
-        const delayMs = Math.min(initialDelayMs * Math.pow(2, attempt), maxDelayMs);
-        logger(`Request failed, retrying in ${delayMs}ms... (${attempt + 1}/${maxRetries})`);
-        logger(`Error: ${error.message}`);
-        await new Promise(resolve => setTimeout(resolve, delayMs));
-      }
-    }
-  }
-
-  throw lastError;
-}
-
-/**
- * Fetch with retry functionality
- * @param {string} url - URL to fetch
- * @param {Object} [options] - Fetch options
- * @param {Object} [retryOptions] - Retry options
- * @returns {Promise<Response>} - Fetch response
- */
-async function fetchWithRetry(url, options = {}, retryOptions = {}) {
-  return retry(
-    () => fetch(url, options),
-    retryOptions
-  );
-}
+import { fetchWithRetry } from "./retries.js";
 
 /**
  * @typedef {Object} ArtifactResource

--- a/.github/workflows/test/retries.test.js
+++ b/.github/workflows/test/retries.test.js
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { retry, fetchWithRetry } from '../src/retries.js';
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { retry, fetchWithRetry } from "../src/retries.js";
 
 // Mock console.log to avoid cluttering test output
 const originalConsoleLog = console.log;
@@ -12,19 +12,20 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-describe('retry function', () => {
-  it('should resolve immediately when function succeeds on first attempt', async () => {
-    const mockFn = vi.fn().mockResolvedValue('success');
+describe("retry function", () => {
+  it("should resolve immediately when function succeeds on first attempt", async () => {
+    const mockFn = vi.fn().mockResolvedValue("success");
     const result = await retry(mockFn);
-    
-    expect(result).toBe('success');
+
+    expect(result).toBe("success");
     expect(mockFn).toHaveBeenCalledTimes(1);
   });
 
-  it('should retry when function fails and then succeed', async () => {
-    const mockFn = vi.fn()
-      .mockRejectedValueOnce(new Error('failure'))
-      .mockResolvedValue('success');
+  it("should retry when function fails and then succeed", async () => {
+    const mockFn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("failure"))
+      .mockResolvedValue("success");
 
     // Use fake timers
     vi.useFakeTimers();
@@ -38,37 +39,40 @@ describe('retry function', () => {
 
     // Get the result (third attempt should succeed)
     const result = await promise;
-    expect(result).toBe('success');
+    expect(result).toBe("success");
   });
 
-  it('should throw error after maximum retries', async () => {
-    const mockError = new Error('persistent failure');
+  it("should throw error after maximum retries", async () => {
+    const mockError = new Error("persistent failure");
     const mockFn = vi.fn().mockRejectedValue(mockError);
     const mockLogger = vi.fn();
-  
+
     await expect(
       retry(mockFn, {
         maxRetries: 1,
         logger: mockLogger,
         initialDelayMs: 10, // keep it fast
-      })
-    ).rejects.toThrow('persistent failure');
+      }),
+    ).rejects.toThrow("persistent failure");
   });
 });
 
-describe('fetchWithRetry function', () => {
+describe("fetchWithRetry function", () => {
   beforeEach(() => {
     // Mock global fetch
     global.fetch = vi.fn();
   });
 
-  it('should call fetch with provided url and options', async () => {
-    const mockResponse = { ok: true, json: () => Promise.resolve({ data: 'test' }) };
+  it("should call fetch with provided url and options", async () => {
+    const mockResponse = {
+      ok: true,
+      json: () => Promise.resolve({ data: "test" }),
+    };
     global.fetch.mockResolvedValue(mockResponse);
-    
-    const url = 'https://example.com/api';
-    const options = { method: 'POST', body: JSON.stringify({ key: 'value' }) };    
-    const response = await fetchWithRetry(url, options);    
+
+    const url = "https://example.com/api";
+    const options = { method: "POST", body: JSON.stringify({ key: "value" }) };
+    const response = await fetchWithRetry(url, options);
     expect(response).toBe(mockResponse);
   });
 });

--- a/.github/workflows/test/retries.test.js
+++ b/.github/workflows/test/retries.test.js
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { retry, fetchWithRetry } from '../src/retries.js';
+
+// Mock console.log to avoid cluttering test output
+const originalConsoleLog = console.log;
+beforeEach(() => {
+  console.log = vi.fn();
+});
+afterEach(() => {
+  console.log = originalConsoleLog;
+  vi.resetAllMocks();
+  vi.useRealTimers();
+});
+
+describe('retry function', () => {
+  it('should resolve immediately when function succeeds on first attempt', async () => {
+    const mockFn = vi.fn().mockResolvedValue('success');
+    const result = await retry(mockFn);
+    
+    expect(result).toBe('success');
+    expect(mockFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('should retry when function fails and then succeed', async () => {
+    const mockFn = vi.fn()
+      .mockRejectedValueOnce(new Error('failure'))
+      .mockResolvedValue('success');
+
+    // Use fake timers
+    vi.useFakeTimers();
+
+    // Start the retry process with a specific initialDelayMs
+    const initialDelayMs = 100;
+    const promise = retry(mockFn, { initialDelayMs });
+
+    // First attempt fails immediately
+    await vi.advanceTimersByTimeAsync(initialDelayMs);
+
+    // Get the result (third attempt should succeed)
+    const result = await promise;
+    expect(result).toBe('success');
+  });
+
+  it('should throw error after maximum retries', async () => {
+    const mockError = new Error('persistent failure');
+    const mockFn = vi.fn().mockRejectedValue(mockError);
+    const mockLogger = vi.fn();
+  
+    await expect(
+      retry(mockFn, {
+        maxRetries: 1,
+        logger: mockLogger,
+        initialDelayMs: 10, // keep it fast
+      })
+    ).rejects.toThrow('persistent failure');
+  });
+});
+
+describe('fetchWithRetry function', () => {
+  beforeEach(() => {
+    // Mock global fetch
+    global.fetch = vi.fn();
+  });
+
+  it('should call fetch with provided url and options', async () => {
+    const mockResponse = { ok: true, json: () => Promise.resolve({ data: 'test' }) };
+    global.fetch.mockResolvedValue(mockResponse);
+    
+    const url = 'https://example.com/api';
+    const options = { method: 'POST', body: JSON.stringify({ key: 'value' }) };    
+    const response = await fetchWithRetry(url, options);    
+    expect(response).toBe(mockResponse);
+  });
+});

--- a/.github/workflows/test/sdk-breaking-change-labels.test.js
+++ b/.github/workflows/test/sdk-breaking-change-labels.test.js
@@ -417,16 +417,17 @@ describe("sdk-breaking-change-labels", () => {
         },
       });
 
-      // Call function and expect it to throw
-      await expect(
-        getLabelAndActionImpl({
-          ado_build_id: inputs.ado_build_id,
-          ado_project_url: inputs.ado_project_url,
-          head_sha: inputs.head_sha,
-          github: mockGithub,
-          core: mockCore,
-        }),
-      ).rejects.toThrow();
-    });
+      // Start the async operation that will retry
+      const promise = getLabelAndActionImpl({
+        ado_build_id: inputs.ado_build_id,
+        ado_project_url: inputs.ado_project_url,
+        head_sha: inputs.head_sha,
+        github: mockGithub,
+        core: mockCore,
+      });
+
+      // Now expect the promise to reject
+      await expect(promise).rejects.toThrow("Network error");
+    }, 10000);
   });
 });


### PR DESCRIPTION
* [`.github/workflows/src/retries.js`]: Added a `retry` function with exponential backoff and a `fetchWithRetry` function to handle network requests with retries.
* [`.github/workflows/src/sdk-breaking-change-labels.js`: Updated to use `fetchWithRetry` for fetching artifact content and calling the Azure DevOps API.
* [`.github/workflows/sdk-breaking-change-labels.yaml`]: Updated the condition to run the job only when the check run is from Azure Pipelines SDK Generation job in the azure-sdk/public project.
* [`.github/workflows/test/retries.test.js`]: Added tests for the `retry` and `fetchWithRetry` functions to ensure they work as expected.
* [`.github/workflows/test/sdk-breaking-change-labels.test.js`]: Updated tests to account for the new retry functionality in `getLabelAndActionImpl`.