### PR TITLE
Updated name of spec-gen-sdk

### DIFF
--- a/.github/workflows/post-apiview.yml
+++ b/.github/workflows/post-apiview.yml
@@ -15,7 +15,7 @@ jobs:
     if: |
       github.event.check_run.check_suite.app.name == 'Azure Pipelines' && (
       contains(github.event.check_run.name, 'APIView') ||
-      contains(github.event.check_run.name, 'spec-gen-sdk') )
+      contains(github.event.check_run.name, 'SDK Validation') )
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/sdk-breaking-change-labels.yaml
+++ b/.github/workflows/sdk-breaking-change-labels.yaml
@@ -12,7 +12,7 @@ jobs:
     # Only run this job when the check run is from Azure Pipelines SDK Generation job in the azure-sdk/public(id: 29ec6040-b234-4e31-b139-33dc4287b756) project
     if: |
       github.event.check_run.check_suite.app.name == 'Azure Pipelines' &&
-      contains(github.event.check_run.name, 'spec-gen-sdk') &&
+      contains(github.event.check_run.name, 'SDK Validation') &&
       endsWith(github.event.check_run.external_id, '29ec6040-b234-4e31-b139-33dc4287b756')
     name: SDK Breaking Change Labels
     runs-on: ubuntu-24.04

--- a/.github/workflows/spec-gen-sdk-status.yml
+++ b/.github/workflows/spec-gen-sdk-status.yml
@@ -1,4 +1,4 @@
-name: "spec-gen-sdk status"
+name: "SDK Validation Status"
 
 on:
   check_run:
@@ -9,13 +9,13 @@ permissions:
   statuses: write
 
 jobs:
-  spec-gen-sdk-status:
-    # Only run this job when the check run is from Azure Pipelines SDK Generation job in the azure-sdk/public(id: 29ec6040-b234-4e31-b139-33dc4287b756) project
+  sdk-validation-status:
+    # Only run this job when the check run is from Azure Pipelines(SDK Validation) in the azure-sdk/public(id: 29ec6040-b234-4e31-b139-33dc4287b756) project
     if: |
       github.event.check_run.check_suite.app.name == 'Azure Pipelines' &&
-      contains(github.event.check_run.name, 'spec-gen-sdk') &&
+      contains(github.event.check_run.name, 'SDK Validation') &&
       endsWith(github.event.check_run.external_id, '29ec6040-b234-4e31-b139-33dc4287b756')
-    name: "spec-gen-sdk - set status"
+    name: "SDK Validation - Status"
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -23,8 +23,8 @@ jobs:
           sparse-checkout: |
             .github
       
