### PR TITLE
Add depedency @typespec-migration/swagger-compare

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@azure-tools/typespec-client-generator-core": "0.55.1",
         "@azure-tools/typespec-liftr-base": "0.8.0",
         "@azure/avocado": "^0.9.1",
+        "@typespec-migration/swagger-compare": "0.0.1",
         "@typespec/compiler": "1.0.0-rc.1",
         "@typespec/events": "0.69.0",
         "@typespec/http": "1.0.0-rc.1",
@@ -2895,6 +2896,15 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@ewoudenberg/difflib": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@ewoudenberg/difflib/-/difflib-0.1.0.tgz",
+      "integrity": "sha512-OU5P5mJyD3OoWYMWY+yIgwvgNS9cFAU10f+DDuvtogcWQOoJIsQ4Hy2McSfUfhKjq8L0FuWVb4Rt7kgA+XK86A==",
+      "dev": true,
+      "dependencies": {
+        "heap": ">= 0.2.0"
+      }
+    },
     "node_modules/@faker-js/faker": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-5.5.3.tgz",
@@ -4897,6 +4907,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@typespec-migration/swagger-compare": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@typespec-migration/swagger-compare/-/swagger-compare-0.0.1.tgz",
+      "integrity": "sha512-3g4+Zr5O2Mi6Jd8UKH1yjnxtr7QJVTu9JfB2x64LKtS9KjAga3z5ymxN7+v9+hHEB8t+t47laljsRj+c8PXGnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure-tools/typespec-autorest": ">=0.44.0 <1.0.0",
+        "fs": "^0.0.1-security",
+        "json-diff": "^1.0.6",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "swagger-check": "dist/index.js"
+      }
+    },
     "node_modules/@typespec/asset-emitter": {
       "version": "0.69.0",
       "resolved": "https://registry.npmjs.org/@typespec/asset-emitter/-/asset-emitter-0.69.0.tgz",
@@ -6829,6 +6855,18 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/dreamopt": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/dreamopt/-/dreamopt-0.8.0.tgz",
+      "integrity": "sha512-vyJTp8+mC+G+5dfgsY+r3ckxlz+QMX40VjPQsZc5gxVAxLmi64TBoVkP54A/pRAXMXsbu2GMMBrZPxNv23waMg==",
+      "dev": true,
+      "dependencies": {
+        "wordwrap": ">=0.0.2"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -8088,6 +8126,13 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/fs": {
+      "version": "0.0.1-security",
+      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
+      "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fs-extra": {
       "version": "10.1.0",
@@ -9584,6 +9629,24 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-diff": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/json-diff/-/json-diff-1.0.6.tgz",
+      "integrity": "sha512-tcFIPRdlc35YkYdGxcamJjllUhXWv4n2rK9oJ2RsAzV4FBkuV4ojKEDgcZ+kpKxDmJKv+PFK65+1tVVOnSeEqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ewoudenberg/difflib": "0.1.0",
+        "colors": "^1.4.0",
+        "dreamopt": "~0.8.0"
+      },
+      "bin": {
+        "json-diff": "bin/json-diff.js"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/json-merge-patch": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@typespec/streams": "0.69.0",
     "@typespec/versioning": "0.69.0",
     "@typespec/xml": "0.69.0",
+    "@typespec-migration/swagger-compare": "0.0.1",
     "azure-rest-api-specs-eng-tools": "file:eng/tools",
     "oav": "^3.5.1",
     "prettier": "~3.5.3",


### PR DESCRIPTION
Compare two sets of swaggers: 1) original swaggers before we do TypeSpec migration, 2) generated swagger from TypeSpec.

I want to use this tool to give user a better visualized experience when they do the comparison.
