### PR TITLE
[computeschedule] Remove python configuration for swagger

### DIFF
--- a/specification/computeschedule/resource-manager/readme.md
+++ b/specification/computeschedule/resource-manager/readme.md
@@ -50,7 +50,6 @@ This is not used by Autorest itself.
 
 ```yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-go
   - repo: azure-sdk-for-js
@@ -65,10 +64,6 @@ See configuration in [readme.az.md](./readme.az.md)
 ## Go
 
 See configuration in [readme.go.md](./readme.go.md)
-
-## Python
-
-See configuration in [readme.python.md](./readme.python.md)
 
 ## TypeScript
 


### PR DESCRIPTION
Python SDK is already generated from typespec so no need to keep configuration for swagger.