### PR TITLE
Change scheduler config mode enum string.

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2025-03-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2025-03-02-preview/managedClusters.json
@@ -6830,10 +6830,6 @@
           "$ref": "#/definitions/SchedulerProfile",
           "description": "Profile of the pod scheduler configuration."
         },
-        "schedulerProfile": {
-          "$ref": "#/definitions/SchedulerProfile",
-          "description": "Profile of the pod scheduler configuration."
-        },
         "status": {
           "$ref": "#/definitions/ManagedClusterStatus",
           "description": "Contains read-only information about the Managed Cluster."

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2025-03-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2025-03-02-preview/managedClusters.json
@@ -11116,7 +11116,7 @@
           "type": "string",
           "description": "The config customization mode for this scheduler instance.",
           "enum": [
-            "None",
+            "Default",
             "ManagedByCRD"
           ],
           "x-ms-enum": {
@@ -11124,7 +11124,7 @@
             "modelAsString": true,
             "values": [
               {
-                "value": "None",
+                "value": "Default",
                 "description": "No config customization. Use default configuration."
               },
               {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2025-03-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2025-03-02-preview/managedClusters.json
@@ -6830,6 +6830,10 @@
           "$ref": "#/definitions/SchedulerProfile",
           "description": "Profile of the pod scheduler configuration."
         },
+        "schedulerProfile": {
+          "$ref": "#/definitions/SchedulerProfile",
+          "description": "Profile of the pod scheduler configuration."
+        },
         "status": {
           "$ref": "#/definitions/ManagedClusterStatus",
           "description": "Contains read-only information about the Managed Cluster."


### PR DESCRIPTION
## Description

Change scheduler config mode enum string from `None` to `Default`. `Default` is more intuitive for the customer and more directly describes the specified behavior.