### PR TITLE
Removed test prefixes from the check names

### DIFF
--- a/.github/workflows/sdk-breaking-change-labels.yaml
+++ b/.github/workflows/sdk-breaking-change-labels.yaml
@@ -1,4 +1,4 @@
-name: SDK Breaking Change Labels (Preview)
+name: SDK Breaking Change Labels
 
 on:
   check_run:
@@ -14,7 +14,7 @@ jobs:
       github.event.check_run.check_suite.app.name == 'Azure Pipelines' &&
       contains(github.event.check_run.name, 'SDK Generation') &&
       endsWith(github.event.check_run.external_id, '29ec6040-b234-4e31-b139-33dc4287b756')
-    name: SDK Breaking Change Labels (Preview)
+    name: SDK Breaking Change Labels
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/spec-gen-sdk-status.yml
+++ b/.github/workflows/spec-gen-sdk-status.yml
@@ -1,4 +1,4 @@
-name: "[TEST IGNORE] spec-gen-sdk status"
+name: "spec-gen-sdk status"
 
 on:
   check_run:
@@ -15,7 +15,7 @@ jobs:
       github.event.check_run.check_suite.app.name == 'Azure Pipelines' &&
       contains(github.event.check_run.name, 'SDK Generation') &&
       endsWith(github.event.check_run.external_id, '29ec6040-b234-4e31-b139-33dc4287b756')
-    name: "[TEST IGNORE] spec-gen-sdk - set status"
+    name: "spec-gen-sdk - set status"
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/src/spec-gen-sdk-status.js
+++ b/.github/workflows/src/spec-gen-sdk-status.js
@@ -60,7 +60,7 @@ export async function setSpecGenSdkStatusImpl({
   github,
   core,
 }) {
-  const statusName = "[TEST IGNORE] spec-gen-sdk status";
+  const statusName = "spec-gen-sdk status";
   const checks = await github.paginate(github.rest.checks.listForRef, {
     owner,
     repo,

--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -35,7 +35,7 @@ extends:
     Use1ESOfficial: false
     stages:
     - stage: Build
-      displayName: 'SDK Generation Preview'
+      displayName: 'SDK Generation'
       jobs:
       - job:
         timeoutInMinutes: 2400


### PR DESCRIPTION
Updates to workflow and script naming conventions by removing test-related prefixes and preview labels. 