### PR TITLE
Update service upgrade properties

### DIFF
--- a/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchCreateOrUpdateService.json
+++ b/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchCreateOrUpdateService.json
@@ -58,8 +58,8 @@
             "apiKeyOnly": {}
           },
           "disabledDataExfiltrationOptions": [],
-          "upgradeAvailable": false,
-          "serviceUpgradeDate": null
+          "upgradeAvailable": "notAvailable",
+          "serviceUpgradedAt": null
         },
         "systemData": {
           "createdBy": "My e-commerce app",
@@ -108,8 +108,8 @@
             "apiKeyOnly": {}
           },
           "disabledDataExfiltrationOptions": [],
-          "upgradeAvailable": false,
-          "serviceUpgradeDate": null
+          "upgradeAvailable": "notAvailable",
+          "serviceUpgradedAt": null
         },
         "systemData": {
           "createdBy": "My e-commerce app",

--- a/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchCreateOrUpdateServiceAuthOptions.json
+++ b/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchCreateOrUpdateServiceAuthOptions.json
@@ -64,8 +64,8 @@
             }
           },
           "disabledDataExfiltrationOptions": [],
-          "upgradeAvailable": true,
-          "serviceUpgradeDate": null
+          "upgradeAvailable": "notAvailable",
+          "serviceUpgradedAt": null
         },
         "systemData": {
           "createdBy": "My e-commerce app",
@@ -115,8 +115,8 @@
             }
           },
           "disabledDataExfiltrationOptions": [],
-          "upgradeAvailable": false,
-          "serviceUpgradeDate": null
+          "upgradeAvailable": "notAvailable",
+          "serviceUpgradedAt": null
         },
         "systemData": {
           "createdBy": "My e-commerce app",

--- a/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchCreateOrUpdateServiceDisableLocalAuth.json
+++ b/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchCreateOrUpdateServiceDisableLocalAuth.json
@@ -57,8 +57,8 @@
           "disableLocalAuth": true,
           "authOptions": null,
           "disabledDataExfiltrationOptions": [],
-          "upgradeAvailable": false,
-          "serviceUpgradeDate": null
+          "upgradeAvailable": "notAvailable",
+          "serviceUpgradedAt": null
         },
         "systemData": {
           "createdBy": "My e-commerce app",
@@ -105,8 +105,8 @@
           "disableLocalAuth": true,
           "authOptions": null,
           "disabledDataExfiltrationOptions": [],
-          "upgradeAvailable": false,
-          "serviceUpgradeDate": null
+          "upgradeAvailable": "notAvailable",
+          "serviceUpgradedAt": null
         },
         "systemData": {
           "createdBy": "My e-commerce app",

--- a/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchCreateOrUpdateServiceToAllowAccessFromPrivateEndpoints.json
+++ b/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchCreateOrUpdateServiceToAllowAccessFromPrivateEndpoints.json
@@ -59,8 +59,8 @@
             "apiKeyOnly": {}
           },
           "disabledDataExfiltrationOptions": [],
-          "upgradeAvailable": false,
-          "serviceUpgradeDate": null
+          "upgradeAvailable": "notAvailable",
+          "serviceUpgradedAt": null
         },
         "systemData": {
           "createdBy": "My e-commerce app",
@@ -109,8 +109,8 @@
             "apiKeyOnly": {}
           },
           "disabledDataExfiltrationOptions": [],
-          "upgradeAvailable": false,
-          "serviceUpgradeDate": null
+          "upgradeAvailable": "notAvailable",
+          "serviceUpgradedAt": null
         },
         "systemData": {
           "createdBy": "My e-commerce app",

--- a/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchCreateOrUpdateServiceToAllowAccessFromPublicCustomIPs.json
+++ b/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchCreateOrUpdateServiceToAllowAccessFromPublicCustomIPs.json
@@ -74,8 +74,8 @@
             "apiKeyOnly": {}
           },
           "disabledDataExfiltrationOptions": [],
