### PR TITLE
chore: add new ubuntu OSSKUs enums to 2025-03-02-preview 

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2025-03-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2025-03-02-preview/managedClusters.json
@@ -7692,7 +7692,9 @@
         "AzureLinux",
         "Windows2019",
         "Windows2022",
-        "WindowsAnnual"
+        "WindowsAnnual",
+        "Ubuntu2204",
+        "Ubuntu2404"
       ],
       "x-ms-enum": {
         "name": "OSSKU",
@@ -7725,6 +7727,14 @@
           {
             "value": "WindowsAnnual",
             "description": "Use Windows Annual Channel version as the OS for node images. Unsupported for system node pools. Details about supported container images and kubernetes versions under different AKS Annual Channel versions could be seen in https://aka.ms/aks/windows-annual-channel-details."
+          },
+          {
+            "description": "Use Ubuntu2204 as the OS for node images, however, Ubuntu 22.04 may not be supported for all nodepools. For limitations and supported kubernetes versions, see see https://aka.ms/aks/supported-ubuntu-versions",
+            "value": "Ubuntu2204"
+          },
+          {
+            "description": "Use Ubuntu2404 as the OS for node images, however, Ubuntu 24.04 may not be supported for all nodepools. For limitations and supported kubernetes versions, see see https://aka.ms/aks/supported-ubuntu-versions",
+            "value": "Ubuntu2404"
           }
         ]
       },

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2025-03-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2025-03-02-preview/managedClusters.json
@@ -7729,12 +7729,12 @@
             "description": "Use Windows Annual Channel version as the OS for node images. Unsupported for system node pools. Details about supported container images and kubernetes versions under different AKS Annual Channel versions could be seen in https://aka.ms/aks/windows-annual-channel-details."
           },
           {
-            "description": "Use Ubuntu2204 as the OS for node images, however, Ubuntu 22.04 may not be supported for all nodepools. For limitations and supported kubernetes versions, see see https://aka.ms/aks/supported-ubuntu-versions",
-            "value": "Ubuntu2204"
+            "value": "Ubuntu2204",
+            "description": "Use Ubuntu2204 as the OS for node images, however, Ubuntu 22.04 may not be supported for all nodepools. For limitations and supported kubernetes versions, see see https://aka.ms/aks/supported-ubuntu-versions"
           },
           {
-            "description": "Use Ubuntu2404 as the OS for node images, however, Ubuntu 24.04 may not be supported for all nodepools. For limitations and supported kubernetes versions, see see https://aka.ms/aks/supported-ubuntu-versions",
-            "value": "Ubuntu2404"
+            "value": "Ubuntu2404",
+            "description": "Use Ubuntu2404 as the OS for node images, however, Ubuntu 24.04 may not be supported for all nodepools. For limitations and supported kubernetes versions, see see https://aka.ms/aks/supported-ubuntu-versions"
           }
         ]
       },


### PR DESCRIPTION
This PR adds the new OSSKU's Ubuntu2204 and Ubuntu2404 to the 2025-03-02-preview API spec.

It uses the exact same format and wording as the approved API doc: https://msazure.visualstudio.com/CloudNativeCompute/_wiki/wikis/CloudNativeCompute.wiki/748089/Add-Ubuntu2204-and-Ubuntu2404-to-ossku
