### PR TITLE
[DO NOT MERGE] Testing LintDiff behavior on duplicate "input-file" definition in tag

### DIFF
--- a/specification/azureactivedirectory/resource-manager/Microsoft.Aadiam/preview/2020-03-01-preview/privateLinkForAzureAD.json
+++ b/specification/azureactivedirectory/resource-manager/Microsoft.Aadiam/preview/2020-03-01-preview/privateLinkForAzureAD.json
@@ -3,7 +3,7 @@
   "info": {
     "version": "2020-03-01-preview",
     "title": "azureactivedirectory",
-    "description": "Private link Policy for Azure Active Directory."
+    "description": "Private link Policy for Azure Active Directory. Test 2: change file in second definition."
   },
   "host": "management.azure.com",
   "schemes": [

--- a/specification/azureactivedirectory/resource-manager/Microsoft.Aadiam/preview/2020-07-01-preview/azureADMetrics.json
+++ b/specification/azureactivedirectory/resource-manager/Microsoft.Aadiam/preview/2020-07-01-preview/azureADMetrics.json
@@ -3,7 +3,7 @@
   "info": {
     "version": "2020-07-01-preview",
     "title": "azureactivedirectory",
-    "description": "Metrics and Alerts for Azure Active Directory."
+    "description": "Metrics and Alerts for Azure Active Directory. Trivial change to trigger LintDiff (part 1: change first instance of input-files)"
   },
   "host": "management.azure.com",
   "schemes": [

--- a/specification/azureactivedirectory/resource-manager/Microsoft.Aadiam/preview/2020-07-01-preview/azureADMetrics.json
+++ b/specification/azureactivedirectory/resource-manager/Microsoft.Aadiam/preview/2020-07-01-preview/azureADMetrics.json
@@ -3,7 +3,7 @@
   "info": {
     "version": "2020-07-01-preview",
     "title": "azureactivedirectory",
-    "description": "Metrics and Alerts for Azure Active Directory. Trivial change to trigger LintDiff (part 1: change first instance of input-files)"
+    "description": "Metrics and Alerts for Azure Active Directory."
   },
   "host": "management.azure.com",
   "schemes": [


### PR DESCRIPTION
First change: ran against the whole readme.md file itself, no tag https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4795947&view=logs&j=0574a2a6-2d0a-5ec6-40e4-4c6e2f70bea2&t=80c3e782-49f0-5d1c-70dd-cbee57bdd0c7 (the default tag?) 

Second change: Ran against the specific tag... it's as if the later definition overrides https://github.com/Azure/azure-rest-api-specs/pull/34215/checks?check_run_id=41108302900