-          "upgradeAvailable": false,
-          "serviceUpgradeDate": null
+          "upgradeAvailable": "notAvailable",
+          "serviceUpgradedAt": null
         },
         "systemData": {
           "createdBy": "My e-commerce app",
@@ -130,8 +130,8 @@
             "apiKeyOnly": {}
           },
           "disabledDataExfiltrationOptions": [],
-          "upgradeAvailable": false,
-          "serviceUpgradeDate": null
+          "upgradeAvailable": "notAvailable",
+          "serviceUpgradedAt": null
         },
         "systemData": {
           "createdBy": "My e-commerce app",

--- a/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchCreateOrUpdateServiceToAllowAccessFromPublicCustomIPsAndBypass.json
+++ b/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchCreateOrUpdateServiceToAllowAccessFromPublicCustomIPsAndBypass.json
@@ -76,8 +76,8 @@
             "apiKeyOnly": {}
           },
           "disabledDataExfiltrationOptions": [],
-          "upgradeAvailable": false,
-          "serviceUpgradeDate": null
+          "upgradeAvailable": "notAvailable",
+          "serviceUpgradedAt": null
         },
         "systemData": {
           "createdBy": "My e-commerce app",
@@ -133,8 +133,8 @@
             "apiKeyOnly": {}
           },
           "disabledDataExfiltrationOptions": [],
-          "upgradeAvailable": false,
-          "serviceUpgradeDate": null
+          "upgradeAvailable": "notAvailable",
+          "serviceUpgradedAt": null
         },
         "systemData": {
           "createdBy": "My e-commerce app",

--- a/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchCreateOrUpdateServiceWithCmkEnforcement.json
+++ b/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchCreateOrUpdateServiceWithCmkEnforcement.json
@@ -61,8 +61,8 @@
             "apiKeyOnly": {}
           },
           "disabledDataExfiltrationOptions": [],
-          "upgradeAvailable": false,
-          "serviceUpgradeDate": null
+          "upgradeAvailable": "notAvailable",
+          "serviceUpgradedAt": null
         },
         "systemData": {
           "createdBy": "My e-commerce app",
@@ -111,8 +111,8 @@
             "apiKeyOnly": {}
           },
           "disabledDataExfiltrationOptions": [],
-          "upgradeAvailable": false,
-          "serviceUpgradeDate": null
+          "upgradeAvailable": "notAvailable",
+          "serviceUpgradedAt": null
         },
         "systemData": {
           "createdBy": "My e-commerce app",

--- a/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchCreateOrUpdateServiceWithDataExfiltration.json
+++ b/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchCreateOrUpdateServiceWithDataExfiltration.json
@@ -63,8 +63,8 @@
           "disabledDataExfiltrationOptions": [
             "All"
           ],
-          "upgradeAvailable": false,
-          "serviceUpgradeDate": null
+          "upgradeAvailable": "notAvailable",
+          "serviceUpgradedAt": null
         },
         "systemData": {
           "createdBy": "My e-commerce app",
@@ -115,8 +115,8 @@
           "disabledDataExfiltrationOptions": [
             "All"
           ],
-          "upgradeAvailable": false,
-          "serviceUpgradeDate": null
+          "upgradeAvailable": "notAvailable",
+          "serviceUpgradedAt": null
         },
         "systemData": {
           "createdBy": "My e-commerce app",

--- a/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchCreateOrUpdateServiceWithIdentity.json
+++ b/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchCreateOrUpdateServiceWithIdentity.json
@@ -64,8 +64,8 @@
             "apiKeyOnly": {}
           },
           "disabledDataExfiltrationOptions": [],
-          "upgradeAvailable": false,
-          "serviceUpgradeDate": null
+          "upgradeAvailable": "notAvailable",
+          "serviceUpgradedAt": null
         },
         "identity": {
           "type": "SystemAssigned, UserAssigned",
@@ -125,8 +125,8 @@
             "apiKeyOnly": {}
           },
           "disabledDataExfiltrationOptions": [],
