### PR TITLE
Rust renames for Key Vault

### DIFF
--- a/specification/keyvault/Security.KeyVault.Certificates/client.tsp
+++ b/specification/keyvault/Security.KeyVault.Certificates/client.tsp
@@ -88,3 +88,63 @@ using KeyVault;
 
 @@clientName(JsonWebKeyCurveName, "CurveName", "go");
 @@clientName(JsonWebKeyType, "KeyType", "go");
+
+// Rust configuration
+@@clientName(setCertificateContacts, "SetContacts", "rust");
+
+@@clientName(CertificateCreateParameters, "CreateCertificateParameters", "rust");
+@@clientName(CertificateImportParameters, "ImportCertificateParameters", "rust");
+@@clientName(CertificateIssuerSetParameters, "SetIssuerParameters", "rust");
+@@clientName(CertificateIssuerUpdateParameters, "UpdateIssuerParameters", "rust");
+@@clientName(CertificateMergeParameters, "MergeCertificateParameters", "rust");
+@@clientName(CertificateOperationUpdateParameter,
+  "UpdateCertificateOperationParameter",
+  "rust"
+);
+@@clientName(CertificateRestoreParameters,
+  "RestoreCertificateParameters",
+  "rust"
+);
+@@clientName(CertificateUpdateParameters, "UpdateCertificateParameters", "rust");
+
+@@clientName(getCertificates, "ListCertificateProperties", "rust");
+@@clientName(getCertificateIssuers, "ListIssuerProperties", "rust");
+@@clientName(getCertificateVersions, "ListCertificatePropertiesVersions", "rust");
+@@clientName(getDeletedCertificates, "ListDeletedCertificateProperties", "rust");
+@@clientName(CertificateListResult, "ListCertificatePropertiesResult", "rust");
+@@clientName(DeletedCertificateListResult,
+  "ListDeletedCertificatePropertiesResult",
+  "rust"
+);
+
+@@clientName(getCertificateContacts, "GetContacts", "rust");
+@@clientName(deleteCertificateContacts, "DeleteContacts", "rust");
+@@clientName(setCertificateIssuer, "SetIssuer", "rust");
+@@clientName(updateCertificateIssuer, "UpdateIssuer", "rust");
+@@clientName(getCertificateIssuer, "GetIssuer", "rust");
+@@clientName(deleteCertificateIssuer, "DeleteIssuer", "rust");
+@@clientName(CertificateIssuerListResult, "ListIssuerPropertiesResult", "rust");
+
+@@clientName(Action, "LifetimeActionType", "rust");
+@@clientName(Trigger, "LifetimeActionTrigger", "rust");
+@@clientName(CertificateBundle, "Certificate", "rust");
+@@clientName(CertificateItem, "CertificateProperties", "rust");
+@@clientName(DeletedCertificateBundle, "DeletedCertificate", "rust");
+@@clientName(DeletedCertificateItem, "DeletedCertificateProperties", "rust");
+@@clientName(IssuerBundle, "Issuer", "rust");
+@@clientName(CertificateIssuerItem, "IssuerProperties", "rust");
+@@clientName(CertificateRestoreParameters.certificateBundleBackup,
+  "CertificateBackup",
+  "rust"
+);
+
+@@clientName(AdministratorDetails, "AdministratorContact", "rust");
+@@clientName(OrganizationDetails.admin_details, "AdminContacts", "rust");
+@@clientName(Contact.EmailAddress, "Email", "rust");
+@@clientName(AdministratorDetails.EmailAddress, "Email", "rust");
+
+@@clientName(SubjectAlternativeNames.upns, "UserPrincipalNames", "rust");
+@@clientName(X509CertificateProperties.ekus, "EnhancedKeyUsage", "rust");
+
+@@clientName(JsonWebKeyCurveName, "CurveName", "rust");
+@@clientName(JsonWebKeyType, "KeyType", "rust");

--- a/specification/keyvault/Security.KeyVault.Certificates/client.tsp
+++ b/specification/keyvault/Security.KeyVault.Certificates/client.tsp
@@ -92,10 +92,19 @@ using KeyVault;
 // Rust configuration
 @@clientName(setCertificateContacts, "SetContacts", "rust");
 
-@@clientName(CertificateCreateParameters, "CreateCertificateParameters", "rust");
-@@clientName(CertificateImportParameters, "ImportCertificateParameters", "rust");
+@@clientName(CertificateCreateParameters,
+  "CreateCertificateParameters",
+  "rust"
+);
+@@clientName(CertificateImportParameters,
+  "ImportCertificateParameters",
+  "rust"
+);
 @@clientName(CertificateIssuerSetParameters, "SetIssuerParameters", "rust");
