### PR TITLE
Remove -pr from the repo name when matching the SDK repo configuration for private repo scenario

### DIFF
--- a/eng/tools/spec-gen-sdk-runner/src/commands.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/commands.ts
@@ -67,7 +67,7 @@ export async function generateSdkForSingleSpec(): Promise<number> {
   }
 
   logMessage("ending group logging", LogLevel.EndGroup);
-  logIssuesToPipeline(executionReport.vsoLogPath, specConfigPathText);
+  logIssuesToPipeline(executionReport?.vsoLogPath, specConfigPathText);
 
   return statusCode;
 }
@@ -131,7 +131,7 @@ export async function generateSdkForSpecPr(): Promise<number> {
       statusCode = 1;
     }
     logMessage("ending group logging", LogLevel.EndGroup);
-    logIssuesToPipeline(executionReport.vsoLogPath, changedSpecPathText);
+    logIssuesToPipeline(executionReport?.vsoLogPath, changedSpecPathText);
   }
   // Process the breaking change label artifacts
   statusCode =
@@ -209,7 +209,7 @@ export async function generateSdkForBatchSpecs(runMode: string): Promise<number>
       statusCode = 1;
     }
     logMessage("ending group logging", LogLevel.EndGroup);
-    logIssuesToPipeline(executionReport.vsoLogPath, specConfigPath);
+    logIssuesToPipeline(executionReport?.vsoLogPath, specConfigPath);
   }
   if (failedCount > 0) {
     markdownContent += `${failedContent}\n`;
@@ -252,7 +252,7 @@ function getExecutionReport(commandInput: SpecGenSdkCmdInput): any {
   // Read the execution report to determine if the generation was successful
   const executionReportPath = path.join(
     commandInput.workingFolder,
-    `${commandInput.sdkRepoName}_tmp/execution-report.json`,
+    `${commandInput.sdkLanguage}_tmp/execution-report.json`,
   );
   return JSON.parse(fs.readFileSync(executionReportPath, "utf8"));
 }
@@ -295,6 +295,7 @@ function parseArguments(): SpecGenSdkCmdInput {
     localSpecRepoPath,
     localSdkRepoPath,
     sdkRepoName,
+    sdkLanguage: sdkRepoName.replace("-pr", ""),
     isTriggeredByPipeline: getArgumentValue(args, "--tr", "false"),
     tspConfigPath: getArgumentValue(args, "--tsp-config-relative-path", ""),
     readmePath: getArgumentValue(args, "--readme-relative-path", ""),
@@ -472,7 +473,7 @@ function processBreakingChangeLabelArtifacts(
         breakingChangeLabelArtifactFileName,
       ),
       JSON.stringify({
-        language: commandInput.sdkRepoName,
+        language: commandInput.sdkLanguage,
         labelAction: shouldLabelBreakingChange,
       }),
     );

--- a/eng/tools/spec-gen-sdk-runner/src/types.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/types.ts
@@ -9,6 +9,7 @@ export interface SpecGenSdkCmdInput {
   tspConfigPath?: string;
   readmePath?: string;
   sdkRepoName: string;
+  sdkLanguage: string;
   apiVersion?: string;
   prNumber?: string;
   sdkReleaseType?: string;


### PR DESCRIPTION
* Updated the `logIssuesToPipeline` function calls to safely handle potential null values for `executionReport.vsoLogPath` 
* Added a new field `sdkLanguage` to the `SpecGenSdkCmdInput` interface and set its value in the `parseArguments` function by replacing `-pr` from `sdkRepoName`.* Changed the `executionReportPath` construction to use `commandInput.sdkLanguage` instead of `commandInput.sdkRepoName`.
* Modified the `processBreakingChangeLabelArtifacts` function to use `commandInput.sdkLanguage` instead of `commandInput.sdkRepoName` for the `language` field.