### PR TITLE
Updated swagger files for Azure AI Projects TypeSpec

### DIFF
--- a/specification/ai/data-plane/Azure.AI.Projects/preview/2025-05-15-preview/azure-ai-projects.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/preview/2025-05-15-preview/azure-ai-projects.json
@@ -456,7 +456,7 @@
             "description": "The definition of the DatasetVersion to create or update",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/DatasetVersion"
+              "$ref": "#/definitions/DatasetVersionUpdate"
             }
           }
         ],
@@ -1167,7 +1167,7 @@
             "description": "The definition of the Index to create or update",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/Index"
+              "$ref": "#/definitions/IndexUpdate"
             }
           }
         ],
@@ -1852,6 +1852,16 @@
       ],
       "x-ms-discriminator-value": "AzureSearch"
     },
+    "AzureAISearchIndexUpdate": {
+      "type": "object",
+      "description": "Azure AI Search Index Definition",
+      "allOf": [
+        {
+          "$ref": "#/definitions/IndexUpdate"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureSearch"
+    },
     "AzureOpenAIModelConfiguration": {
       "type": "object",
       "description": "Azure OpenAI model configuration. The API version would be selected by the service for querying the model.",
@@ -2082,6 +2092,16 @@
       ],
       "x-ms-discriminator-value": "CosmosDBNoSqlVectorStore"
     },
+    "CosmosDBIndexUpdate": {
+      "type": "object",
+      "description": "CosmosDB Vector Store Index Definition",
+      "allOf": [
+        {
+          "$ref": "#/definitions/IndexUpdate"
+        }
+      ],
+      "x-ms-discriminator-value": "CosmosDBNoSqlVectorStore"
+    },
     "CredentialType": {
       "type": "string",
       "description": "The credential type used by the connection",
@@ -2243,6 +2263,39 @@
         "type",
         "name",
         "version"
+      ]
+    },
+    "DatasetVersionUpdate": {
+      "type": "object",
+      "description": "DatasetVersion Definition",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/DatasetType",
+          "description": "Dataset type"
+        },
+        "description": {
+          "type": "string",
+          "description": "The asset description text.",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ]
+        },
+        "tags": {
+          "type": "object",
+          "description": "Tag dictionary. Tags can be added, removed, and updated.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ]
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "type"
       ]
     },
     "Deployment": {
@@ -2466,12 +2519,32 @@
       ],
       "x-ms-discriminator-value": "uri_file"
     },
+    "FileDatasetVersionUpdate": {
+      "type": "object",
+      "description": "FileDatasetVersion Definition",
+      "allOf": [
+        {
+          "$ref": "#/definitions/DatasetVersionUpdate"
+        }
+      ],
+      "x-ms-discriminator-value": "uri_file"
+    },
     "FolderDatasetVersion": {
       "type": "object",
       "description": "FileDatasetVersion Definition",
       "allOf": [
         {
           "$ref": "#/definitions/DatasetVersion"
+        }
+      ],
+      "x-ms-discriminator-value": "uri_folder"
+    },
+    "FolderDatasetVersionUpdate": {
+      "type": "object",
+      "description": "FileDatasetVersion Definition",
+      "allOf": [
+        {
+          "$ref": "#/definitions/DatasetVersionUpdate"
         }
       ],
       "x-ms-discriminator-value": "uri_folder"
@@ -2555,6 +2628,39 @@
         ]
       }
     },
+    "IndexUpdate": {
+      "type": "object",
+      "description": "Index resource Definition",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/IndexType",
+          "description": "Type of index"
+        },
+        "description": {
+          "type": "string",
+          "description": "The asset description text.",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ]
+        },
+        "tags": {
+          "type": "object",
+          "description": "Tag dictionary. Tags can be added, removed, and updated.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ]
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "type"
+      ]
+    },
     "InputData": {
       "type": "object",
       "description": "Abstract data class.",
@@ -2606,6 +2712,16 @@
       "allOf": [
         {
           "$ref": "#/definitions/Index"
+        }
+      ],
+      "x-ms-discriminator-value": "ManagedAzureSearch"
+    },
+    "ManagedAzureAISearchIndexUpdate": {
+      "type": "object",
+      "description": "Managed Azure AI Search Index Definition",
+      "allOf": [
+        {
+          "$ref": "#/definitions/IndexUpdate"
         }
       ],
       "x-ms-discriminator-value": "ManagedAzureSearch"

--- a/specification/ai/data-plane/Azure.AI.Projects/stable/2025-05-01/azure-ai-projects.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/stable/2025-05-01/azure-ai-projects.json
@@ -456,7 +456,7 @@
             "description": "The definition of the DatasetVersion to create or update",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/DatasetVersion"
+              "$ref": "#/definitions/DatasetVersionUpdate"
             }
           }
         ],
