### PR TITLE
Updated check run name in WFs

### DIFF
--- a/.github/workflows/post-apiview.yml
+++ b/.github/workflows/post-apiview.yml
@@ -15,7 +15,7 @@ jobs:
     if: |
       github.event.check_run.check_suite.app.name == 'Azure Pipelines' && (
       contains(github.event.check_run.name, 'APIView') ||
-      contains(github.event.check_run.name, 'SDK Generation') )
+      contains(github.event.check_run.name, 'spec-gen-sdk') )
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/sdk-breaking-change-labels.yaml
+++ b/.github/workflows/sdk-breaking-change-labels.yaml
@@ -12,7 +12,7 @@ jobs:
     # Only run this job when the check run is from Azure Pipelines SDK Generation job in the azure-sdk/public(id: 29ec6040-b234-4e31-b139-33dc4287b756) project
     if: |
       github.event.check_run.check_suite.app.name == 'Azure Pipelines' &&
-      contains(github.event.check_run.name, 'SDK Generation') &&
+      contains(github.event.check_run.name, 'spec-gen-sdk') &&
       endsWith(github.event.check_run.external_id, '29ec6040-b234-4e31-b139-33dc4287b756')
     name: SDK Breaking Change Labels
     runs-on: ubuntu-24.04

--- a/.github/workflows/spec-gen-sdk-status.yml
+++ b/.github/workflows/spec-gen-sdk-status.yml
@@ -13,7 +13,7 @@ jobs:
     # Only run this job when the check run is from Azure Pipelines SDK Generation job in the azure-sdk/public(id: 29ec6040-b234-4e31-b139-33dc4287b756) project
     if: |
       github.event.check_run.check_suite.app.name == 'Azure Pipelines' &&
-      contains(github.event.check_run.name, 'SDK Generation') &&
+      contains(github.event.check_run.name, 'spec-gen-sdk') &&
       endsWith(github.event.check_run.external_id, '29ec6040-b234-4e31-b139-33dc4287b756')
     name: "spec-gen-sdk - set status"
     runs-on: ubuntu-24.04

