### PR TITLE
Switch AppInsights connection string to be mandatory for SDKs and add…

### DIFF
--- a/specification/ai/Azure.AI.Projects/evaluations/models.tsp
+++ b/specification/ai/Azure.AI.Projects/evaluations/models.tsp
@@ -120,7 +120,7 @@ model AgentEvaluationRequest {
   @doc("Redaction configuration for the evaluation.")
   redactionConfiguration?: AgentEvaluationRedactionConfiguration;
 
-  @doc("Optional and temporary way to pass the AppInsights connection string to the evaluator. When this string is not null, the evaluation results will be logged to Azure AppInsights.")
+  @doc("Pass the AppInsights connection string to the agent evaluation for the evaluation results and the errors logs.")
   appInsightsConnectionString: string;
 }
 

--- a/specification/ai/Azure.AI.Projects/evaluations/models.tsp
+++ b/specification/ai/Azure.AI.Projects/evaluations/models.tsp
@@ -121,7 +121,7 @@ model AgentEvaluationRequest {
   redactionConfiguration?: AgentEvaluationRedactionConfiguration;
 
   @doc("Optional and temporary way to pass the AppInsights connection string to the evaluator. When this string is not null, the evaluation results will be logged to Azure AppInsights.")
-  appInsightsConnectionString?: string;
+  appInsightsConnectionString: string;
 }
 
 @doc("Result for the agent evaluation evaluator run.")
@@ -165,6 +165,9 @@ model AgentEvaluation {
 
   @doc("Status of the agent evaluation. Options: Running, Completed, Failed.")
   status: string;
+
+  @doc("The reason of the request failure for the long running process, if applicable.")
+  error?: string;
 
   @doc("The agent evaluation result.")
   result?: Array<AgentEvaluationResult>;

--- a/specification/ai/data-plane/Azure.AI.Projects/preview/2025-05-15-preview/azure-ai-projects-1dp.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/preview/2025-05-15-preview/azure-ai-projects-1dp.json
@@ -1549,7 +1549,7 @@
         },
         "appInsightsConnectionString": {
           "type": "string",
-          "description": "Optional and temporary way to pass the AppInsights connection string to the evaluator. When this string is not null, the evaluation results will be logged to Azure AppInsights."
+          "description": "Pass the AppInsights connection string to the agent evaluation for the evaluation results and the errors logs."
         }
       },
       "required": [

--- a/specification/ai/data-plane/Azure.AI.Projects/preview/2025-05-15-preview/azure-ai-projects-1dp.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/preview/2025-05-15-preview/azure-ai-projects-1dp.json
@@ -1492,6 +1492,10 @@
           "type": "string",
           "description": "Status of the agent evaluation. Options: Running, Completed, Failed."
         },
+        "error": {
+          "type": "string",
+          "description": "The reason of the request failure for the long running process, if applicable."
+        },
         "result": {
           "type": "array",
           "description": "The agent evaluation result.",
@@ -1550,7 +1554,8 @@
       },
       "required": [
         "runId",
-        "evaluators"
+        "evaluators",
+        "appInsightsConnectionString"
       ]
     },
     "AgentEvaluationResult": {


### PR DESCRIPTION
… top level error field for get agent evaluation results API

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.

There are 2 fields updated:
1. Update `appInsightsConnectionString` in `AgentEvaluationRequest` from optional to mandatory. As AI Foundry SDKs are using this TypeSpec to generate the SDK, while other than AppInsights, there are no way to log user errors for Build, we want to flip it to mandatory
2. Add optional `error` field in `AgentEvaluation`. There are 3 types of errors for the request, this error is for the (ii) type from the list below:
    1. Immediately failure before sending back to the user, we will send non-200 status code with reason
    2. After the response to the user with 200, the code may still fail, e.g. when talking agent service for chat history, the paginated requests may take very long time, it's not good to combine it with type (i) above
    3. For any evaluator failures, the error will be shown within the array of evaluator results