### PR TITLE
[Do not merge] Demo change: Add documentation for state property in Employee model

### DIFF
--- a/specification/contosowidgetmanager/Contoso.Management/employee.tsp
+++ b/specification/contosowidgetmanager/Contoso.Management/employee.tsp
@@ -25,6 +25,7 @@ model EmployeeProperties {
 
   /** State or province of employee */
   state?: string;
+
   /** Profile of employee */
   @encode("base64url")
   profile?: bytes;

--- a/specification/contosowidgetmanager/Contoso.Management/employee.tsp
+++ b/specification/contosowidgetmanager/Contoso.Management/employee.tsp
@@ -23,6 +23,8 @@ model EmployeeProperties {
   /** City of employee */
   city?: string;
 
+  /** State or province of employee */
+  state?: string;
   /** Profile of employee */
   @encode("base64url")
   profile?: bytes;

--- a/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/preview/2021-10-01-preview/contoso.json
+++ b/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/preview/2021-10-01-preview/contoso.json
@@ -469,6 +469,10 @@
           "type": "string",
           "description": "City of employee"
         },
+        "state": {
+          "type": "string",
+          "description": "State or province of employee"
+        },
         "profile": {
           "type": "string",
           "format": "base64url",

--- a/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/stable/2021-11-01/contoso.json
+++ b/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/stable/2021-11-01/contoso.json
@@ -469,6 +469,10 @@
           "type": "string",
           "description": "City of employee"
         },
+        "state": {
+          "type": "string",
+          "description": "State or province of employee"
+        },
         "profile": {
           "type": "string",
           "format": "base64url",


### PR DESCRIPTION
This PR adds the missing documentation for the state property in the Employee model to fix TypeSpec validation errors. The fix adds a doc comment to the state property in employee.tsp and updates the generated Swagger files accordingly.