-          "upgradeAvailable": false,
-          "serviceUpgradeDate": null
+          "upgradeAvailable": "notAvailable",
+          "serviceUpgradedAt": null
         },
         "identity": {
           "type": "SystemAssigned, UserAssigned",

--- a/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchCreateOrUpdateWithSemanticSearch.json
+++ b/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchCreateOrUpdateWithSemanticSearch.json
@@ -60,8 +60,8 @@
           },
           "disabledDataExfiltrationOptions": [],
           "semanticSearch": "free",
-          "upgradeAvailable": false,
-          "serviceUpgradeDate": null
+          "upgradeAvailable": "notAvailable",
+          "serviceUpgradedAt": null
         },
         "systemData": {
           "createdBy": "My e-commerce app",
@@ -111,8 +111,8 @@
           },
           "disabledDataExfiltrationOptions": [],
           "semanticSearch": "free",
-          "upgradeAvailable": false,
-          "serviceUpgradeDate": null
+          "upgradeAvailable": "notAvailable",
+          "serviceUpgradedAt": null
         },
         "systemData": {
           "createdBy": "My e-commerce app",

--- a/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchGetService.json
+++ b/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchGetService.json
@@ -43,8 +43,8 @@
             "apiKeyOnly": {}
           },
           "disabledDataExfiltrationOptions": [],
-          "upgradeAvailable": false,
-          "serviceUpgradeDate": "2025-02-01T00:00:00Z"
+          "upgradeAvailable": "notAvailable",
+          "serviceUpgradedAt": "2025-05-01T00:00:00Z"
         },
         "systemData": {
           "createdBy": "My e-commerce app",

--- a/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchListServicesByResourceGroup.json
+++ b/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchListServicesByResourceGroup.json
@@ -44,8 +44,8 @@
                 "apiKeyOnly": {}
               },
               "disabledDataExfiltrationOptions": [],
-              "upgradeAvailable": false,
-              "serviceUpgradeDate": null
+              "upgradeAvailable": "notAvailable",
+              "serviceUpgradedAt": null
             },
             "systemData": {
               "createdBy": "My e-commerce app",
@@ -92,8 +92,8 @@
                 "apiKeyOnly": {}
               },
               "disabledDataExfiltrationOptions": [],
-              "upgradeAvailable": false,
-              "serviceUpgradeDate": null
+              "upgradeAvailable": "notAvailable",
+              "serviceUpgradedAt": null
             },
             "systemData": {
               "createdBy": "My e-commerce app",

--- a/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchListServicesBySubscription.json
+++ b/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchListServicesBySubscription.json
@@ -43,8 +43,8 @@
                 "apiKeyOnly": {}
               },
               "disabledDataExfiltrationOptions": [],
-              "upgradeAvailable": false,
-              "serviceUpgradeDate": null
+              "upgradeAvailable": "notAvailable",
+              "serviceUpgradedAt": null
             },
             "systemData": {
               "createdBy": "My e-commerce app",
@@ -91,8 +91,8 @@
                 "apiKeyOnly": {}
               },
               "disabledDataExfiltrationOptions": [],
-              "upgradeAvailable": false,
-              "serviceUpgradeDate": null
+              "upgradeAvailable": "notAvailable",
+              "serviceUpgradedAt": null
             },
             "systemData": {
               "createdBy": "My e-commerce app",

--- a/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchUpdateService.json
+++ b/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchUpdateService.json
@@ -53,8 +53,8 @@
             "apiKeyOnly": {}
           },
           "disabledDataExfiltrationOptions": [],
