### PR TITLE
Repurposed breaking chagne artifact to be spec-gen-sdk artifact

### DIFF
--- a/.github/workflows/src/sdk-breaking-change-labels.js
+++ b/.github/workflows/src/sdk-breaking-change-labels.js
@@ -62,7 +62,7 @@ export async function getLabelAndActionImpl({
   let issue_number = NaN;
   let labelAction;
   let labelName = "";
-  const artifactName = "spec-gen-sdk-breaking-change-artifact";
+  const artifactName = "spec-gen-sdk-artifact";
   const artifactFileName = artifactName + ".json";
   const apiUrl = `${ado_project_url}/_apis/build/builds/${ado_build_id}/artifacts?artifactName=${artifactName}&api-version=7.0`;
   core.info(`Calling Azure DevOps API to get the artifact: ${apiUrl}`);

--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -210,9 +210,9 @@ extends:
 
           - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
             parameters:
-              ArtifactName: $(BreakingChangeLabelArtifactName)
-              ArtifactPath: "$(System.DefaultWorkingDirectory)/$(BreakingChangeLabelArtifactPath)"
-              CustomCondition: and(succeeded(), ne(variables['BreakingChangeLabelArtifactName'], ''))
+              ArtifactName: $(SpecGenSdkArtifactName)
+              ArtifactPath: "$(System.DefaultWorkingDirectory)/$(SpecGenSdkArtifactPath)"
+              CustomCondition: and(succeeded(), ne(variables['SpecGenSdkArtifactName'], ''))
 
           - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
             parameters:

--- a/eng/tools/spec-gen-sdk-runner/src/types.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/types.ts
@@ -29,3 +29,14 @@ export type VsoLogs = Map<
     warnings?: string[];
   }
 >;
+
+/**
+ * Represents the result of the spec-gen-sdk generation process.
+ */
+export interface SpecGenSdkArtifactInfo {
+  managementPlane: boolean;
+  dataPlane: boolean;
+  language?: string;
+  labelAction?: boolean;
+  isSpecGenSdkCheckRequired?: boolean;
+}


### PR DESCRIPTION
This PR repurposed the SDK breaking change artifact to be the spec-gen-sdk artifact, which includes additional information such as spec types in the PR, required settings. This information will be used to determine whether `spec-gen-sdk` check is required or not.

* Renamed the breaking change artifact to `spec-gen-sdk-artifact` across the codebase, including variable names, file paths, and related logic. This ensures consistency and reflects the broader purpose of the artifact. (`.github/workflows/src/sdk-breaking-change-labels.js`, `eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml`, `eng/tools/spec-gen-sdk-runner/src/commands.ts`)

* Added logic to detect and differentiate between management plane and data plane specifications based on file paths. This information is stored in the new `SpecGenSdkArtifactInfo` interface. (`eng/tools/spec-gen-sdk-runner/src/commands.ts`)

* Introduced a new `SpecGenSdkArtifactInfo` interface to encapsulate metadata about the spec-gen-sdk generation process, such as whether the specification belongs to the management or data plane, the programming language, and the label action. (`eng/tools/spec-gen-sdk-runner/src/types.ts`) 

This is a [test run](https://github.com/raych1/azure-rest-api-specs/actions/runs/14581553550) for the SDK breaking change labels workflow, ensuring no impact to it.
