### PR TITLE
[Swagger Avocado] Convert to GitHub Workflow

### DIFF
--- a/.github/workflows/avocado.yml
+++ b/.github/workflows/avocado.yml
@@ -1,0 +1,36 @@
+name: "[TEST-IGNORE] Swagger Avocado"
+
+on: pull_request
+
+permissions:
+  contents: read
+
+jobs:
+  avocado:
+    name: "[TEST-IGNORE] Swagger Avocado"
+
+    runs-on: ubuntu-24.04
+
+    steps:
+      # Default checkout of head branch with depth=1 should be sufficient,
+      # since avocado has internal code to clone and diff the base branch
+      # (passed via env var SYSTEM_PULLREQUEST_TARGETBRANCH).
+      - uses: actions/checkout@v4
+
+      - name: Setup Node and install deps
+        uses: ./.github/actions/setup-node-install-deps
+
+      - name: Run Avocado
+        run: |
+          npm exec --no avocado \
+          --excludePaths \
+            "/common-types/" \
+            "/scenarios/" \
+            "/package.json" \
+            "/package-lock.json" \
+            "/cadl/examples/" \
+          --includePaths \
+            "data-plane" \
+            "resource-manager"
+        env:
+          SYSTEM_PULLREQUEST_TARGETBRANCH: ${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/avocado.yml
+++ b/.github/workflows/avocado.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      # Default checkout of head branch with depth=1 should be sufficient,
-      # since avocado has internal code to clone and diff the base branch
-      # (passed via env var SYSTEM_PULLREQUEST_TARGETBRANCH).
       - uses: actions/checkout@v4
+        with:
+          # Must include all branches, for git branch logic in Avocado to work correctly
+          fetch-depth: 0
 
       - name: Setup Node and install deps
         uses: ./.github/actions/setup-node-install-deps

--- a/.github/workflows/avocado.yml
+++ b/.github/workflows/avocado.yml
@@ -33,4 +33,6 @@ jobs:
             "data-plane" \
             "resource-manager"
         env:
+          # Tells Avocado to analyze the files changed between the PR head (default checkout)
+          # and the PR base branch.
           SYSTEM_PULLREQUEST_TARGETBRANCH: ${{ github.event.pull_request.base.ref }}


### PR DESCRIPTION
- Workflow is very simple, because external tool `avocado` includes its own code to:
  - Detect files changed in a PR
  - Ignore (certainly types of) errors also appearing in the base branch
- Console output is sufficient to verify tool ran on correct folders and show any errors

# Before
![image](https://github.com/user-attachments/assets/923f9d81-3ab0-434e-aec9-5125c3561cfd)
https://github.com/Azure/azure-rest-api-specs/pull/33067/checks?check_run_id=40150938473

# After
![image](https://github.com/user-attachments/assets/9ec7d98b-424b-4935-9125-4e8b7a7b2055)
https://github.com/mikeharder/azure-rest-api-specs/actions/runs/14325792724/job/40150937940?pr=17