--- a/.github/workflows/src/spec-gen-sdk-status.js
+++ b/.github/workflows/src/spec-gen-sdk-status.js
@@ -71,7 +71,7 @@ export async function setSpecGenSdkStatusImpl({
   const specGenSdkChecks = checks.filter(
     (check) =>
       check.app?.name === "Azure Pipelines" &&
-      check.name.includes("SDK Generation"),
+      check.name.includes("spec-gen-sdk"),
   );
 
   core.info(

--- a/.github/workflows/src/spec-gen-sdk-status.js
+++ b/.github/workflows/src/spec-gen-sdk-status.js
@@ -97,7 +97,7 @@ export async function setSpecGenSdkStatusImpl({
   if (!allCompleted) {
     // At least one check is still running or none found yet, set status to pending
     core.info(
-      "Some SDK generation checks are not completed. Setting status to pending.",
+      "Some spec-gen-sdk checks are not completed. Setting status to pending.",
     );
 
     await github.rest.repos.createCommitStatus({
@@ -117,7 +117,7 @@ export async function setSpecGenSdkStatusImpl({
     });
 
     core.info(
-      `All SDK generation checks completed. Setting status to ${result.state}.`,
+      `All spec-gen-sdk checks completed. Setting status to ${result.state}.`,
     );
 
     await github.rest.repos.createCommitStatus({

--- a/.github/workflows/test/spec-gen-sdk-status.test.js
+++ b/.github/workflows/test/spec-gen-sdk-status.test.js
@@ -66,7 +66,7 @@ describe("spec-gen-sdk-status", () => {
         check_runs: [
           {
             app: { name: "Azure Pipelines" },
-            name: "SDK Generation",
+            name: "spec-gen-sdk",
             status: "in_progress",
             conclusion: null,
           },
@@ -102,7 +102,7 @@ describe("spec-gen-sdk-status", () => {
         check_runs: [
           {
             app: { name: "Azure Pipelines" },
-            name: "SDK Generation",
+            name: "spec-gen-sdk",
             status: "completed",
             conclusion: "success",
             details_url:
@@ -150,7 +150,7 @@ describe("spec-gen-sdk-status", () => {
         check_runs: [
           {
             app: { name: "Azure Pipelines" },
-            name: "SDK Generation",
+            name: "spec-gen-sdk",
             status: "completed",
             conclusion: "success",
             details_url:
@@ -158,7 +158,7 @@ describe("spec-gen-sdk-status", () => {
           },
           {
             app: { name: "Azure Pipelines" },
-            name: "SDK Generation",
+            name: "spec-gen-sdk",
             status: "completed",
             conclusion: "failure",
             details_url:
@@ -220,7 +220,7 @@ describe("spec-gen-sdk-status", () => {
         check_runs: [
           {
             app: { name: "Azure Pipelines" },
-            name: "SDK Generation",
+            name: "spec-gen-sdk",
             status: "completed",
             conclusion: "success",
             details_url:
@@ -254,7 +254,7 @@ describe("spec-gen-sdk-status", () => {
         check_runs: [
           {
             app: { name: "Azure Pipelines" },
-            name: "SDK Generation",
+            name: "spec-gen-sdk",
             status: "completed",
             conclusion: "success",
             details_url:
@@ -287,7 +287,7 @@ describe("spec-gen-sdk-status", () => {
         check_runs: [
           {
             app: { name: "Azure Pipelines" },
-            name: "SDK Generation",
+            name: "spec-gen-sdk",
             status: "completed",
             conclusion: "success",
             details_url:
@@ -295,7 +295,7 @@ describe("spec-gen-sdk-status", () => {
           },
           {
             app: { name: "Azure Pipelines" },
-            name: "SDK Generation",
+            name: "spec-gen-sdk",
             status: "completed",
             conclusion: "failure",
             details_url:

--- a/eng/tools/spec-gen-sdk-runner/test/src/commands.test.ts
+++ b/eng/tools/spec-gen-sdk-runner/test/src/commands.test.ts
@@ -14,9 +14,9 @@ import { LogLevel } from "../../src/log.js";
 
 function getNormalizedFsCalls(mockFn: Mock): unknown[][] {
   return mockFn.mock.calls.map((args: unknown[]) => {
-    const [filePath, ...rest] = args
-    return [String(filePath).replaceAll('\\', '/'), ...rest]
-  })
+    const [filePath, ...rest] = args;
+    return [String(filePath).replaceAll("\\", "/"), ...rest];
+  });
 }
 
 describe("generateSdkForSingleSpec", () => {
@@ -400,8 +400,8 @@ describe("generateSdkForBatchSpecs", () => {
       `Runner: markdown file written to ${markdownFilePath}`,
     );
     expect(log.vsoAddAttachment).toHaveBeenCalledWith("Generation Summary", markdownFilePath);
-    
-    const calls = getNormalizedFsCalls(fs.writeFileSync as Mock)
+
+    const calls = getNormalizedFsCalls(fs.writeFileSync as Mock);
     expect(calls).toMatchSnapshot();
   });
 
@@ -451,7 +451,7 @@ describe("generateSdkForBatchSpecs", () => {
     );
     expect(log.vsoAddAttachment).toHaveBeenCalledWith("Generation Summary", markdownFilePath);
 
-    const calls = getNormalizedFsCalls(fs.writeFileSync as Mock)
+    const calls = getNormalizedFsCalls(fs.writeFileSync as Mock);
     expect(calls).toMatchSnapshot();
   });
 
@@ -507,7 +507,7 @@ describe("generateSdkForBatchSpecs", () => {
     expect(logSpy).toHaveBeenCalledWith(`Runner: markdown file written to ${markdownFilePath}`);
     expect(log.vsoAddAttachment).toHaveBeenCalledWith("Generation Summary", markdownFilePath);
 
-    const calls = getNormalizedFsCalls(fs.writeFileSync as Mock)
+    const calls = getNormalizedFsCalls(fs.writeFileSync as Mock);
     expect(calls).toMatchSnapshot();
     logSpy.mockRestore();
   });


### PR DESCRIPTION
This pull request updates workflow and test configurations to rename references from "SDK Generation" to "spec-gen-sdk" and includes minor formatting changes in test files. Below is a summary of the most important changes:

### Workflow Updates:
* Updated `.github/workflows/post-apiview.yml` and `.github/workflows/spec-gen-sdk-status.yml` to use "spec-gen-sdk" instead of "SDK Generation" in conditional checks for Azure Pipelines job names. [[1]](diffhunk://#diff-ae67cf93057bd82e097e0f1b95e5fc4a9279bf1017f0856b71b771670708ee97L18-R18) [[2]](diffhunk://#diff-1c2160901e4278835ad52cab0b53dd14891930af206358e5f3b07691b3a5e9a6L16-R16)

### Code Updates:
* Modified `.github/workflows/src/spec-gen-sdk-status.js` to filter Azure Pipelines check runs by "spec-gen-sdk" instead of "SDK Generation."

### Test Updates:
* Updated `.github/workflows/test/spec-gen-sdk-status.test.js` to replace "SDK Generation" with "spec-gen-sdk" in multiple test cases. [[1]](diffhunk://#diff-39593585fccecbecefcf62c2ef1d26ca32bb3b4eed00d8b696ad5066c7a91a93L69-R69) [[2]](diffhunk://#diff-39593585fccecbecefcf62c2ef1d26ca32bb3b4eed00d8b696ad5066c7a91a93L105-R105) [[3]](diffhunk://#diff-39593585fccecbecefcf62c2ef1d26ca32bb3b4eed00d8b696ad5066c7a91a93L153-R161) [[4]](diffhunk://#diff-39593585fccecbecefcf62c2ef1d26ca32bb3b4eed00d8b696ad5066c7a91a93L223-R223) [[5]](diffhunk://#diff-39593585fccecbecefcf62c2ef1d26ca32bb3b4eed00d8b696ad5066c7a91a93L257-R257) [[6]](diffhunk://#diff-39593585fccecbecefcf62c2ef1d26ca32bb3b4eed00d8b696ad5066c7a91a93L290-R298)

### Test PRs:
https://github.com/raych1/azure-rest-api-specs/pull/49
