### PR TITLE
[communication.messages] build: disable saving dotnet gen. metadata

### DIFF
--- a/specification/communication/Communication.Messages/tspconfig.yaml
+++ b/specification/communication/Communication.Messages/tspconfig.yaml
@@ -33,7 +33,7 @@ options:
     emitter-output-dir: "{csharp-sdk-folder}/sdk/{service-directory-name}/{namespace}/src"
     namespace: Azure.Communication.Messages
     package-dir: "Azure.Communication.Messages"
-    save-inputs: true
+    save-inputs: false
     flavor: azure
   "@azure-tools/typespec-python":
     package-pprint-name: '"Communication Messages"'


### PR DESCRIPTION
The generated output metadata for the dotnet SDK is being checked into the [azure-sdk-for-net repo](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/communication/Azure.Communication.Messages/tspCodeModel.json). Unless there's an explicit reason for keeping these metadata files (Configuration.json + tspCodeModel.json), we should disable saving them upon generation so they don't get checked in.