### PR TITLE
Use --max-old-space-size=8192 for LintDiff

### DIFF
--- a/.github/workflows/lintdiff-code.yaml
+++ b/.github/workflows/lintdiff-code.yaml
@@ -64,3 +64,7 @@ jobs:
           echo "⚠️ This check is testing a new version of 'Swagger LintDiff'."
           echo "⚠️ Failures are expected, and should be completely ignored by spec authors and reviewers."
           echo "⚠️ Meaningful results for this PR are are in required check 'Swagger LintDiff'."
+        env:
+          # Some LintDiff runs are memory intensive and require more than the
+          # default.
+          NODE_OPTIONS: '--max-old-space-size=8192'


### PR DESCRIPTION
Example broken run: https://github.com/Azure/azure-rest-api-specs/actions/runs/14931189663/job/41947606290#step:8:619

Example run: https://github.com/Azure/azure-rest-api-specs/actions/runs/14963848474/job/42030239368?pr=34591