### PR TITLE
[sdk-breaking-change-labels] Improve perf of unit test from 7s to 7ms

### DIFF
--- a/.github/workflows/src/issues.js
+++ b/.github/workflows/src/issues.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * Retrieves the PR number associated with a specific commit SHA
  * @param {Object} params

--- a/.github/workflows/src/retries.js
+++ b/.github/workflows/src/retries.js
@@ -1,13 +1,17 @@
 // @ts-check
 
 /**
+ * @typedef {Object} RetryOptions
+ * @property {number} [maxRetries] Default: 3
+ * @property {number} [initialDelayMs] Default: 1000
+ * @property {number} [maxDelayMs] - Default: 10000
+ * @property {Function} [logger] - Default: console.log
+ */
+
+/**
  * Retry a function with exponential backoff
  * @param {Function} fn - Function to retry
- * @param {Object} [options]
- * @param {number} [options.maxRetries] Default: 3
- * @param {number} [options.initialDelayMs] Default: 1000
- * @param {number} [options.maxDelayMs] - Default: 10000
- * @param {Function} [options.logger] - Default: console.log
+ * @param {RetryOptions} [options] - Retry options
  * @returns {Promise<any>} - Result of the function
  */
 export async function retry(fn, options = {}) {
@@ -49,11 +53,7 @@ export async function retry(fn, options = {}) {
  * Fetch with retry functionality
  * @param {string} url - URL to fetch
  * @param {Object} [options] - Fetch options
- * @param {Object} [retryOptions]
- * @param {number} [retryOptions.maxRetries] Default: 3
- * @param {number} [retryOptions.initialDelayMs] Default: 1000
- * @param {number} [retryOptions.maxDelayMs] - Default: 10000
- * @param {Function} [retryOptions.logger] - Default: console.log
+ * @param {RetryOptions} [retryOptions] - Retry options
  * @returns {Promise<Response>} - Fetch response
  */
 export async function fetchWithRetry(url, options = {}, retryOptions = {}) {

--- a/.github/workflows/src/retries.js
+++ b/.github/workflows/src/retries.js
@@ -3,22 +3,21 @@
 /**
  * Retry a function with exponential backoff
  * @param {Function} fn - Function to retry
- * @param {Object} options - Retry options
- * @param {number} [options.maxRetries=3] - Maximum number of retries
- * @param {number} [options.initialDelayMs=1000] - Initial delay in milliseconds
- * @param {number} [options.maxDelayMs=10000] - Maximum delay in milliseconds
- * @param {Function} [options.logger] - Logger function
+ * @param {Object} [options]
+ * @param {number} [options.maxRetries] Default: 3
+ * @param {number} [options.initialDelayMs] Default: 1000
+ * @param {number} [options.maxDelayMs] - Default: 10000
+ * @param {Function} [options.logger] - Default: console.log
  * @returns {Promise<any>} - Result of the function
  */
-export async function retry(
-  fn,
-  {
+export async function retry(fn, options = {}) {
+  const {
     maxRetries = 3,
     initialDelayMs = 1000,
     maxDelayMs = 10000,
     logger = console.log,
-  } = {},
-) {
+  } = options;
+
   let lastError;
 
   for (let attempt = 0; attempt < maxRetries + 1; attempt++) {
@@ -50,7 +49,11 @@ export async function retry(
  * Fetch with retry functionality
  * @param {string} url - URL to fetch
  * @param {Object} [options] - Fetch options
- * @param {Object} [retryOptions] - Retry options
+ * @param {Object} [retryOptions]
+ * @param {number} [retryOptions.maxRetries] Default: 3
+ * @param {number} [retryOptions.initialDelayMs] Default: 1000
+ * @param {number} [retryOptions.maxDelayMs] - Default: 10000
+ * @param {Function} [retryOptions.logger] - Default: console.log
  * @returns {Promise<Response>} - Fetch response
  */
 export async function fetchWithRetry(url, options = {}, retryOptions = {}) {

--- a/.github/workflows/src/retries.js
+++ b/.github/workflows/src/retries.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * Retry a function with exponential backoff
  * @param {Function} fn - Function to retry

--- a/.github/workflows/src/sdk-breaking-change-labels.js
+++ b/.github/workflows/src/sdk-breaking-change-labels.js
@@ -44,8 +44,9 @@ export async function getLabelAndAction({ github, context, core }) {
  * @param {string} params.ado_build_id
  * @param {string} params.ado_project_url
  * @param {string} params.head_sha
- * @param {(import("@octokit/core").Octokit & import("@octokit/plugin-rest-endpoint-methods/dist-types/types.js").Api)} params.github
  * @param {typeof import("@actions/core")} params.core
+ * @param {(import("@octokit/core").Octokit & import("@octokit/plugin-rest-endpoint-methods/dist-types/types.js").Api)} params.github
+ * @param {import('./retries.js').RetryOptions} [params.retryOptions]
  * @returns {Promise<{labelName: string, labelAction: LabelAction, issueNumber: number}>}
  */
 export async function getLabelAndActionImpl({
@@ -54,7 +55,11 @@ export async function getLabelAndActionImpl({
   head_sha,
   core,
   github,
+  retryOptions = {},
 }) {
+  // Override default logger from console.log to core.info
+  retryOptions = { logger: core.info, ...retryOptions };
+
   let issue_number = NaN;
   let labelAction;
   let labelName = "";
@@ -72,7 +77,7 @@ export async function getLabelAndActionImpl({
         "Content-Type": "application/json",
       },
     },
-    { logger: core.info },
+    retryOptions,
   );
 
   if (response.status === 404) {

--- a/.github/workflows/src/sdk-breaking-change-labels.js
+++ b/.github/workflows/src/sdk-breaking-change-labels.js
@@ -1,8 +1,9 @@
 // @ts-check
+
 import { sdkLabels } from "../../src/sdk-types.js";
-import { LabelAction } from "./label.js";
 import { extractInputs } from "./context.js";
 import { getIssueNumber } from "./issues.js";
+import { LabelAction } from "./label.js";
 import { fetchWithRetry } from "./retries.js";
 
 /**

--- a/.github/workflows/test/sdk-breaking-change-labels.test.js
+++ b/.github/workflows/test/sdk-breaking-change-labels.test.js
@@ -1,15 +1,15 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { sdkLabels } from "../../src/sdk-types.js";
 import { LabelAction } from "../src/label.js";
-import {
-  createMockCore,
-  createMockGithub,
-  createMockContext,
-} from "./mocks.js";
 import {
   getLabelAndAction,
   getLabelAndActionImpl,
 } from "../src/sdk-breaking-change-labels.js";
-import { sdkLabels } from "../../src/sdk-types.js";
+import {
+  createMockContext,
+  createMockCore,
+  createMockGithub,
+} from "./mocks.js";
 
 // Mock dependencies
 vi.mock("../src/context.js", () => ({
@@ -424,6 +424,7 @@ describe("sdk-breaking-change-labels", () => {
         head_sha: inputs.head_sha,
         github: mockGithub,
         core: mockCore,
+        retryOptions: { initialDelayMs: 1 },
       });
 
       // Now expect the promise to reject

--- a/.github/workflows/test/sdk-breaking-change-labels.test.js
+++ b/.github/workflows/test/sdk-breaking-change-labels.test.js
@@ -424,6 +424,7 @@ describe("sdk-breaking-change-labels", () => {
         head_sha: inputs.head_sha,
         github: mockGithub,
         core: mockCore,
+        // Change default retry delay from 1000ms to 1ms to reduce test time
         retryOptions: { initialDelayMs: 1 },
       });
 


### PR DESCRIPTION
## Before
```
stdout | workflows/test/sdk-breaking-change-labels.test.js > sdk-breaking-change-labels > getLabelAndActionImpl error handling > should handle exception during processing
Request failed, retrying in 2000ms... (2/3)
Error: Network error

stdout | workflows/test/sdk-breaking-change-labels.test.js > sdk-breaking-change-labels > getLabelAndActionImpl error handling > should handle exception during processing
Request failed, retrying in 4000ms... (3/3)
Error: Network error
```

## After
```
Request failed, retrying in 1ms... (1/3)
Error: Network error

stdout | workflows/test/sdk-breaking-change-labels.test.js > sdk-breaking-change-labels > getLabelAndActionImpl error handling > should handle exception during processing
Request failed, retrying in 2ms... (2/3)
Error: Network error

stdout | workflows/test/sdk-breaking-change-labels.test.js > sdk-breaking-change-labels > getLabelAndActionImpl error handling > should handle exception during processing
Request failed, retrying in 4ms... (3/3)
Error: Network error
```