@@ -969,7 +969,7 @@
             "description": "The definition of the Index to create or update",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/Index"
+              "$ref": "#/definitions/IndexUpdate"
             }
           }
         ],
@@ -1188,6 +1188,16 @@
       ],
       "x-ms-discriminator-value": "AzureSearch"
     },
+    "AzureAISearchIndexUpdate": {
+      "type": "object",
+      "description": "Azure AI Search Index Definition",
+      "allOf": [
+        {
+          "$ref": "#/definitions/IndexUpdate"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureSearch"
+    },
     "BaseCredentials": {
       "type": "object",
       "description": "A base class for connection credentials",
@@ -1399,6 +1409,16 @@
       ],
       "x-ms-discriminator-value": "CosmosDBNoSqlVectorStore"
     },
+    "CosmosDBIndexUpdate": {
+      "type": "object",
+      "description": "CosmosDB Vector Store Index Definition",
+      "allOf": [
+        {
+          "$ref": "#/definitions/IndexUpdate"
+        }
+      ],
+      "x-ms-discriminator-value": "CosmosDBNoSqlVectorStore"
+    },
     "CredentialType": {
       "type": "string",
       "description": "The credential type used by the connection",
@@ -1562,6 +1582,39 @@
         "version"
       ]
     },
+    "DatasetVersionUpdate": {
+      "type": "object",
+      "description": "DatasetVersion Definition",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/DatasetType",
+          "description": "Dataset type"
+        },
+        "description": {
+          "type": "string",
+          "description": "The asset description text.",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ]
+        },
+        "tags": {
+          "type": "object",
+          "description": "Tag dictionary. Tags can be added, removed, and updated.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ]
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "type"
+      ]
+    },
     "Deployment": {
       "type": "object",
       "description": "Model Deployment Definition",
@@ -1703,12 +1756,32 @@
       ],
       "x-ms-discriminator-value": "uri_file"
     },
+    "FileDatasetVersionUpdate": {
+      "type": "object",
+      "description": "FileDatasetVersion Definition",
+      "allOf": [
+        {
+          "$ref": "#/definitions/DatasetVersionUpdate"
+        }
+      ],
+      "x-ms-discriminator-value": "uri_file"
+    },
     "FolderDatasetVersion": {
       "type": "object",
       "description": "FileDatasetVersion Definition",
       "allOf": [
         {
           "$ref": "#/definitions/DatasetVersion"
+        }
+      ],
+      "x-ms-discriminator-value": "uri_folder"
+    },
+    "FolderDatasetVersionUpdate": {
+      "type": "object",
+      "description": "FileDatasetVersion Definition",
+      "allOf": [
+        {
+          "$ref": "#/definitions/DatasetVersionUpdate"
         }
       ],
       "x-ms-discriminator-value": "uri_folder"
@@ -1792,6 +1865,39 @@
         ]
       }
     },
+    "IndexUpdate": {
+      "type": "object",
+      "description": "Index resource Definition",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/IndexType",
+          "description": "Type of index"
+        },
+        "description": {
+          "type": "string",
+          "description": "The asset description text.",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ]
+        },
+        "tags": {
+          "type": "object",
+          "description": "Tag dictionary. Tags can be added, removed, and updated.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ]
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "type"
+      ]
+    },
     "ManagedAzureAISearchIndex": {
       "type": "object",
       "description": "Managed Azure AI Search Index Definition",
@@ -1810,6 +1916,16 @@
       "allOf": [
         {
           "$ref": "#/definitions/Index"
+        }
+      ],
+      "x-ms-discriminator-value": "ManagedAzureSearch"
+    },
+    "ManagedAzureAISearchIndexUpdate": {
+      "type": "object",
+      "description": "Managed Azure AI Search Index Definition",
+      "allOf": [
+        {
+          "$ref": "#/definitions/IndexUpdate"
         }
       ],
       "x-ms-discriminator-value": "ManagedAzureSearch"

--- a/specification/ai/data-plane/Azure.AI.Projects/stable/v1/azure-ai-projects.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/stable/v1/azure-ai-projects.json
@@ -456,7 +456,7 @@
             "description": "The definition of the DatasetVersion to create or update",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/DatasetVersion"
+              "$ref": "#/definitions/DatasetVersionUpdate"
             }
           }
         ],
