### PR TITLE
Test changes: Add documentation for contentTitle header and update generated cts.json

### DIFF
--- a/specification/confidentialledger/Microsoft.CodeTransparency/main.tsp
+++ b/specification/confidentialledger/Microsoft.CodeTransparency/main.tsp
@@ -110,6 +110,12 @@ model CreateEntryCreated {
   @statusCode
   statusCode: 201;
 
+  /**
+   * Title of the content
+   */
+  @header("Content-Title")
+  contentTitle?: string;
+
   @doc("The MIME content type a Cose body is application/cose, containing a CoseSign1 signature.")
   @header("Content-Type")
   contentType: "application/cose";

--- a/specification/confidentialledger/data-plane/Microsoft.CodeTransparency/preview/2025-01-31-preview/cts.json
+++ b/specification/confidentialledger/data-plane/Microsoft.CodeTransparency/preview/2025-01-31-preview/cts.json
@@ -114,6 +114,10 @@
               "type": "file"
             },
             "headers": {
+              "Content-Title": {
+                "type": "string",
+                "description": "Title of the content"
+              },
               "Location": {
                 "type": "string",
                 "description": "Location of the receipt"


### PR DESCRIPTION
This PR adds a documentation block for the contentTitle header in the CreateEntryCreated model and updates the generated cts.json accordingly. This resolves TypeSpec validation and linter requirements for documentation and prepares the spec for SDK generation.