### PR TITLE
[Storage] [ContainerClient] `set_metadata` TypeSpec Changes

### DIFF
--- a/specification/storage/Microsoft.BlobStorage/routes.tsp
+++ b/specification/storage/Microsoft.BlobStorage/routes.tsp
@@ -259,9 +259,6 @@ namespace Storage.Blob {
         ...IfModifiedSinceParameter;
       },
       {
-        ...EtagResponseHeader;
-        ...LastModifiedResponseHeader;
-        ...DateResponseHeader;
       }
     >;
 


### PR DESCRIPTION
This PR omits the `EtagResponseHeader`, `LastModifiedResponseHeader` andc `DateResponseHeader` to result in an empty `Result<()>`