### PR TITLE
[Avocado] GH Action should support label Approved-Avocado

### DIFF
--- a/.github/workflows/arm-auto-signoff.yaml
+++ b/.github/workflows/arm-auto-signoff.yaml
@@ -6,7 +6,7 @@ on:
       - edited
   # Must run on pull_request_target instead of pull_request, since the latter cannot trigger on
   # labels from bot accounts in fork PRs. pull_request_target is also more similar to the other
-  # triggers "issue_comment" and "workflow_run" -- they are all privileged# and run in the target
+  # triggers "issue_comment" and "workflow_run" -- they are all privileged and run in the target
   # branch and repo -- which simplifies implementation.
   pull_request_target:
     types:

--- a/.github/workflows/arm-auto-signoff.yaml
+++ b/.github/workflows/arm-auto-signoff.yaml
@@ -6,7 +6,7 @@ on:
       - edited
   # Must run on pull_request_target instead of pull_request, since the latter cannot trigger on
   # labels from bot accounts in fork PRs. pull_request_target is also more similar to the other
-  # triggers "issue_comment" and "workflow_run" -- they are all privileged and run in the target
+  # triggers "issue_comment" and "workflow_run" -- they are all privileged# and run in the target
   # branch and repo -- which simplifies implementation.
   pull_request_target:
     types:

--- a/.github/workflows/avocado-code.yml
+++ b/.github/workflows/avocado-code.yml
@@ -1,4 +1,4 @@
-name: "[TEST-IGNORE] Swagger Avocado"
+name: "[TEST-IGNORE] Swagger Avocado - Analyze Code"
 
 on: pull_request
 
@@ -6,8 +6,8 @@ permissions:
   contents: read
 
 jobs:
-  avocado:
-    name: "[TEST-IGNORE] Swagger Avocado"
+  avocado-code:
+    name: "[TEST-IGNORE] Swagger Avocado - Analyze Code"
 
     runs-on: ubuntu-24.04
 

--- a/.github/workflows/avocado-status.yml
+++ b/.github/workflows/avocado-status.yml
@@ -3,8 +3,8 @@ name: "[TEST-IGNORE] Swagger Avocado - Set Status"
 on:
   # Must run on pull_request_target instead of pull_request, since the latter cannot trigger on
   # labels from bot accounts in fork PRs. pull_request_target is also more similar to the other
-  # triggers "issue_comment" and "workflow_run" -- they are all privileged and run in the target
-  # branch and repo -- which simplifies implementation.
+  # trigger "workflow_run" -- they are both privileged and run in the target branch and repo --
+  # which simplifies implementation.
   pull_request_target:
     types:
       # Run workflow on default types, to update status as quickly as possible.

--- a/.github/workflows/avocado-status.yml
+++ b/.github/workflows/avocado-status.yml
@@ -7,6 +7,10 @@ on:
   # branch and repo -- which simplifies implementation.
   pull_request_target:
     types:
+      # Run workflow on default types, to update status as quickly as possible.
+      - opened
+      - synchronize
+      - reopened
       # Depends on labels, so must re-evaluate whenever a relevant label is manually added or removed.
       - labeled
       - unlabeled

--- a/.github/workflows/avocado-status.yml
+++ b/.github/workflows/avocado-status.yml
@@ -22,7 +22,6 @@ jobs:
   avocado-status:
     name: "[TEST-IGNORE] Swagger Avocado - Set Status"
 