-      - name: "spec-gen-sdk - set status"
-        id: spec-gen-sdk-status
+      - name: "SDK Validation - Status"
+        id: sdk-validation-status
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/src/spec-gen-sdk-status.js
+++ b/.github/workflows/src/spec-gen-sdk-status.js
@@ -60,7 +60,7 @@ export async function setSpecGenSdkStatusImpl({
   github,
   core,
 }) {
-  const statusName = "spec-gen-sdk status";
+  const statusName = "SDK Validation Status";
   const checks = await github.paginate(github.rest.checks.listForRef, {
     owner,
     repo,
@@ -71,7 +71,7 @@ export async function setSpecGenSdkStatusImpl({
   const specGenSdkChecks = checks.filter(
     (check) =>
       check.app?.name === "Azure Pipelines" &&
-      check.name.includes("spec-gen-sdk"),
+      check.name.includes("SDK Validation"),
   );
 
   core.info(
@@ -97,7 +97,7 @@ export async function setSpecGenSdkStatusImpl({
   if (!allCompleted) {
     // At least one check is still running or none found yet, set status to pending
     core.info(
-      "Some spec-gen-sdk checks are not completed. Setting status to pending.",
+      "Some SDK Validation checks are not completed. Setting status to pending.",
     );
 
     await github.rest.repos.createCommitStatus({
@@ -106,7 +106,7 @@ export async function setSpecGenSdkStatusImpl({
       sha: head_sha,
       state: CommitStatusState.PENDING,
       context: statusName,
-      description: "Waiting for all spec-gen-sdk checks to complete",
+      description: "Waiting for all SDK Validation checks to complete",
       target_url,
     });
   } else {
@@ -117,7 +117,7 @@ export async function setSpecGenSdkStatusImpl({
     });
 
     core.info(
-      `All spec-gen-sdk checks completed. Setting status to ${result.state}.`,
+      `All SDK Validation checks completed. Setting status to ${result.state}.`,
     );
 
     await github.rest.repos.createCommitStatus({
@@ -142,10 +142,10 @@ async function processResult({ checkRuns, core }) {
   /** @type {import("./github.js").CommitStatusState} */
   let state = CommitStatusState.SUCCESS;
   let specGenSdkFailedRequiredLanguages = "";
-  let description = "spec-gen-sdk checks succeeded";
+  let description = "SDK Validation CI checks succeeded";
 
   // Create a summary of the results
-  let summaryContent = "## spec-gen-sdk Checks Result\n\n";
+  let summaryContent = "## SDK Validation CI Checks Result\n\n";
   summaryContent += "| Language | Status | Required Check |\n";
   summaryContent += "|----------|--------|---------------|\n";
 
@@ -200,21 +200,21 @@ async function processResult({ checkRuns, core }) {
   if (state === CommitStatusState.FAILURE) {
     specGenSdkFailedRequiredLanguages =
       specGenSdkFailedRequiredLanguages.replace(/,\s*$/, "");
-    description = `spec-gen-sdk failed for ${specGenSdkFailedRequiredLanguages} languages`;
+    description = `SDK Validation failed for ${specGenSdkFailedRequiredLanguages} languages`;
   }
 
   // Add overall result
   summaryContent += "\n### Overall Result\n\n";
   summaryContent +=
     state === CommitStatusState.SUCCESS
-      ? "✅ All required spec-gen-sdk checks passed successfully!"
-      : `❌ spec-gen-sdk checks failed for: ${specGenSdkFailedRequiredLanguages}`;
+      ? "✅ All required SDK Validation CI checks passed successfully!"
+      : `❌ SDK Validation CI checks failed for: ${specGenSdkFailedRequiredLanguages}`;
 
   // Add next steps
   if (state === CommitStatusState.FAILURE) {
     summaryContent +=
       "\n### Next Steps\n\n" +
-      `Please fix any issues in the the spec-gen-sdk checks for languages: ${specGenSdkFailedRequiredLanguages}.`;
+      `Please fix any issues in the the SDK Validation CI checks for languages: ${specGenSdkFailedRequiredLanguages}.`;
   }
 
   // Write to the summary page

--- a/.github/workflows/test/spec-gen-sdk-status.test.js
+++ b/.github/workflows/test/spec-gen-sdk-status.test.js
@@ -66,7 +66,7 @@ describe("spec-gen-sdk-status", () => {
         check_runs: [
           {
             app: { name: "Azure Pipelines" },
-            name: "spec-gen-sdk",
+            name: "SDK Validation",
             status: "in_progress",
             conclusion: null,
           },
@@ -102,7 +102,7 @@ describe("spec-gen-sdk-status", () => {
         check_runs: [
           {
             app: { name: "Azure Pipelines" },
-            name: "spec-gen-sdk",
+            name: "SDK Validation",
             status: "completed",
             conclusion: "success",
             details_url:
@@ -150,7 +150,7 @@ describe("spec-gen-sdk-status", () => {
         check_runs: [
           {
             app: { name: "Azure Pipelines" },
-            name: "spec-gen-sdk",
+            name: "SDK Validation",
             status: "completed",
             conclusion: "success",
             details_url:
@@ -158,7 +158,7 @@ describe("spec-gen-sdk-status", () => {
           },
           {
             app: { name: "Azure Pipelines" },
-            name: "spec-gen-sdk",
+            name: "SDK Validation",
             status: "completed",
             conclusion: "failure",
             details_url:
@@ -220,7 +220,7 @@ describe("spec-gen-sdk-status", () => {
         check_runs: [
           {
             app: { name: "Azure Pipelines" },
-            name: "spec-gen-sdk",
+            name: "SDK Validation",
             status: "completed",
             conclusion: "success",
             details_url:
@@ -254,7 +254,7 @@ describe("spec-gen-sdk-status", () => {
         check_runs: [
           {
             app: { name: "Azure Pipelines" },
-            name: "spec-gen-sdk",
+            name: "SDK Validation",
             status: "completed",
             conclusion: "success",
             details_url:
@@ -287,7 +287,7 @@ describe("spec-gen-sdk-status", () => {
         check_runs: [
           {
             app: { name: "Azure Pipelines" },
-            name: "spec-gen-sdk",
+            name: "SDK Validation",
             status: "completed",
             conclusion: "success",
             details_url:
@@ -295,7 +295,7 @@ describe("spec-gen-sdk-status", () => {
           },
           {
             app: { name: "Azure Pipelines" },
-            name: "spec-gen-sdk",
+            name: "SDK Validation",
             status: "completed",
             conclusion: "failure",
             details_url:

--- a/.github/workflows/test/spec-gen-sdk-status.test.js
+++ b/.github/workflows/test/spec-gen-sdk-status.test.js
@@ -138,7 +138,7 @@ describe("spec-gen-sdk-status", () => {
         repo: "testRepo",
         sha: "testSha",
         state: "success",
-        description: "spec-gen-sdk checks succeeded",
+        description: "SDK Validation CI checks succeeded",
       }),
     );
   });
@@ -243,7 +243,7 @@ describe("spec-gen-sdk-status", () => {
     // Verify summary was written
     expect(writeToActionsSummaryMock).toHaveBeenCalled();
     expect(writeToActionsSummaryMock.mock.calls[0][0]).toContain(
-      "spec-gen-sdk Checks Result",
+      "SDK Validation CI Checks Result",
     );
   });
 
@@ -345,7 +345,7 @@ describe("spec-gen-sdk-status", () => {
         repo: "testRepo",
         sha: "testSha",
         state: "success",
-        description: "spec-gen-sdk checks succeeded",
+        description: "SDK Validation CI checks succeeded",
       }),
     );
   });


### PR DESCRIPTION
This pull request renames the "spec-gen-sdk" checks and workflows to "SDK Validation" across multiple files in the repository. The changes ensure consistency in naming conventions and update all relevant references in workflows, scripts, and tests.

### Workflow Updates:
* [`.github/workflows/post-apiview.yml`](diffhunk://#diff-ae67cf93057bd82e097e0f1b95e5fc4a9279bf1017f0856b71b771670708ee97L18-R18): Updated the condition to check for "SDK Validation" instead of "spec-gen-sdk" in the workflow triggers.
* [`.github/workflows/sdk-breaking-change-labels.yaml`](diffhunk://#diff-23bc6e5f25d3869907a8ffc24b2075b505d5ef979872870aab04f32bef22efc7L15-R15): Modified the condition to reference "SDK Validation" instead of "spec-gen-sdk" for Azure Pipelines jobs.
* [`.github/workflows/spec-gen-sdk-status.yml`](diffhunk://#diff-1c2160901e4278835ad52cab0b53dd14891930af206358e5f3b07691b3a5e9a6L1-R1): Renamed the workflow to "SDK Validation Status" and updated all job names, descriptions, and conditions accordingly. 
### Script Updates:
* [`.github/workflows/src/spec-gen-sdk-status.js`](diffhunk://#diff-410f1d9b7cf1ea63bd905c016d27c33f001af44ae4f67162acb8d68d0831391eL63-R63): Replaced all occurrences of "spec-gen-sdk" with "SDK Validation" in variable names, log messages, and logic for handling check statuses.
### Test Updates:
* [`.github/workflows/test/spec-gen-sdk-status.test.js`](diffhunk://#diff-39593585fccecbecefcf62c2ef1d26ca32bb3b4eed00d8b696ad5066c7a91a93L69-R69): Updated test cases to reflect the new "SDK Validation" naming convention in mocked check runs and assertions.
### Test PR:
https://github.com/raych1/azure-rest-api-specs/pull/50