### PR TITLE
[Storage] `start_copy_from_url` updated route

### DIFF
--- a/specification/storage/Microsoft.BlobStorage/routes.tsp
+++ b/specification/storage/Microsoft.BlobStorage/routes.tsp
@@ -1112,7 +1112,7 @@ namespace Storage.Blob {
       #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Existing API"
       #suppress "@azure-tools/typespec-azure-core/no-response-body" "Existing API"
       @put
-      @route("{blobName}?comp=copy")
+      @route("{blobName}")
       op startCopyFromUrl is StorageOperation<
         {
           ...ContainerNamePathParameter;


### PR DESCRIPTION
Example request from Python asset file: https://github.com/Azure/azure-sdk-assets/blob/python/storage/azure-storage-blob_6322eb5299/python/sdk/storage/azure-storage-blob/tests/recordings/test_common_blob.pyTestStorageCommonBlobtest_copy_blob_with_existing_blob.json#L121
`"RequestUri": "https://storagename.blob.core.windows.net/utcontainer42162f06/blob1copy"`

Seems to only apply narrowly to this operation, as abort_copy **does** have `comp=copy&copyid` as defined routes.tsp currently:
Python example [asset](https://github.com/Azure/azure-sdk-assets/blob/python/storage/azure-storage-blob_275000b78a/python/sdk/storage/azure-storage-blob/tests/recordings/test_common_blob.pyTestStorageCommonBlobtest_abort_copy_blob.json#L88)
`"RequestUri": "https://storagename.blob.core.windows.net/utcontainerf2da299a/59466-0.txt?comp=copy\u0026copyid=1c072780-3ed4-446d-83fc-d8f9c875068a"`

Addresses issue in https://github.com/Azure/azure-sdk-for-rust/pull/2541 path-building logic