-          "upgradeAvailable": false,
-          "serviceUpgradeDate": null
+          "upgradeAvailable": "notAvailable",
+          "serviceUpgradedAt": null
         },
         "systemData": {
           "createdBy": "My e-commerce app",

--- a/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchUpdateServiceAuthOptions.json
+++ b/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchUpdateServiceAuthOptions.json
@@ -59,8 +59,8 @@
             }
           },
           "disabledDataExfiltrationOptions": [],
-          "upgradeAvailable": false,
-          "serviceUpgradeDate": null
+          "upgradeAvailable": "notAvailable",
+          "serviceUpgradedAt": null
         },
         "systemData": {
           "createdBy": "My e-commerce app",

--- a/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchUpdateServiceDisableLocalAuth.json
+++ b/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchUpdateServiceDisableLocalAuth.json
@@ -52,8 +52,8 @@
           "disableLocalAuth": true,
           "authOptions": null,
           "disabledDataExfiltrationOptions": [],
-          "upgradeAvailable": false,
-          "serviceUpgradeDate": null
+          "upgradeAvailable": "notAvailable",
+          "serviceUpgradedAt": null
         },
         "systemData": {
           "createdBy": "My e-commerce app",

--- a/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchUpdateServiceToAllowAccessFromPrivateEndpoints.json
+++ b/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchUpdateServiceToAllowAccessFromPrivateEndpoints.json
@@ -51,8 +51,8 @@
             "apiKeyOnly": {}
           },
           "disabledDataExfiltrationOptions": [],
-          "upgradeAvailable": false,
-          "serviceUpgradeDate": null
+          "upgradeAvailable": "notAvailable",
+          "serviceUpgradedAt": null
         },
         "systemData": {
           "createdBy": "My e-commerce app",

--- a/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchUpdateServiceToAllowAccessFromPublicCustomIPs.json
+++ b/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchUpdateServiceToAllowAccessFromPublicCustomIPs.json
@@ -64,8 +64,8 @@
             "apiKeyOnly": {}
           },
           "disabledDataExfiltrationOptions": [],
-          "upgradeAvailable": false,
-          "serviceUpgradeDate": null
+          "upgradeAvailable": "notAvailable",
+          "serviceUpgradedAt": null
         },
         "systemData": {
           "createdBy": "My e-commerce app",

--- a/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchUpdateServiceToAllowAccessFromPublicCustomIPsAndBypass.json
+++ b/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchUpdateServiceToAllowAccessFromPublicCustomIPsAndBypass.json
@@ -66,8 +66,8 @@
             "apiKeyOnly": {}
           },
           "disabledDataExfiltrationOptions": [],
-          "upgradeAvailable": false,
-          "serviceUpgradeDate": null
+          "upgradeAvailable": "notAvailable",
+          "serviceUpgradedAt": null
         },
         "systemData": {
           "createdBy": "My e-commerce app",

--- a/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchUpdateServiceToRemoveIdentity.json
+++ b/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchUpdateServiceToRemoveIdentity.json
@@ -49,8 +49,8 @@
             "apiKeyOnly": {}
           },
           "disabledDataExfiltrationOptions": [],
-          "upgradeAvailable": false,
-          "serviceUpgradeDate": null
+          "upgradeAvailable": "notAvailable",
+          "serviceUpgradedAt": null
         },
         "systemData": {
           "createdBy": "My e-commerce app",

--- a/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchUpdateServiceWithCmkEnforcement.json
+++ b/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchUpdateServiceWithCmkEnforcement.json
@@ -56,8 +56,8 @@
             "apiKeyOnly": {}
           },
           "disabledDataExfiltrationOptions": [],
