### PR TITLE
Add connection operations with credentials

### DIFF
--- a/specification/ai/Azure.AI.Projects/connections/models.tsp
+++ b/specification/ai/Azure.AI.Projects/connections/models.tsp
@@ -15,7 +15,6 @@ namespace Azure.AI.Projects;
 @discriminator("authType")
 @added(Versions.v2025_05_01)
 model Connection {
-
   @doc("The name of the resource")
   @visibility(Lifecycle.Read)
   @key("name")
@@ -45,7 +44,6 @@ model Connection {
 @doc("A base class for connection credentials")
 @discriminator("authType")
 model BaseCredentials {
-
   @doc("The type of credential used by the connection")
   @visibility(Lifecycle.Read)
   authType: CredentialType;
@@ -53,7 +51,6 @@ model BaseCredentials {
 
 @doc("API Key Credential definition")
 model ApiKeyCredentials extends BaseCredentials {
-
   @doc("The credentail type")
   @visibility(Lifecycle.Read)
   authType: CredentialType.apiKey;
@@ -66,7 +63,6 @@ model ApiKeyCredentials extends BaseCredentials {
 #suppress "@azure-tools/typespec-azure-core/casing-style"
 @doc("Entra ID credential definition")
 model EntraIDCredentials extends BaseCredentials {
-
   @doc("The credential type")
   @visibility(Lifecycle.Read)
   authType: CredentialType.entraId;
@@ -74,7 +70,6 @@ model EntraIDCredentials extends BaseCredentials {
 
 @doc("Custom credential defintion")
 model CustomCredential extends BaseCredentials {
-
   @doc("The credential type ")
   @visibility(Lifecycle.Read)
   authType: CredentialType.custom;
@@ -83,7 +78,6 @@ model CustomCredential extends BaseCredentials {
 #suppress "@azure-tools/typespec-azure-core/casing-style"
 @doc("Shared Access Signature (SAS) credential definition")
 model SASCredentials extends BaseCredentials {
-
   @doc("The credential type")
   @visibility(Lifecycle.Read)
   authType: CredentialType.SAS;
@@ -95,7 +89,6 @@ model SASCredentials extends BaseCredentials {
 
 @doc("Credentials that do not require authentication")
 model NoAuthenticationCredentials extends BaseCredentials {
-
   @doc("The credential type ")
   @visibility(Lifecycle.Read)
   authType: CredentialType.None;

--- a/specification/ai/Azure.AI.Projects/connections/routes.tsp
+++ b/specification/ai/Azure.AI.Projects/connections/routes.tsp
@@ -26,7 +26,7 @@ interface Connections {
   @TypeSpec.Http.post
   //@Rest.actionSeparator("/")
   //@Rest.action("withCredentials")
-  getWithCredentials is ConnectionOperations.ResourceAction<Connection, {}, Connection>;
+  withCredentials is ConnectionOperations.ResourceAction<Connection, {}, Connection>;
 
   @doc("List all connections in the project, without populating connection credentials")
   list is ConnectionOperations.ResourceList<

--- a/specification/ai/Azure.AI.Projects/connections/routes.tsp
+++ b/specification/ai/Azure.AI.Projects/connections/routes.tsp
@@ -44,24 +44,27 @@ interface Connections {
     }>
   >;
 
-  /*
   @doc("List all connections in the project, with their connection credentials")
   @TypeSpec.Http.post
-  @Rest.actionSeparator("/")
   @Rest.action("withCredentials")
-  listWithCredentials is ConnectionOperations.ResourceList<
+  listWithCredentials is ConnectionOperations.ResourceCollectionAction<
     Connection,
-    ListQueryParametersTrait<{
+    {
       @doc("List connections of this specific type")
       @query("connectionType")
       connectionType?: ConnectionType;
-
+ 
       @doc("List connections that are default connections")
       @query("defaultConnection")
       defaultConnection?: boolean;
-
+ 
       ...StandardListQueryParameters;
-    }>
+    },
+    Internal.ConnectionPaged
   >;
-  */
 }
+
+namespace Internal {
+  model ConnectionPaged is Azure.Core.Page<Connection>;
+}
+

--- a/specification/ai/Azure.AI.Projects/connections/routes.tsp
+++ b/specification/ai/Azure.AI.Projects/connections/routes.tsp
@@ -24,9 +24,9 @@ interface Connections {
 
   @doc("Get a connection by name, with its connection credentials")
   @TypeSpec.Http.post
-  //@Rest.actionSeparator("/")
-  //@Rest.action("withCredentials")
-  withCredentials is ConnectionOperations.ResourceAction<Connection, {}, Connection>;
+  @Rest.actionSeparator("/")
+  @Rest.action("withCredentials")
+  getWithCredentials is ConnectionOperations.ResourceAction<Connection, {}, Connection>;
 
   @doc("List all connections in the project, without populating connection credentials")
   list is ConnectionOperations.ResourceList<
@@ -46,6 +46,7 @@ interface Connections {
 
   @doc("List all connections in the project, with their connection credentials")
   @TypeSpec.Http.post
+  @Rest.actionSeparator("/")
   @Rest.action("withCredentials")
   listWithCredentials is ConnectionOperations.ResourceCollectionAction<
     Connection,

--- a/specification/ai/Azure.AI.Projects/connections/routes.tsp
+++ b/specification/ai/Azure.AI.Projects/connections/routes.tsp
@@ -26,7 +26,11 @@ interface Connections {
   @TypeSpec.Http.post
   @Rest.actionSeparator("/")
   @Rest.action("withCredentials")
-  getWithCredentials is ConnectionOperations.ResourceAction<Connection, {}, Connection>;
+  getWithCredentials is ConnectionOperations.ResourceAction<
+    Connection,
+    {},
+    Connection
+  >;
 
   @doc("List all connections in the project, without populating connection credentials")
   list is ConnectionOperations.ResourceList<
@@ -54,11 +58,11 @@ interface Connections {
       @doc("List connections of this specific type")
       @query("connectionType")
       connectionType?: ConnectionType;
- 
+
       @doc("List connections that are default connections")
       @query("defaultConnection")
       defaultConnection?: boolean;
- 
+
       ...StandardListQueryParameters;
     },
     Internal.ConnectionPaged
@@ -68,4 +72,3 @@ interface Connections {
 namespace Internal {
   model ConnectionPaged is Azure.Core.Page<Connection>;
 }
-

--- a/specification/ai/Azure.AI.Projects/connections/routes.tsp
+++ b/specification/ai/Azure.AI.Projects/connections/routes.tsp
@@ -23,9 +23,11 @@ interface Connections {
   get is ConnectionOperations.ResourceRead<Connection>;
 
   @doc("Get a connection by name, with its connection credentials")
-  @Rest.actionSeparator("/")
-  @Rest.action("withCredentials")
-  getWithCredentials is ConnectionOperations.ResourceRead<Connection>;
+  @TypeSpec.Http.post
+  //@Rest.actionSeparator("/")
+  //@Rest.action("withCredentials")
+  getWithCredentials is ConnectionOperations.ResourceAction<Connection, {}, Connection>;
+
   @doc("List all connections in the project, without populating connection credentials")
   list is ConnectionOperations.ResourceList<
     Connection,
@@ -41,4 +43,25 @@ interface Connections {
       ...StandardListQueryParameters;
     }>
   >;
+
+  /*
+  @doc("List all connections in the project, with their connection credentials")
+  @TypeSpec.Http.post
+  @Rest.actionSeparator("/")
+  @Rest.action("withCredentials")
+  listWithCredentials is ConnectionOperations.ResourceList<
+    Connection,
+    ListQueryParametersTrait<{
+      @doc("List connections of this specific type")
+      @query("connectionType")
+      connectionType?: ConnectionType;
+
+      @doc("List connections that are default connections")
+      @query("defaultConnection")
+      defaultConnection?: boolean;
+
+      ...StandardListQueryParameters;
+    }>
+  >;
+  */
 }

--- a/specification/ai/Azure.AI.Projects/evaluations/models.tsp
+++ b/specification/ai/Azure.AI.Projects/evaluations/models.tsp
@@ -77,5 +77,4 @@ model Evaluation {
 
   @doc("Evaluators to be used for the evaluation.")
   evaluators: Record<EvaluatorConfiguration>;
-
 }

--- a/specification/ai/Azure.AI.Projects/main.tsp
+++ b/specification/ai/Azure.AI.Projects/main.tsp
@@ -34,7 +34,10 @@ namespace Azure.AI {
   "Azure AI",
   {
     @doc("""
-      Project endpoint in the form of: https://<aiservices-id>.services.ai.azure.com/api/projects/<project-name>
+      Project endpoint. In the form "https://<your-ai-services-account-name>.services.ai.azure.com/api/projects/_project"
+      if your Foundry Hub has only one Project, or to use the default Project in your Hub. Or in the form 
+      "https://<your-ai-services-account-name>.services.ai.azure.com/api/projects/<your-project-name>" if you want to explicitly
+      specify the Foundry Project name.
       """)
     endpoint: url,
   }

--- a/specification/ai/data-plane/Azure.AI.Projects/preview/2025-05-15-preview/azure-ai-projects-1dp.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/preview/2025-05-15-preview/azure-ai-projects-1dp.json
@@ -229,9 +229,9 @@
         }
       }
     },
-    "/connections/{name}:withCredentials": {
+    "/connections/{name}/withCredentials": {
       "post": {
-        "operationId": "Connections_WithCredentials",
+        "operationId": "Connections_GetWithCredentials",
         "description": "Get a connection by name, with its connection credentials",
         "parameters": [
           {
@@ -277,7 +277,7 @@
         }
       }
     },
-    "/connections:withCredentials": {
+    "/connections/withCredentials": {
       "post": {
         "operationId": "Connections_ListWithCredentials",
         "description": "List all connections in the project, with their connection credentials",

--- a/specification/ai/data-plane/Azure.AI.Projects/preview/2025-05-15-preview/azure-ai-projects-1dp.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/preview/2025-05-15-preview/azure-ai-projects-1dp.json
@@ -229,9 +229,9 @@
         }
       }
     },
-    "/connections/{name}:getWithCredentials": {
+    "/connections/{name}:withCredentials": {
       "post": {
-        "operationId": "Connections_GetWithCredentials",
+        "operationId": "Connections_WithCredentials",
         "description": "Get a connection by name, with its connection credentials",
         "parameters": [
           {

--- a/specification/ai/data-plane/Azure.AI.Projects/preview/2025-05-15-preview/azure-ai-projects-1dp.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/preview/2025-05-15-preview/azure-ai-projects-1dp.json
@@ -19,7 +19,7 @@
       {
         "name": "endpoint",
         "in": "path",
-        "description": "Project endpoint in the form of: https://<aiservices-id>.services.ai.azure.com/api/projects/<project-name>",
+        "description": "Project endpoint. In the form \"https://<your-ai-services-account-name>.services.ai.azure.com/api/projects/_project\"\nif your Foundry Hub has only one Project, or to use the default Project in your Hub. Or in the form \n\"https://<your-ai-services-account-name>.services.ai.azure.com/api/projects/<your-project-name>\" if you want to explicitly\nspecify the Foundry Project name.",
         "required": true,
         "type": "string",
         "format": "uri",
@@ -229,8 +229,8 @@
         }
       }
     },
-    "/connections/{name}/withCredentials": {
-      "get": {
+    "/connections/{name}:getWithCredentials": {
+      "post": {
         "operationId": "Connections_GetWithCredentials",
         "description": "Get a connection by name, with its connection credentials",
         "parameters": [
@@ -589,6 +589,60 @@
         "responses": {
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/datasets/{name}/versions/{version}/credentials": {
+      "post": {
+        "operationId": "Datasets_GetCredentials",
+        "description": "Get download sas for dataset version.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "The name of the resource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The specific version id of the DatasetVersion to operate on.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Parameters for the action",
+            "required": true,
+            "schema": {
+              "type": "object"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/AssetCredentialResponse"
+            }
           },
           "default": {
             "description": "An unexpected error response.",
@@ -1402,6 +1456,19 @@
         }
       ],
       "x-ms-discriminator-value": "ApiKey"
+    },
+    "AssetCredentialResponse": {
+      "type": "object",
+      "description": "Represents a reference to a blob for consumption",
+      "properties": {
+        "blobReferenceForConsumption": {
+          "$ref": "#/definitions/BlobReferenceForConsumption",
+          "description": "Credential info to access the storage account."
+        }
+      },
+      "required": [
+        "blobReferenceForConsumption"
+      ]
     },
     "AttackStrategy": {
       "type": "string",

--- a/specification/ai/data-plane/Azure.AI.Projects/preview/2025-05-15-preview/azure-ai-projects-1dp.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/preview/2025-05-15-preview/azure-ai-projects-1dp.json
@@ -277,6 +277,135 @@
         }
       }
     },
+    "/connections:withCredentials": {
+      "post": {
+        "operationId": "Connections_ListWithCredentials",
+        "description": "List all connections in the project, with their connection credentials",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "connectionType",
+            "in": "query",
+            "description": "List connections of this specific type",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "AzureOpenAI",
+              "AzureBlob",
+              "AzureStorageAccount",
+              "CognitiveSearch",
+              "CosmosDB",
+              "ApiKey",
+              "AppConfig",
+              "AppInsights",
+              "CustomKeys"
+            ],
+            "x-ms-enum": {
+              "name": "ConnectionType",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "AzureOpenAI",
+                  "value": "AzureOpenAI",
+                  "description": "Azure OpenAI Service"
+                },
+                {
+                  "name": "AzureBlobStorage",
+                  "value": "AzureBlob",
+                  "description": "Azure Blob Storage, with specified container"
+                },
+                {
+                  "name": "AzureStorageAccount",
+                  "value": "AzureStorageAccount",
+                  "description": "Azure Blob Storage, with container not specified (used by Assistants)"
+                },
+                {
+                  "name": "AzureAISearch",
+                  "value": "CognitiveSearch",
+                  "description": "Azure AI Search"
+                },
+                {
+                  "name": "CosmosDB",
+                  "value": "CosmosDB",
+                  "description": "CosmosDB"
+                },
+                {
+                  "name": "APIKey",
+                  "value": "ApiKey",
+                  "description": "Generic connection that uses API Key authentication"
+                },
+                {
+                  "name": "ApplicationConfiguration",
+                  "value": "AppConfig",
+                  "description": "Application Configuration"
+                },
+                {
+                  "name": "ApplicationInsights",
+                  "value": "AppInsights",
+                  "description": "Application Insights"
+                },
+                {
+                  "name": "Custom",
+                  "value": "CustomKeys",
+                  "description": "Custom Keys"
+                }
+              ]
+            }
+          },
+          {
+            "name": "defaultConnection",
+            "in": "query",
+            "description": "List connections that are default connections",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.TopQueryParameter"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.SkipQueryParameter"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.MaxPageSizeQueryParameter"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.ClientRequestIdHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/Internal.ConnectionPaged"
+            },
+            "headers": {
+              "x-ms-client-request-id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "An opaque, globally-unique, client-generated string identifier for the request."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
     "/datasets": {
       "get": {
         "operationId": "Datasets_ListLatest",
@@ -2240,6 +2369,28 @@
         }
       ],
       "x-ms-discriminator-value": "dataset"
+    },
+    "Internal.ConnectionPaged": {
+      "type": "object",
+      "description": "Paged collection of Connection items",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Connection items on this page",
+          "items": {
+            "$ref": "#/definitions/Connection"
+          },
+          "x-ms-identifiers": []
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
     },
     "ListSortOrder": {
       "type": "string",

--- a/specification/ai/data-plane/Azure.AI.Projects/stable/2025-05-01/azure-ai-projects-1dp.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/stable/2025-05-01/azure-ai-projects-1dp.json
@@ -229,9 +229,9 @@
         }
       }
     },
-    "/connections/{name}:withCredentials": {
+    "/connections/{name}/withCredentials": {
       "post": {
-        "operationId": "Connections_WithCredentials",
+        "operationId": "Connections_GetWithCredentials",
         "description": "Get a connection by name, with its connection credentials",
         "parameters": [
           {
@@ -277,7 +277,7 @@
         }
       }
     },
-    "/connections:withCredentials": {
+    "/connections/withCredentials": {
       "post": {
         "operationId": "Connections_ListWithCredentials",
         "description": "List all connections in the project, with their connection credentials",

--- a/specification/ai/data-plane/Azure.AI.Projects/stable/2025-05-01/azure-ai-projects-1dp.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/stable/2025-05-01/azure-ai-projects-1dp.json
@@ -229,9 +229,9 @@
         }
       }
     },
-    "/connections/{name}:getWithCredentials": {
+    "/connections/{name}:withCredentials": {
       "post": {
-        "operationId": "Connections_GetWithCredentials",
+        "operationId": "Connections_WithCredentials",
         "description": "Get a connection by name, with its connection credentials",
         "parameters": [
           {

--- a/specification/ai/data-plane/Azure.AI.Projects/stable/2025-05-01/azure-ai-projects-1dp.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/stable/2025-05-01/azure-ai-projects-1dp.json
@@ -277,6 +277,135 @@
         }
       }
     },
+    "/connections:withCredentials": {
+      "post": {
+        "operationId": "Connections_ListWithCredentials",
+        "description": "List all connections in the project, with their connection credentials",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "connectionType",
+            "in": "query",
+            "description": "List connections of this specific type",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "AzureOpenAI",
+              "AzureBlob",
+              "AzureStorageAccount",
+              "CognitiveSearch",
+              "CosmosDB",
+              "ApiKey",
+              "AppConfig",
+              "AppInsights",
+              "CustomKeys"
+            ],
+            "x-ms-enum": {
+              "name": "ConnectionType",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "AzureOpenAI",
+                  "value": "AzureOpenAI",
+                  "description": "Azure OpenAI Service"
+                },
+                {
+                  "name": "AzureBlobStorage",
+                  "value": "AzureBlob",
+                  "description": "Azure Blob Storage, with specified container"
+                },
+                {
+                  "name": "AzureStorageAccount",
+                  "value": "AzureStorageAccount",
+                  "description": "Azure Blob Storage, with container not specified (used by Assistants)"
+                },
+                {
+                  "name": "AzureAISearch",
+                  "value": "CognitiveSearch",
+                  "description": "Azure AI Search"
+                },
+                {
+                  "name": "CosmosDB",
+                  "value": "CosmosDB",
+                  "description": "CosmosDB"
+                },
+                {
+                  "name": "APIKey",
+                  "value": "ApiKey",
+                  "description": "Generic connection that uses API Key authentication"
+                },
+                {
+                  "name": "ApplicationConfiguration",
+                  "value": "AppConfig",
+                  "description": "Application Configuration"
+                },
+                {
+                  "name": "ApplicationInsights",
+                  "value": "AppInsights",
+                  "description": "Application Insights"
+                },
+                {
+                  "name": "Custom",
+                  "value": "CustomKeys",
+                  "description": "Custom Keys"
+                }
+              ]
+            }
+          },
+          {
+            "name": "defaultConnection",
+            "in": "query",
+            "description": "List connections that are default connections",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.TopQueryParameter"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.SkipQueryParameter"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.MaxPageSizeQueryParameter"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.ClientRequestIdHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/Internal.ConnectionPaged"
+            },
+            "headers": {
+              "x-ms-client-request-id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "An opaque, globally-unique, client-generated string identifier for the request."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
     "/datasets": {
       "get": {
         "operationId": "Datasets_ListLatest",
@@ -1780,6 +1909,28 @@
           }
         ]
       }
+    },
+    "Internal.ConnectionPaged": {
+      "type": "object",
+      "description": "Paged collection of Connection items",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Connection items on this page",
+          "items": {
+            "$ref": "#/definitions/Connection"
+          },
+          "x-ms-identifiers": []
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
     },
     "ListSortOrder": {
       "type": "string",

--- a/specification/ai/data-plane/Azure.AI.Projects/stable/2025-05-01/azure-ai-projects-1dp.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/stable/2025-05-01/azure-ai-projects-1dp.json
@@ -19,7 +19,7 @@
       {
         "name": "endpoint",
         "in": "path",
-        "description": "Project endpoint in the form of: https://<aiservices-id>.services.ai.azure.com/api/projects/<project-name>",
+        "description": "Project endpoint. In the form \"https://<your-ai-services-account-name>.services.ai.azure.com/api/projects/_project\"\nif your Foundry Hub has only one Project, or to use the default Project in your Hub. Or in the form \n\"https://<your-ai-services-account-name>.services.ai.azure.com/api/projects/<your-project-name>\" if you want to explicitly\nspecify the Foundry Project name.",
         "required": true,
         "type": "string",
         "format": "uri",
@@ -229,8 +229,8 @@
         }
       }
     },
-    "/connections/{name}/withCredentials": {
-      "get": {
+    "/connections/{name}:getWithCredentials": {
+      "post": {
         "operationId": "Connections_GetWithCredentials",
         "description": "Get a connection by name, with its connection credentials",
         "parameters": [
@@ -589,6 +589,60 @@
         "responses": {
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/datasets/{name}/versions/{version}/credentials": {
+      "post": {
+        "operationId": "Datasets_GetCredentials",
+        "description": "Get download sas for dataset version.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "The name of the resource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The specific version id of the DatasetVersion to operate on.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Parameters for the action",
+            "required": true,
+            "schema": {
+              "type": "object"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/AssetCredentialResponse"
+            }
           },
           "default": {
             "description": "An unexpected error response.",
@@ -1120,6 +1174,19 @@
         }
       ],
       "x-ms-discriminator-value": "ApiKey"
+    },
+    "AssetCredentialResponse": {
+      "type": "object",
+      "description": "Represents a reference to a blob for consumption",
+      "properties": {
+        "blobReferenceForConsumption": {
+          "$ref": "#/definitions/BlobReferenceForConsumption",
+          "description": "Credential info to access the storage account."
+        }
+      },
+      "required": [
+        "blobReferenceForConsumption"
+      ]
     },
     "Azure.Core.Foundations.Error": {
       "type": "object",

--- a/specification/ai/data-plane/Azure.AI.Projects/stable/latest/azure-ai-projects-1dp.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/stable/latest/azure-ai-projects-1dp.json
@@ -229,9 +229,9 @@
         }
       }
     },
-    "/connections/{name}:withCredentials": {
+    "/connections/{name}/withCredentials": {
       "post": {
-        "operationId": "Connections_WithCredentials",
+        "operationId": "Connections_GetWithCredentials",
         "description": "Get a connection by name, with its connection credentials",
         "parameters": [
           {
@@ -277,7 +277,7 @@
         }
       }
     },
-    "/connections:withCredentials": {
+    "/connections/withCredentials": {
       "post": {
         "operationId": "Connections_ListWithCredentials",
         "description": "List all connections in the project, with their connection credentials",

--- a/specification/ai/data-plane/Azure.AI.Projects/stable/latest/azure-ai-projects-1dp.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/stable/latest/azure-ai-projects-1dp.json
@@ -229,9 +229,9 @@
         }
       }
     },
-    "/connections/{name}:getWithCredentials": {
+    "/connections/{name}:withCredentials": {
       "post": {
-        "operationId": "Connections_GetWithCredentials",
+        "operationId": "Connections_WithCredentials",
         "description": "Get a connection by name, with its connection credentials",
         "parameters": [
           {

--- a/specification/ai/data-plane/Azure.AI.Projects/stable/latest/azure-ai-projects-1dp.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/stable/latest/azure-ai-projects-1dp.json
@@ -277,6 +277,135 @@
         }
       }
     },
+    "/connections:withCredentials": {
+      "post": {
+        "operationId": "Connections_ListWithCredentials",
+        "description": "List all connections in the project, with their connection credentials",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "connectionType",
+            "in": "query",
+            "description": "List connections of this specific type",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "AzureOpenAI",
+              "AzureBlob",
+              "AzureStorageAccount",
+              "CognitiveSearch",
+              "CosmosDB",
+              "ApiKey",
+              "AppConfig",
+              "AppInsights",
+              "CustomKeys"
+            ],
+            "x-ms-enum": {
+              "name": "ConnectionType",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "AzureOpenAI",
+                  "value": "AzureOpenAI",
+                  "description": "Azure OpenAI Service"
+                },
+                {
+                  "name": "AzureBlobStorage",
+                  "value": "AzureBlob",
+                  "description": "Azure Blob Storage, with specified container"
+                },
+                {
+                  "name": "AzureStorageAccount",
+                  "value": "AzureStorageAccount",
+                  "description": "Azure Blob Storage, with container not specified (used by Assistants)"
+                },
+                {
+                  "name": "AzureAISearch",
+                  "value": "CognitiveSearch",
+                  "description": "Azure AI Search"
+                },
+                {
+                  "name": "CosmosDB",
+                  "value": "CosmosDB",
+                  "description": "CosmosDB"
+                },
+                {
+                  "name": "APIKey",
+                  "value": "ApiKey",
+                  "description": "Generic connection that uses API Key authentication"
+                },
+                {
+                  "name": "ApplicationConfiguration",
+                  "value": "AppConfig",
+                  "description": "Application Configuration"
+                },
+                {
+                  "name": "ApplicationInsights",
+                  "value": "AppInsights",
+                  "description": "Application Insights"
+                },
+                {
+                  "name": "Custom",
+                  "value": "CustomKeys",
+                  "description": "Custom Keys"
+                }
+              ]
+            }
+          },
+          {
+            "name": "defaultConnection",
+            "in": "query",
+            "description": "List connections that are default connections",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.TopQueryParameter"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.SkipQueryParameter"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.MaxPageSizeQueryParameter"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.ClientRequestIdHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/Internal.ConnectionPaged"
+            },
+            "headers": {
+              "x-ms-client-request-id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "An opaque, globally-unique, client-generated string identifier for the request."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
     "/datasets": {
       "get": {
         "operationId": "Datasets_ListLatest",
@@ -1780,6 +1909,28 @@
           }
         ]
       }
+    },
+    "Internal.ConnectionPaged": {
+      "type": "object",
+      "description": "Paged collection of Connection items",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Connection items on this page",
+          "items": {
+            "$ref": "#/definitions/Connection"
+          },
+          "x-ms-identifiers": []
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
     },
     "ListSortOrder": {
       "type": "string",

--- a/specification/ai/data-plane/Azure.AI.Projects/stable/latest/azure-ai-projects-1dp.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/stable/latest/azure-ai-projects-1dp.json
@@ -19,7 +19,7 @@
       {
         "name": "endpoint",
         "in": "path",
-        "description": "Project endpoint in the form of: https://<aiservices-id>.services.ai.azure.com/api/projects/<project-name>",
+        "description": "Project endpoint. In the form \"https://<your-ai-services-account-name>.services.ai.azure.com/api/projects/_project\"\nif your Foundry Hub has only one Project, or to use the default Project in your Hub. Or in the form \n\"https://<your-ai-services-account-name>.services.ai.azure.com/api/projects/<your-project-name>\" if you want to explicitly\nspecify the Foundry Project name.",
         "required": true,
         "type": "string",
         "format": "uri",
@@ -229,8 +229,8 @@
         }
       }
     },
-    "/connections/{name}/withCredentials": {
-      "get": {
+    "/connections/{name}:getWithCredentials": {
+      "post": {
         "operationId": "Connections_GetWithCredentials",
         "description": "Get a connection by name, with its connection credentials",
         "parameters": [
@@ -589,6 +589,60 @@
         "responses": {
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/datasets/{name}/versions/{version}/credentials": {
+      "post": {
+        "operationId": "Datasets_GetCredentials",
+        "description": "Get download sas for dataset version.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "The name of the resource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The specific version id of the DatasetVersion to operate on.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Parameters for the action",
+            "required": true,
+            "schema": {
+              "type": "object"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/AssetCredentialResponse"
+            }
           },
           "default": {
             "description": "An unexpected error response.",
@@ -1120,6 +1174,19 @@
         }
       ],
       "x-ms-discriminator-value": "ApiKey"
+    },
+    "AssetCredentialResponse": {
+      "type": "object",
+      "description": "Represents a reference to a blob for consumption",
+      "properties": {
+        "blobReferenceForConsumption": {
+          "$ref": "#/definitions/BlobReferenceForConsumption",
+          "description": "Credential info to access the storage account."
+        }
+      },
+      "required": [
+        "blobReferenceForConsumption"
+      ]
     },
     "Azure.Core.Foundations.Error": {
       "type": "object",


### PR DESCRIPTION
- Fix some issues with how URLs are shown in doc strings
- Add support for getting a connection with credentials and listing connections with credentials. With this PR, we now have the following four operations:
  - GET &nbsp; `/connections/{name}`  - Get a single connection without credentials
  - POST `/connections/{name}/withCredentials`  - Get a single connection with credentials
  - GET &nbsp; `/connections` - List connections without credentials
  - POST `/connections/withCredentials` - List connections with credentials
