### PR TITLE
[containerregistry] add directive for python

### DIFF
--- a/specification/containerregistry/resource-manager/readme.python.md
+++ b/specification/containerregistry/resource-manager/readme.python.md
@@ -176,3 +176,20 @@ directive:
     transform: >
         $['required'] = ['type'];
 ```
+
+``` yaml $(python)
+directive:
+  - from: swagger-document
+    where: $.definitions
+    transform: >
+      $.LoginServerProperties.properties.tls = {
+          "$ref": "#/definitions/TlsProperties",
+          "description": "The TLS properties of the connected registry login server.",
+          "readOnly": true
+        };
+      $.TlsProperties.properties.certificate = {
+          "$ref": "#/definitions/TlsCertificateProperties",
+          "description": "The certificate used to configure HTTPS for the login server.",
+          "readOnly": true
+        };
+```


### PR DESCRIPTION
fix https://github.com/Azure/sdk-release-request/issues/6093#issuecomment-2826141841

There is bug in swagger but service team can't fix it in time to catch up target release date. We have to add directive in readme.python.md to fix it for now like [.NET do](https://github.com/Azure/azure-sdk-for-net/pull/49475/commits/7adcd8f734da9ad54056f91df51e9cd2ca3d53c1#diff-8ff2c65bc5c780cea98f7ada56e7a81129c9c02dc01cc14a9071d1d628f713eb). After service team fix swagger, we can revert this PR.