### PR TITLE
Validate api version and sdk release type values in pipeline

### DIFF
--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -77,11 +77,11 @@ extends:
                 Write-Host "##vso[task.logissue type=error]'ConfigPath' must be a valid 'readme.md' file path when 'ConfigType' is set to 'OpenAPI'. For example, 'specification/appplatform/resource-manager/readme.md'"
                 Exit 1
               }
+              Write-Host "batchTypes: '${{ parameters.SpecBatchTypes }}'"
+              Write-Host "buildReason: '$(Build.Reason)'"
+              Write-Host "apiVersion: '${{ parameters.ApiVersion }}'"
+              Write-Host "sdkReleaseType: '${{ parameters.SdkReleaseType }}'"
               if (('$(Build.Reason)' -ne 'PullRequest') -and ('${{ parameters.SpecBatchTypes }}' -eq '')) {
-                if ('${{ parameters.ApiVersion }}' -eq '') {
-                  Write-Host "##vso[task.logissue type=error]Api version parameter is empty. Ensure it is set when trigger the pipeline."
-                  Exit 1
-                }
                 if (('${{ parameters.SdkReleaseType }}' -eq 'stable') -and ('${{ parameters.ApiVersion}}' -contains 'preview')) {
                   Write-Host "##vso[task.logissue type=error]'SdkReleaseType' must be set to 'beta' for the preview API specifications."
                   Exit 1

--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -77,12 +77,8 @@ extends:
                 Write-Host "##vso[task.logissue type=error]'ConfigPath' must be a valid 'readme.md' file path when 'ConfigType' is set to 'OpenAPI'. For example, 'specification/appplatform/resource-manager/readme.md'"
                 Exit 1
               }
-              Write-Host "batchTypes: '${{ parameters.SpecBatchTypes }}'"
-              Write-Host "buildReason: '$(Build.Reason)'"
-              Write-Host "apiVersion: '${{ parameters.ApiVersion }}'"
-              Write-Host "sdkReleaseType: '${{ parameters.SdkReleaseType }}'"
               if (('$(Build.Reason)' -ne 'PullRequest') -and ('${{ parameters.SpecBatchTypes }}' -eq '')) {
-                if (('${{ parameters.SdkReleaseType }}' -eq 'stable') -and ('${{ parameters.ApiVersion}}' -contains 'preview')) {
+                if (('${{ parameters.SdkReleaseType }}' -eq 'stable') -and ('${{ parameters.ApiVersion}}' -match 'preview')) {
                   Write-Host "##vso[task.logissue type=error]'SdkReleaseType' must be set to 'beta' for the preview API specifications."
                   Exit 1
                 }

--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -79,7 +79,7 @@ extends:
               }
               if (('$(Build.Reason)' -ne 'PullRequest') -and ('${{ parameters.SpecBatchTypes }}' -eq '')) {
                 if (('${{ parameters.SdkReleaseType }}' -eq 'stable') -and ('${{ parameters.ApiVersion}}' -match 'preview')) {
-                  Write-Host "##vso[task.logissue type=error]'SdkReleaseType' must be set to 'beta' for the preview API specifications."
+                  Write-Host "##vso[task.logissue type=error]'SDK release type' must be set to 'beta' for the preview API specifications."
                   Exit 1
                 }
               }


### PR DESCRIPTION
Error handling improvement:

* Removed the check for an empty `ApiVersion` parameter since it's already validated by azure pipeline UI 
* Updated the condition to use `-match` instead of `-contains` for the `SdkReleaseType` parameter

[Test Run](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4734825&view=results)
![image](https://github.com/user-attachments/assets/b146f23e-aae3-436e-b019-238d85f419cc)
