### PR TITLE
chore: add new Ubuntu2204 OSSKU enum value to 2025-03-01

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2025-03-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2025-03-01/managedClusters.json
@@ -5939,7 +5939,8 @@
         "CBLMariner",
         "AzureLinux",
         "Windows2019",
-        "Windows2022"
+        "Windows2022",
+        "Ubuntu2204"
       ],
       "x-ms-enum": {
         "name": "OSSKU",
@@ -5964,6 +5965,10 @@
           {
             "value": "Windows2022",
             "description": "Use Windows2022 as the OS for node images. Unsupported for system node pools. Windows2022 only supports Windows2022 containers; it cannot run Windows2019 containers and vice versa."
+          },
+          {
+            "description": "Use Ubuntu2204 as the OS for node images, however, Ubuntu 22.04 may not be supported for all nodepools. For limitations and supported kubernetes versions, see see https://aka.ms/aks/supported-ubuntu-versions",
+            "value": "Ubuntu2204"
           }
         ]
       },

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2025-03-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2025-03-01/managedClusters.json
@@ -5967,8 +5967,8 @@
             "description": "Use Windows2022 as the OS for node images. Unsupported for system node pools. Windows2022 only supports Windows2022 containers; it cannot run Windows2019 containers and vice versa."
           },
           {
-            "description": "Use Ubuntu2204 as the OS for node images, however, Ubuntu 22.04 may not be supported for all nodepools. For limitations and supported kubernetes versions, see see https://aka.ms/aks/supported-ubuntu-versions",
-            "value": "Ubuntu2204"
+            "value": "Ubuntu2204",
+            "description": "Use Ubuntu2204 as the OS for node images, however, Ubuntu 22.04 may not be supported for all nodepools. For limitations and supported kubernetes versions, see see https://aka.ms/aks/supported-ubuntu-versions"
           }
         ]
       },


### PR DESCRIPTION
This PR adds the new OSSKU's Ubuntu2204 to the 2025-03-01 API spec.

It uses the exact same format and wording as the approved API doc: https://msazure.visualstudio.com/CloudNativeCompute/_wiki/wikis/CloudNativeCompute.wiki/748089/Add-Ubuntu2204-and-Ubuntu2404-to-ossku