-@@clientName(CertificateIssuerUpdateParameters, "UpdateIssuerParameters", "rust");
+@@clientName(CertificateIssuerUpdateParameters,
+  "UpdateIssuerParameters",
+  "rust"
+);
 @@clientName(CertificateMergeParameters, "MergeCertificateParameters", "rust");
 @@clientName(CertificateOperationUpdateParameter,
   "UpdateCertificateOperationParameter",
@@ -105,7 +114,10 @@ using KeyVault;
   "RestoreCertificateParameters",
   "rust"
 );
-@@clientName(CertificateUpdateParameters, "UpdateCertificatePropertiesParameters", "rust");
+@@clientName(CertificateUpdateParameters,
+  "UpdateCertificatePropertiesParameters",
+  "rust"
+);
 @@clientName(DeletedCertificateListResult,
   "ListDeletedCertificatePropertiesResult",
   "rust"
@@ -115,8 +127,14 @@ using KeyVault;
 
 @@clientName(getCertificates, "ListCertificateProperties", "rust");
 @@clientName(getCertificateIssuers, "ListIssuerProperties", "rust");
-@@clientName(getCertificateVersions, "ListCertificatePropertiesVersions", "rust");
-@@clientName(getDeletedCertificates, "ListDeletedCertificateProperties", "rust");
+@@clientName(getCertificateVersions,
+  "ListCertificatePropertiesVersions",
+  "rust"
+);
+@@clientName(getDeletedCertificates,
+  "ListDeletedCertificateProperties",
+  "rust"
+);
 @@clientName(updateCertificate, "UpdateCertificateProperties", "rust");
 
 @@clientName(getCertificateContacts, "GetContacts", "rust");

--- a/specification/keyvault/Security.KeyVault.Certificates/client.tsp
+++ b/specification/keyvault/Security.KeyVault.Certificates/client.tsp
@@ -105,17 +105,19 @@ using KeyVault;
   "RestoreCertificateParameters",
   "rust"
 );
-@@clientName(CertificateUpdateParameters, "UpdateCertificateParameters", "rust");
+@@clientName(CertificateUpdateParameters, "UpdateCertificatePropertiesParameters", "rust");
+@@clientName(DeletedCertificateListResult,
+  "ListDeletedCertificatePropertiesResult",
+  "rust"
+);
+@@clientName(CertificateListResult, "ListCertificatePropertiesResult", "rust");
+@@clientName(CertificateIssuerListResult, "ListIssuerPropertiesResult", "rust");
 
 @@clientName(getCertificates, "ListCertificateProperties", "rust");
 @@clientName(getCertificateIssuers, "ListIssuerProperties", "rust");
 @@clientName(getCertificateVersions, "ListCertificatePropertiesVersions", "rust");
 @@clientName(getDeletedCertificates, "ListDeletedCertificateProperties", "rust");
-@@clientName(CertificateListResult, "ListCertificatePropertiesResult", "rust");
-@@clientName(DeletedCertificateListResult,
-  "ListDeletedCertificatePropertiesResult",
-  "rust"
-);
+@@clientName(updateCertificate, "UpdateCertificateProperties", "rust");
 
 @@clientName(getCertificateContacts, "GetContacts", "rust");
 @@clientName(deleteCertificateContacts, "DeleteContacts", "rust");
@@ -123,7 +125,6 @@ using KeyVault;
 @@clientName(updateCertificateIssuer, "UpdateIssuer", "rust");
 @@clientName(getCertificateIssuer, "GetIssuer", "rust");
 @@clientName(deleteCertificateIssuer, "DeleteIssuer", "rust");
-@@clientName(CertificateIssuerListResult, "ListIssuerPropertiesResult", "rust");
 
 @@clientName(Action, "LifetimeActionType", "rust");
 @@clientName(Trigger, "LifetimeActionTrigger", "rust");

--- a/specification/keyvault/Security.KeyVault.Keys/client.tsp
+++ b/specification/keyvault/Security.KeyVault.Keys/client.tsp
@@ -128,13 +128,14 @@ using KeyVault;
 @@clientName(KeyReleaseParameters, "ReleaseParameters", "rust");
 @@clientName(KeyRestoreParameters, "RestoreKeyParameters", "rust");
 @@clientName(KeySignParameters, "SignParameters", "rust");
