### PR TITLE
Microsoft.CodeTransparency: Fix documentation for contentTitle property

### DIFF
--- a/specification/confidentialledger/Microsoft.CodeTransparency/main.tsp
+++ b/specification/confidentialledger/Microsoft.CodeTransparency/main.tsp
@@ -110,6 +110,10 @@ model CreateEntryCreated {
   @statusCode
   statusCode: 201;
 
+  @doc("The title of the content")
+  @header("Contnet-Title")
+  contentTitle?: string;
+
   @doc("The MIME content type a Cose body is application/cose, containing a CoseSign1 signature.")
   @header("Content-Type")
   contentType: "application/cose";

--- a/specification/confidentialledger/data-plane/Microsoft.CodeTransparency/preview/2025-01-31-preview/cts.json
+++ b/specification/confidentialledger/data-plane/Microsoft.CodeTransparency/preview/2025-01-31-preview/cts.json
@@ -114,6 +114,10 @@
               "type": "file"
             },
             "headers": {
+              "Contnet-Title": {
+                "type": "string",
+                "description": "The title of the content"
+              },
               "Location": {
                 "type": "string",
                 "description": "Location of the receipt"


### PR DESCRIPTION
This PR fixes the documentation for the contentTitle property in the CreateEntryCreated model. Added missing documentation to address TypeSpec validation error.