### PR TITLE
[LintDiff] Fix correlation: tags are strings, not Date

### DIFF
--- a/eng/tools/lint-diff/src/markdown-utils.ts
+++ b/eng/tools/lint-diff/src/markdown-utils.ts
@@ -200,7 +200,7 @@ export function getDefaultTag(markdownContent: string): string {
 
   const lh = codeBlockMap[latestHeader];
   if (lh) {
-    const latestDefinition = YAML.load(lh.literal!, { schema: YAML.JSON_SCHEMA }) as undefined | { tag: string };
+    const latestDefinition = YAML.load(lh.literal!, { schema: YAML.FAILSAFE_SCHEMA }) as undefined | { tag: string };
     if (latestDefinition) {
       return latestDefinition.tag;
     }
@@ -210,7 +210,7 @@ export function getDefaultTag(markdownContent: string): string {
       if (!lh || !lh.info || lh.info.trim().toLocaleLowerCase() !== "yaml") {
         continue;
       }
-      const latestDefinition = YAML.load(lh.literal!, { schema: YAML.JSON_SCHEMA }) as
+      const latestDefinition = YAML.load(lh.literal!, { schema: YAML.FAILSAFE_SCHEMA }) as
         | undefined
         | { tag: string };
 

--- a/eng/tools/lint-diff/src/markdown-utils.ts
+++ b/eng/tools/lint-diff/src/markdown-utils.ts
@@ -200,7 +200,7 @@ export function getDefaultTag(markdownContent: string): string {
 
   const lh = codeBlockMap[latestHeader];
   if (lh) {
-    const latestDefinition = YAML.load(lh.literal!) as undefined | { tag: string };
+    const latestDefinition = YAML.load(lh.literal!, { schema: YAML.JSON_SCHEMA }) as undefined | { tag: string };
     if (latestDefinition) {
       return latestDefinition.tag;
     }
@@ -210,7 +210,9 @@ export function getDefaultTag(markdownContent: string): string {
       if (!lh || !lh.info || lh.info.trim().toLocaleLowerCase() !== "yaml") {
         continue;
       }
-      const latestDefinition = YAML.load(lh.literal!) as undefined | { tag: string };
+      const latestDefinition = YAML.load(lh.literal!, { schema: YAML.JSON_SCHEMA }) as
+        | undefined
+        | { tag: string };
 
       if (latestDefinition) {
         return latestDefinition.tag;

--- a/eng/tools/lint-diff/test/markdown-utils.test.ts
+++ b/eng/tools/lint-diff/test/markdown-utils.test.ts
@@ -116,6 +116,36 @@ describe("getDefaultTag", () => {
 
     expect(defaultTag).toEqual("");
   });
+
+  test.each([
+    {
+      description: "without Basic Information header",
+      readmeContent: `# Some header
+This should be parsed as a string, not a Date object.
+\`\`\`yaml
+tag: 2025-01-01
+\`\`\`
+`,
+    },
+    {
+      description: "with Basic Information header",
+      readmeContent: `# Basic Information
+This should be parsed as a string, not a Date object.
+\`\`\`yaml
+tag: 2025-01-01
+\`\`\`
+`,
+    },
+  ])(
+    "returns a string for default tag even when the tag is formatted like a date ($description)",
+    ({ readmeContent }) => {
+      const defaultTag = getDefaultTag(readmeContent);
+
+      expect(defaultTag).not.toBeInstanceOf(Date);
+      expect(defaultTag).toBeTypeOf("string");
+      expect(defaultTag).toEqual("2025-01-01");
+    },
+  );
 });
 
 describe("getAllTags", () => {


### PR DESCRIPTION
Configure YAML parser to return basic JSON-compatible objects. 

Legacy LintDiff: https://github.com/Azure/azure-rest-api-specs/pull/34379/checks?check_run_id=41443910398
New LintDiff: https://github.com/Azure/azure-rest-api-specs/actions/runs/14761776132