-@@clientName(KeyUpdateParameters, "UpdateKeyParameters", "rust");
+@@clientName(KeyUpdateParameters, "UpdateKeyPropertiesParameters", "rust");
 @@clientName(KeyVerifyParameters, "VerifyParameters", "rust");
 @@clientName(GetRandomBytesRequest, "GetRandomBytesParameters", "rust");
 @@clientName(getDeletedKeys, "ListDeletedKeyProperties", "rust");
 @@clientName(getKeys, "ListKeyProperties", "rust");
 @@clientName(getKeyVersions, "ListKeyPropertiesVersions", "rust");
 @@clientName(DeletedKeyBundle, "DeletedKey", "rust");
+@@clientName(KeyBundle, "Key", "rust");
 @@clientName(KeyProperties, "OmitKeyProperties", "rust");
 @@clientName(KeyItem, "KeyProperties", "rust");
 @@clientName(DeletedKeyItem, "DeletedKeyProperties", "rust");
@@ -145,6 +146,11 @@ using KeyVault;
 @@clientName(LifetimeActionsTrigger, "LifetimeActionTrigger", "rust");
 @@clientName(KeyRestoreParameters.keyBundleBackup, "KeyBackup", "rust");
 @@clientName(KeyOperationsParameters, "KeyOperationParameters", "rust");
+
+@@clientName(getDeletedKeys, "ListDeletedKeyProperties", "rust");
+@@clientName(getKeys, "ListKeyProperties", "rust");
+@@clientName(getKeyVersions, "ListKeyPropertiesVersions", "rust");
+@@clientName(updateKey, "UpdateKeyProperties", "rust");
 
 @@clientName(KeyReleaseParameters.enc, "algorithm", "rust");
 @@clientName(KeyOperationsParameters.aad, "AdditionalAuthenticatedData", "rust");

--- a/specification/keyvault/Security.KeyVault.Keys/client.tsp
+++ b/specification/keyvault/Security.KeyVault.Keys/client.tsp
@@ -120,3 +120,38 @@ using KeyVault;
   "RsaAesKeyWrap384",
   "javascript"
 );
+
+// Rust configuration
+@@clientName(KeyCreateParameters, "CreateKeyParameters", "rust");
+@@clientName(KeyExportParameters, "ExportKeyParameters", "rust");
+@@clientName(KeyImportParameters, "ImportKeyParameters", "rust");
+@@clientName(KeyReleaseParameters, "ReleaseParameters", "rust");
+@@clientName(KeyRestoreParameters, "RestoreKeyParameters", "rust");
+@@clientName(KeySignParameters, "SignParameters", "rust");
+@@clientName(KeyUpdateParameters, "UpdateKeyParameters", "rust");
+@@clientName(KeyVerifyParameters, "VerifyParameters", "rust");
+@@clientName(GetRandomBytesRequest, "GetRandomBytesParameters", "rust");
+@@clientName(getDeletedKeys, "ListDeletedKeyProperties", "rust");
+@@clientName(getKeys, "ListKeyProperties", "rust");
+@@clientName(getKeyVersions, "ListKeyPropertiesVersions", "rust");
+@@clientName(DeletedKeyBundle, "DeletedKey", "rust");
+@@clientName(KeyProperties, "OmitKeyProperties", "rust");
+@@clientName(KeyItem, "KeyProperties", "rust");
+@@clientName(DeletedKeyItem, "DeletedKeyProperties", "rust");
+@@clientName(DeletedKeyListResult, "ListDeletedKeyPropertiesResult", "rust");
+@@clientName(KeyListResult, "ListKeyPropertiesResult", "rust");
+@@clientName(LifetimeActions, "LifetimeAction", "rust");
+@@clientName(LifetimeActionsType, "LifetimeActionType", "rust");
+@@clientName(LifetimeActionsTrigger, "LifetimeActionTrigger", "rust");
+@@clientName(KeyRestoreParameters.keyBundleBackup, "KeyBackup", "rust");
+@@clientName(KeyOperationsParameters, "KeyOperationParameters", "rust");
+
+@@clientName(KeyReleaseParameters.enc, "algorithm", "rust");
+@@clientName(KeyOperationsParameters.aad, "AdditionalAuthenticatedData", "rust");
+@@clientName(KeyOperationsParameters.tag, "AuthenticationTag", "rust");
+
+@@clientName(JsonWebKeyType, "KeyType", "rust");
+@@clientName(JsonWebKeyOperation, "KeyOperation", "rust");
+@@clientName(JsonWebKeyEncryptionAlgorithm, "EncryptionAlgorithm", "rust");
+@@clientName(JsonWebKeyCurveName, "CurveName", "rust");
+@@clientName(JsonWebKeySignatureAlgorithm, "SignatureAlgorithm", "rust");

