### PR TITLE
Remove api-key auth

### DIFF
--- a/specification/ai/Azure.AI.Projects/main.tsp
+++ b/specification/ai/Azure.AI.Projects/main.tsp
@@ -24,7 +24,7 @@ namespace Azure.AI {
     {
       type: OAuth2FlowType.implicit,
       authorizationUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
-      scopes: ["https://cognitiveservices.azure.com/.default"],
+      scopes: ["https://cognitiveservices.azure.com/.default"], // TODO: Replace with ["https://ai.azure.com/.default"]
     }
   ]>
 )

--- a/specification/ai/Azure.AI.Projects/main.tsp
+++ b/specification/ai/Azure.AI.Projects/main.tsp
@@ -19,8 +19,7 @@ namespace Azure.AI {
 }
 
 #suppress "@azure-tools/typespec-autorest/unsupported-http-auth-scheme"
-@useAuth(
-  BearerAuth | OAuth2Auth<[
+@useAuth(OAuth2Auth<[
     {
       type: OAuth2FlowType.implicit,
       authorizationUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",

--- a/specification/ai/Azure.AI.Projects/main.tsp
+++ b/specification/ai/Azure.AI.Projects/main.tsp
@@ -19,7 +19,8 @@ namespace Azure.AI {
 }
 
 #suppress "@azure-tools/typespec-autorest/unsupported-http-auth-scheme"
-@useAuth(OAuth2Auth<[
+@useAuth(
+  OAuth2Auth<[
     {
       type: OAuth2FlowType.implicit,
       authorizationUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",

--- a/specification/ai/Azure.AI.Projects/red-teams/models.tsp
+++ b/specification/ai/Azure.AI.Projects/red-teams/models.tsp
@@ -91,7 +91,7 @@ union AttackStrategy {
   Url: "url",
 
   @doc("Represents the baseline direct adversarial probing, which is used by attack strategies as the attack objective.")
-  Baseline: "baseline"
+  Baseline: "baseline",
 }
 
 @doc("Risk category for the attack objective.")

--- a/specification/ai/data-plane/Azure.AI.Projects/preview/2025-05-15-preview/azure-ai-projects-1dp.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/preview/2025-05-15-preview/azure-ai-projects-1dp.json
@@ -717,7 +717,7 @@
           {
             "name": "body",
             "in": "body",
-            "description": "The definition of the DatasetVersion to create",
+            "description": "The definition of the DatasetVersion to create or update",
             "required": true,
             "schema": {
               "$ref": "#/definitions/DatasetVersionUpdate"
@@ -1467,7 +1467,7 @@
           {
             "name": "body",
             "in": "body",
-            "description": "The definition of the Index to create",
+            "description": "The definition of the Index to create or update",
             "required": true,
             "schema": {
               "$ref": "#/definitions/IndexUpdate"

--- a/specification/ai/data-plane/Azure.AI.Projects/stable/2025-05-01/azure-ai-projects-1dp.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/stable/2025-05-01/azure-ai-projects-1dp.json
@@ -717,7 +717,7 @@
           {
             "name": "body",
             "in": "body",
-            "description": "The definition of the DatasetVersion to create",
+            "description": "The definition of the DatasetVersion to create or update",
             "required": true,
             "schema": {
               "$ref": "#/definitions/DatasetVersionUpdate"
@@ -1326,7 +1326,7 @@
           {
             "name": "body",
             "in": "body",
-            "description": "The definition of the Index to create",
+            "description": "The definition of the Index to create or update",
             "required": true,
             "schema": {
               "$ref": "#/definitions/IndexUpdate"

--- a/specification/ai/data-plane/Azure.AI.Projects/stable/latest/azure-ai-projects-1dp.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/stable/latest/azure-ai-projects-1dp.json
@@ -717,7 +717,7 @@
           {
             "name": "body",
             "in": "body",
-            "description": "The definition of the DatasetVersion to create",
+            "description": "The definition of the DatasetVersion to create or update",
             "required": true,
             "schema": {
               "$ref": "#/definitions/DatasetVersionUpdate"
@@ -1326,7 +1326,7 @@
           {
             "name": "body",
             "in": "body",
-            "description": "The definition of the Index to create",
+            "description": "The definition of the Index to create or update",
             "required": true,
             "schema": {
               "$ref": "#/definitions/IndexUpdate"


### PR DESCRIPTION
Also 

- Update formatting as a result of running `npx tsp format **\*.tsp`
- Update swagger to latest, following `npx tsv .`

There will also be a separate change at some point soon to update the credential scope from `https://cognitiveservices.azure.com/.default` to `https://ai.azure.com/.default`