### PR TITLE
Enabled apiview creation step in public repo

### DIFF
--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -279,9 +279,9 @@ extends:
                     -PRBody "$(GeneratedSDKInformation)"
                     -OpenAsDraft $true
 
-            - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-              - template: /eng/common/pipelines/templates/steps/detect-api-changes.yml
-                parameters:
-                  ArtifactPath: $(GeneratedSDK.StagedArtifactsFolder)
-                  ArtifactName: $(PipelineArtifactsName)
-                  RepoRoot: $(SdkRepoDirectory)
+          - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+            - template: /eng/common/pipelines/templates/steps/detect-api-changes.yml
+              parameters:
+                ArtifactPath: $(GeneratedSDK.StagedArtifactsFolder)
+                ArtifactName: $(PipelineArtifactsName)
+                RepoRoot: $(SdkRepoDirectory)


### PR DESCRIPTION
This step needs to be enabled when we decommission the old alps sdk gen pipelines.