### PR TITLE
[Storage] `set_metadata` TypeSpec Changes

### DIFF
--- a/specification/storage/Microsoft.BlobStorage/routes.tsp
+++ b/specification/storage/Microsoft.BlobStorage/routes.tsp
@@ -965,13 +965,6 @@ namespace Storage.Blob {
           ...IfTagsParameter;
         },
         {
-          ...EtagResponseHeader;
-          ...LastModifiedResponseHeader;
-          ...VersionIdResponseHeader;
-          ...DateResponseHeader;
-          ...IsServerEncryptedResponseHeader;
-          ...EncryptionKeySha256ResponseHeader;
-          ...EncryptionScopeResponseHeader;
         }
       >;
 


### PR DESCRIPTION
Typespec changes:

- Omit `date`, `last_modified`, `etag`, `encryption_key_sha256`, `encryption_scope`, `is_server_encrypted`, and `version_id` from `BlobClientSetMetadataResult` to effectively yield `Response<()>`