-    # Filter to only label "Approved-Avocado"
     if: |
       github.event_name == 'workflow_run' ||
       (github.event_name == 'pull_request_target' &&

--- a/.github/workflows/avocado-status.yml
+++ b/.github/workflows/avocado-status.yml
@@ -11,7 +11,7 @@ on:
       - labeled
       - unlabeled
   workflow_run:
-    workflows: ["ARM Incremental TypeSpec"]
+    workflows: ["[TEST-IGNORE] Swagger Avocado - Analyze Code"]
     types: [completed]
 
 permissions:
@@ -20,6 +20,13 @@ permissions:
 jobs:
   avocado-status:
     name: "[TEST-IGNORE] Swagger Avocado - Set Status"
+
+    # Filter to only label "Approved-Avocado"
+    if: |
+      github.event_name == 'workflow_run' ||
+      (github.event_name == 'pull_request_target' &&
+       (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
+       (github.event.label.name == 'Approved-Avocado'))
 
     runs-on: ubuntu-24.04
 

--- a/.github/workflows/avocado-status.yml
+++ b/.github/workflows/avocado-status.yml
@@ -1,0 +1,47 @@
+name: "[TEST-IGNORE] Swagger Avocado - Set Status"
+
+on:
+  # Must run on pull_request_target instead of pull_request, since the latter cannot trigger on
+  # labels from bot accounts in fork PRs. pull_request_target is also more similar to the other
+  # triggers "issue_comment" and "workflow_run" -- they are all privileged and run in the target
+  # branch and repo -- which simplifies implementation.
+  pull_request_target:
+    types:
+      # Depends on labels, so must re-evaluate whenever a relevant label is manually added or removed.
+      - labeled
+      - unlabeled
+  workflow_run:
+    workflows: ["ARM Incremental TypeSpec"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  avocado-status:
+    name: "[TEST-IGNORE] Swagger Avocado - Set Status"
+
+    runs-on: ubuntu-24.04
+
+    steps:
+      # *** IMPORTANT ***
+      # For workflows that are triggered by the pull_request_target event, the workflow runs in the
+      # context of the base of the pull request.  You should make sure that you do not check out,
+      # build, or run untrusted code from the head of the pull request.
+      - uses: actions/checkout@v4
+        with:
+          # Only needs .github folder for automation, not the files in the PR (analyzed in a
+          # separate workflow).
+          #
+          # Uses the .github folder from the PR base branch (pull_request_target trigger),
+          # or the repo default branch (other triggers).
+          sparse-checkout: |
+            .github
+
+      - name: "Swagger Avocado - Set Status"
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { default: setStatus } =
+                await import('${{ github.workspace }}/.github/workflows/src/avocado-status.js');
+            return await setStatus({ github, context, core });

--- a/.github/workflows/avocado-status.yml
+++ b/.github/workflows/avocado-status.yml
@@ -29,8 +29,11 @@ jobs:
     if: |
       github.event_name == 'workflow_run' ||
       (github.event_name == 'pull_request_target' &&
-       (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
-       (github.event.label.name == 'Approved-Avocado'))
+       ((github.event.action == 'opened' ||
+         github.event.action == 'synchronize' ||
+         github.event.action == 'reopened') ||
+        ((github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
+         (github.event.label.name == 'Approved-Avocado'))))
 
     runs-on: ubuntu-24.04
 

--- a/.github/workflows/avocado-status.yml
+++ b/.github/workflows/avocado-status.yml
@@ -11,7 +11,7 @@ on:
       - labeled
       - unlabeled
   workflow_run:
-    workflows: ["[TEST-IGNORE] Swagger Avocado - Analyze Code"]
+    workflows: ["\\[TEST-IGNORE\\] Swagger Avocado - Analyze Code"]
     types: [completed]
 
 permissions:

--- a/.github/workflows/avocado-status.yml
+++ b/.github/workflows/avocado-status.yml
@@ -16,6 +16,7 @@ on:
 
 permissions:
   contents: read
+  statuses: write
 
 jobs:
   avocado-status:

--- a/.github/workflows/avocado-status.yml
+++ b/.github/workflows/avocado-status.yml
@@ -19,7 +19,10 @@ on:
     types: [completed]
 
 permissions:
+  actions: read
   contents: read
+  issues: read
+  pull-requests: read
   statuses: write
 
 jobs:

--- a/.github/workflows/src/avocado-status.js
+++ b/.github/workflows/src/avocado-status.js
@@ -1,9 +1,34 @@
 // @ts-check
 
+import { extractInputs } from "./context.js";
+
 /**
  * @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments
  * @returns {Promise<void>}
  */
-export default async function getStatus({ core }) {
-  core.info("avocado-status.js:getSatus()");
+export default async function getStatus({ github, context, core }) {
+  core.info("avocado-status.js:getStatus()");
+
+  const { owner, repo, head_sha } = await extractInputs(github, context, core);
+
+  // TODO
+  // - Get status of check avocado-code
+  // - If success, set status to success
+  // - If fail, get status of label Approved-Avocado
+  // - If label, set status to neutral
+  // - If no label, set status to failed
+
+  const target_url =
+    `https://github.com/${context.repo.owner}/${context.repo.repo}` +
+    `/actions/runs/${context.runId}`;
+
+  github.rest.repos.createCommitStatus({
+    owner,
+    repo,
+    sha: head_sha,
+    state: "pending",
+    context: "[TEST IGNORE] Swagger Avocado",
+    description: "Check is running...",
+    target_url,
+  });
 }

--- a/.github/workflows/src/avocado-status.js
+++ b/.github/workflows/src/avocado-status.js
@@ -90,7 +90,6 @@ export default async function getStatus({ github, context, core }) {
       sha: head_sha,
       state: "pending",
       context: statusName,
-      description: "Check is running...",
       target_url,
     });
   }

--- a/.github/workflows/src/avocado-status.js
+++ b/.github/workflows/src/avocado-status.js
@@ -82,7 +82,7 @@ export default async function getStatus({ github, context, core }) {
     // TODO: Can we update to deep-link directly to the failure?
     // Current: https://github.com/mikeharder/azure-rest-api-specs/actions/runs/14509047569
     // Desired: ^+/job/40703679014?pr=18
-    target_url = run.url;
+    target_url = run.html_url;
   }
 
   if (run?.status === "completed") {

--- a/.github/workflows/src/avocado-status.js
+++ b/.github/workflows/src/avocado-status.js
@@ -18,7 +18,8 @@ export default async function getStatus({ github, context, core }) {
     core,
   );
 
-  const target_url =
+  // Default target is this run itself
+  let target_url =
     `https://github.com/${context.repo.owner}/${context.repo.repo}` +
     `/actions/runs/${context.runId}`;
 
@@ -41,6 +42,7 @@ export default async function getStatus({ github, context, core }) {
       description: "Found label 'Approved-Avocado'",
       target_url,
     });
+
     return;
   }
 
@@ -72,6 +74,13 @@ export default async function getStatus({ github, context, core }) {
   // Sorted by "updated_at" descending, so most recent run is at index 0
   const run = avocadoCodeRuns[0];
 
+  if (run) {
+    // Update target to the "Analyze Code" run, which contains the meaningful output.
+    target_url =
+      `https://github.com/${context.repo.owner}/${context.repo.repo}` +
+      `/actions/runs/${run.id}`;
+  }
+
   if (run?.status === "completed") {
     const state = run.conclusion === "success" ? "success" : "failure";
 
@@ -84,6 +93,7 @@ export default async function getStatus({ github, context, core }) {
       target_url,
     });
   } else {
+    // Run was not found (not started), or not completed
     await github.rest.repos.createCommitStatus({
       owner,
       repo,

--- a/.github/workflows/src/avocado-status.js
+++ b/.github/workflows/src/avocado-status.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 import { extractInputs } from "./context.js";
+import { PER_PAGE_MAX } from "./github.js";
 
 /**
  * @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments
@@ -9,7 +10,37 @@ import { extractInputs } from "./context.js";
 export default async function getStatus({ github, context, core }) {
   core.info("avocado-status.js:getStatus()");
 
-  const { owner, repo, head_sha } = await extractInputs(github, context, core);
+  const { owner, repo, head_sha, issue_number } = await extractInputs(
+    github,
+    context,
+    core,
+  );
+
+  const target_url =
+    `https://github.com/${context.repo.owner}/${context.repo.repo}` +
+    `/actions/runs/${context.runId}`;
+
+  // TODO: Try to extract labels from context (when available) to avoid unnecessary API call
+  const labels = await github.paginate(github.rest.issues.listLabelsOnIssue, {
+    owner: owner,
+    repo: repo,
+    issue_number: issue_number,
+    per_page: PER_PAGE_MAX,
+  });
+  const labelNames = labels.map((label) => label.name);
+
+  if (labelNames.includes("Approved-Avocado")) {
+    await github.rest.repos.createCommitStatus({
+      owner,
+      repo,
+      sha: head_sha,
+      state: "success",
+      context: "[TEST IGNORE] Swagger Avocado",
+      description: "Succeeded due to label 'Approved-Avocado'",
+      target_url,
+    });
+    return;
+  }
 
   // TODO
   // - Get status of check avocado-code
@@ -18,11 +49,23 @@ export default async function getStatus({ github, context, core }) {
   // - If label, set status to neutral
   // - If no label, set status to failed
 
-  const target_url =
-    `https://github.com/${context.repo.owner}/${context.repo.repo}` +
-    `/actions/runs/${context.runId}`;
+  const workflowRuns = await github.paginate(
+    github.rest.actions.listWorkflowRunsForRepo,
+    {
+      owner,
+      repo,
+      event: "pull_request",
+      head_sha,
+      per_page: PER_PAGE_MAX,
+    },
+  );
 
-  github.rest.repos.createCommitStatus({
+  core.info("Workflow Runs:");
+  workflowRuns.forEach((wf) => {
+    core.info(`- ${wf.name}: ${wf.conclusion || wf.status}`);
+  });
+
+  await github.rest.repos.createCommitStatus({
     owner,
     repo,
     sha: head_sha,

--- a/.github/workflows/src/avocado-status.js
+++ b/.github/workflows/src/avocado-status.js
@@ -78,9 +78,11 @@ export default async function getStatus({ github, context, core }) {
 
   if (run) {
     // Update target to the "Analyze Code" run, which contains the meaningful output.
-    target_url =
-      `https://github.com/${context.repo.owner}/${context.repo.repo}` +
-      `/actions/runs/${run.id}`;
+    //
+    // TODO: Can we update to deep-link directly to the failure?
+    // Current: https://github.com/mikeharder/azure-rest-api-specs/actions/runs/14509047569
+    // Desired: ^+/job/40703679014?pr=18
+    target_url = run.url;
   }
 
   if (run?.status === "completed") {

--- a/.github/workflows/src/avocado-status.js
+++ b/.github/workflows/src/avocado-status.js
@@ -32,14 +32,22 @@ export default async function getStatus({ github, context, core }) {
   });
   const labelNames = labels.map((label) => label.name);
 
+  core.info(`Labels: ${labelNames}`);
+
   if (labelNames.includes("Approved-Avocado")) {
+    const description = "Found label 'Approved-Avocado'";
+    core.info(description);
+
+    const state = "success";
+    core.info(`Setting status to '${state}'`);
+
     await github.rest.repos.createCommitStatus({
       owner,
       repo,
       sha: head_sha,
-      state: "success",
+      state,
       context: statusName,
-      description: "Found label 'Approved-Avocado'",
+      description,
       target_url,
     });
 

--- a/.github/workflows/src/avocado-status.js
+++ b/.github/workflows/src/avocado-status.js
@@ -71,7 +71,9 @@ export default async function getStatus({ github, context, core }) {
         new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
     );
 
-  // Sorted by "updated_at" descending, so most recent run is at index 0
+  // Sorted by "updated_at" descending, so most recent run is at index 0.
+  // If "avocadoCodeRuns.length === 0", run will be "undefined", which the following
+  // code must handle.
   const run = avocadoCodeRuns[0];
 
   if (run) {

--- a/.github/workflows/src/avocado-status.js
+++ b/.github/workflows/src/avocado-status.js
@@ -103,7 +103,7 @@ export default async function getStatus({ github, context, core }) {
       const failedJobs = jobs.filter((job) => job.conclusion === "failure");
       const failedJob = failedJobs[0];
       if (failedJob?.html_url) {
-        target_url = failedJob.html_url;
+        target_url = `${failedJob.html_url}?pr=${issue_number}`;
       }
     }
   }

--- a/.github/workflows/src/avocado-status.js
+++ b/.github/workflows/src/avocado-status.js
@@ -5,12 +5,14 @@ import { PER_PAGE_MAX } from "./github.js";
 
 const statusName = "[TEST IGNORE] Swagger Avocado";
 
+// TODO: Add tests
+/* v8 ignore start */
 /**
  * @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments
  * @returns {Promise<void>}
  */
-export default async function getStatus({ github, context, core }) {
-  core.info("avocado-status.js:getStatus()");
+export default async function setStatus({ github, context, core }) {
+  core.info("avocado-status.js:setStatus()");
 
   const { owner, repo, head_sha, issue_number } = await extractInputs(
     github,
@@ -22,6 +24,40 @@ export default async function getStatus({ github, context, core }) {
   let target_url =
     `https://github.com/${context.repo.owner}/${context.repo.repo}` +
     `/actions/runs/${context.runId}`;
+
+  return await setStatusImpl({
+    owner,
+    repo,
+    head_sha,
+    issue_number,
+    target_url,
+    github,
+    core,
+  });
+}
+/* v8 ignore stop */
+
+/**
+ * @param {Object} params
+ * @param {string} params.owner
+ * @param {string} params.repo
+ * @param {string} params.head_sha
+ * @param {number} params.issue_number
+ * @param {string} params.target_url
+ * @param {(import("@octokit/core").Octokit & import("@octokit/plugin-rest-endpoint-methods/dist-types/types.js").Api & { paginate: import("@octokit/plugin-paginate-rest").PaginateInterface; })} params.github
+ * @param {typeof import("@actions/core")} params.core
+ * @returns {Promise<void>}
+ */
+export async function setStatusImpl({
+  owner,
+  repo,
+  head_sha,
+  issue_number,
+  target_url,
+  github,
+  core,
+}) {
+  core.info("getStatusImpl()");
 
   // TODO: Try to extract labels from context (when available) to avoid unnecessary API call
   const labels = await github.paginate(github.rest.issues.listLabelsOnIssue, {

--- a/.github/workflows/src/avocado-status.js
+++ b/.github/workflows/src/avocado-status.js
@@ -1,0 +1,9 @@
+// @ts-check
+
+/**
+ * @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments
+ * @returns {Promise<void>}
+ */
+export default async function getStatus({ core }) {
+  core.info("avocado-status.js:getSatus()");
+}

--- a/.github/workflows/src/context.js
+++ b/.github/workflows/src/context.js
@@ -32,7 +32,10 @@ export async function extractInputs(github, context, core) {
     context.eventName === "pull_request" ||
     (context.eventName === "pull_request_target" &&
       // "pull_request_target" is particularly dangerous, so only support actions as needed
-      (context.payload.action === "labeled" ||
+      (context.payload.action === "opened" ||
+        context.payload.action === "synchronize" ||
+        context.payload.action === "reopened" ||
+        context.payload.action === "labeled" ||
         context.payload.action === "unlabeled"))
   ) {
     // Most properties on payload should be the same for both pull_request and pull_request_target

--- a/.github/workflows/src/github.js
+++ b/.github/workflows/src/github.js
@@ -98,3 +98,25 @@ export const CheckConclusion = {
    */
   TIMED_OUT: "timed_out",
 };
+
+/**
+ * https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28#create-a-commit-status--parameters
+ */
+export const CommitStatusState = {
+  /**
+   * @type {"error"}
+   */
+  ERROR: "error",
+  /**
+   * @type {"failure"}
+   */
+  FAILURE: "failure",
+  /**
+   * @type {"pending"}
+   */
+  PENDING: "pending",
+  /**
+   * @type {"success"}
+   */
+  SUCCESS: "success",
+};

--- a/.github/workflows/src/github.js
+++ b/.github/workflows/src/github.js
@@ -1,3 +1,27 @@
 // @ts-check
 
 export const PER_PAGE_MAX = 100;
+
+/**
+ * https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks#check-statuses-and-conclusions
+ */
+export const CheckStatus = {
+  /** @description The check run completed and has a conclusion. */
+  COMPLETED: "completed",
+  /** @description The check run is waiting for a status to be reported. */
+  EXPECTED: "expected",
+  /** @description The check run failed. */
+  FAILURE: "failure",
+  /** @description The check run is in progress. */
+  IN_PROGRESS: "in_progress",
+  /** @description The check run is at the front of the queue but the group-based concurrency limit has been reached. */
+  PENDING: "pending",
+  /** @description The check run has been queued. */
+  QUEUED: "queued",
+  /** @description The check run has been created but has not been queued. */
+  REQUESTED: "requested",
+  /** @description The check suite failed during startup. This status is not applicable to check runs. */
+  STARTUP_FAILURE: "startup_failure",
+  /** @description The check run is waiting for a deployment protection rule to be satisfied. */
+  WAITING: "waiting",
+};

--- a/.github/workflows/src/github.js
+++ b/.github/workflows/src/github.js
@@ -6,23 +6,50 @@ export const PER_PAGE_MAX = 100;
  * https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks#check-statuses-and-conclusions
  */
 export const CheckStatus = {
-  /** @description The check run completed and has a conclusion. */
+  /**
+   * @type {"completed"}
+   * @description The check run completed and has a conclusion.
+   */
   COMPLETED: "completed",
-  /** @description The check run is waiting for a status to be reported. */
+  /**
+   * @type {"expected"}
+   * @description The check run is waiting for a status to be reported.
+   */
   EXPECTED: "expected",
-  /** @description The check run failed. */
+  /**
+   * @type {"failure"}
+   * @description The check run failed.
+   */
   FAILURE: "failure",
-  /** @description The check run is in progress. */
+  /**
+   * @type {"in_progress"}
+   * @description The check run is in progress.
+   */
   IN_PROGRESS: "in_progress",
-  /** @description The check run is at the front of the queue but the group-based concurrency limit has been reached. */
+  /**
+   * @type {"pending"}
+   * @description The check run is at the front of the queue but the group-based concurrency limit has been reached.
+   */
   PENDING: "pending",
-  /** @description The check run has been queued. */
+  /**
+   * @type {"queued"}
+   * @description The check run has been queued.
+   */
   QUEUED: "queued",
-  /** @description The check run has been created but has not been queued. */
+  /**
+   * @type {"requested"}
+   * @description The check run has been created but has not been queued.
+   */
   REQUESTED: "requested",
-  /** @description The check suite failed during startup. This status is not applicable to check runs. */
+  /**
+   * @type {"startup_failure"}
+   * @description The check suite failed during startup. This status is not applicable to check runs.
+   */
   STARTUP_FAILURE: "startup_failure",
-  /** @description The check run is waiting for a deployment protection rule to be satisfied. */
+  /**
+   * @type {"waiting"}
+   * @description The check run is waiting for a deployment protection rule to be satisfied.
+   */
   WAITING: "waiting",
 };
 
@@ -30,20 +57,44 @@ export const CheckStatus = {
  * https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks#check-statuses-and-conclusions
  */
 export const CheckConclusion = {
-  /** @description The check run provided required actions upon its completion. For more information, see Using the REST API to interact with checks. */
+  /**
+   * @type {"action_required"}
+   * @description The check run provided required actions upon its completion. For more information, see Using the REST API to interact with checks.
+   */
   ACTION_REQUIRED: "action_required",
-  /** @description The check run was cancelled before it completed. */
+  /**
+   * @type {"cancelled"}
+   * @description The check run was cancelled before it completed.
+   */
   CANCELLED: "cancelled",
-  /** @description The check run failed. */
+  /**
+   * @type {"failure"}
+   * @description The check run failed.
+   */
   FAILURE: "failure",
-  /** @description The check run completed with a neutral result. This is treated as a success for dependent checks in GitHub Actions. */
+  /**
+   * @type {"neutral"}
+   * @description The check run completed with a neutral result. This is treated as a success for dependent checks in GitHub Actions.
+   */
   NEUTRAL: "neutral",
-  /** @description The check run was skipped. This is treated as a success for dependent checks in GitHub Actions. */
+  /**
+   * @type {"skipped"}
+   * @description The check run was skipped. This is treated as a success for dependent checks in GitHub Actions.
+   */
   SKIPPED: "skipped",
-  /** @description The check run was marked stale by GitHub because it took too long. */
+  /**
+   * @type {"stale"}
+   * @description The check run was marked stale by GitHub because it took too long.
+   */
   STALE: "stale",
-  /** @description The check run completed successfully. */
+  /**
+   * @type {"success"}
+   * @description The check run completed successfully.
+   */
   SUCCESS: "success",
-  /** @description The check run timed out. */
+  /**
+   * @type {"timed_out"}
+   * @description The check run timed out.
+   */
   TIMED_OUT: "timed_out",
 };

--- a/.github/workflows/src/github.js
+++ b/.github/workflows/src/github.js
@@ -25,3 +25,25 @@ export const CheckStatus = {
   /** @description The check run is waiting for a deployment protection rule to be satisfied. */
   WAITING: "waiting",
 };
+
+/**
+ * https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks#check-statuses-and-conclusions
+ */
+export const CheckConclusion = {
+  /** @description The check run provided required actions upon its completion. For more information, see Using the REST API to interact with checks. */
+  ACTION_REQUIRED: "action_required",
+  /** @description The check run was cancelled before it completed. */
+  CANCELLED: "cancelled",
+  /** @description The check run failed. */
+  FAILURE: "failure",
+  /** @description The check run completed with a neutral result. This is treated as a success for dependent checks in GitHub Actions. */
+  NEUTRAL: "neutral",
+  /** @description The check run was skipped. This is treated as a success for dependent checks in GitHub Actions. */
+  SKIPPED: "skipped",
+  /** @description The check run was marked stale by GitHub because it took too long. */
+  STALE: "stale",
+  /** @description The check run completed successfully. */
+  SUCCESS: "success",
+  /** @description The check run timed out. */
+  TIMED_OUT: "timed_out",
+};

--- a/.github/workflows/src/label.js
+++ b/.github/workflows/src/label.js
@@ -15,3 +15,10 @@ export const LabelAction = Object.freeze({
   Remove: "remove",
 });
 // @ts-check
+
+export const Label = {
+  /**
+   * @type {"Approved-Avocado"}
+   */
+  APPROVED_AVOCADO: "Approved-Avocado",
+};

--- a/.github/workflows/test/avocado-status.test.js
+++ b/.github/workflows/test/avocado-status.test.js
@@ -49,15 +49,18 @@ describe("setStatusImpl", () => {
     });
   });
 
-  it.each([CheckConclusion.SUCCESS, CheckConclusion.FAILURE])(
-    "sets state to code run conclusion: %s",
-    async (state) => {
+  it.each([
+    [CheckStatus.COMPLETED, CheckConclusion.SUCCESS, CommitStatusState.SUCCESS],
+    [CheckStatus.COMPLETED, CheckConclusion.FAILURE, CommitStatusState.FAILURE],
+  ])(
+    "(%s, %s) => %s",
+    async (checkStatus, checkConclusion, commitStatusState) => {
       github.rest.actions.listWorkflowRunsForRepo.mockResolvedValue({
         data: [
           {
             name: "[TEST-IGNORE] Swagger Avocado - Analyze Code",
-            status: CheckStatus.COMPLETED,
-            conclusion: state,
+            status: checkStatus,
+            conclusion: checkConclusion,
             updated_at: "2025-01-01",
             html_url: "https://test.com/workflow_run_html_url",
           },
@@ -66,7 +69,10 @@ describe("setStatusImpl", () => {
 
       github.rest.actions.listJobsForWorkflowRun.mockResolvedValue({
         data: [
-          { conclusion: state, html_url: "https://test.com/job_html_url" },
+          {
+            conclusion: checkConclusion,
+            html_url: "https://test.com/job_html_url",
+          },
         ],
       });
 
@@ -86,10 +92,10 @@ describe("setStatusImpl", () => {
         owner: "test-owner",
         repo: "test-repo",
         sha: "test-head-sha",
-        state,
+        state: commitStatusState,
         context: "[TEST IGNORE] Swagger Avocado",
         target_url:
-          state === CheckConclusion.SUCCESS
+          commitStatusState === CommitStatusState.SUCCESS
             ? "https://test.com/workflow_run_html_url"
             : "https://test.com/job_html_url?pr=123",
       });

--- a/.github/workflows/test/avocado-status.test.js
+++ b/.github/workflows/test/avocado-status.test.js
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { setStatusImpl } from "../src/avocado-status.js";
 
-import { CheckConclusion } from "../src/github.js";
+import {
+  CheckConclusion,
+  CheckStatus,
+  CommitStatusState,
+} from "../src/github.js";
 import { createMockCore, createMockGithub } from "./mocks.js";
 
 describe("setStatusImpl", () => {
@@ -38,21 +42,21 @@ describe("setStatusImpl", () => {
       owner: "test-owner",
       repo: "test-repo",
       sha: "test-head-sha",
-      state: "success",
+      state: CommitStatusState.SUCCESS,
       context: "[TEST IGNORE] Swagger Avocado",
       description: "Found label 'Approved-Avocado'",
       target_url: "https://test.com/target_url",
     });
   });
 
-  it.each(["success", "failure"])(
+  it.each([CheckConclusion.SUCCESS, CheckConclusion.FAILURE])(
     "sets state to code run conclusion: %s",
     async (state) => {
       github.rest.actions.listWorkflowRunsForRepo.mockResolvedValue({
         data: [
           {
             name: "[TEST-IGNORE] Swagger Avocado - Analyze Code",
-            status: "completed",
+            status: CheckStatus.COMPLETED,
             conclusion: state,
             updated_at: "2025-01-01",
             html_url: "https://test.com/workflow_run_html_url",

--- a/.github/workflows/test/avocado-status.test.js
+++ b/.github/workflows/test/avocado-status.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { setStatusImpl } from "../src/avocado-status.js";
 
 import { createMockCore, createMockGithub } from "./mocks.js";
@@ -7,6 +7,10 @@ const core = createMockCore();
 const github = createMockGithub();
 
 describe("setStatusImpl", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("throws if inputs null", async () => {
     await expect(setStatusImpl({})).rejects.toThrow();
   });

--- a/.github/workflows/test/avocado-status.test.js
+++ b/.github/workflows/test/avocado-status.test.js
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { setStatusImpl } from "../src/avocado-status.js";
 
+import { CheckConclusion } from "../src/github.js";
 import { createMockCore, createMockGithub } from "./mocks.js";
 
 const core = createMockCore();
@@ -83,7 +84,7 @@ describe("setStatusImpl", () => {
         state,
         context: "[TEST IGNORE] Swagger Avocado",
         target_url:
-          state === "success"
+          state === CheckConclusion.SUCCESS
             ? "https://test.com/workflow_run_html_url"
             : "https://test.com/job_html_url?pr=123",
       });

--- a/.github/workflows/test/avocado-status.test.js
+++ b/.github/workflows/test/avocado-status.test.js
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { setStatusImpl } from "../src/avocado-status.js";
+
+import { createMockCore, createMockGithub } from "./mocks.js";
+
+const core = createMockCore();
+const github = createMockGithub();
+
+describe("setStatusImpl", () => {
+  it("throws if inputs null", async () => {
+    await expect(setStatusImpl({})).rejects.toThrow();
+  });
+
+  it("sets success if approved by label", async () => {
+    github.rest.issues.listLabelsOnIssue.mockResolvedValue({
+      data: [{ name: "test" }, { name: "Approved-Avocado" }],
+    });
+
+    await expect(
+      setStatusImpl({
+        owner: "test-owner",
+        repo: "test-repo",
+        head_sha: "test-head-sha",
+        issue_number: 123,
+        target_url: "https://test.com/target_url",
+        github,
+        core,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(github.rest.repos.createCommitStatus).toBeCalledWith({
+      owner: "test-owner",
+      repo: "test-repo",
+      sha: "test-head-sha",
+      state: "success",
+      context: "[TEST IGNORE] Swagger Avocado",
+      description: "Found label 'Approved-Avocado'",
+      target_url: "https://test.com/target_url",
+    });
+  });
+
+  it.each(["success", "failure"])(
+    "sets state to code run conclusion: %s",
+    async (state) => {
+      github.rest.actions.listWorkflowRunsForRepo.mockResolvedValue({
+        data: [
+          {
+            name: "[TEST-IGNORE] Swagger Avocado - Analyze Code",
+            status: "completed",
+            conclusion: state,
+            updated_at: "2025-01-01",
+            html_url: "https://test.com/workflow_run_html_url",
+          },
+        ],
+      });
+
+      github.rest.actions.listJobsForWorkflowRun.mockResolvedValue({
+        data: [
+          { conclusion: state, html_url: "https://test.com/job_html_url" },
+        ],
+      });
+
+      await expect(
+        setStatusImpl({
+          owner: "test-owner",
+          repo: "test-repo",
+          head_sha: "test-head-sha",
+          issue_number: 123,
+          target_url: "https://test.com/target_url",
+          github,
+          core,
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(github.rest.repos.createCommitStatus).toBeCalledWith({
+        owner: "test-owner",
+        repo: "test-repo",
+        sha: "test-head-sha",
+        state,
+        context: "[TEST IGNORE] Swagger Avocado",
+        target_url:
+          state === "success"
+            ? "https://test.com/workflow_run_html_url"
+            : "https://test.com/job_html_url?pr=123",
+      });
+    },
+  );
+});

--- a/.github/workflows/test/avocado-status.test.js
+++ b/.github/workflows/test/avocado-status.test.js
@@ -1,15 +1,16 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { setStatusImpl } from "../src/avocado-status.js";
 
 import { CheckConclusion } from "../src/github.js";
 import { createMockCore, createMockGithub } from "./mocks.js";
 
-const core = createMockCore();
-const github = createMockGithub();
-
 describe("setStatusImpl", () => {
-  afterEach(() => {
-    vi.clearAllMocks();
+  let core;
+  let github;
+
+  beforeEach(() => {
+    core = createMockCore();
+    github = createMockGithub();
   });
 
   it("throws if inputs null", async () => {

--- a/.github/workflows/test/context.test.js
+++ b/.github/workflows/test/context.test.js
@@ -84,7 +84,20 @@ describe("extractInputs", () => {
       extractInputs(null, context, createMockCore()),
     ).resolves.toEqual(expected);
 
-    // TODO: Add tests for new supported actions
+    context.payload.action = "opened";
+    await expect(
+      extractInputs(null, context, createMockCore()),
+    ).resolves.toEqual(expected);
+
+    context.payload.action = "synchronize";
+    await expect(
+      extractInputs(null, context, createMockCore()),
+    ).resolves.toEqual(expected);
+
+    context.payload.action = "reopened";
+    await expect(
+      extractInputs(null, context, createMockCore()),
+    ).resolves.toEqual(expected);
 
     // Action not yet supported
     context.payload.action = "assigned";

--- a/.github/workflows/test/context.test.js
+++ b/.github/workflows/test/context.test.js
@@ -84,8 +84,10 @@ describe("extractInputs", () => {
       extractInputs(null, context, createMockCore()),
     ).resolves.toEqual(expected);
 
+    // TODO: Add tests for new supported actions
+
     // Action not yet supported
-    context.payload.action = "synchronize";
+    context.payload.action = "assigned";
     await expect(
       extractInputs(null, context, createMockCore()),
     ).rejects.toThrow();

--- a/.github/workflows/test/mocks.js
+++ b/.github/workflows/test/mocks.js
@@ -33,6 +33,7 @@ export function createMockGithub() {
         get: vi.fn(),
       },
       repos: {
+        createCommitStatus: vi.fn(),
         listPullRequestsAssociatedWithCommit: vi.fn().mockResolvedValue({
           data: [],
         }),

--- a/.github/workflows/test/mocks.js
+++ b/.github/workflows/test/mocks.js
@@ -13,6 +13,7 @@ export function createMockGithub() {
     },
     rest: {
       actions: {
+        listJobsForWorkflowRun: vi.fn().mockResolvedValue({ data: [] }),
         listWorkflowRunArtifacts: vi
           .fn()
           .mockResolvedValue({ data: { artifacts: [] } }),


### PR DESCRIPTION
- Fixes #33864
- Rename existing wf to `Avocado - Analyze Code`
- Add new wf `Avocado - Set Status`, which sets final status named just `Avocado`
- PRs will be gated on status of just `Avocado`, not the two sub-wf

## New UI
### Fail
![image](https://github.com/user-attachments/assets/1f99e351-14b8-4492-8c1d-3f8dc15ea505)

### Override with Label
![image](https://github.com/user-attachments/assets/15101760-4f48-4394-ae57-696c6cd08d7b)


## Test
https://github.com/mikeharder/azure-rest-api-specs/pull/18