@@ -969,7 +969,7 @@
             "description": "The definition of the Index to create or update",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/Index"
+              "$ref": "#/definitions/IndexUpdate"
             }
           }
         ],
@@ -1188,6 +1188,16 @@
       ],
       "x-ms-discriminator-value": "AzureSearch"
     },
+    "AzureAISearchIndexUpdate": {
+      "type": "object",
+      "description": "Azure AI Search Index Definition",
+      "allOf": [
+        {
+          "$ref": "#/definitions/IndexUpdate"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureSearch"
+    },
     "BaseCredentials": {
       "type": "object",
       "description": "A base class for connection credentials",
@@ -1399,6 +1409,16 @@
       ],
       "x-ms-discriminator-value": "CosmosDBNoSqlVectorStore"
     },
+    "CosmosDBIndexUpdate": {
+      "type": "object",
+      "description": "CosmosDB Vector Store Index Definition",
+      "allOf": [
+        {
+          "$ref": "#/definitions/IndexUpdate"
+        }
+      ],
+      "x-ms-discriminator-value": "CosmosDBNoSqlVectorStore"
+    },
     "CredentialType": {
       "type": "string",
       "description": "The credential type used by the connection",
@@ -1562,6 +1582,39 @@
         "version"
       ]
     },
+    "DatasetVersionUpdate": {
+      "type": "object",
+      "description": "DatasetVersion Definition",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/DatasetType",
+          "description": "Dataset type"
+        },
+        "description": {
+          "type": "string",
+          "description": "The asset description text.",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ]
+        },
+        "tags": {
+          "type": "object",
+          "description": "Tag dictionary. Tags can be added, removed, and updated.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ]
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "type"
+      ]
+    },
     "Deployment": {
       "type": "object",
       "description": "Model Deployment Definition",
@@ -1703,12 +1756,32 @@
       ],
       "x-ms-discriminator-value": "uri_file"
     },
+    "FileDatasetVersionUpdate": {
+      "type": "object",
+      "description": "FileDatasetVersion Definition",
+      "allOf": [
+        {
+          "$ref": "#/definitions/DatasetVersionUpdate"
+        }
+      ],
+      "x-ms-discriminator-value": "uri_file"
+    },
     "FolderDatasetVersion": {
       "type": "object",
       "description": "FileDatasetVersion Definition",
       "allOf": [
         {
           "$ref": "#/definitions/DatasetVersion"
+        }
+      ],
+      "x-ms-discriminator-value": "uri_folder"
+    },
+    "FolderDatasetVersionUpdate": {
+      "type": "object",
+      "description": "FileDatasetVersion Definition",
+      "allOf": [
+        {
+          "$ref": "#/definitions/DatasetVersionUpdate"
         }
       ],
       "x-ms-discriminator-value": "uri_folder"
@@ -1792,6 +1865,39 @@
         ]
       }
     },
+    "IndexUpdate": {
+      "type": "object",
+      "description": "Index resource Definition",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/IndexType",
+          "description": "Type of index"
+        },
+        "description": {
+          "type": "string",
+          "description": "The asset description text.",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ]
+        },
+        "tags": {
+          "type": "object",
+          "description": "Tag dictionary. Tags can be added, removed, and updated.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ]
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "type"
+      ]
+    },
     "ManagedAzureAISearchIndex": {
       "type": "object",
       "description": "Managed Azure AI Search Index Definition",
@@ -1810,6 +1916,16 @@
       "allOf": [
         {
           "$ref": "#/definitions/Index"
+        }
+      ],
+      "x-ms-discriminator-value": "ManagedAzureSearch"
+    },
+    "ManagedAzureAISearchIndexUpdate": {
+      "type": "object",
+      "description": "Managed Azure AI Search Index Definition",
+      "allOf": [
+        {
+          "$ref": "#/definitions/IndexUpdate"
         }
       ],
       "x-ms-discriminator-value": "ManagedAzureSearch"


### PR DESCRIPTION
This is a result of running `npx tsv .` in the folder `\specification\ai\Azure.AI.Projects`. I was surprised that the swagger files were refreshed, even though there is no change to TypeSpec files. 

@johanste investigated this. He opened issue https://github.com/Azure/typespec-azure/issues/2696 but suggested I check in the updated swagger files. That way further PRs will not be polluted with these swagger updates.
