### PR TITLE
[Avocado] Fix "npm exec" params

### DIFF
--- a/.github/workflows/avocado.yml
+++ b/.github/workflows/avocado.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Run Avocado
         run: |
-          npm exec --no avocado \
+          npm exec --no -- avocado \
           --excludePaths \
             "/common-types/" \
             "/scenarios/" \


### PR DESCRIPTION
- Prevented excludePaths and includePaths from flowing to avocado