### PR TITLE
[TypeSpecValidation] Revert SdkTspConfigValidation to warning-only

### DIFF
--- a/eng/tools/typespec-validation/src/rules/sdk-tspconfig-validation.ts
+++ b/eng/tools/typespec-validation/src/rules/sdk-tspconfig-validation.ts
@@ -528,8 +528,9 @@ export class SdkTspConfigValidationRule implements Rule {
         ? `${failedResults.map((r) => r.errorOutput).join("\n")}\nPlease see https://aka.ms/azsdk/spec-gen-sdk-config for more info.\nFor additional information on TypeSpec validation, please refer to https://aka.ms/azsdk/specs/typespec-validation.`
         : "";
 
+    // NOTE: to avoid huge impact on existing PRs, we always return true with info/warning messages.
     return {
-      success: isManagementSdk(folder) ? success : true,
+      success: true,
       stdOutput: `[${this.name}]: validation ${success ? "passed" : "failed"}.\n${stdOutputFailedResults}`,
     };
   }

--- a/eng/tools/typespec-validation/test/sdk-tspconfig-validation.test.ts
+++ b/eng/tools/typespec-validation/test/sdk-tspconfig-validation.test.ts
@@ -597,7 +597,8 @@ describe("tspconfig", function () {
 
     const rule = new SdkTspConfigValidationRule(c.subRules);
     const result = await rule.execute(c.folder);
-    const returnSuccess = c.folder.includes(".Management") ? c.success : true;
+    // NOTE: to avoid huge impact on existing PRs, we always return true with info/warning messages.
+    const returnSuccess = true;
     strictEqual(result.success, returnSuccess);
     if (c.success)
       strictEqual(result.stdOutput?.includes("[SdkTspConfigValidation]: validation passed."), true);


### PR DESCRIPTION
- Fixes TSV for all exsting specs
- Reverts failures introduced by #34156
