### PR TITLE
[.github] Change exec and git funcs to return {stdout, stderr}

### DIFF
--- a/.github/package-lock.json
+++ b/.github/package-lock.json
@@ -20,6 +20,7 @@
         "eslint": "^9.22.0",
         "globals": "^16.0.0",
         "prettier": "~3.5.3",
+        "semver": "^7.7.1",
         "typescript": "~5.8.2",
         "vitest": "^3.0.7"
       }

--- a/.github/package.json
+++ b/.github/package.json
@@ -21,6 +21,7 @@
     "eslint": "^9.22.0",
     "globals": "^16.0.0",
     "prettier": "~3.5.3",
+    "semver": "^7.7.1",
     "typescript": "~5.8.2",
     "vitest": "^3.0.7"
   },

--- a/.github/shared/package-lock.json
+++ b/.github/shared/package-lock.json
@@ -19,6 +19,7 @@
         "eslint": "^9.22.0",
         "globals": "^16.0.0",
         "prettier": "~3.5.3",
+        "semver": "^7.7.1",
         "typescript": "~5.8.2",
         "vitest": "^3.0.7"
       }

--- a/.github/shared/package.json
+++ b/.github/shared/package.json
@@ -32,6 +32,7 @@
     "eslint": "^9.22.0",
     "globals": "^16.0.0",
     "prettier": "~3.5.3",
+    "semver": "^7.7.1",
     "typescript": "~5.8.2",
     "vitest": "^3.0.7"
   },

--- a/.github/shared/src/changed-files.js
+++ b/.github/shared/src/changed-files.js
@@ -29,7 +29,7 @@ export async function getChangedFiles(options = {}) {
     logger: logger,
   });
 