-          "upgradeAvailable": false,
-          "serviceUpgradeDate": null
+          "upgradeAvailable": "notAvailable",
+          "serviceUpgradedAt": null
         },
         "systemData": {
           "createdBy": "My e-commerce app",

--- a/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchUpdateServiceWithDataExfiltration.json
+++ b/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchUpdateServiceWithDataExfiltration.json
@@ -58,8 +58,8 @@
           "disabledDataExfiltrationOptions": [
             "All"
           ],
-          "upgradeAvailable": false,
-          "serviceUpgradeDate": null
+          "upgradeAvailable": "notAvailable",
+          "serviceUpgradedAt": null
         },
         "systemData": {
           "createdBy": "My e-commerce app",

--- a/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchUpdateServiceWithSemanticSearch.json
+++ b/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchUpdateServiceWithSemanticSearch.json
@@ -55,8 +55,8 @@
           },
           "disabledDataExfiltrationOptions": [],
           "semanticSearch": "standard",
-          "upgradeAvailable": false,
-          "serviceUpgradeDate": null
+          "upgradeAvailable": "notAvailable",
+          "serviceUpgradedAt": null
         },
         "systemData": {
           "createdBy": "My e-commerce app",

--- a/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchUpdateServiceWithSku.json
+++ b/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/SearchUpdateServiceWithSku.json
@@ -52,8 +52,8 @@
             "apiKeyOnly": {}
           },
           "disabledDataExfiltrationOptions": [],
-          "upgradeAvailable": false,
-          "serviceUpgradeDate": null
+          "upgradeAvailable": "notAvailable",
+          "serviceUpgradedAt": null
         },
         "systemData": {
           "createdBy": "My e-commerce app",

--- a/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/UpgradeSearchServiceToLatestVersion.json
+++ b/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/examples/UpgradeSearchServiceToLatestVersion.json
@@ -48,8 +48,8 @@
             "apiKeyOnly": {}
           },
           "disabledDataExfiltrationOptions": [],
-          "upgradeAvailable": false,
-          "serviceUpgradeDate": "2025-05-01T00:00:00Z"
+          "upgradeAvailable": "notAvailable",
+          "serviceUpgradedAt": "2025-05-01T00:00:00Z"
         },
         "systemData": {
           "createdBy": "My e-commerce app",

--- a/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/search.json
+++ b/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/search.json
@@ -2660,11 +2660,30 @@
           "description": "A system generated property representing the service's etag that can be for optimistic concurrency control during updates."
         },
         "upgradeAvailable": {
-          "readOnly": true,
-          "type": "boolean",
-          "description": "Indicates whether or not the search service has an upgrade available."
+          "type": "string",
+          "description": "Indicates whether if the search service has an upgrade available.",
+          "enum": [
+            "notAvailable",
+            "available"
+          ],
+          "x-ms-enum": {
+            "name": "UpgradeAvailable",
+            "modelAsString": true,
+            "values": [
+              {
+                "value": "notAvailable",
+                "name": "NotAvailable",
+                "description": "An upgrade is currently not available for the service."
+              },
+              {
+                "value": "available",
+                "name": "Available",
+                "description": "There is an upgrade avialable for the service."
+              }
+            ]
+          }
         },
-        "serviceUpgradeDate": {
+        "serviceUpgradedAt": {
           "readOnly": true,
           "type": "string",
           "format": "date-time",

--- a/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/search.json
+++ b/specification/search/resource-manager/Microsoft.Search/stable/2025-05-01/search.json
@@ -2661,7 +2661,7 @@
         },
         "upgradeAvailable": {
           "type": "string",
-          "description": "Indicates whether if the search service has an upgrade available.",
+          "description": "Indicates if the search service has an upgrade available.",
           "enum": [
             "notAvailable",
             "available"
@@ -2678,7 +2678,7 @@
               {
                 "value": "available",
                 "name": "Available",
-                "description": "There is an upgrade avialable for the service."
+                "description": "There is an upgrade available for the service."
               }
             ]
           }


### PR DESCRIPTION
- Update `upgradeAvailable` Search service property to use a enum value (string) instead of a boolean value to indicate the availability of an upgrade.
- Renamed `serviceUpgradeDate` to `serviceUpgradedAt` to match with API standards
