### PR TITLE
Update additional directory implementation for tsp-client

### DIFF
--- a/specification/ai/HealthInsights/HealthInsights.RadiologyInsights/tspconfig.yaml
+++ b/specification/ai/HealthInsights/HealthInsights.RadiologyInsights/tspconfig.yaml
@@ -4,9 +4,6 @@ parameters:
   "service-name":
     default: "HealthInsights"
   "dependencies":
-    # "additionalDirectories":
-    #   - "specification/ai/HealthInsights/HealthInsights.Common/"
-    #   - "specification/ai/HealthInsights/HealthInsights.OpenAPI/"
     default: ""
   "python-sdk-folder":
     default: "{project-root}/azure-sdk-for-python/"
@@ -60,3 +57,7 @@ options:
     packageDetails:
       name: "@azure-rest/health-insights-radiologyinsights"
     flavor: azure
+  "@azure-tools/typespec-client-generator-cli":
+    additionalDirectories:
+      - "specification/ai/HealthInsights/HealthInsights.Common/"
+      - "specification/ai/HealthInsights/HealthInsights.OpenAPI/"

--- a/specification/contosowidgetmanager/Contoso.WidgetManager/tspconfig.yaml
+++ b/specification/contosowidgetmanager/Contoso.WidgetManager/tspconfig.yaml
@@ -44,3 +44,6 @@ options:
     inject-spans: true
     single-client: true
     slice-elements-byval: true
+  "@azure-tools/typespec-client-generator-cli":
+    additionalDirectories:
+      - "specification/contosowidgetmanager/Contoso.WidgetManager.Shared/"

--- a/specification/keyvault/Security.KeyVault.Administration/tspconfig.yaml
+++ b/specification/keyvault/Security.KeyVault.Administration/tspconfig.yaml
@@ -2,11 +2,6 @@ parameters:
   "service-dir":
     default: "sdk/keyvault"
   "dependencies":
-    # "additionalDirectories":
-    #   - "specification/keyvault/Security.KeyVault.BackupRestore/"
-    #   - "specification/keyvault/Security.KeyVault.Common/"
-    #   - "specification/keyvault/Security.KeyVault.RBAC/"
-    #   - "specification/keyvault/Security.KeyVault.Settings/"
     default: ""
 
 emit:
@@ -59,3 +54,9 @@ options:
       name: "@azure/keyvault-admin"
       description: "Azure Key Vault Administration"
     flavor: azure
+  "@azure-tools/typespec-client-generator-cli":
+    additionalDirectories:
+      - "specification/keyvault/Security.KeyVault.BackupRestore/"
+      - "specification/keyvault/Security.KeyVault.Common/"
+      - "specification/keyvault/Security.KeyVault.RBAC/"
+      - "specification/keyvault/Security.KeyVault.Settings/"

--- a/specification/keyvault/Security.KeyVault.BackupRestore/tspconfig.yaml
+++ b/specification/keyvault/Security.KeyVault.BackupRestore/tspconfig.yaml
@@ -2,8 +2,6 @@ parameters:
   "service-dir":
     default: "sdk/keyvault"
   "dependencies":
-    # "additionalDirectories":
-    #   - "specification/keyvault/Security.KeyVault.Common/"
     default: ""
 
 emit:
@@ -31,3 +29,6 @@ options:
     package-dir: "azadmin/backup"
     inject-spans: true
     single-client: true
+  "@azure-tools/typespec-client-generator-cli":
+    additionalDirectories:
+      - "specification/keyvault/Security.KeyVault.Common/"

--- a/specification/keyvault/Security.KeyVault.Certificates/tspconfig.yaml
+++ b/specification/keyvault/Security.KeyVault.Certificates/tspconfig.yaml
@@ -2,8 +2,6 @@ parameters:
   "service-dir":
     default: "sdk/keyvault"
   "dependencies":
-    # "additionalDirectories":
-    #   - "specification/keyvault/Security.KeyVault.Common/"
     default: ""
 
 emit:
@@ -64,3 +62,6 @@ options:
     crate-name: "azure_security_keyvault_certificates"
     crate-version: "0.0.1"
     emitter-output-dir: "{project-root}/generated"
+  "@azure-tools/typespec-client-generator-cli":
+    additionalDirectories:
+      - "specification/keyvault/Security.KeyVault.Common/"

--- a/specification/keyvault/Security.KeyVault.Keys/tspconfig.yaml
+++ b/specification/keyvault/Security.KeyVault.Keys/tspconfig.yaml
@@ -2,8 +2,6 @@ parameters:
   "service-dir":
     default: "sdk/keyvault"
   "dependencies":
-    # "additionalDirectories":
-    #   - "specification/keyvault/Security.KeyVault.Common/"
     default: ""
 
 emit:
@@ -64,3 +62,6 @@ options:
     crate-name: "azure_security_keyvault_keys"
     crate-version: "0.0.1"
     emitter-output-dir: "{project-root}/generated"
+  "@azure-tools/typespec-client-generator-cli":
+    additionalDirectories:
+      - "specification/keyvault/Security.KeyVault.Common/"

--- a/specification/keyvault/Security.KeyVault.RBAC/tspconfig.yaml
+++ b/specification/keyvault/Security.KeyVault.RBAC/tspconfig.yaml
@@ -2,8 +2,6 @@ parameters:
   "service-dir":
     default: "sdk/keyvault"
   "dependencies":
-    # "additionalDirectories":
-    #   - "specification/keyvault/Security.KeyVault.Common/"
     default: ""
 
 emit:
@@ -31,3 +29,6 @@ options:
     package-dir: "azadmin/rbac"
     inject-spans: true
     single-client: true
+  "@azure-tools/typespec-client-generator-cli":
+    additionalDirectories:
+      - "specification/keyvault/Security.KeyVault.Common/"

--- a/specification/keyvault/Security.KeyVault.Secrets/tspconfig.yaml
+++ b/specification/keyvault/Security.KeyVault.Secrets/tspconfig.yaml
@@ -2,8 +2,6 @@ parameters:
   "service-dir":
     default: "sdk/keyvault"
   "dependencies":
-    # "additionalDirectories":
-    #   - "specification/keyvault/Security.KeyVault.Common/"
     default: ""
 
 emit:
@@ -62,3 +60,6 @@ options:
     crate-name: "azure_security_keyvault_secrets"
     crate-version: "0.0.1"
     emitter-output-dir: "{project-root}/generated"
+  "@azure-tools/typespec-client-generator-cli":
+    additionalDirectories:
+      - "specification/keyvault/Security.KeyVault.Common/"

--- a/specification/keyvault/Security.KeyVault.Settings/tspconfig.yaml
+++ b/specification/keyvault/Security.KeyVault.Settings/tspconfig.yaml
@@ -2,8 +2,6 @@ parameters:
   "service-dir":
     default: "sdk/keyvault"
   "dependencies":
-    # "additionalDirectories":
-    #   - "specification/keyvault/Security.KeyVault.Common/"
     default: ""
 
 emit:
@@ -31,3 +29,6 @@ options:
     package-dir: "azadmin/settings"
     inject-spans: true
     single-client: true
+  "@azure-tools/typespec-client-generator-cli":
+    additionalDirectories:
+      - "specification/keyvault/Security.KeyVault.Common/"

--- a/specification/oracle/Oracle.Database.Management/tspconfig.yaml
+++ b/specification/oracle/Oracle.Database.Management/tspconfig.yaml
@@ -2,8 +2,6 @@ parameters:
   "service-dir":
     default: "sdk/oracledatabase"
   "dependencies":
-    # "additionalDirectories":
-    #   - "specification/oracle/models"
     default: ""
 
 emit:
@@ -27,6 +25,9 @@ options:
     package-details:
       name: "@azure/arm-oracledatabase"
     flavor: azure
+  "@azure-tools/typespec-client-generator-cli":
+    additionalDirectories:
+      - "specification/oracle/models"
 
 linter:
   extends:

--- a/specification/playwrighttesting/PlaywrightTesting.AuthManager/tspconfig.yaml
+++ b/specification/playwrighttesting/PlaywrightTesting.AuthManager/tspconfig.yaml
@@ -46,4 +46,3 @@ options:
   "@azure-tools/typespec-client-generator-cli":
     additionalDirectories:
       - "specification/playwrighttesting/PlaywrightTesting.Shared/"
-      

--- a/specification/playwrighttesting/PlaywrightTesting.AuthManager/tspconfig.yaml
+++ b/specification/playwrighttesting/PlaywrightTesting.AuthManager/tspconfig.yaml
@@ -7,8 +7,6 @@ parameters:
   "service-dir":
     default: "sdk/playwrighttesting"
   "dependencies":
-    # "additionalDirectories":
-    #   - "specification/playwrighttesting/PlaywrightTesting.Shared/"
     default: ""
 options:
   "@azure-tools/typespec-autorest":
@@ -45,3 +43,7 @@ options:
     generate-tests: false
     service-name: Microsoft Playwright Testing
     flavor: azure
+  "@azure-tools/typespec-client-generator-cli":
+    additionalDirectories:
+      - "specification/playwrighttesting/PlaywrightTesting.Shared/"
+      


### PR DESCRIPTION
The additional directory lists commented out [here](https://github.com/Azure/azure-rest-api-specs/commit/d8ad39e63a7cf0071c0c59f57e2ea1bd3dd7867c) are used in a limited set of cases with tsp-client to initialize a client library. Moving these options under tsp-client package to maintain configurations for future use.