### PR TITLE
Fixed folder path for private repo

### DIFF
--- a/eng/tools/spec-gen-sdk-runner/src/commands.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/commands.ts
@@ -252,7 +252,7 @@ function getExecutionReport(commandInput: SpecGenSdkCmdInput): any {
   // Read the execution report to determine if the generation was successful
   const executionReportPath = path.join(
     commandInput.workingFolder,
-    `${commandInput.sdkLanguage}_tmp/execution-report.json`,
+    `${commandInput.sdkRepoName}_tmp/execution-report.json`,
   );
   return JSON.parse(fs.readFileSync(executionReportPath, "utf8"));
 }


### PR DESCRIPTION
Fixing the error occurred when the sdk repo is a private repo. `sdkRepoName` is original repo name, while `sdkLanguage` trims the '-pr' from the repo name when it's a private repo.
```
Runner: error reading execution-report.json:Error: ENOENT: no such file or directory, open '/mnt/vss/_work/1/s/azure-sdk-for-java_tmp/execution-report.json'
```

Test runs:
[private repo](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4775946&view=results)
[public repo](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4775988&view=results)