### PR TITLE
Remove listing connections with credentials

### DIFF
--- a/specification/ai/Azure.AI.Projects/connections/models.tsp
+++ b/specification/ai/Azure.AI.Projects/connections/models.tsp
@@ -57,6 +57,7 @@ model ApiKeyCredentials extends BaseCredentials {
 
   @doc("API Key")
   @visibility(Lifecycle.Read)
+  @encodedName("application/json", "key")
   apiKey?: string;
 }
 

--- a/specification/ai/Azure.AI.Projects/connections/models.tsp
+++ b/specification/ai/Azure.AI.Projects/connections/models.tsp
@@ -12,7 +12,6 @@ namespace Azure.AI.Projects;
 
 @doc("Response from the list and get connections operations")
 @resource("connections")
-@discriminator("authType")
 @added(Versions.v2025_05_01)
 model Connection {
   @doc("The name of the resource")
@@ -42,18 +41,18 @@ model Connection {
 }
 
 @doc("A base class for connection credentials")
-@discriminator("authType")
+@discriminator("type")
 model BaseCredentials {
   @doc("The type of credential used by the connection")
   @visibility(Lifecycle.Read)
-  authType: CredentialType;
+  type: CredentialType;
 }
 
 @doc("API Key Credential definition")
 model ApiKeyCredentials extends BaseCredentials {
   @doc("The credentail type")
   @visibility(Lifecycle.Read)
-  authType: CredentialType.apiKey;
+  type: CredentialType.apiKey;
 
   @doc("API Key")
   @visibility(Lifecycle.Read)
@@ -66,14 +65,14 @@ model ApiKeyCredentials extends BaseCredentials {
 model EntraIDCredentials extends BaseCredentials {
   @doc("The credential type")
   @visibility(Lifecycle.Read)
-  authType: CredentialType.entraId;
+  type: CredentialType.entraId;
 }
 
 @doc("Custom credential defintion")
 model CustomCredential extends BaseCredentials {
   @doc("The credential type ")
   @visibility(Lifecycle.Read)
-  authType: CredentialType.custom;
+  type: CredentialType.custom;
 }
 
 #suppress "@azure-tools/typespec-azure-core/casing-style"
@@ -81,10 +80,11 @@ model CustomCredential extends BaseCredentials {
 model SASCredentials extends BaseCredentials {
   @doc("The credential type")
   @visibility(Lifecycle.Read)
-  authType: CredentialType.SAS;
+  type: CredentialType.SAS;
 
   @doc("SAS token")
   @visibility(Lifecycle.Read)
+  @encodedName("application/json", "SAS")
   sasToken?: string;
 }
 
@@ -92,7 +92,7 @@ model SASCredentials extends BaseCredentials {
 model NoAuthenticationCredentials extends BaseCredentials {
   @doc("The credential type ")
   @visibility(Lifecycle.Read)
-  authType: CredentialType.None;
+  type: CredentialType.None;
 }
 
 // https://learn.microsoft.com/rest/api/azureml/workspace-connections/list-secrets?view=rest-azureml-2024-04-01&tabs=HTTP#ConnectionType

--- a/specification/ai/Azure.AI.Projects/connections/models.tsp
+++ b/specification/ai/Azure.AI.Projects/connections/models.tsp
@@ -70,9 +70,13 @@ model EntraIDCredentials extends BaseCredentials {
 
 @doc("Custom credential defintion")
 model CustomCredential extends BaseCredentials {
-  @doc("The credential type ")
+  @doc("The credential type")
   @visibility(Lifecycle.Read)
   type: CredentialType.custom;
+
+  @doc("The credential type")
+  @visibility(Lifecycle.Read)
+  keys: Record<string>;
 }
 
 #suppress "@azure-tools/typespec-azure-core/casing-style"

--- a/specification/ai/Azure.AI.Projects/connections/routes.tsp
+++ b/specification/ai/Azure.AI.Projects/connections/routes.tsp
@@ -47,28 +47,4 @@ interface Connections {
       ...StandardListQueryParameters;
     }>
   >;
-
-  @doc("List all connections in the project, with their connection credentials")
-  @TypeSpec.Http.post
-  @Rest.actionSeparator("/")
-  @Rest.action("withCredentials")
-  listWithCredentials is ConnectionOperations.ResourceCollectionAction<
-    Connection,
-    {
-      @doc("List connections of this specific type")
-      @query("connectionType")
-      connectionType?: ConnectionType;
-
-      @doc("List connections that are default connections")
-      @query("defaultConnection")
-      defaultConnection?: boolean;
-
-      ...StandardListQueryParameters;
-    },
-    Internal.ConnectionPaged
-  >;
-}
-
-namespace Internal {
-  model ConnectionPaged is Azure.Core.Page<Connection>;
 }

--- a/specification/ai/data-plane/Azure.AI.Projects/preview/2025-05-15-preview/azure-ai-projects-1dp.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/preview/2025-05-15-preview/azure-ai-projects-1dp.json
@@ -1922,15 +1922,15 @@
       "type": "object",
       "description": "A base class for connection credentials",
       "properties": {
-        "authType": {
+        "type": {
           "$ref": "#/definitions/CredentialType",
           "description": "The type of credential used by the connection",
           "readOnly": true
         }
       },
-      "discriminator": "authType",
+      "discriminator": "type",
       "required": [
-        "authType"
+        "type"
       ]
     },
     "BlobReferenceForConsumption": {
@@ -1960,10 +1960,6 @@
       "type": "object",
       "description": "Response from the list and get connections operations",
       "properties": {
-        "authType": {
-          "type": "string",
-          "description": "Discriminator property for Connection."
-        },
         "name": {
           "type": "string",
           "description": "The name of the resource",
@@ -1998,9 +1994,7 @@
           "readOnly": true
         }
       },
-      "discriminator": "authType",
       "required": [
-        "authType",
         "name",
         "type",
         "target",
@@ -3196,10 +3190,11 @@
       "type": "object",
       "description": "Shared Access Signature (SAS) credential definition",
       "properties": {
-        "sasToken": {
+        "SAS": {
           "type": "string",
           "description": "SAS token",
-          "readOnly": true
+          "readOnly": true,
+          "x-ms-client-name": "sasToken"
         }
       },
       "allOf": [

--- a/specification/ai/data-plane/Azure.AI.Projects/preview/2025-05-15-preview/azure-ai-projects-1dp.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/preview/2025-05-15-preview/azure-ai-projects-1dp.json
@@ -2170,6 +2170,19 @@
     "CustomCredential": {
       "type": "object",
       "description": "Custom credential defintion",
+      "properties": {
+        "keys": {
+          "type": "object",
+          "description": "The credential type",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "readOnly": true
+        }
+      },
+      "required": [
+        "keys"
+      ],
       "allOf": [
         {
           "$ref": "#/definitions/BaseCredentials"

--- a/specification/ai/data-plane/Azure.AI.Projects/preview/2025-05-15-preview/azure-ai-projects-1dp.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/preview/2025-05-15-preview/azure-ai-projects-1dp.json
@@ -277,135 +277,6 @@
         }
       }
     },
-    "/connections/withCredentials": {
-      "post": {
-        "operationId": "Connections_ListWithCredentials",
-        "description": "List all connections in the project, with their connection credentials",
-        "parameters": [
-          {
-            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
-          },
-          {
-            "name": "connectionType",
-            "in": "query",
-            "description": "List connections of this specific type",
-            "required": false,
-            "type": "string",
-            "enum": [
-              "AzureOpenAI",
-              "AzureBlob",
-              "AzureStorageAccount",
-              "CognitiveSearch",
-              "CosmosDB",
-              "ApiKey",
-              "AppConfig",
-              "AppInsights",
-              "CustomKeys"
-            ],
-            "x-ms-enum": {
-              "name": "ConnectionType",
-              "modelAsString": true,
-              "values": [
-                {
-                  "name": "AzureOpenAI",
-                  "value": "AzureOpenAI",
-                  "description": "Azure OpenAI Service"
-                },
-                {
-                  "name": "AzureBlobStorage",
-                  "value": "AzureBlob",
-                  "description": "Azure Blob Storage, with specified container"
-                },
-                {
-                  "name": "AzureStorageAccount",
-                  "value": "AzureStorageAccount",
-                  "description": "Azure Blob Storage, with container not specified (used by Agents)"
-                },
-                {
-                  "name": "AzureAISearch",
-                  "value": "CognitiveSearch",
-                  "description": "Azure AI Search"
-                },
-                {
-                  "name": "CosmosDB",
-                  "value": "CosmosDB",
-                  "description": "CosmosDB"
-                },
-                {
-                  "name": "APIKey",
-                  "value": "ApiKey",
-                  "description": "Generic connection that uses API Key authentication"
-                },
-                {
-                  "name": "ApplicationConfiguration",
-                  "value": "AppConfig",
-                  "description": "Application Configuration"
-                },
-                {
-                  "name": "ApplicationInsights",
-                  "value": "AppInsights",
-                  "description": "Application Insights"
-                },
-                {
-                  "name": "Custom",
-                  "value": "CustomKeys",
-                  "description": "Custom Keys"
-                }
-              ]
-            }
-          },
-          {
-            "name": "defaultConnection",
-            "in": "query",
-            "description": "List connections that are default connections",
-            "required": false,
-            "type": "boolean"
-          },
-          {
-            "$ref": "#/parameters/Azure.Core.TopQueryParameter"
-          },
-          {
-            "$ref": "#/parameters/Azure.Core.SkipQueryParameter"
-          },
-          {
-            "$ref": "#/parameters/Azure.Core.MaxPageSizeQueryParameter"
-          },
-          {
-            "$ref": "#/parameters/Azure.Core.ClientRequestIdHeader"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "The request has succeeded.",
-            "schema": {
-              "$ref": "#/definitions/Internal.ConnectionPaged"
-            },
-            "headers": {
-              "x-ms-client-request-id": {
-                "type": "string",
-                "format": "uuid",
-                "description": "An opaque, globally-unique, client-generated string identifier for the request."
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
-            },
-            "headers": {
-              "x-ms-error-code": {
-                "type": "string",
-                "description": "String error code indicating what went wrong."
-              }
-            }
-          }
-        },
-        "x-ms-pageable": {
-          "nextLinkName": "nextLink"
-        }
-      }
-    },
     "/datasets": {
       "get": {
         "operationId": "Datasets_ListLatest",
@@ -1763,10 +1634,11 @@
       "type": "object",
       "description": "API Key Credential definition",
       "properties": {
-        "apiKey": {
+        "key": {
           "type": "string",
           "description": "API Key",
-          "readOnly": true
+          "readOnly": true,
+          "x-ms-client-name": "apiKey"
         }
       },
       "allOf": [
@@ -2819,28 +2691,6 @@
         }
       ],
       "x-ms-discriminator-value": "dataset"
-    },
-    "Internal.ConnectionPaged": {
-      "type": "object",
-      "description": "Paged collection of Connection items",
-      "properties": {
-        "value": {
-          "type": "array",
-          "description": "The Connection items on this page",
-          "items": {
-            "$ref": "#/definitions/Connection"
-          },
-          "x-ms-identifiers": []
-        },
-        "nextLink": {
-          "type": "string",
-          "format": "uri",
-          "description": "The link to the next page of items"
-        }
-      },
-      "required": [
-        "value"
-      ]
     },
     "ListSortOrder": {
       "type": "string",

--- a/specification/ai/data-plane/Azure.AI.Projects/stable/2025-05-01/azure-ai-projects-1dp.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/stable/2025-05-01/azure-ai-projects-1dp.json
@@ -277,135 +277,6 @@
         }
       }
     },
-    "/connections/withCredentials": {
-      "post": {
-        "operationId": "Connections_ListWithCredentials",
-        "description": "List all connections in the project, with their connection credentials",
-        "parameters": [
-          {
-            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
-          },
-          {
-            "name": "connectionType",
-            "in": "query",
-            "description": "List connections of this specific type",
-            "required": false,
-            "type": "string",
-            "enum": [
-              "AzureOpenAI",
-              "AzureBlob",
-              "AzureStorageAccount",
-              "CognitiveSearch",
-              "CosmosDB",
-              "ApiKey",
-              "AppConfig",
-              "AppInsights",
-              "CustomKeys"
-            ],
-            "x-ms-enum": {
-              "name": "ConnectionType",
-              "modelAsString": true,
-              "values": [
-                {
-                  "name": "AzureOpenAI",
-                  "value": "AzureOpenAI",
-                  "description": "Azure OpenAI Service"
-                },
-                {
-                  "name": "AzureBlobStorage",
-                  "value": "AzureBlob",
-                  "description": "Azure Blob Storage, with specified container"
-                },
-                {
-                  "name": "AzureStorageAccount",
-                  "value": "AzureStorageAccount",
-                  "description": "Azure Blob Storage, with container not specified (used by Agents)"
-                },
-                {
-                  "name": "AzureAISearch",
-                  "value": "CognitiveSearch",
-                  "description": "Azure AI Search"
-                },
-                {
-                  "name": "CosmosDB",
-                  "value": "CosmosDB",
-                  "description": "CosmosDB"
-                },
-                {
-                  "name": "APIKey",
-                  "value": "ApiKey",
-                  "description": "Generic connection that uses API Key authentication"
-                },
-                {
-                  "name": "ApplicationConfiguration",
-                  "value": "AppConfig",
-                  "description": "Application Configuration"
-                },
-                {
-                  "name": "ApplicationInsights",
-                  "value": "AppInsights",
-                  "description": "Application Insights"
-                },
-                {
-                  "name": "Custom",
-                  "value": "CustomKeys",
-                  "description": "Custom Keys"
-                }
-              ]
-            }
-          },
-          {
-            "name": "defaultConnection",
-            "in": "query",
-            "description": "List connections that are default connections",
-            "required": false,
-            "type": "boolean"
-          },
-          {
-            "$ref": "#/parameters/Azure.Core.TopQueryParameter"
-          },
-          {
-            "$ref": "#/parameters/Azure.Core.SkipQueryParameter"
-          },
-          {
-            "$ref": "#/parameters/Azure.Core.MaxPageSizeQueryParameter"
-          },
-          {
-            "$ref": "#/parameters/Azure.Core.ClientRequestIdHeader"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "The request has succeeded.",
-            "schema": {
-              "$ref": "#/definitions/Internal.ConnectionPaged"
-            },
-            "headers": {
-              "x-ms-client-request-id": {
-                "type": "string",
-                "format": "uuid",
-                "description": "An opaque, globally-unique, client-generated string identifier for the request."
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
-            },
-            "headers": {
-              "x-ms-error-code": {
-                "type": "string",
-                "description": "String error code indicating what went wrong."
-              }
-            }
-          }
-        },
-        "x-ms-pageable": {
-          "nextLinkName": "nextLink"
-        }
-      }
-    },
     "/datasets": {
       "get": {
         "operationId": "Datasets_ListLatest",
@@ -1291,10 +1162,11 @@
       "type": "object",
       "description": "API Key Credential definition",
       "properties": {
-        "apiKey": {
+        "key": {
           "type": "string",
           "description": "API Key",
-          "readOnly": true
+          "readOnly": true,
+          "x-ms-client-name": "apiKey"
         }
       },
       "allOf": [
@@ -2078,28 +1950,6 @@
       "discriminator": "type",
       "required": [
         "type"
-      ]
-    },
-    "Internal.ConnectionPaged": {
-      "type": "object",
-      "description": "Paged collection of Connection items",
-      "properties": {
-        "value": {
-          "type": "array",
-          "description": "The Connection items on this page",
-          "items": {
-            "$ref": "#/definitions/Connection"
-          },
-          "x-ms-identifiers": []
-        },
-        "nextLink": {
-          "type": "string",
-          "format": "uri",
-          "description": "The link to the next page of items"
-        }
-      },
-      "required": [
-        "value"
       ]
     },
     "ListSortOrder": {

--- a/specification/ai/data-plane/Azure.AI.Projects/stable/2025-05-01/azure-ai-projects-1dp.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/stable/2025-05-01/azure-ai-projects-1dp.json
@@ -1542,6 +1542,19 @@
     "CustomCredential": {
       "type": "object",
       "description": "Custom credential defintion",
+      "properties": {
+        "keys": {
+          "type": "object",
+          "description": "The credential type",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "readOnly": true
+        }
+      },
+      "required": [
+        "keys"
+      ],
       "allOf": [
         {
           "$ref": "#/definitions/BaseCredentials"

--- a/specification/ai/data-plane/Azure.AI.Projects/stable/2025-05-01/azure-ai-projects-1dp.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/stable/2025-05-01/azure-ai-projects-1dp.json
@@ -1294,15 +1294,15 @@
       "type": "object",
       "description": "A base class for connection credentials",
       "properties": {
-        "authType": {
+        "type": {
           "$ref": "#/definitions/CredentialType",
           "description": "The type of credential used by the connection",
           "readOnly": true
         }
       },
-      "discriminator": "authType",
+      "discriminator": "type",
       "required": [
-        "authType"
+        "type"
       ]
     },
     "BlobReferenceForConsumption": {
@@ -1332,10 +1332,6 @@
       "type": "object",
       "description": "Response from the list and get connections operations",
       "properties": {
-        "authType": {
-          "type": "string",
-          "description": "Discriminator property for Connection."
-        },
         "name": {
           "type": "string",
           "description": "The name of the resource",
@@ -1370,9 +1366,7 @@
           "readOnly": true
         }
       },
-      "discriminator": "authType",
       "required": [
-        "authType",
         "name",
         "type",
         "target",
@@ -2292,10 +2286,11 @@
       "type": "object",
       "description": "Shared Access Signature (SAS) credential definition",
       "properties": {
-        "sasToken": {
+        "SAS": {
           "type": "string",
           "description": "SAS token",
-          "readOnly": true
+          "readOnly": true,
+          "x-ms-client-name": "sasToken"
         }
       },
       "allOf": [

--- a/specification/ai/data-plane/Azure.AI.Projects/stable/latest/azure-ai-projects-1dp.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/stable/latest/azure-ai-projects-1dp.json
@@ -277,135 +277,6 @@
         }
       }
     },
-    "/connections/withCredentials": {
-      "post": {
-        "operationId": "Connections_ListWithCredentials",
-        "description": "List all connections in the project, with their connection credentials",
-        "parameters": [
-          {
-            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
-          },
-          {
-            "name": "connectionType",
-            "in": "query",
-            "description": "List connections of this specific type",
-            "required": false,
-            "type": "string",
-            "enum": [
-              "AzureOpenAI",
-              "AzureBlob",
-              "AzureStorageAccount",
-              "CognitiveSearch",
-              "CosmosDB",
-              "ApiKey",
-              "AppConfig",
-              "AppInsights",
-              "CustomKeys"
-            ],
-            "x-ms-enum": {
-              "name": "ConnectionType",
-              "modelAsString": true,
-              "values": [
-                {
-                  "name": "AzureOpenAI",
-                  "value": "AzureOpenAI",
-                  "description": "Azure OpenAI Service"
-                },
-                {
-                  "name": "AzureBlobStorage",
-                  "value": "AzureBlob",
-                  "description": "Azure Blob Storage, with specified container"
-                },
-                {
-                  "name": "AzureStorageAccount",
-                  "value": "AzureStorageAccount",
-                  "description": "Azure Blob Storage, with container not specified (used by Agents)"
-                },
-                {
-                  "name": "AzureAISearch",
-                  "value": "CognitiveSearch",
-                  "description": "Azure AI Search"
-                },
-                {
-                  "name": "CosmosDB",
-                  "value": "CosmosDB",
-                  "description": "CosmosDB"
-                },
-                {
-                  "name": "APIKey",
-                  "value": "ApiKey",
-                  "description": "Generic connection that uses API Key authentication"
-                },
-                {
-                  "name": "ApplicationConfiguration",
-                  "value": "AppConfig",
-                  "description": "Application Configuration"
-                },
-                {
-                  "name": "ApplicationInsights",
-                  "value": "AppInsights",
-                  "description": "Application Insights"
-                },
-                {
-                  "name": "Custom",
-                  "value": "CustomKeys",
-                  "description": "Custom Keys"
-                }
-              ]
-            }
-          },
-          {
-            "name": "defaultConnection",
-            "in": "query",
-            "description": "List connections that are default connections",
-            "required": false,
-            "type": "boolean"
-          },
-          {
-            "$ref": "#/parameters/Azure.Core.TopQueryParameter"
-          },
-          {
-            "$ref": "#/parameters/Azure.Core.SkipQueryParameter"
-          },
-          {
-            "$ref": "#/parameters/Azure.Core.MaxPageSizeQueryParameter"
-          },
-          {
-            "$ref": "#/parameters/Azure.Core.ClientRequestIdHeader"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "The request has succeeded.",
-            "schema": {
-              "$ref": "#/definitions/Internal.ConnectionPaged"
-            },
-            "headers": {
-              "x-ms-client-request-id": {
-                "type": "string",
-                "format": "uuid",
-                "description": "An opaque, globally-unique, client-generated string identifier for the request."
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
-            },
-            "headers": {
-              "x-ms-error-code": {
-                "type": "string",
-                "description": "String error code indicating what went wrong."
-              }
-            }
-          }
-        },
-        "x-ms-pageable": {
-          "nextLinkName": "nextLink"
-        }
-      }
-    },
     "/datasets": {
       "get": {
         "operationId": "Datasets_ListLatest",
@@ -1291,10 +1162,11 @@
       "type": "object",
       "description": "API Key Credential definition",
       "properties": {
-        "apiKey": {
+        "key": {
           "type": "string",
           "description": "API Key",
-          "readOnly": true
+          "readOnly": true,
+          "x-ms-client-name": "apiKey"
         }
       },
       "allOf": [
@@ -2078,28 +1950,6 @@
       "discriminator": "type",
       "required": [
         "type"
-      ]
-    },
-    "Internal.ConnectionPaged": {
-      "type": "object",
-      "description": "Paged collection of Connection items",
-      "properties": {
-        "value": {
-          "type": "array",
-          "description": "The Connection items on this page",
-          "items": {
-            "$ref": "#/definitions/Connection"
-          },
-          "x-ms-identifiers": []
-        },
-        "nextLink": {
-          "type": "string",
-          "format": "uri",
-          "description": "The link to the next page of items"
-        }
-      },
-      "required": [
-        "value"
       ]
     },
     "ListSortOrder": {

--- a/specification/ai/data-plane/Azure.AI.Projects/stable/latest/azure-ai-projects-1dp.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/stable/latest/azure-ai-projects-1dp.json
@@ -1542,6 +1542,19 @@
     "CustomCredential": {
       "type": "object",
       "description": "Custom credential defintion",
+      "properties": {
+        "keys": {
+          "type": "object",
+          "description": "The credential type",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "readOnly": true
+        }
+      },
+      "required": [
+        "keys"
+      ],
       "allOf": [
         {
           "$ref": "#/definitions/BaseCredentials"

--- a/specification/ai/data-plane/Azure.AI.Projects/stable/latest/azure-ai-projects-1dp.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/stable/latest/azure-ai-projects-1dp.json
@@ -1294,15 +1294,15 @@
       "type": "object",
       "description": "A base class for connection credentials",
       "properties": {
-        "authType": {
+        "type": {
           "$ref": "#/definitions/CredentialType",
           "description": "The type of credential used by the connection",
           "readOnly": true
         }
       },
-      "discriminator": "authType",
+      "discriminator": "type",
       "required": [
-        "authType"
+        "type"
       ]
     },
     "BlobReferenceForConsumption": {
@@ -1332,10 +1332,6 @@
       "type": "object",
       "description": "Response from the list and get connections operations",
       "properties": {
-        "authType": {
-          "type": "string",
-          "description": "Discriminator property for Connection."
-        },
         "name": {
           "type": "string",
           "description": "The name of the resource",
@@ -1370,9 +1366,7 @@
           "readOnly": true
         }
       },
-      "discriminator": "authType",
       "required": [
-        "authType",
         "name",
         "type",
         "target",
@@ -2292,10 +2286,11 @@
       "type": "object",
       "description": "Shared Access Signature (SAS) credential definition",
       "properties": {
-        "sasToken": {
+        "SAS": {
           "type": "string",
           "description": "SAS token",
-          "readOnly": true
+          "readOnly": true,
+          "x-ms-client-name": "sasToken"
         }
       },
       "allOf": [


### PR DESCRIPTION
Per recent discussions:
- We agreed to remove listing connections with credentials
- The API key credential will be in the JSON element named "key" and not "apikey". However, since I still want to use `api_key` in emitted Python code instead of just `key`, I added an `encodedName` decorator.
- Use "type" as the discriminator instead of `authType`, as this is our norm
- Assume "SAS" over the wire instead of "sasToken"
- Treat custom credentials as `Record<string>`
