### PR TITLE
[spec-model] Move specModel to options

### DIFF
--- a/.github/shared/src/readme.js
+++ b/.github/shared/src/readme.js
@@ -23,19 +23,19 @@ export class Readme {
   /** @type {string} absolute path */
   #path;
 
-  /** @type {SpecModel} backpointer to owning SpecModel */
+  /** @type {SpecModel | undefined} backpointer to owning SpecModel */
   #specModel;
 
   /**
-   * @param {SpecModel} specModel
    * @param {string} path
    * @param {Object} [options]
    * @param {import('./logger.js').ILogger} [options.logger]
+   * @param {SpecModel} [options.specModel]
    */
-  constructor(specModel, path, options) {
-    this.#specModel = specModel;
+  constructor(path, options) {
     this.#path = resolve(path);
     this.#logger = options?.logger;
+    this.#specModel = options?.specModel;
   }
 
   /**
@@ -147,8 +147,9 @@ export class Readme {
             dirname(this.#path),
             swaggerPathNormalized,
           );
-          const swagger = new Swagger(this.#specModel, swaggerPathResolved, {
+          const swagger = new Swagger(swaggerPathResolved, {
             logger: this.#logger,
+            specModel: this.#specModel,
           });
           inputFiles.add(swagger);
         }
@@ -193,9 +194,10 @@ export class Readme {
     );
 
     return {
-      path: options?.relativePaths
-        ? relative(this.#specModel.folder, this.#path)
-        : this.#path,
+      path:
+        options?.relativePaths && this.#specModel
+          ? relative(this.#specModel.folder, this.#path)
+          : this.#path,
       globalConfig: await this.getGlobalConfig(),
       tags,
     };

--- a/.github/shared/src/spec-model.js
+++ b/.github/shared/src/spec-model.js
@@ -180,7 +180,9 @@ export class SpecModel {
       this.#logger?.debug(`Found ${readmePaths.length} readme files`);
 
       this.#readmes = new Set(
-        readmePaths.map((p) => new Readme(this, p, { logger: this.#logger })),
+        readmePaths.map(
+          (p) => new Readme(p, { logger: this.#logger, specModel: this }),
+        ),
       );
     }
 

--- a/.github/shared/test/readme.test.js
+++ b/.github/shared/test/readme.test.js
@@ -3,12 +3,11 @@
 import { resolve } from "path";
 import { describe, expect, it } from "vitest";
 import { getInputFiles, Readme } from "../src/readme.js";
-import { SpecModel } from "../src/spec-model.js";
 import { contosoReadme } from "./examples.js";
 
 describe("readme", () => {
   it("can be created with mock path", async () => {
-    const readme = new Readme(new SpecModel("foo"), "bar");
+    const readme = new Readme("bar");
     expect(readme.path).toBe(resolve("bar"));
 
     await expect(readme.getTags()).rejects.toThrowError(

--- a/.github/shared/test/swagger.test.js
+++ b/.github/shared/test/swagger.test.js
@@ -2,12 +2,11 @@
 
 import { resolve } from "path";
 import { describe, expect, it } from "vitest";
-import { SpecModel } from "../src/spec-model.js";
 import { Swagger } from "../src/swagger.js";
 
 describe("Swagger", () => {
   it("can be created with mock path", async () => {
-    const swagger = new Swagger(new SpecModel("foo"), "bar");
+    const swagger = new Swagger("bar");
     expect(swagger.path).toBe(resolve("bar"));
 
     await expect(swagger.getRefs()).rejects.toThrowError(

--- a/.github/shared/test/tag.test.js
+++ b/.github/shared/test/tag.test.js
@@ -3,16 +3,12 @@
 import { describe, expect, it } from "vitest";
 
 import { resolve } from "path";
-import { SpecModel } from "../src/spec-model.js";
 import { Swagger } from "../src/swagger.js";
 import { Tag } from "../src/tag.js";
 
 describe("Tag", () => {
   it("can be created with mock swaggers", async () => {
-    const tag = new Tag(
-      "tag",
-      new Set([new Swagger(new SpecModel("foo"), "swagger")]),
-    );
+    const tag = new Tag("tag", new Set([new Swagger("swagger")]));
     expect(tag.name).toBe("tag");
     expect(tag.inputFiles.size).toBe(1);
 


### PR DESCRIPTION
- Only needed for relative paths in toJsonAsync()
- Improves testability