### PR TITLE
Update Microsoft.CodeTransparency TypeSpec with location header for TransparentStatement

### DIFF
--- a/specification/confidentialledger/Microsoft.CodeTransparency/main.tsp
+++ b/specification/confidentialledger/Microsoft.CodeTransparency/main.tsp
@@ -225,6 +225,10 @@ model TransparentStatement {
   @doc("CoseSign1 signature envelope with the receipt embedded in the unprotected header")
   @bodyRoot
   body: bytes;
+
+  @doc("Location of the receipt")
+  @header("Location")
+  location?: string;
 }
 
 @doc("A ledger receipt, see IETF SCITT draft")


### PR DESCRIPTION
Added location header to TransparentStatement model to provide proper IETF SCITT draft compliance.