-  const files = result.trim().split("\n");
+  const files = result.stdout.trim().split("\n");
 
   logger?.info("Changed Files:");
   for (const file of files) {

--- a/.github/shared/src/git.js
+++ b/.github/shared/src/git.js
@@ -7,6 +7,10 @@ import { execFile } from "./exec.js";
  */
 
 /**
+ * @typedef {import('./exec.js').ExecResult} ExecResult
+ */
+
+/**
  * @typedef {Object} GitOptions
  * @property {string[]} [args]
  * @property {string} [cwd] Current working directory. Default: process.cwd().
@@ -17,7 +21,7 @@ import { execFile } from "./exec.js";
  * @param {string} baseCommitish
  * @param {string} headCommitish
  * @param {GitOptions} [options]
- * @returns {Promise<string>}
+ * @returns {Promise<ExecResult>}
  */
 export async function diff(baseCommitish, headCommitish, options = {}) {
   const { args = [], cwd, logger } = options;
@@ -32,7 +36,7 @@ export async function diff(baseCommitish, headCommitish, options = {}) {
  * @param {string} treeIsh
  * @param {string} path
  * @param {GitOptions} [options]
- * @returns {Promise<string>}
+ * @returns {Promise<ExecResult>}
  */
 export async function lsTree(treeIsh, path, options = {}) {
   const { args = [], cwd, logger } = options;
@@ -44,7 +48,7 @@ export async function lsTree(treeIsh, path, options = {}) {
  * @param {string} treeIsh
  * @param {string} path
  * @param {GitOptions} [options]
- * @returns {Promise<string>}
+ * @returns {Promise<ExecResult>}
  */
 export async function show(treeIsh, path, options = {}) {
   const { args = [], cwd, logger } = options;
@@ -57,7 +61,7 @@ export async function show(treeIsh, path, options = {}) {
 
 /**
  * @param {GitOptions} [options]
- * @returns {Promise<string>}
+ * @returns {Promise<ExecResult>}
  */
 export async function status(options = {}) {
   const { args = [], cwd, logger } = options;
@@ -73,7 +77,7 @@ export async function status(options = {}) {
  * @param {Object} [options]
  * @param {string} [options.cwd] Current working directory. Default: process.cwd().
  * @param {ILogger} [options.logger]
- * @returns {Promise<string>}
+ * @returns {Promise<ExecResult>}
  */
 async function execGit(args, options = {}) {
   const { cwd, logger } = options;

--- a/.github/shared/test/changed-files.test.js
+++ b/.github/shared/test/changed-files.test.js
@@ -23,7 +23,10 @@ describe("changedFiles", () => {
         "specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/stable/2021-11-01/examples/Employees_Get.json",
       ];
 
-      vi.spyOn(git, "diff").mockResolvedValue(files.join("\n"));
+      vi.spyOn(git, "diff").mockResolvedValue({
+        stdout: files.join("\n"),
+        stderr: "",
+      });
 
       await expect(getChangedFiles(options)).resolves.toEqual(files);
     },

--- a/.github/shared/test/exec.test.js
+++ b/.github/shared/test/exec.test.js
@@ -1,5 +1,6 @@
+import semver from "semver";
 import { describe, expect, it } from "vitest";
-import { execFile } from "../src/exec.js";
+import { execFile, execNpm } from "../src/exec.js";
 import { consoleLogger } from "../src/logger.js";
 
 describe("execFile", () => {
@@ -10,21 +11,47 @@ describe("execFile", () => {
   it.each([{}, { logger: consoleLogger }])(
     "exec succeeds with default buffer (options: %o)",
     async (options) => {
-      await expect(execFile(file, args, options)).resolves.toEqual(expected);
+      await expect(execFile(file, args, options)).resolves.toEqual({
+        stdout: expected,
+        stderr: "",
+      });
     },
   );
 
   it("exec succeeds with exact-sized buffer", async () => {
     await expect(
       execFile(file, args, { maxBuffer: expected.length }),
-    ).resolves.toEqual(expected);
+    ).resolves.toEqual({ stdout: expected, stderr: "" });
   });
 
   it("exec fails with too-small buffer", async () => {
     await expect(
       execFile(file, args, { maxBuffer: expected.length - 1 }),
     ).rejects.toThrowError(
-      expect.objectContaining({ code: "ERR_CHILD_PROCESS_STDIO_MAXBUFFER" }),
+      expect.objectContaining({
+        stdout: "test",
+        stderr: "",
+        code: "ERR_CHILD_PROCESS_STDIO_MAXBUFFER",
+      }),
+    );
+  });
+});
+
+describe("execNpm", () => {
+  it("succeeds with --version", async () => {
+    await expect(execNpm(["--version"])).resolves.toEqual({
+      stdout: expect.toSatisfy((v) => semver.valid(v)),
+      stderr: "",
+    });
+  });
+
+  it("fails with --help", async () => {
+    await expect(execNpm(["--help"])).rejects.toThrowError(
+      expect.objectContaining({
+        stdout: expect.stringMatching(/usage/i),
+        stderr: "",
+        code: 1,
+      }),
     );
   });
 });

--- a/.github/shared/test/git.test.js
+++ b/.github/shared/test/git.test.js
@@ -7,37 +7,48 @@ import { diff, lsTree, show, status } from "../src/git.js";
 describe("git", () => {
   describe("e2e", () => {
     it("diff", async () => {
-      await expect(diff("HEAD", "HEAD")).resolves.toBe("");
+      await expect(diff("HEAD", "HEAD")).resolves.toEqual({
+        stdout: "",
+        stderr: "",
+      });
     });
 
     it("lsTree", async () => {
       // lsTree always uses "\n" in output, even on windows
-      const expected = ".github\n";
+      const expected = { stdout: ".github\n", stderr: "" };
 
       await expect(
         lsTree("HEAD", ".github", { args: ["--full-tree", "--name-only"] }),
-      ).resolves.toBe(expected);
+      ).resolves.toEqual(expected);
     });
 
     it("show", async () => {
       await expect(
         show("HEAD", ".github/shared/package.json"),
-      ).resolves.toContain("scripts");
+      ).resolves.toEqual({
+        stdout: expect.stringContaining("scripts"),
+        stderr: "",
+      });
     });
 
     it("status", async () => {
       // example: "## main...origin/main"
       await expect(
         status({ args: ["-b", "--porcelain", "does-not-exist"] }),
-      ).resolves.toContain("##");
+      ).resolves.toEqual({
+        stdout: expect.stringContaining("##"),
+        stderr: "",
+      });
     });
   });
 
   describe("mocked", () => {
     it("diff", async () => {
-      const execSpy = vi.spyOn(exec, "execFile").mockResolvedValue("test diff");
+      const execResult = { stdout: "test diff", stderr: "" };
 
-      await expect(diff("HEAD^", "HEAD")).resolves.toBe("test diff");
+      const execSpy = vi.spyOn(exec, "execFile").mockResolvedValue(execResult);
+
+      await expect(diff("HEAD^", "HEAD")).resolves.toBe(execResult);
 
       expect(execSpy).toBeCalledWith(
         "git",
@@ -47,13 +58,13 @@ describe("git", () => {
     });
 
     it("lsTree", async () => {
-      const execSpy = vi
-        .spyOn(exec, "execFile")
-        .mockResolvedValue("test lstree");
+      const execResult = { stdout: "test lstree", stderr: "" };
+
+      const execSpy = vi.spyOn(exec, "execFile").mockResolvedValue(execResult);
 
       await expect(
         lsTree("HEAD", "specification/contosowidgetmanager"),
-      ).resolves.toBe("test lstree");
+      ).resolves.toBe(execResult);
 
       expect(execSpy).toBeCalledWith(
         "git",
@@ -69,11 +80,13 @@ describe("git", () => {
     });
 
     it("show", async () => {
-      const execSpy = vi.spyOn(exec, "execFile").mockResolvedValue("test show");
+      const execResult = { stdout: "test show", stderr: "" };
+
+      const execSpy = vi.spyOn(exec, "execFile").mockResolvedValue(execResult);
 
       await expect(
         show("HEAD", "specification/contosowidgetmanager/cspell.yaml"),
-      ).resolves.toBe("test show");
+      ).resolves.toBe(execResult);
 
       expect(execSpy).toBeCalledWith(
         "git",
@@ -88,13 +101,13 @@ describe("git", () => {
     });
 
     it("status", async () => {
-      const execSpy = vi
-        .spyOn(exec, "execFile")
-        .mockResolvedValue("test status");
+      const execResult = { stdout: "test status", stderr: "" };
+
+      const execSpy = vi.spyOn(exec, "execFile").mockResolvedValue(execResult);
 
       await expect(
         status({ args: ["-b", "--porcelain", "does-not-exist"] }),
-      ).resolves.toBe("test status");
+      ).resolves.toBe(execResult);
 
       expect(execSpy).toBeCalledWith(
         "git",

--- a/.github/workflows/src/arm-incremental-typespec.js
+++ b/.github/workflows/src/arm-incremental-typespec.js
@@ -38,7 +38,7 @@ export default async function incrementalTypeSpec({ core }) {
     /** @type string */
     let swaggerText;
     try {
-      swaggerText = await show("HEAD", file, options);
+      swaggerText = (await show("HEAD", file, options)).stdout;
     } catch (e) {
       if (e instanceof Error && e.message.includes("does not exist")) {
         // To simplify logic, if PR deletes a swagger file, it's not "incremental typespec"
@@ -73,7 +73,7 @@ export default async function incrementalTypeSpec({ core }) {
 
     let readmeText;
     try {
-      readmeText = await show("HEAD", readmeFile, options);
+      readmeText = (await show("HEAD", readmeFile, options)).stdout;
     } catch (e) {
       if (e instanceof Error && e.message.includes("does not exist")) {
         // To simplify logic, if PR deletes a readme file, it's not "incremental typespec"
@@ -109,10 +109,12 @@ export default async function incrementalTypeSpec({ core }) {
 
   // Ensure that each changed spec dir contained at least one typespec-generated swagger in the base commitish
   for (const changedSpecDir of changedSpecDirs) {
-    const specFilesBaseBranch = await lsTree("HEAD^", changedSpecDir, {
-      args: ["-r", "--name-only"],
-      ...options,
-    });
+    const specFilesBaseBranch = (
+      await lsTree("HEAD^", changedSpecDir, {
+        args: ["-r", "--name-only"],
+        ...options,
+      })
+    ).stdout;
 
     // Filter files to only include RM swagger files
     const specRmSwaggerFilesBaseBranch = specFilesBaseBranch
@@ -129,7 +131,7 @@ export default async function incrementalTypeSpec({ core }) {
     let containsTypeSpecGeneratedSwagger = false;
     // TODO: Add lint rule to prevent using "for...in" instead of "for...of"
     for (const file of specRmSwaggerFilesBaseBranch) {
-      const baseSwagger = await show("HEAD^", file, options);
+      const baseSwagger = (await show("HEAD^", file, options)).stdout;
       const baseSwaggerObj = JSON.parse(baseSwagger);
       if (baseSwaggerObj["info"]?.["x-typespec-generated"]) {
         core.info(

--- a/.github/workflows/test/arm-incremental-typespec.test.js
+++ b/.github/workflows/test/arm-incremental-typespec.test.js
@@ -28,7 +28,9 @@ describe("incrementalTypeSpec", () => {
 
     vi.spyOn(changedFiles, "getChangedFiles").mockResolvedValue([swaggerPath]);
 
-    const showSpy = vi.spyOn(git, "show").mockResolvedValue(swaggerHandWritten);
+    const showSpy = vi
+      .spyOn(git, "show")
+      .mockResolvedValue({ stdout: swaggerHandWritten, stderr: "" });
 
     await expect(incrementalTypeSpec({ core })).resolves.toBe(false);
 
@@ -44,10 +46,12 @@ describe("incrementalTypeSpec", () => {
 
     const showSpy = vi
       .spyOn(git, "show")
-      .mockResolvedValue(swaggerTypeSpecGenerated);
+      .mockResolvedValue({ stdout: swaggerTypeSpecGenerated, stderr: "" });
 
     // "git ls-tree" returns "" if the spec folder doesn't exist in the base branch
-    const lsTreeSpy = vi.spyOn(git, "lsTree").mockResolvedValue("");
+    const lsTreeSpy = vi
+      .spyOn(git, "lsTree")
+      .mockResolvedValue({ stdout: "", stderr: "" });
 
     await expect(incrementalTypeSpec({ core })).resolves.toBe(false);
 
@@ -100,7 +104,9 @@ describe("incrementalTypeSpec", () => {
 
     vi.spyOn(changedFiles, "getChangedFiles").mockResolvedValue([readmePath]);
 
-    const showSpy = vi.spyOn(git, "show").mockResolvedValue("");
+    const showSpy = vi
+      .spyOn(git, "show")
+      .mockResolvedValue({ stdout: "", stderr: "" });
 
     await expect(incrementalTypeSpec({ core })).resolves.toBe(false);
 
@@ -129,13 +135,17 @@ describe("incrementalTypeSpec", () => {
 
     vi.spyOn(changedFiles, "getChangedFiles").mockResolvedValue([swaggerPath]);
 
-    const showSpy = vi
-      .spyOn(git, "show")
-      .mockImplementation((treeIsh) =>
-        treeIsh == "HEAD" ? swaggerTypeSpecGenerated : swaggerHandWritten,
-      );
+    const showSpy = vi.spyOn(git, "show").mockImplementation((treeIsh) => {
+      return {
+        stdout:
+          treeIsh == "HEAD" ? swaggerTypeSpecGenerated : swaggerHandWritten,
+        stderr: "",
+      };
+    });
 
-    const lsTreeSpy = vi.spyOn(git, "lsTree").mockResolvedValue(swaggerPath);
+    const lsTreeSpy = vi
+      .spyOn(git, "lsTree")
+      .mockResolvedValue({ stdout: swaggerPath, stderr: "" });
 
     await expect(incrementalTypeSpec({ core })).resolves.toBe(false);
 
@@ -184,9 +194,11 @@ describe("incrementalTypeSpec", () => {
 
     const showSpy = vi
       .spyOn(git, "show")
-      .mockResolvedValue(swaggerTypeSpecGenerated);
+      .mockResolvedValue({ stdout: swaggerTypeSpecGenerated, stderr: "" });
 
-    const lsTreeSpy = vi.spyOn(git, "lsTree").mockResolvedValue(swaggerPath);
+    const lsTreeSpy = vi
+      .spyOn(git, "lsTree")
+      .mockResolvedValue({ stdout: swaggerPath, stderr: "" });
 
     await expect(incrementalTypeSpec({ core })).resolves.toBe(true);
 
@@ -217,15 +229,17 @@ describe("incrementalTypeSpec", () => {
       .spyOn(git, "show")
       .mockImplementation(async (_treeIsh, path) => {
         if (path === swaggerPath) {
-          return swaggerTypeSpecGenerated;
+          return { stdout: swaggerTypeSpecGenerated, stderr: "" };
         } else if (path === readmePath) {
-          return contosoReadme;
+          return { stdout: contosoReadme, stderr: "" };
         } else {
           throw new Error("does not exist");
         }
       });
 
-    const lsTreeSpy = vi.spyOn(git, "lsTree").mockResolvedValue(swaggerPath);
+    const lsTreeSpy = vi
+      .spyOn(git, "lsTree")
+      .mockResolvedValue({ stdout: swaggerPath, stderr: "" });
 
     await expect(incrementalTypeSpec({ core })).resolves.toBe(true);
 
@@ -250,9 +264,11 @@ describe("incrementalTypeSpec", () => {
 
     const showSpy = vi
       .spyOn(git, "show")
-      .mockResolvedValue(swaggerTypeSpecGenerated);
+      .mockResolvedValue({ stdout: swaggerTypeSpecGenerated, stderr: "" });
 
-    const lsTreeSpy = vi.spyOn(git, "lsTree").mockResolvedValue(swaggerPath);
+    const lsTreeSpy = vi
+      .spyOn(git, "lsTree")
+      .mockResolvedValue({ stdout: swaggerPath, stderr: "" });
 
     await expect(incrementalTypeSpec({ core })).resolves.toBe(true);
 

--- a/eng/tools/sdk-suppressions/src/updateSdkSuppressionsLabel.ts
+++ b/eng/tools/sdk-suppressions/src/updateSdkSuppressionsLabel.ts
@@ -1,16 +1,16 @@
-import { show, status } from "@azure-tools/specs-shared/git";
-import { consoleLogger } from "@azure-tools/specs-shared/logger";
-import { writeFileSync } from "fs";
 import _ from "lodash";
-import { parseYamlContent } from "./common.js";
+import { writeFileSync } from "fs";
 import { sdkLabels, SdkName } from "./sdk.js";
 import {
-  SdkPackageSuppressionsEntry,
-  sdkSuppressionsFileName,
-  SdkSuppressionsSection,
   SdkSuppressionsYml,
+  SdkSuppressionsSection,
+  sdkSuppressionsFileName,
+  SdkPackageSuppressionsEntry,
   validateSdkSuppressionsFile,
 } from "./sdkSuppressions.js";
+import { parseYamlContent } from "./common.js";
+import { show, status } from "@azure-tools/specs-shared/git";
+import { consoleLogger } from "@azure-tools/specs-shared/logger";
 
 /**
  *

--- a/eng/tools/sdk-suppressions/src/updateSdkSuppressionsLabel.ts
+++ b/eng/tools/sdk-suppressions/src/updateSdkSuppressionsLabel.ts
@@ -26,11 +26,9 @@ import {
 export async function getSdkSuppressionsSdkNames(
   prChangeFiles: string,
   baseCommitHash: string,
-  headCommitHash: string,
+  headCommitHash: string
 ): Promise<SdkName[]> {
-  console.log(
-    `Will compare base commit: ${baseCommitHash} and head commit: ${headCommitHash} to get different SDK.`,
-  );
+  console.log(`Will compare base commit: ${baseCommitHash} and head commit: ${headCommitHash} to get different SDK.`);
   const filesChangedPaths = prChangeFiles.split(" ");
   console.log(`The pr origin changed files: ${filesChangedPaths.join(", ")}`);
   let suppressionFileList = filterSuppressionList(filesChangedPaths);
@@ -38,14 +36,8 @@ export async function getSdkSuppressionsSdkNames(
   let sdkNameList: SdkName[] = [];
   if (suppressionFileList.length > 0) {
     for (const suppressionFile of suppressionFileList) {
-      let baseSuppressionContent = await getSdkSuppressionsFileContent(
-        baseCommitHash,
-        suppressionFile,
-      );
-      const headSuppressionContent = await getSdkSuppressionsFileContent(
-        headCommitHash,
-        suppressionFile,
-      );
+      let baseSuppressionContent = await getSdkSuppressionsFileContent(baseCommitHash, suppressionFile);
+      const headSuppressionContent = await getSdkSuppressionsFileContent(headCommitHash, suppressionFile);
 
       // if the head suppression file is present but anything is wrong like schema error with it return
       const validateSdkSuppressionsFileResult =
@@ -60,9 +52,9 @@ export async function getSdkSuppressionsSdkNames(
 
       console.log(
         `updateSdkSuppressionsLabels: Will compare base suppressions content:\n ` +
-          `${JSON.stringify(baseSuppressionContent)}\n ` +
-          `and head suppressions content:\n ` +
-          `${JSON.stringify(headSuppressionContent)} to get different SDK.`,
+        `${JSON.stringify(baseSuppressionContent)}\n ` + 
+        `and head suppressions content:\n ` +
+        `${JSON.stringify(headSuppressionContent)} to get different SDK.`,
       );
 
       sdkNameList = getSdkNamesWithChangedSuppressions(
@@ -94,11 +86,11 @@ function getSdksWithSuppressionsDefined(suppressions: SdkSuppressionsSection): S
 }
 
 /**
- *
- * @param headSuppressionFile
- * @param baseSuppressionFile
+ * 
+ * @param headSuppressionFile 
+ * @param baseSuppressionFile 
  * @returns SdkName[]
- *
+ * 
  * Analyze the suppression files across three dimensions: language, package, and breaking-change. Finally, determine the outermost sdkName.
  */
 
@@ -219,7 +211,7 @@ export async function updateSdkSuppressionsLabels(
 
   const result = processLabels(presentLabels, sdkNames);
 
-  if (outputFile) {
+  if(outputFile){
     writeFileSync(outputFile, JSON.stringify(result));
     console.log(`😊 JSON output saved to ${outputFile}`);
   }
@@ -228,23 +220,20 @@ export async function updateSdkSuppressionsLabels(
 }
 
 /**
- *
- * @param presentLabels
- * @param sdkNames
+ * 
+ * @param presentLabels 
+ * @param sdkNames 
  * @returns {labelsToAdd: String[], labelsToRemove: String[]}
- *
+ * 
  * Based on the various sdknames and existing labels, process the suppression label of PR.
- *
- * Add logic:    If the breakingChangeSuppression label corresponding to an SDK in sdkNames is not in the current presentLabels list,
+ * 
+ * Add logic:    If the breakingChangeSuppression label corresponding to an SDK in sdkNames is not in the current presentLabels list, 
  *               add the label to labelsToAdd.
- * Remove logic: If a label is in presentLabels and the corresponding breakingChangeSuppression is not in sdkNames
+ * Remove logic: If a label is in presentLabels and the corresponding breakingChangeSuppression is not in sdkNames 
  *               and there is no corresponding breakingChangeSuppressionApproved label, then the label is deleted.
  *               Otherwise, the label is not deleted.
  */
-export function processLabels(
-  presentLabels: string[],
-  sdkNames: string[],
-): { labelsToAdd: String[]; labelsToRemove: String[] } {
+export function processLabels(presentLabels: string[], sdkNames: string[]): { labelsToAdd: String[]; labelsToRemove: String[] } {
   // The sdkNames indicates whether any suppression files have been modified. If it is empty
   // then check if the suppression label was previously applied and remove it if so. Otherwise, no action is needed.
   let addSdkSuppressionsLabels: string[] = [];
@@ -253,39 +242,33 @@ export function processLabels(
     const sdk = sdkLabels[sdkName as SdkName];
     const breakingChangeSuppression = sdk.breakingChangeSuppression;
     // If breakingChangeSuppression is not in the existing labels, add it to labelsToAdd
-    if (breakingChangeSuppression && !presentLabels.includes(breakingChangeSuppression)) {
+    if (
+      breakingChangeSuppression &&
+      !presentLabels.includes(breakingChangeSuppression)
+    ) {
       addSdkSuppressionsLabels.push(breakingChangeSuppression);
     }
   });
-
-  presentLabels.forEach((label) => {
+  
+  presentLabels.forEach(label => {
     // Check if it is a suppression label
-    const suppressionLabelExists = Object.values(sdkLabels).some((sdk) => {
-      return sdk.breakingChangeSuppression === label;
+    const suppressionLabelExists = Object.values(sdkLabels).some(sdk => {
+      return sdk.breakingChangeSuppression === label; 
     });
-
+  
     // If it is a suppression label
     if (suppressionLabelExists) {
       // Check if there is a corresponding approved label
-      const hasApprovedLabel = Object.values(sdkLabels).some((sdk) => {
-        return (
-          sdk.breakingChangeSuppression === label &&
-          sdk.breakingChangeSuppressionApproved &&
-          presentLabels.includes(sdk.breakingChangeSuppressionApproved)
-        );
+      const hasApprovedLabel = Object.values(sdkLabels).some(sdk => {
+        return sdk.breakingChangeSuppression === label && sdk.breakingChangeSuppressionApproved && presentLabels.includes(sdk.breakingChangeSuppressionApproved);
       });
       // If there is no corresponding approved label and there is no suppression label in sdkNames, delete it.
-      if (
-        !hasApprovedLabel &&
-        !sdkNames.some(
-          (sdkName) => sdkLabels[sdkName as SdkName].breakingChangeSuppression === label,
-        )
-      ) {
+      if (!hasApprovedLabel && !sdkNames.some(sdkName => sdkLabels[sdkName as SdkName].breakingChangeSuppression === label)) {
         removeSdkSuppressionsLabels.push(label);
       }
     }
   });
-
+  
   return {
     labelsToAdd: addSdkSuppressionsLabels,
     labelsToRemove: removeSdkSuppressionsLabels,

--- a/eng/tools/sdk-suppressions/src/updateSdkSuppressionsLabel.ts
+++ b/eng/tools/sdk-suppressions/src/updateSdkSuppressionsLabel.ts
@@ -1,16 +1,16 @@
-import _ from "lodash";
-import { writeFileSync } from "fs";
-import { sdkLabels, SdkName } from "./sdk.js";
-import {
-  SdkSuppressionsYml,
-  SdkSuppressionsSection,
-  sdkSuppressionsFileName,
-  SdkPackageSuppressionsEntry,
-  validateSdkSuppressionsFile,
-} from "./sdkSuppressions.js";
-import { parseYamlContent } from "./common.js";
 import { show, status } from "@azure-tools/specs-shared/git";
 import { consoleLogger } from "@azure-tools/specs-shared/logger";
+import { writeFileSync } from "fs";
+import _ from "lodash";
+import { parseYamlContent } from "./common.js";
+import { sdkLabels, SdkName } from "./sdk.js";
+import {
+  SdkPackageSuppressionsEntry,
+  sdkSuppressionsFileName,
+  SdkSuppressionsSection,
+  SdkSuppressionsYml,
+  validateSdkSuppressionsFile,
+} from "./sdkSuppressions.js";
 
 /**
  *
@@ -26,9 +26,11 @@ import { consoleLogger } from "@azure-tools/specs-shared/logger";
 export async function getSdkSuppressionsSdkNames(
   prChangeFiles: string,
   baseCommitHash: string,
-  headCommitHash: string
+  headCommitHash: string,
 ): Promise<SdkName[]> {
-  console.log(`Will compare base commit: ${baseCommitHash} and head commit: ${headCommitHash} to get different SDK.`);
+  console.log(
+    `Will compare base commit: ${baseCommitHash} and head commit: ${headCommitHash} to get different SDK.`,
+  );
   const filesChangedPaths = prChangeFiles.split(" ");
   console.log(`The pr origin changed files: ${filesChangedPaths.join(", ")}`);
   let suppressionFileList = filterSuppressionList(filesChangedPaths);
@@ -36,8 +38,14 @@ export async function getSdkSuppressionsSdkNames(
   let sdkNameList: SdkName[] = [];
   if (suppressionFileList.length > 0) {
     for (const suppressionFile of suppressionFileList) {
-      let baseSuppressionContent = await getSdkSuppressionsFileContent(baseCommitHash, suppressionFile);
-      const headSuppressionContent = await getSdkSuppressionsFileContent(headCommitHash, suppressionFile);
+      let baseSuppressionContent = await getSdkSuppressionsFileContent(
+        baseCommitHash,
+        suppressionFile,
+      );
+      const headSuppressionContent = await getSdkSuppressionsFileContent(
+        headCommitHash,
+        suppressionFile,
+      );
 
       // if the head suppression file is present but anything is wrong like schema error with it return
       const validateSdkSuppressionsFileResult =
@@ -52,9 +60,9 @@ export async function getSdkSuppressionsSdkNames(
 
       console.log(
         `updateSdkSuppressionsLabels: Will compare base suppressions content:\n ` +
-        `${JSON.stringify(baseSuppressionContent)}\n ` + 
-        `and head suppressions content:\n ` +
-        `${JSON.stringify(headSuppressionContent)} to get different SDK.`,
+          `${JSON.stringify(baseSuppressionContent)}\n ` +
+          `and head suppressions content:\n ` +
+          `${JSON.stringify(headSuppressionContent)} to get different SDK.`,
       );
 
       sdkNameList = getSdkNamesWithChangedSuppressions(
@@ -72,7 +80,7 @@ export async function getSdkSuppressionsFileContent(
   path: string,
 ): Promise<string | object | undefined | null> {
   try {
-    const suppressionFileContent = await show(ref, path, { logger: consoleLogger });
+    const suppressionFileContent = (await show(ref, path, { logger: consoleLogger })).stdout;
     console.log(`Found content in ${ref}#${path}`);
     return parseYamlContent(suppressionFileContent, path).result;
   } catch (error) {
@@ -86,11 +94,11 @@ function getSdksWithSuppressionsDefined(suppressions: SdkSuppressionsSection): S
 }
 
 /**
- * 
- * @param headSuppressionFile 
- * @param baseSuppressionFile 
+ *
+ * @param headSuppressionFile
+ * @param baseSuppressionFile
  * @returns SdkName[]
- * 
+ *
  * Analyze the suppression files across three dimensions: language, package, and breaking-change. Finally, determine the outermost sdkName.
  */
 
@@ -194,7 +202,7 @@ export async function updateSdkSuppressionsLabels(
   outputFile?: string,
 ): Promise<{ labelsToAdd: String[]; labelsToRemove: String[] }> {
   try {
-    const result = await status({ logger: consoleLogger });
+    const result = (await status({ logger: consoleLogger })).stdout;
     console.log("Git status:", result);
   } catch (err) {
     console.error("Error running git command:", err);
@@ -211,7 +219,7 @@ export async function updateSdkSuppressionsLabels(
 
   const result = processLabels(presentLabels, sdkNames);
 
-  if(outputFile){
+  if (outputFile) {
     writeFileSync(outputFile, JSON.stringify(result));
     console.log(`😊 JSON output saved to ${outputFile}`);
   }
@@ -220,20 +228,23 @@ export async function updateSdkSuppressionsLabels(
 }
 
 /**
- * 
- * @param presentLabels 
- * @param sdkNames 
+ *
+ * @param presentLabels
+ * @param sdkNames
  * @returns {labelsToAdd: String[], labelsToRemove: String[]}
- * 
+ *
  * Based on the various sdknames and existing labels, process the suppression label of PR.
- * 
- * Add logic:    If the breakingChangeSuppression label corresponding to an SDK in sdkNames is not in the current presentLabels list, 
+ *
+ * Add logic:    If the breakingChangeSuppression label corresponding to an SDK in sdkNames is not in the current presentLabels list,
  *               add the label to labelsToAdd.
- * Remove logic: If a label is in presentLabels and the corresponding breakingChangeSuppression is not in sdkNames 
+ * Remove logic: If a label is in presentLabels and the corresponding breakingChangeSuppression is not in sdkNames
  *               and there is no corresponding breakingChangeSuppressionApproved label, then the label is deleted.
  *               Otherwise, the label is not deleted.
  */
-export function processLabels(presentLabels: string[], sdkNames: string[]): { labelsToAdd: String[]; labelsToRemove: String[] } {
+export function processLabels(
+  presentLabels: string[],
+  sdkNames: string[],
+): { labelsToAdd: String[]; labelsToRemove: String[] } {
   // The sdkNames indicates whether any suppression files have been modified. If it is empty
   // then check if the suppression label was previously applied and remove it if so. Otherwise, no action is needed.
   let addSdkSuppressionsLabels: string[] = [];
@@ -242,33 +253,39 @@ export function processLabels(presentLabels: string[], sdkNames: string[]): { la
     const sdk = sdkLabels[sdkName as SdkName];
     const breakingChangeSuppression = sdk.breakingChangeSuppression;
     // If breakingChangeSuppression is not in the existing labels, add it to labelsToAdd
-    if (
-      breakingChangeSuppression &&
-      !presentLabels.includes(breakingChangeSuppression)
-    ) {
+    if (breakingChangeSuppression && !presentLabels.includes(breakingChangeSuppression)) {
       addSdkSuppressionsLabels.push(breakingChangeSuppression);
     }
   });
-  
-  presentLabels.forEach(label => {
+
+  presentLabels.forEach((label) => {
     // Check if it is a suppression label
-    const suppressionLabelExists = Object.values(sdkLabels).some(sdk => {
-      return sdk.breakingChangeSuppression === label; 
+    const suppressionLabelExists = Object.values(sdkLabels).some((sdk) => {
+      return sdk.breakingChangeSuppression === label;
     });
-  
+
     // If it is a suppression label
     if (suppressionLabelExists) {
       // Check if there is a corresponding approved label
-      const hasApprovedLabel = Object.values(sdkLabels).some(sdk => {
-        return sdk.breakingChangeSuppression === label && sdk.breakingChangeSuppressionApproved && presentLabels.includes(sdk.breakingChangeSuppressionApproved);
+      const hasApprovedLabel = Object.values(sdkLabels).some((sdk) => {
+        return (
+          sdk.breakingChangeSuppression === label &&
+          sdk.breakingChangeSuppressionApproved &&
+          presentLabels.includes(sdk.breakingChangeSuppressionApproved)
+        );
       });
       // If there is no corresponding approved label and there is no suppression label in sdkNames, delete it.
-      if (!hasApprovedLabel && !sdkNames.some(sdkName => sdkLabels[sdkName as SdkName].breakingChangeSuppression === label)) {
+      if (
+        !hasApprovedLabel &&
+        !sdkNames.some(
+          (sdkName) => sdkLabels[sdkName as SdkName].breakingChangeSuppression === label,
+        )
+      ) {
         removeSdkSuppressionsLabels.push(label);
       }
     }
   });
-  
+
   return {
     labelsToAdd: addSdkSuppressionsLabels,
     labelsToRemove: removeSdkSuppressionsLabels,

--- a/eng/tools/typespec-validation/src/rules/compile.ts
+++ b/eng/tools/typespec-validation/src/rules/compile.ts
@@ -5,7 +5,7 @@ import stripAnsi from "strip-ansi";
 import { RuleResult } from "../rule-result.js";
 import { Rule } from "../rule.js";
 import { TsvHost } from "../tsv-host.js";
-import { fileExists, getSuppressions } from "../utils.js";
+import { fileExists, getSuppressions, runNpm } from "../utils.js";
 import { filterAsync } from "@azure-tools/specs-shared/array";
 
 export class CompileRule implements Rule {
@@ -18,7 +18,7 @@ export class CompileRule implements Rule {
     let errorOutput = "";
 
     if (await fileExists(path.join(folder, "main.tsp"))) {
-      let [err, stdout, stderr] = await host.runNpm(
+      let [err, stdout, stderr] = await runNpm(
         ["exec", "--no", "--", "tsp", "compile", "--list-files", "--warn-as-error", folder],
       );
 
@@ -171,7 +171,7 @@ export class CompileRule implements Rule {
 
     const clientTsp = path.join(folder, "client.tsp");
     if (await fileExists(clientTsp)) {
-      let [err, stdout, stderr] = await host.runNpm(
+      let [err, stdout, stderr] = await runNpm(
         ["exec", "--no", "--", "tsp", "compile", "--no-emit", "--warn-as-error", clientTsp]
       );
       if (err) {

--- a/eng/tools/typespec-validation/src/rules/format.ts
+++ b/eng/tools/typespec-validation/src/rules/format.ts
@@ -1,6 +1,7 @@
 import { RuleResult } from "../rule-result.js";
 import { Rule } from "../rule.js";
 import { TsvHost } from "../tsv-host.js";
+import { runNpm } from "../utils.js";
 
 export class FormatRule implements Rule {
   readonly name = "Format";
@@ -11,7 +12,7 @@ export class FormatRule implements Rule {
     let stdOutput = "";
     let errorOutput = "";
 
-    let [err, stdout, stderr] = await host.runNpm(
+    let [err, stdout, stderr] = await runNpm(
       // Format parent folder to include shared files
       ["exec", "--no", "--", "tsp", "format", "../**/*.tsp"],
       folder,
@@ -23,7 +24,7 @@ export class FormatRule implements Rule {
     stdOutput += stdout;
     errorOutput += stderr;
 
-    [err, stdout, stderr] = await host.runNpm(
+    [err, stdout, stderr] = await runNpm(
       ["exec", "--no", "--", "prettier", "--write", "tspconfig.yaml"],
       folder,
     );

--- a/eng/tools/typespec-validation/src/rules/npm-prefix.ts
+++ b/eng/tools/typespec-validation/src/rules/npm-prefix.ts
@@ -1,7 +1,7 @@
 import { RuleResult } from "../rule-result.js";
 import { Rule } from "../rule.js";
 import { TsvHost } from "../tsv-host.js";
-import { normalizePath } from "../utils.js";
+import { normalizePath, runNpm } from "../utils.js";
 
 export class NpmPrefixRule implements Rule {
   readonly name = "NpmPrefix";
@@ -22,9 +22,7 @@ export class NpmPrefixRule implements Rule {
       };
     }
 
-    const actual_npm_prefix = normalizePath(
-      (await host.runNpm(["prefix"], folder))[1].trim(),
-    );
+    const actual_npm_prefix = normalizePath((await runNpm(["prefix"], folder))[1].trim());
 
     let success = true;
     let stdOutput =

--- a/eng/tools/typespec-validation/src/rules/npm-prefix.ts
+++ b/eng/tools/typespec-validation/src/rules/npm-prefix.ts
@@ -22,7 +22,9 @@ export class NpmPrefixRule implements Rule {
       };
     }
 
-    const actual_npm_prefix = normalizePath((await runNpm(["prefix"], folder))[1].trim());
+    const actual_npm_prefix = normalizePath(
+      (await runNpm(["prefix"], folder))[1].trim(),
+    );
 
     let success = true;
     let stdOutput =

--- a/eng/tools/typespec-validation/src/tsv-host.ts
+++ b/eng/tools/typespec-validation/src/tsv-host.ts
@@ -3,8 +3,6 @@ import { RuleResult } from "./rule-result.js";
 
 export interface TsvHost {
   gitOperation(folder: string): IGitOperation;
-  runFile(file: string, args: string[], cwd?: string): Promise<[Error | null, string, string]>;
-  runNpm(args: string[], cwd?: string): Promise<[Error | null, string, string]>;
   gitDiffTopSpecFolder(host: TsvHost, folder: string): Promise<RuleResult>;
   globby(patterns: string | string[], options?: GlobbyOptions): Promise<string[]>;
 }

--- a/eng/tools/typespec-validation/src/tsv-runner-host.ts
+++ b/eng/tools/typespec-validation/src/tsv-runner-host.ts
@@ -1,40 +1,12 @@
 import { globby, Options as GlobbyOptions } from "globby";
-import { dirname, join } from "path";
 import { simpleGit } from "simple-git";
 import { RuleResult } from "./rule-result.js";
 import { IGitOperation, TsvHost } from "./tsv-host.js";
-import { gitDiffTopSpecFolder, runFile } from "./utils.js";
+import { gitDiffTopSpecFolder } from "./utils.js";
 
 export class TsvRunnerHost implements TsvHost {
   gitOperation(folder: string): IGitOperation {
     return simpleGit(folder);
-  }
-
-  runFile(file: string, args: string[], cwd?: string): Promise<[Error | null, string, string]> {
-    return runFile(file, args, cwd);
-  }
-
-  runNpm(args: string[], cwd?: string): Promise<[Error | null, string, string]> {
-    const [file, defaultArgs] =
-      process.platform === "win32"
-        ? [
-            // Only way I could find to run "npm" on Windows, without using the shell (e.g. "cmd /c npm ...")
-            //
-            // "node.exe", ["--", "npm-cli.js", ...args]
-            //
-            // The "--" MUST come BEFORE "npm-cli.js", to ensure args are sent to the script unchanged.
-            // If the "--" comes after "npm-cli.js", the args sent to the script will be ["--", ...args],
-            // which is NOT equivalent, and can break if args itself contains another "--".
-
-            // example: "C:\Program Files\nodejs\node.exe"
-            process.execPath,
-
-            // example: "C:\Program Files\nodejs\node_modules\npm\bin\npm-cli.js"
-            ["--", join(dirname(process.execPath), "node_modules", "npm", "bin", "npm-cli.js")],
-          ]
-        : ["npm", []];
-
-    return this.runFile(file, [...defaultArgs, ...args], cwd);
   }
 
   gitDiffTopSpecFolder(host: TsvHost, folder: string): Promise<RuleResult> {

--- a/eng/tools/typespec-validation/src/utils.ts
+++ b/eng/tools/typespec-validation/src/utils.ts
@@ -4,6 +4,7 @@ import { access, readFile } from "fs/promises";
 import defaultPath, { join, PlatformPath } from "path";
 import { getSuppressions as getSuppressionsImpl, Suppression } from "suppressions";
 
+// Wraps execNpm() to return error (and coalesce stdout and stderr) instead of throwing
 export async function runNpm(
   args: string[],
   cwd?: string,

--- a/eng/tools/typespec-validation/src/utils.ts
+++ b/eng/tools/typespec-validation/src/utils.ts
@@ -1,23 +1,48 @@
-import { execFile } from "child_process";
+import { execFile, execNpm, isExecError } from "@azure-tools/specs-shared/exec";
+import { ConsoleLogger } from "@azure-tools/specs-shared/logger";
 import { access, readFile } from "fs/promises";
 import defaultPath, { join, PlatformPath } from "path";
-import { TsvHost } from "./tsv-host.js";
 import { getSuppressions as getSuppressionsImpl, Suppression } from "suppressions";
 
-export async function runFile(file: string, args: string[], cwd?: string) {
-  console.log(`run command:${file} ${args.join(' ')}`);
-  const { err, stdout, stderr } = (await new Promise((res) =>
-    // execFile(file, args) is more secure than exec(cmd), since the latter is vulnerable to shell injection
-    execFile(
-      file,
-      args,
-      { encoding: "utf8", maxBuffer: 1024 * 1024 * 64, cwd: cwd },
-      (err: unknown, stdout: unknown, stderr: unknown) =>
-        res({ err: err, stdout: stdout, stderr: stderr }),
-    ),
-  )) as any;
+const defaultExecOptions = { logger: new ConsoleLogger(), maxBuffer: 64 * 1024 * 1024 };
 
-  return [err, stdout, stderr] as [Error | null, string, string];
+export async function runFile(
+  file: string,
+  args: string[],
+  cwd?: string,
+): Promise<[Error | null, string, string]> {
+  try {
+    const { stdout, stderr } = await execFile(file, args, {
+      ...defaultExecOptions,
+      cwd,
+    });
+    return [null, stdout, stderr];
+  } catch (error) {
+    if (isExecError(error)) {
+      return [error, error.stdout ?? "", error.stderr ?? ""];
+    } else {
+      throw error;
+    }
+  }
+}
+
+export async function runNpm(
+  args: string[],
+  cwd?: string,
+): Promise<[Error | null, string, string]> {
+  try {
+    const { stdout, stderr } = await execNpm(args, {
+      ...defaultExecOptions,
+      cwd,
+    });
+    return [null, stdout, stderr];
+  } catch (error) {
+    if (isExecError(error)) {
+      return [error, error.stdout ?? "", error.stderr ?? ""];
+    } else {
+      throw error;
+    }
+  }
 }
 
 export async function fileExists(file: string) {

--- a/eng/tools/typespec-validation/src/utils.ts
+++ b/eng/tools/typespec-validation/src/utils.ts
@@ -1,30 +1,8 @@
-import { execFile, execNpm, isExecError } from "@azure-tools/specs-shared/exec";
+import { execNpm, isExecError } from "@azure-tools/specs-shared/exec";
 import { ConsoleLogger } from "@azure-tools/specs-shared/logger";
 import { access, readFile } from "fs/promises";
 import defaultPath, { join, PlatformPath } from "path";
 import { getSuppressions as getSuppressionsImpl, Suppression } from "suppressions";
-
-const defaultExecOptions = { logger: new ConsoleLogger(), maxBuffer: 64 * 1024 * 1024 };
-
-export async function runFile(
-  file: string,
-  args: string[],
-  cwd?: string,
-): Promise<[Error | null, string, string]> {
-  try {
-    const { stdout, stderr } = await execFile(file, args, {
-      ...defaultExecOptions,
-      cwd,
-    });
-    return [null, stdout, stderr];
-  } catch (error) {
-    if (isExecError(error)) {
-      return [error, error.stdout ?? "", error.stderr ?? ""];
-    } else {
-      throw error;
-    }
-  }
-}
 
 export async function runNpm(
   args: string[],
@@ -32,7 +10,8 @@ export async function runNpm(
 ): Promise<[Error | null, string, string]> {
   try {
     const { stdout, stderr } = await execNpm(args, {
-      ...defaultExecOptions,
+      logger: new ConsoleLogger(),
+      maxBuffer: 64 * 1024 * 1024,
       cwd,
     });
     return [null, stdout, stderr];

--- a/eng/tools/typespec-validation/src/utils.ts
+++ b/eng/tools/typespec-validation/src/utils.ts
@@ -3,6 +3,7 @@ import { ConsoleLogger } from "@azure-tools/specs-shared/logger";
 import { access, readFile } from "fs/promises";
 import defaultPath, { join, PlatformPath } from "path";
 import { getSuppressions as getSuppressionsImpl, Suppression } from "suppressions";
+import { TsvHost } from "./tsv-host.js";
 
 // Wraps execNpm() to return error (and coalesce stdout and stderr) instead of throwing
 export async function runNpm(

--- a/eng/tools/typespec-validation/test/compile.test.ts
+++ b/eng/tools/typespec-validation/test/compile.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from "vitest";
 
 vi.mock("fs/promises", () => ({
   readFile: vi.fn().mockResolvedValue('{"info": {"x-typespec-generated": true}}'),
@@ -17,9 +17,14 @@ const swaggerPath = "data-plane/Azure.Foo/preview/2022-11-01-preview/foo.json";
 const handwrittenSwaggerPath = "data-plane/Azure.Foo/preview/2021-11-01-preview/foo.json";
 
 describe("compile", function () {
+  let runNpmSpy: MockInstance;
+
   beforeEach(() => {
     vi.spyOn(utils, "fileExists").mockResolvedValue(true);
     vi.spyOn(utils, "getSuppressions").mockResolvedValue([]);
+    runNpmSpy = vi
+      .spyOn(utils, "runNpm")
+      .mockImplementation(async (args, cwd) => [null, `runNpm ${args.join(" ")} at ${cwd}`, ""]);
   });
 
   afterEach(() => {
@@ -43,9 +48,11 @@ describe("compile", function () {
       // ensure examples are skipped
       `${swaggerPath.replace("foo.json", "examples/example.json")}\n`;
 
-    host.runFile = async (_file: string, _args: string[], _cwd: string): Promise<[Error | null, string, string]> => {
-      return [null, compileOutput, ""];
-    };
+    runNpmSpy.mockImplementation(
+      async (_args: string[], _cwd?: string): Promise<[Error | null, string, string]> => {
+        return [null, compileOutput, ""];
+      },
+    );
 
     // ensure handwritten swaggers are ignored
     host.globby = async () => [swaggerPath, handwrittenSwaggerPath];
@@ -60,13 +67,15 @@ describe("compile", function () {
 
   it("should fail if no emitter was configured", async function () {
     let host = new TsvTestHost();
-    host.runFile = async (file: string, args: string[], _cwd: string): Promise<[Error | null, string, string]> => {
-      if ([file, ...args].join(' ').includes("tsp compile")) {
-        return [null, "no emitter was configured", ""];
-      } else {
-        return [null, "", ""];
-      }
-    };
+    runNpmSpy.mockImplementation(
+      async (args: string[], _cwd: string): Promise<[Error | null, string, string]> => {
+        if (args.join(" ").includes("tsp compile")) {
+          return [null, "no emitter was configured", ""];
+        } else {
+          return [null, "", ""];
+        }
+      },
+    );
 
     await expect(new CompileRule().execute(host, TsvTestHost.folder)).resolves.toMatchObject({
       success: false,
@@ -75,13 +84,15 @@ describe("compile", function () {
 
   it("should fail if no output was generated", async function () {
     let host = new TsvTestHost();
-    host.runFile = async (file: string, args: string[], _cwd: string): Promise<[Error | null, string, string]> => {
-      if ([file, ...args].join(' ').includes("tsp compile")) {
-        return [null, "no output was generated", ""];
-      } else {
-        return [null, "", ""];
-      }
-    };
+    runNpmSpy.mockImplementation(
+      async (args: string[], _cwd: string): Promise<[Error | null, string, string]> => {
+        if (args.join(" ").includes("tsp compile")) {
+          return [null, "no output was generated", ""];
+        } else {
+          return [null, "", ""];
+        }
+      },
+    );
 
     await expect(new CompileRule().execute(host, TsvTestHost.folder)).resolves.toMatchObject({
       success: false,
@@ -90,11 +101,13 @@ describe("compile", function () {
 
   it("should throw if output has no generated swaggers", async function () {
     let host = new TsvTestHost();
-    host.runFile = async (_file: string, _args: string[], _cwd: string): Promise<[Error | null, string, string]> => [
-      null,
-      "not-swagger",
-      "",
-    ];
+    runNpmSpy.mockImplementation(
+      async (_args: string[], _cwd: string): Promise<[Error | null, string, string]> => [
+        null,
+        "not-swagger",
+        "",
+      ],
+    );
 
     await expect(
       new CompileRule().execute(host, TsvTestHost.folder),
@@ -106,9 +119,11 @@ describe("compile", function () {
   it("should fail if extra swaggers", async function () {
     const host = new TsvTestHost();
 
-    host.runFile = async (_file: string, _args: string[], _cwd: string): Promise<[Error | null, string, string]> => {
-      return [null, swaggerPath, ""];
-    };
+    runNpmSpy.mockImplementation(
+      async (_args: string[], _cwd: string): Promise<[Error | null, string, string]> => {
+        return [null, swaggerPath, ""];
+      },
+    );
 
     // Simulate extra swagger
     host.globby = async () => [
@@ -132,9 +147,11 @@ describe("compile", function () {
   it("supports suppressions", async function () {
     const host = new TsvTestHost();
 
-    host.runFile = async (_file: string, _args: string[], _cwd: string): Promise<[Error | null, string, string]> => {
-      return [null, swaggerPath, ""];
-    };
+    runNpmSpy.mockImplementation(
+      async (_args: string[], _cwd: string): Promise<[Error | null, string, string]> => {
+        return [null, swaggerPath, ""];
+      },
+    );
 
     // Simulate extra swagger
     host.globby = async () => [
@@ -171,9 +188,11 @@ describe("compile", function () {
   it("throws on invalid suppressions", async function () {
     const host = new TsvTestHost();
 
-    host.runFile = async (_file: string, _args: string[], _cwd: string): Promise<[Error | null, string, string]> => {
-      return [null, swaggerPath, ""];
-    };
+    runNpmSpy.mockImplementation(
+      async (_args: string[], _cwd: string): Promise<[Error | null, string, string]> => {
+        return [null, swaggerPath, ""];
+      },
+    );
 
     vi.spyOn(utils, "getSuppressions").mockImplementation(async () => [
       {
@@ -192,21 +211,23 @@ describe("compile", function () {
 
   it("should skip git diff check if compile fails", async function () {
     let host = new TsvTestHost();
-    host.runFile = async (file: string, args: string[], _cwd: string): Promise<[Error | null, string, string]> => {
-      if ([file, ...args].join(' ').includes("tsp compile")) {
-        return [
-          { name: "compilation_error", message: "compilation error" },
-          "running tsp compile",
-          "compilation failure",
-        ];
-      }
-      return [null, "", ""];
-    };
-    host.gitDiffTopSpecFolder = async (host: TsvHost, folder: string): Promise<RuleResult> => {
-      let stdOut = `Running git diff on folder ${folder}, running default cmd ${host.runFile(
+    runNpmSpy.mockImplementation(
+      async (args: string[], _cwd: string): Promise<[Error | null, string, string]> => {
+        if (args.join(" ").includes("tsp compile")) {
+          return [
+            { name: "compilation_error", message: "compilation error" },
+            "running tsp compile",
+            "compilation failure",
+          ];
+        }
+        return [null, "", ""];
+      },
+    );
+    host.gitDiffTopSpecFolder = async (_host: TsvHost, folder: string): Promise<RuleResult> => {
+      let stdOut = `Running git diff on folder ${folder}, running default cmd ${utils.runFile(
         "",
         [],
-        ""
+        "",
       )}`;
       return {
         success: true,
@@ -223,17 +244,19 @@ describe("compile", function () {
   it("should fail if git diff fails", async function () {
     let host = new TsvTestHost();
 
-    host.runFile = async (_file: string, _args: string[], _cwd: string): Promise<[Error | null, string, string]> => {
-      return [null, swaggerPath, ""];
-    };
+    runNpmSpy.mockImplementation(
+      async (_args: string[], _cwd: string): Promise<[Error | null, string, string]> => {
+        return [null, swaggerPath, ""];
+      },
+    );
 
     host.globby = async () => [swaggerPath];
 
-    host.gitDiffTopSpecFolder = async (host: TsvHost, folder: string): Promise<RuleResult> => {
-      let stdOut = `Running git diff on folder ${folder}, running default cmd ${host.runFile(
+    host.gitDiffTopSpecFolder = async (_host: TsvHost, folder: string): Promise<RuleResult> => {
+      let stdOut = `Running git diff on folder ${folder}, running default cmd ${utils.runFile(
         "",
         [],
-        ""
+        "",
       )}`;
 
       return {
@@ -252,14 +275,16 @@ describe("compile", function () {
   it("should succeed if git diff succeeds", async function () {
     let host = new TsvTestHost();
 
-    host.runFile = async (_file: string, _args: string[], _cwd: string): Promise<[Error | null, string, string]> => {
-      return [null, swaggerPath, ""];
-    };
+    runNpmSpy.mockImplementation(
+      async (_args: string[], _cwd: string): Promise<[Error | null, string, string]> => {
+        return [null, swaggerPath, ""];
+      },
+    );
 
     host.globby = async () => [swaggerPath];
 
     host.gitDiffTopSpecFolder = async (host: TsvHost, folder: string): Promise<RuleResult> => {
-      let stdOut = `Running git diff on folder ${folder}, running default cmd ${host.runFile(
+      let stdOut = `Running git diff on folder ${folder}, running default cmd ${utils.runFile(
         "",
         [],
         "",

--- a/eng/tools/typespec-validation/test/compile.test.ts
+++ b/eng/tools/typespec-validation/test/compile.test.ts
@@ -275,7 +275,7 @@ describe("compile", function () {
 
     host.globby = async () => [swaggerPath];
 
-    host.gitDiffTopSpecFolder = async (host: TsvHost, folder: string): Promise<RuleResult> => {
+    host.gitDiffTopSpecFolder = async (_host: TsvHost, folder: string): Promise<RuleResult> => {
       let stdOut = `Running git diff on folder ${folder}`;
       return {
         success: true,

--- a/eng/tools/typespec-validation/test/compile.test.ts
+++ b/eng/tools/typespec-validation/test/compile.test.ts
@@ -224,11 +224,7 @@ describe("compile", function () {
       },
     );
     host.gitDiffTopSpecFolder = async (_host: TsvHost, folder: string): Promise<RuleResult> => {
-      let stdOut = `Running git diff on folder ${folder}, running default cmd ${utils.runFile(
-        "",
-        [],
-        "",
-      )}`;
+      let stdOut = `Running git diff on folder ${folder}`;
       return {
         success: true,
         stdOutput: stdOut,
@@ -253,11 +249,7 @@ describe("compile", function () {
     host.globby = async () => [swaggerPath];
 
     host.gitDiffTopSpecFolder = async (_host: TsvHost, folder: string): Promise<RuleResult> => {
-      let stdOut = `Running git diff on folder ${folder}, running default cmd ${utils.runFile(
-        "",
-        [],
-        "",
-      )}`;
+      let stdOut = `Running git diff on folder ${folder}`;
 
       return {
         success: false,
@@ -284,11 +276,7 @@ describe("compile", function () {
     host.globby = async () => [swaggerPath];
 
     host.gitDiffTopSpecFolder = async (host: TsvHost, folder: string): Promise<RuleResult> => {
-      let stdOut = `Running git diff on folder ${folder}, running default cmd ${utils.runFile(
-        "",
-        [],
-        "",
-      )}`;
+      let stdOut = `Running git diff on folder ${folder}`;
       return {
         success: true,
         stdOutput: stdOut,

--- a/eng/tools/typespec-validation/test/tsv-test-host.ts
+++ b/eng/tools/typespec-validation/test/tsv-test-host.ts
@@ -2,7 +2,6 @@ import { Options as GlobbyOptions } from "globby";
 import defaultPath, { PlatformPath } from "path";
 import { RuleResult } from "../src/rule-result.js";
 import { IGitOperation, TsvHost } from "../src/tsv-host.js";
-import { runFile } from "../src/utils.js";
 
 export { IGitOperation } from "../src/tsv-host.js";
 
@@ -35,9 +34,9 @@ export class TsvTestHost implements TsvHost {
     };
   }
 
-  async gitDiffTopSpecFolder(host: TsvHost, folder: string): Promise<RuleResult> {
+  async gitDiffTopSpecFolder(_host: TsvHost, folder: string): Promise<RuleResult> {
     let success = true;
-    let stdout = `Running git diff on folder ${folder}, running default cmd ${runFile("", [], "")}`;
+    let stdout = `Running git diff on folder ${folder}}`;
     let stderr = "";
 
     return {

--- a/eng/tools/typespec-validation/test/tsv-test-host.ts
+++ b/eng/tools/typespec-validation/test/tsv-test-host.ts
@@ -1,7 +1,8 @@
 import { Options as GlobbyOptions } from "globby";
-import defaultPath, { dirname, join, PlatformPath } from "path";
+import defaultPath, { PlatformPath } from "path";
 import { RuleResult } from "../src/rule-result.js";
 import { IGitOperation, TsvHost } from "../src/tsv-host.js";
+import { runFile } from "../src/utils.js";
 
 export { IGitOperation } from "../src/tsv-host.js";
 
@@ -34,35 +35,9 @@ export class TsvTestHost implements TsvHost {
     };
   }
 
-  async runFile(
-    file: string,
-    args: string[],
-    cwd?: string,
-  ): Promise<[Error | null, string, string]> {
-    let err = null;
-    let stdout = `default ${file} ${args.join(" ")} at ${cwd}`;
-    let stderr = "";
-
-    return [err, stdout, stderr];
-  }
-
-  async runNpm(args: string[], cwd?: string): Promise<[Error | null, string, string]> {
-    const [file, defaultArgs] =
-      process.platform === "win32"
-        ? // Only way I could find to run "npm" on Windows, without using the shell (e.g. "cmd /c npm ...")
-          // "C:\Program Files\nodejs\node.exe", ["C:\Program Files\nodejs\node_modules\npm\bin\npm-cli.js"]
-          [
-            process.execPath,
-            [join(dirname(process.execPath), "node_modules", "npm", "bin", "npm-cli.js")],
-          ]
-        : ["npm", []];
-
-    return this.runFile(file, [...defaultArgs, ...args], cwd);
-  }
-
   async gitDiffTopSpecFolder(host: TsvHost, folder: string): Promise<RuleResult> {
     let success = true;
-    let stdout = `Running git diff on folder ${folder}, running default cmd ${host.runFile("", [], "")}`;
+    let stdout = `Running git diff on folder ${folder}, running default cmd ${runFile("", [], "")}`;
     let stderr = "";
 
     return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "eslint": "^9.22.0",
         "globals": "^16.0.0",
         "prettier": "~3.5.3",
+        "semver": "^7.7.1",
         "typescript": "~5.8.2",
         "vitest": "^3.0.7"
       }


### PR DESCRIPTION
- Change exec and git funcs to return {stdout: string, stderr: string}
- Update all consumers of exec and git funcs
- Add execNpm() helper to shared
- TypeSpecValidation: Remove host.runFile() and host.runNpm()
