### PR TITLE
Revert tag change.

### DIFF
--- a/specification/resources/resource-manager/readme.md
+++ b/specification/resources/resource-manager/readme.md
@@ -26,9 +26,6 @@ These are the global settings for the Resource API.
 
 ``` yaml
 openapi-type: arm
-```
-
-``` yaml $(package-2022-12)
 tag: package-2022-12
 ```
 


### PR DESCRIPTION
Reverts change made in config that broke LintDiff/Avacado.

Requested by: https://github.com/Azure/azure-rest-api-specs/pull/33570
Caused by: https://github.com/Azure/azure-rest-api-specs/pull/32822