### PR TITLE
Add sharedModelList property to WidgetSuite model

### DIFF
--- a/specification/contosowidgetmanager/Contoso.WidgetManager/main.tsp
+++ b/specification/contosowidgetmanager/Contoso.WidgetManager/main.tsp
@@ -38,6 +38,9 @@ model WidgetSuite {
 
   @doc("The faked shared model.")
   sharedModel?: FakedSharedModel;
+
+  @doc("The faked shared model list.")
+  sharedModelList?: FakedSharedModel[];
 }
 
 interface Widgets {

--- a/specification/contosowidgetmanager/data-plane/Azure.Contoso.WidgetManager/preview/2022-11-01-preview/widgets.json
+++ b/specification/contosowidgetmanager/data-plane/Azure.Contoso.WidgetManager/preview/2022-11-01-preview/widgets.json
@@ -513,6 +513,14 @@
         "sharedModel": {
           "$ref": "#/definitions/FakedSharedModel",
           "description": "The faked shared model."
+        },
+        "sharedModelList": {
+          "type": "array",
+          "description": "The faked shared model list.",
+          "items": {
+            "$ref": "#/definitions/FakedSharedModel"
+          },
+          "x-ms-identifiers": []
         }
       },
       "required": [
@@ -531,6 +539,14 @@
         "sharedModel": {
           "$ref": "#/definitions/FakedSharedModelCreateOrUpdate",
           "description": "The faked shared model."
+        },
+        "sharedModelList": {
+          "type": "array",
+          "description": "The faked shared model list.",
+          "items": {
+            "$ref": "#/definitions/FakedSharedModel"
+          },
+          "x-ms-identifiers": []
         }
       }
     }

--- a/specification/contosowidgetmanager/data-plane/Azure.Contoso.WidgetManager/stable/2022-12-01/widgets.json
+++ b/specification/contosowidgetmanager/data-plane/Azure.Contoso.WidgetManager/stable/2022-12-01/widgets.json
@@ -513,6 +513,14 @@
         "sharedModel": {
           "$ref": "#/definitions/FakedSharedModel",
           "description": "The faked shared model."
+        },
+        "sharedModelList": {
+          "type": "array",
+          "description": "The faked shared model list.",
+          "items": {
+            "$ref": "#/definitions/FakedSharedModel"
+          },
+          "x-ms-identifiers": []
         }
       },
       "required": [
@@ -531,6 +539,14 @@
         "sharedModel": {
           "$ref": "#/definitions/FakedSharedModelCreateOrUpdate",
           "description": "The faked shared model."
+        },
+        "sharedModelList": {
+          "type": "array",
+          "description": "The faked shared model list.",
+          "items": {
+            "$ref": "#/definitions/FakedSharedModel"
+          },
+          "x-ms-identifiers": []
         }
       }
     }


### PR DESCRIPTION
This pull request adds a new property `sharedModelList` to the WidgetSuite model in the Contoso.WidgetManager TypeSpec project. This property is an array of FakedSharedModel objects that allows storing multiple shared models for a widget.