### PR TITLE
revert spec-gen-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "azure-rest-api-specs",
       "devDependencies": {
         "@autorest/openapi-to-typespec": "0.11.0",
-        "@azure-tools/spec-gen-sdk": "^0.5.1",
+        "@azure-tools/spec-gen-sdk": "~0.4.2",
         "@azure-tools/typespec-apiview": "0.7.0",
         "@azure-tools/typespec-autorest": "0.55.0",
         "@azure-tools/typespec-azure-core": "0.55.0",
@@ -1447,9 +1447,9 @@
       "link": true
     },
     "node_modules/@azure-tools/spec-gen-sdk": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@azure-tools/spec-gen-sdk/-/spec-gen-sdk-0.5.1.tgz",
-      "integrity": "sha512-A8tUduTYniMrXxgjCjYW8nojN287yFPmoDpLCHn5deE30Hes2BS61Kgu6VO+Lq0jgLfoQPUXACUDfWGLi3CG7w==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@azure-tools/spec-gen-sdk/-/spec-gen-sdk-0.4.2.tgz",
+      "integrity": "sha512-ASNhxiAKe6BvY71CfcGV6dhdvWeZ/TtDwxiGSoWBiutH/ges0YUOlvl4ZQq1iwc2y102mPV0gHyj5GYlsFJ8DQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "azure-rest-api-specs",
   "devDependencies": {
-    "@azure-tools/spec-gen-sdk": "^0.5.1",
+    "@azure-tools/spec-gen-sdk": "~0.4.2",
     "@azure-tools/typespec-apiview": "0.7.0",
     "@azure-tools/typespec-autorest": "0.55.0",
     "@azure-tools/typespec-azure-core": "0.55.0",


### PR DESCRIPTION
Revert the change made by dependabot. It needs to lock the minor version bump for spec-gen-sdk tool.

Fixed the error for the runs in private spec repo.
[Test run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4816309&view=logs&s=6884a131-87da-5381-61f3-d7acc3b91d76)