### PR TITLE
Override spec repo commit by the source commit of the pull request

### DIFF
--- a/eng/common/pipelines/templates/steps/sparse-checkout.yml
+++ b/eng/common/pipelines/templates/steps/sparse-checkout.yml
@@ -14,6 +14,9 @@ parameters:
   - name: TokenToUseForAuth
     type: string
     default: ''
+  - name: PreserveAuthToken
+    type: boolean
+    default: false
 
 steps:
   - ${{ if not(parameters.SkipCheckoutNone) }}:
@@ -137,7 +140,7 @@ steps:
       pwsh: true
       workingDirectory: $(System.DefaultWorkingDirectory)
 
-  - ${{ if ne(parameters.TokenToUseForAuth, '') }}:
+  - ${{ if and(ne(parameters.TokenToUseForAuth, ''), ne(parameters.PreserveAuthToken, true)) }}:
     - pwsh: |
         git config unset --global "http.extraheader"
       displayName: Removing git config auth header

--- a/eng/common/pipelines/templates/steps/sparse-checkout.yml
+++ b/eng/common/pipelines/templates/steps/sparse-checkout.yml
@@ -14,9 +14,6 @@ parameters:
   - name: TokenToUseForAuth
     type: string
     default: ''
-  - name: PreserveAuthToken
-    type: boolean
-    default: false
 
 steps:
   - ${{ if not(parameters.SkipCheckoutNone) }}:
@@ -140,7 +137,7 @@ steps:
       pwsh: true
       workingDirectory: $(System.DefaultWorkingDirectory)
 
-  - ${{ if and(ne(parameters.TokenToUseForAuth, ''), ne(parameters.PreserveAuthToken, true)) }}:
+  - ${{ if ne(parameters.TokenToUseForAuth, '') }}:
     - pwsh: |
         git config unset --global "http.extraheader"
       displayName: Removing git config auth header

--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -140,6 +140,7 @@ extends:
                   Commitish: ${{ parameters.SdkRepoCommit }}
                   WorkingDirectory: $(SdkRepoDirectory)
               SkipCheckoutNone: true
+              PreserveAuthToken: true
               ${{ if and(eq(variables['System.TeamProject'], 'internal'), endsWith(variables['Build.Repository.Name'], '-pr')) }}:
                 TokenToUseForAuth: $(azuresdk-github-pat)
 

--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -164,10 +164,12 @@ extends:
                 sdk_gen_info="$sdk_gen_info '${{ parameters.ConfigPath }}',"
               fi
 
+              $updatedSpecRepoCommit = "$(SpecRepoCommit)"
               if [ "$(Build.Reason)" = "PullRequest" ]; then
                 optional_params="$optional_params --pr-number $(System.PullRequest.PullRequestNumber)"
                 specPrUrl="${{ parameters.SpecRepoUrl }}/pull/$(System.PullRequest.PullRequestNumber)"
                 sdk_gen_info="$sdk_gen_info spec PR: $specPrUrl"
+                $updatedSpecRepoCommit="$(System.PullRequest.SourceCommitId)"
               fi
 
               if [ "${{ parameters.SpecBatchTypes }}" != "" ]; then
@@ -179,7 +181,7 @@ extends:
                 optional_params="$optional_params --api-version ${{ parameters.ApiVersion }} --sdk-release-type ${{ parameters.SdkReleaseType }}"
                 sdk_gen_info="$sdk_gen_info API Version: ${{ parameters.ApiVersion }}, SDK Release Type: ${{ parameters.SdkReleaseType }},"
               fi
-              sdk_gen_info="$sdk_gen_info and CommitSHA: '$(SpecRepoCommit)' in SpecRepo: '${{ parameters.SpecRepoUrl }}'"
+              sdk_gen_info="$sdk_gen_info and CommitSHA: '$updatedSpecRepoCommit' in SpecRepo: '${{ parameters.SpecRepoUrl }}'"
               echo "##vso[task.setvariable variable=GeneratedSDKInformation]$sdk_gen_info"
               echo "$sdk_gen_info"
 
@@ -192,7 +194,7 @@ extends:
                 --sdp $(SdkRepoDirectory) \
                 --wf $(System.DefaultWorkingDirectory) \
                 --lang $(SdkRepoName) \
-                --commit $(SpecRepoCommit) \
+                --commit $updatedSpecRepoCommit \
                 --spec-repo-url ${{ parameters.SpecRepoUrl }} \
                 $optional_params || true # return true always to suppress exit error logging
             displayName: 'Generate SDK'

--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -140,9 +140,9 @@ extends:
                   Commitish: ${{ parameters.SdkRepoCommit }}
                   WorkingDirectory: $(SdkRepoDirectory)
               SkipCheckoutNone: true
-              PreserveAuthToken: true
               ${{ if and(eq(variables['System.TeamProject'], 'internal'), endsWith(variables['Build.Repository.Name'], '-pr')) }}:
                 TokenToUseForAuth: $(azuresdk-github-pat)
+                PreserveAuthToken: true
 
           - task: NodeTool@0
             inputs:

--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -165,12 +165,12 @@ extends:
                 sdk_gen_info="$sdk_gen_info '${{ parameters.ConfigPath }}',"
               fi
 
-              $updatedSpecRepoCommit = "$(SpecRepoCommit)"
+              updatedSpecRepoCommit="$(SpecRepoCommit)"
               if [ "$(Build.Reason)" = "PullRequest" ]; then
                 optional_params="$optional_params --pr-number $(System.PullRequest.PullRequestNumber)"
                 specPrUrl="${{ parameters.SpecRepoUrl }}/pull/$(System.PullRequest.PullRequestNumber)"
                 sdk_gen_info="$sdk_gen_info spec PR: $specPrUrl"
-                $updatedSpecRepoCommit="$(System.PullRequest.SourceCommitId)"
+                updatedSpecRepoCommit="$(System.PullRequest.SourceCommitId)"
               fi
 
               if [ "${{ parameters.SpecBatchTypes }}" != "" ]; then


### PR DESCRIPTION
Downstream SDK generation should use this commit, such as the commit in the `tsp-location.yaml` file.

[Test run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4872380&view=logs&s=6884a131-87da-5381-61f3-d7acc3b91d76)