### PR TITLE
[LintDiff] New warnings pass

### DIFF
--- a/eng/tools/lint-diff/src/generateReport.ts
+++ b/eng/tools/lint-diff/src/generateReport.ts
@@ -49,9 +49,13 @@ export async function generateReport(
   newViolations.sort(compareLintDiffViolations);
   existingViolations.sort(compareLintDiffViolations);
 
-  if (newViolations.length > 0) {
-    // New violations fail the build
+  if (newViolations.some((v) => isFailure(v.level))) {
+    // New violations with level error or fatal fail the build. If all new
+    // violations are warnings, the build passes.
     pass = false;
+  }
+
+  if (newViolations.length > 0) {
     outputMarkdown += "**[must fix]The following errors/warnings are intorduced by current PR:**\n";
     if (newViolations.length > 50) {
       outputMarkdown += `${LIMIT_50_MESSAGE}\n`;

--- a/eng/tools/lint-diff/src/util.ts
+++ b/eng/tools/lint-diff/src/util.ts
@@ -1,11 +1,6 @@
 import { access, constants, readFile } from "node:fs/promises";
 import { dirname, join } from "path";
-
-// Use createRequire because Node 16 does not directly support
-// import.meta.resolve
-// https://nodejs.org/docs/latest-v16.x/api/esm.html#importmetaresolvespecifier-parent
-import { createRequire } from "node:module";
-const require = createRequire(import.meta.url);
+import { fileURLToPath } from "url";
 
 /**
  * Enumerate files in a directory that match the given string ending
@@ -48,7 +43,7 @@ export async function getDependencyVersion(dependenciesDir: string): Promise<str
 // TODO: This should probably be moved to another more general location
 export async function getPathToDependency(dependency: string): Promise<string> {
   // Example: /home/user/foo/node_modules/@autorest/bar/dist/index.js
-  const entrypoint = require.resolve(dependency);
+  const entrypoint = fileURLToPath(import.meta.resolve(dependency));
 
   // Walk up directory tree to first folder containing "package.json"
   let currentDir = dirname(entrypoint);

--- a/eng/tools/lint-diff/src/util.ts
+++ b/eng/tools/lint-diff/src/util.ts
@@ -1,6 +1,5 @@
 import { access, constants, readFile } from "node:fs/promises";
 import { dirname, join } from "path";
-import { fileURLToPath } from "url";
 
 /**
  * Enumerate files in a directory that match the given string ending

--- a/eng/tools/lint-diff/src/util.ts
+++ b/eng/tools/lint-diff/src/util.ts
@@ -1,6 +1,9 @@
 import { access, constants, readFile } from "node:fs/promises";
 import { dirname, join } from "path";
 
+// Use createRequire because Node 16 does not directly support
+// import.meta.resolve
+// https://nodejs.org/docs/latest-v16.x/api/esm.html#importmetaresolvespecifier-parent
 import { createRequire } from "node:module";
 const require = createRequire(import.meta.url);
 

--- a/eng/tools/lint-diff/src/util.ts
+++ b/eng/tools/lint-diff/src/util.ts
@@ -1,5 +1,6 @@
 import { access, constants, readFile } from "node:fs/promises";
 import { dirname, join } from "path";
+import { fileURLToPath } from "url";
 
 /**
  * Enumerate files in a directory that match the given string ending
@@ -42,7 +43,7 @@ export async function getDependencyVersion(dependenciesDir: string): Promise<str
 // TODO: This should probably be moved to another more general location
 export async function getPathToDependency(dependency: string): Promise<string> {
   // Example: /home/user/foo/node_modules/@autorest/bar/dist/index.js
-  const entrypoint = require.resolve(dependency);
+  const entrypoint = fileURLToPath(import.meta.resolve(dependency));
 
   // Walk up directory tree to first folder containing "package.json"
   let currentDir = dirname(entrypoint);

--- a/eng/tools/lint-diff/src/util.ts
+++ b/eng/tools/lint-diff/src/util.ts
@@ -43,7 +43,7 @@ export async function getDependencyVersion(dependenciesDir: string): Promise<str
 // TODO: This should probably be moved to another more general location
 export async function getPathToDependency(dependency: string): Promise<string> {
   // Example: /home/user/foo/node_modules/@autorest/bar/dist/index.js
-  const entrypoint = fileURLToPath(import.meta.resolve(dependency));
+  const entrypoint = require.resolve(dependency);
 
   // Walk up directory tree to first folder containing "package.json"
   let currentDir = dirname(entrypoint);

--- a/eng/tools/lint-diff/src/util.ts
+++ b/eng/tools/lint-diff/src/util.ts
@@ -1,6 +1,8 @@
 import { access, constants, readFile } from "node:fs/promises";
 import { dirname, join } from "path";
-import { fileURLToPath } from "url";
+
+import { createRequire } from "node:module";
+const require = createRequire(import.meta.url);
 
 /**
  * Enumerate files in a directory that match the given string ending
@@ -43,7 +45,7 @@ export async function getDependencyVersion(dependenciesDir: string): Promise<str
 // TODO: This should probably be moved to another more general location
 export async function getPathToDependency(dependency: string): Promise<string> {
   // Example: /home/user/foo/node_modules/@autorest/bar/dist/index.js
-  const entrypoint = fileURLToPath(import.meta.resolve(dependency));
+  const entrypoint = require.resolve(dependency);
 
   // Walk up directory tree to first folder containing "package.json"
   let currentDir = dirname(entrypoint);

--- a/eng/tools/lint-diff/test/generateReport.test.ts
+++ b/eng/tools/lint-diff/test/generateReport.test.ts
@@ -9,7 +9,7 @@ import {
   getPathSegment,
   compareLintDiffViolations,
 } from "../src/generateReport.js";
-import { Source, LintDiffViolation, BeforeAfter, AutorestRunResult } from "../src/types.js";
+import { Source, LintDiffViolation, BeforeAfter, AutorestRunResult } from "../src/lintdiff-types.js";
 import { isWindows } from "./test-util.js";
 
 describe("iconFor", () => {

--- a/eng/tools/lint-diff/test/generateReport.test.ts
+++ b/eng/tools/lint-diff/test/generateReport.test.ts
@@ -1,4 +1,4 @@
-import { test, describe, expect, vi } from "vitest";
+import { test, describe, expect, vi, afterEach } from "vitest";
 import {
   iconFor,
   getLine,

--- a/eng/tools/lint-diff/test/generateReport.test.ts
+++ b/eng/tools/lint-diff/test/generateReport.test.ts
@@ -9,8 +9,8 @@ import {
   getPathSegment,
   compareLintDiffViolations,
 } from "../src/generateReport.js";
-
-import { Source, LintDiffViolation } from "../src/lintdiff-types.js";
+import { Source, LintDiffViolation, BeforeAfter, AutorestRunResult } from "../src/types.js";
+import { isWindows } from "./test-util.js";
 
 describe("iconFor", () => {
   test.each([
@@ -276,7 +276,7 @@ describe("generateReport", () => {
     vi.restoreAllMocks();
   });
 
-  test("fails if new violations include an error", async ({ expect }) => {
+  test.skipIf(isWindows)("fails if new violations include an error", async ({ expect }) => {
     const afterViolation = {
       extensionName: "@microsoft.azure/openapi-validator",
       level: "error",
@@ -325,52 +325,55 @@ describe("generateReport", () => {
     expect(actual).toBe(false);
   });
 
-  test("passes if new violations do not include an error (warnings only)", async ({ expect }) => {
-    const afterViolation = {
-      extensionName: "@microsoft.azure/openapi-validator",
-      level: "warning",
-      code: "SomeCode",
-      message: "Some Message",
-      source: [
-        {
-          document:
-            "/home/test/specification/contosowidgetmanager/data-plane/Azure.Contoso.WidgetManager/stable/2022-12-01/widgets.json",
-          position: { line: 1, colomn: 1 },
-        } as Source,
-      ],
-      details: {},
-    };
+  test.skipIf(isWindows)(
+    "passes if new violations do not include an error (warnings only)",
+    async ({ expect }) => {
+      const afterViolation = {
+        extensionName: "@microsoft.azure/openapi-validator",
+        level: "warning",
+        code: "SomeCode",
+        message: "Some Message",
+        source: [
+          {
+            document:
+              "/home/test/specification/contosowidgetmanager/data-plane/Azure.Contoso.WidgetManager/stable/2022-12-01/widgets.json",
+            position: { line: 1, colomn: 1 },
+          } as Source,
+        ],
+        details: {},
+      };
 
-    const beforeResult = {
-      error: null,
-      stdout: "",
-      stderr: "",
-      rootPath: "",
-      readme: "file1.md",
-      tag: "",
-    } as AutorestRunResult;
-    const afterResult = {
-      error: null,
-      stdout: JSON.stringify(afterViolation),
-      stderr: "",
-      rootPath: "",
-      readme: "file1.md",
-      tag: "",
-    } as AutorestRunResult;
+      const beforeResult = {
+        error: null,
+        stdout: "",
+        stderr: "",
+        rootPath: "",
+        readme: "file1.md",
+        tag: "",
+      } as AutorestRunResult;
+      const afterResult = {
+        error: null,
+        stdout: JSON.stringify(afterViolation),
+        stderr: "",
+        rootPath: "",
+        readme: "file1.md",
+        tag: "",
+      } as AutorestRunResult;
 
-    const runCorrelations = new Map<string, BeforeAfter>([
-      ["file1.md", { before: beforeResult, after: afterResult }],
-    ]);
+      const runCorrelations = new Map<string, BeforeAfter>([
+        ["file1.md", { before: beforeResult, after: afterResult }],
+      ]);
 
-    const actual = await generateReport(
-      runCorrelations,
-      new Set<string>([
-        "specification/contosowidgetmanager/data-plane/Azure.Contoso.WidgetManager/stable/2022-12-01/widgets.json",
-      ]),
-      "/tmp/outFile",
-      "baseBranch",
-      "compareSha",
-    );
-    expect(actual).toBe(true);
-  });
+      const actual = await generateReport(
+        runCorrelations,
+        new Set<string>([
+          "specification/contosowidgetmanager/data-plane/Azure.Contoso.WidgetManager/stable/2022-12-01/widgets.json",
+        ]),
+        "/tmp/outFile",
+        "baseBranch",
+        "compareSha",
+      );
+      expect(actual).toBe(true);
+    },
+  );
 });

--- a/eng/tools/lint-diff/test/generateReport.test.ts
+++ b/eng/tools/lint-diff/test/generateReport.test.ts
@@ -1,4 +1,4 @@
-import { test, describe, expect } from "vitest";
+import { test, describe, expect, vi } from "vitest";
 import {
   iconFor,
   getLine,
@@ -272,6 +272,10 @@ describe("compareLintDiffViolations", () => {
 });
 
 describe("generateReport", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   test("fails if new violations include an error", async ({ expect }) => {
     const afterViolation = {
       extensionName: "@microsoft.azure/openapi-validator",


### PR DESCRIPTION
Fixes #33849

Warnings, errors, and fatal errors would all break the new LintDiff run. Old LintDiff would succeed (and even say "MUST FIX") if a PR introduced only new warnings.


Test run: https://github.com/Azure/azure-rest-api-specs/pull/33854
* Actions workflow (passed): https://github.com/Azure/azure-rest-api-specs/actions/runs/14373439636?pr=33854
* Legacy LintDiff (passed): https://github.com/Azure/azure-rest-api-specs/pull/33854/checks?check_run_id=40300634845