### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -283,8 +283,6 @@
 /profile/ @shahabhijeet
 
 /specification/**/resource-manager/**/readme.typescript.md @qiaozha
-/specification/**/resource-manager/**/readme.az.md @jsntcy
-/specification/**/resource-manager/**/readme.cli.md @jsntcy
 /specification/**/resource-manager/**/readme.go.md @tadelesh
 /specification/**/resource-manager/**/readme.python.md @msyyc
 


### PR DESCRIPTION
`readme.az.md` and `readme.cli.md` are deprecated, so delete them.
