### PR TITLE
Updated the required check condition

### DIFF
--- a/.github/workflows/src/spec-gen-sdk-status.js
+++ b/.github/workflows/src/spec-gen-sdk-status.js
@@ -177,7 +177,7 @@ async function processResult({ checkRuns, core }) {
     const shortLanguageName = language.split("-").pop();
     const executionResult = artifactJsonObj.result;
     const isSpecGenSdkCheckRequired = artifactJsonObj.isSpecGenSdkCheckRequired;
-    if (isSpecGenSdkCheckRequired && executionResult !== "succeeded") {
+    if (isSpecGenSdkCheckRequired && !(executionResult === "succeeded" || executionResult === "warning")) {
       state = CommitStatusState.FAILURE;
       specGenSdkFailedRequiredLanguages += shortLanguageName + ", ";
     }

--- a/.github/workflows/src/spec-gen-sdk-status.js
+++ b/.github/workflows/src/spec-gen-sdk-status.js
@@ -177,7 +177,7 @@ async function processResult({ checkRuns, core }) {
     const shortLanguageName = language.split("-").pop();
     const executionResult = artifactJsonObj.result;
     const isSpecGenSdkCheckRequired = artifactJsonObj.isSpecGenSdkCheckRequired;
-    if (isSpecGenSdkCheckRequired && !(executionResult === "succeeded" || executionResult === "warning")) {
+    if (isSpecGenSdkCheckRequired && executionResult === "failed") {
       state = CommitStatusState.FAILURE;
       specGenSdkFailedRequiredLanguages += shortLanguageName + ", ";
     }


### PR DESCRIPTION
Allow warnings result while checking the required CI check result. As long as the spec-gen-sdk check doesn't have failures, we should succeed the status check.