--- a/specification/keyvault/Security.KeyVault.Keys/client.tsp
+++ b/specification/keyvault/Security.KeyVault.Keys/client.tsp
@@ -153,7 +153,10 @@ using KeyVault;
 @@clientName(updateKey, "UpdateKeyProperties", "rust");
 
 @@clientName(KeyReleaseParameters.enc, "algorithm", "rust");
-@@clientName(KeyOperationsParameters.aad, "AdditionalAuthenticatedData", "rust");
+@@clientName(KeyOperationsParameters.aad,
+  "AdditionalAuthenticatedData",
+  "rust"
+);
 @@clientName(KeyOperationsParameters.tag, "AuthenticationTag", "rust");
 
 @@clientName(JsonWebKeyType, "KeyType", "rust");

--- a/specification/keyvault/Security.KeyVault.Secrets/client.tsp
+++ b/specification/keyvault/Security.KeyVault.Secrets/client.tsp
@@ -44,7 +44,10 @@ using KeyVault;
 @@clientName(SecretBundle, "Secret", "rust");
 @@clientName(SecretRestoreParameters, "RestoreSecretParameters", "rust");
 @@clientName(SecretSetParameters, "SetSecretParameters", "rust");
-@@clientName(SecretUpdateParameters, "UpdateSecretPropertiesParameters", "rust");
+@@clientName(SecretUpdateParameters,
+  "UpdateSecretPropertiesParameters",
+  "rust"
+);
 @@clientName(DeletedSecretListResult,
   "ListDeletedSecretPropertiesResult",
   "rust"
@@ -56,4 +59,7 @@ using KeyVault;
 @@clientName(getSecretVersions, "ListSecretPropertiesVersions", "rust");
 @@clientName(updateSecret, "UpdateSecretProperties", "rust");
 
-@@clientName(SecretRestoreParameters.secretBundleBackup, "SecretBackup", "rust");
+@@clientName(SecretRestoreParameters.secretBundleBackup,
+  "SecretBackup",
+  "rust"
+);

--- a/specification/keyvault/Security.KeyVault.Secrets/client.tsp
+++ b/specification/keyvault/Security.KeyVault.Secrets/client.tsp
@@ -46,7 +46,7 @@ using KeyVault;
 @@clientName(SecretSetParameters, "SetSecretParameters", "rust");
 @@clientName(SecretUpdateParameters, "UpdateSecretPropertiesParameters", "rust");
 @@clientName(DeletedSecretListResult,
-  "DeletedSecretPropertiesListResult",
+  "ListDeletedSecretPropertiesResult",
   "rust"
 );
 @@clientName(SecretListResult, "ListSecretPropertiesResult", "rust");

--- a/specification/keyvault/Security.KeyVault.Secrets/client.tsp
+++ b/specification/keyvault/Security.KeyVault.Secrets/client.tsp
@@ -34,3 +34,26 @@ using KeyVault;
 
 @@clientName(SecretRestoreParameters.secretBundleBackup, "SecretBackup", "go");
 @@clientName(SecretBundle.kid, "KID", "go");
+
+// Rust configuration
+@@clientName(SecretProperties, "OmitSecretProperties", "rust");
+@@clientName(SecretItem, "SecretProperties", "rust");
+
+@@clientName(DeletedSecretBundle, "DeletedSecret", "rust");
+@@clientName(DeletedSecretItem, "DeletedSecretProperties", "rust");
+@@clientName(SecretBundle, "Secret", "rust");
+@@clientName(SecretRestoreParameters, "RestoreSecretParameters", "rust");
+@@clientName(SecretSetParameters, "SetSecretParameters", "rust");
+@@clientName(SecretUpdateParameters, "UpdateSecretPropertiesParameters", "rust");
+@@clientName(DeletedSecretListResult,
+  "DeletedSecretPropertiesListResult",
+  "rust"
+);
+@@clientName(SecretListResult, "ListSecretPropertiesResult", "rust");
+
+@@clientName(getDeletedSecrets, "ListDeletedSecretProperties", "rust");
+@@clientName(getSecrets, "ListSecretProperties", "rust");
+@@clientName(getSecretVersions, "ListSecretPropertiesVersions", "rust");
+@@clientName(updateSecret, "UpdateSecretProperties", "rust");
+
+@@clientName(SecretRestoreParameters.secretBundleBackup, "SecretBackup", "rust");


### PR DESCRIPTION
Mostly follows what we did for Go, which was to idiomatically match what other languages had (mostly).
