### PR TITLE
Support run mode parameter in spec-gen-sdk runner

### DIFF
--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -171,7 +171,7 @@ extends:
               fi
 
               if [ "${{ parameters.SpecBatchTypes }}" != "" ]; then
-                optional_params="$optional_params --rm ${{ parameters.SpecBatchTypes }}"
+                optional_params="$optional_params --batch-type ${{ parameters.SpecBatchTypes }}"
                 sdk_gen_info="$sdk_gen_info SpecBatchTypes: ${{ parameters.SpecBatchTypes }},"
               fi
 

--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -194,7 +194,6 @@ extends:
                 --lang $(SdkRepoName) \
                 --commit $(SpecRepoCommit) \
                 --spec-repo-url ${{ parameters.SpecRepoUrl }} \
-                --tr true \
                 $optional_params || true # return true always to suppress exit error logging
             displayName: 'Generate SDK'
 

--- a/eng/tools/spec-gen-sdk-runner/src/commands.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/commands.ts
@@ -295,7 +295,7 @@ function parseArguments(): SpecGenSdkCmdInput {
   let runMode = "release";
   const batchType: string = getArgumentValue(args, "--batch-type", "");
   const pullRequestNumber: string = getArgumentValue(args, "--pr-number", "");
-  if (!batchType) {
+  if (batchType) {
     runMode = "batch";
   } else if (pullRequestNumber) {
     runMode = "spec-pull-request";

--- a/eng/tools/spec-gen-sdk-runner/src/commands.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/commands.ts
@@ -290,8 +290,10 @@ function parseArguments(): SpecGenSdkCmdInput {
   const workingFolder: string = path.resolve(
     getArgumentValue(args, "--wf", path.join(localSpecRepoPath, "..")),
   );
+
+  // Set runMode to "release" by default
   let runMode = "release";
-  const batchType: string = getArgumentValue(args, "--bt", "");
+  const batchType: string = getArgumentValue(args, "--batch-type", "");
   const pullRequestNumber: string = getArgumentValue(args, "--pr-number", "");
   if (!batchType) {
     runMode = "batch";

--- a/eng/tools/spec-gen-sdk-runner/src/commands.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/commands.ts
@@ -146,13 +146,13 @@ export async function generateSdkForSpecPr(): Promise<number> {
 /**
  * Generate SDKs for batch specs.
  */
-export async function generateSdkForBatchSpecs(runMode: string): Promise<number> {
+export async function generateSdkForBatchSpecs(batchType: string): Promise<number> {
   // Parse the arguments
   const commandInput: SpecGenSdkCmdInput = parseArguments();
   // Construct the spec-gen-sdk command
   const specGenSdkCommand = prepareSpecGenSdkCommand(commandInput);
-  // Get the spec paths based on the run mode
-  const specConfigPaths = getSpecPaths(runMode, commandInput.localSpecRepoPath);
+  // Get the spec paths based on the batch run type
+  const specConfigPaths = getSpecPaths(batchType, commandInput.localSpecRepoPath);
 
   // Prepare variables
   let statusCode = 0;
@@ -290,13 +290,22 @@ function parseArguments(): SpecGenSdkCmdInput {
   const workingFolder: string = path.resolve(
     getArgumentValue(args, "--wf", path.join(localSpecRepoPath, "..")),
   );
+  let runMode = "release";
+  const batchType: string = getArgumentValue(args, "--bt", "");
+  const pullRequestNumber: string = getArgumentValue(args, "--pr-number", "");
+  if (!batchType) {
+    runMode = "batch";
+  } else if (pullRequestNumber) {
+    runMode = "spec-pull-request";
+  }
+
   return {
     workingFolder,
     localSpecRepoPath,
     localSdkRepoPath,
     sdkRepoName,
     sdkLanguage: sdkRepoName.replace("-pr", ""),
-    isTriggeredByPipeline: getArgumentValue(args, "--tr", "false"),
+    runMode,
     tspConfigPath: getArgumentValue(args, "--tsp-config-relative-path", ""),
     readmePath: getArgumentValue(args, "--readme-relative-path", ""),
     prNumber: getArgumentValue(args, "--pr-number", ""),
@@ -328,11 +337,11 @@ function prepareSpecGenSdkCommand(commandInput: SpecGenSdkCmdInput): string[] {
     commandInput.sdkRepoName,
     "-c",
     commandInput.specCommitSha,
-    "-t",
-    commandInput.isTriggeredByPipeline,
+    "--rm",
+    commandInput.runMode,
   );
   if (commandInput.specRepoHttpsUrl) {
-    specGenSdkCommand.push("--spec-repo-url", commandInput.specRepoHttpsUrl);
+    specGenSdkCommand.push("--spec-repo-https-url", commandInput.specRepoHttpsUrl);
   }
   if (commandInput.prNumber) {
     specGenSdkCommand.push("--pr-number", commandInput.prNumber);
@@ -359,14 +368,14 @@ function prepareSpecGenSdkCommand(commandInput: SpecGenSdkCmdInput): string[] {
 }
 
 /**
- * Get the spec paths based on the run mode.
- * @param runMode The run mode.
+ * Get the spec paths based on the batch run type.
+ * @param batchType The batch run type.
  * @param specRepoPath The specification repository path.
  * @returns The spec paths.
  */
-function getSpecPaths(runMode: string, specRepoPath: string): string[] {
+function getSpecPaths(batchType: string, specRepoPath: string): string[] {
   const specConfigPaths: string[] = [];
-  switch (runMode) {
+  switch (batchType) {
     case "all-specs": {
       specConfigPaths.push(
         ...getAllTypeSpecPaths(specRepoPath),

--- a/eng/tools/spec-gen-sdk-runner/src/index.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/index.ts
@@ -11,7 +11,7 @@ export async function main() {
   const args: string[] = process.argv.slice(2);
   // Log the arguments to the console
   console.log("Arguments passed to the script:", args.join(" "));
-  const batchType: string = getArgumentValue(args, "--bt", "");
+  const batchType: string = getArgumentValue(args, "--batch-type", "");
   const pullRequestNumber: string = getArgumentValue(args, "--pr-number", "");
   let statusCode = 0;
   if (batchType) {

--- a/eng/tools/spec-gen-sdk-runner/src/index.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/index.ts
@@ -11,11 +11,11 @@ export async function main() {
   const args: string[] = process.argv.slice(2);
   // Log the arguments to the console
   console.log("Arguments passed to the script:", args.join(" "));
-  const runMode: string = getArgumentValue(args, "--rm", "");
+  const batchType: string = getArgumentValue(args, "--bt", "");
   const pullRequestNumber: string = getArgumentValue(args, "--pr-number", "");
   let statusCode = 0;
-  if (runMode) {
-    statusCode = await generateSdkForBatchSpecs(runMode);
+  if (batchType) {
+    statusCode = await generateSdkForBatchSpecs(batchType);
   } else if (pullRequestNumber) {
     statusCode = await generateSdkForSpecPr();
   } else {

--- a/eng/tools/spec-gen-sdk-runner/src/types.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/types.ts
@@ -3,7 +3,7 @@
  */
 export interface SpecGenSdkCmdInput {
   workingFolder: string;
-  isTriggeredByPipeline: string;
+  runMode: string;
   localSpecRepoPath: string;
   localSdkRepoPath: string;
   tspConfigPath?: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "azure-rest-api-specs",
       "devDependencies": {
         "@autorest/openapi-to-typespec": "0.10.14",
-        "@azure-tools/spec-gen-sdk": "^0.3.5",
+        "@azure-tools/spec-gen-sdk": "^0.4.0",
         "@azure-tools/typespec-apiview": "0.7.0",
         "@azure-tools/typespec-autorest": "0.54.0",
         "@azure-tools/typespec-azure-core": "0.54.0",
@@ -1104,9 +1104,9 @@
       "link": true
     },
     "node_modules/@azure-tools/spec-gen-sdk": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@azure-tools/spec-gen-sdk/-/spec-gen-sdk-0.3.5.tgz",
-      "integrity": "sha512-UyPTs4LpQhH3bQsw4H+Xo9Katpqizg7MpLBzLOYAqNAufT18YHOYCEiFtc+GPci9B/QUOK6Dj8PFJ+IMZ3gTQQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/spec-gen-sdk/-/spec-gen-sdk-0.4.0.tgz",
+      "integrity": "sha512-nJQ8jCA/bKT1Qlxhukk4eY4jKxvXTHPLi7hN1RiU3i5ADplKVnHUeOLsLVHX+4Y8X9vx+/5qKJf6bHRfwHGGZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "azure-rest-api-specs",
   "devDependencies": {
-    "@azure-tools/spec-gen-sdk": "^0.3.5",
+    "@azure-tools/spec-gen-sdk": "^0.4.0",
     "@azure-tools/typespec-apiview": "0.7.0",
     "@azure-tools/typespec-autorest": "0.54.0",
     "@azure-tools/typespec-azure-core": "0.54.0",


### PR DESCRIPTION

* [`eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml`]: Changed the parameter from `--rm` to `--batch-type` for specifying batch types.
* [`eng/tools/spec-gen-sdk-runner/src/commands.ts`]: Updated the `generateSdkForBatchSpecs` function to use `batchType` instead of `runMode`, and modified related functions such as `parseArguments`, `prepareSpecGenSdkCommand`, and `getSpecPaths` to reflect this change. 
* [`eng/tools/spec-gen-sdk-runner/src/index.ts`]: Adjusted the main function to use `batchType` for generating SDKs.
* [`eng/tools/spec-gen-sdk-runner/src/types.ts`]: Replaced the `isTriggeredByPipeline` field with `runMode` in the `SpecGenSdkCmdInput` interface.