### PR TITLE
[Storage] `set_properties` TypeSpec Change

### DIFF
--- a/specification/storage/Microsoft.BlobStorage/client.tsp
+++ b/specification/storage/Microsoft.BlobStorage/client.tsp
@@ -26,6 +26,7 @@ model BlobServiceClientParameters {
 @@clientName(Storage.Blob.Container.Blob.AppendBlob, "AppendBlobClient", "rust");
 @@clientName(Storage.Blob.Container.Blob.BlockBlob, "BlockBlobClient", "rust");
 @@clientName(Storage.Blob.Container.Blob.PageBlob, "PageBlobClient", "rust");
+@@clientName(Storage.Blob.Container.Blob.setHttpHeaders, "SetProperties", "rust")
 
 @@clientInitialization(Storage.Blob.Container,
   {

--- a/specification/storage/Microsoft.BlobStorage/client.tsp
+++ b/specification/storage/Microsoft.BlobStorage/client.tsp
@@ -26,7 +26,7 @@ model BlobServiceClientParameters {
 @@clientName(Storage.Blob.Container.Blob.AppendBlob, "AppendBlobClient", "rust");
 @@clientName(Storage.Blob.Container.Blob.BlockBlob, "BlockBlobClient", "rust");
 @@clientName(Storage.Blob.Container.Blob.PageBlob, "PageBlobClient", "rust");
-@@clientName(Storage.Blob.Container.Blob.setHttpHeaders, "SetProperties", "rust")
+@@clientName(Storage.Blob.Container.Blob.setHttpHeaders, "SetProperties", "rust");
 
 @@clientInitialization(Storage.Blob.Container,
   {

--- a/specification/storage/Microsoft.BlobStorage/routes.tsp
+++ b/specification/storage/Microsoft.BlobStorage/routes.tsp
@@ -876,10 +876,6 @@ namespace Storage.Blob {
           ...IfTagsParameter;
         },
         {
-          ...EtagResponseHeader;
-          ...LastModifiedResponseHeader;
-          ...BlobSequenceNumberResponseHeader;
-          ...DateResponseHeader;
         }
       >;
 


### PR DESCRIPTION
Typespec changes:
- Renamed `set_http_headers` -> `set_properties`
- Omit `EtagResponseHeader`, `LastModifiedResponseHeader`, `BlobSequenceNumberResponseHeader`, and `DateResponseHeader`