### PR TITLE
Skip sdk gen for specific batch run type

### DIFF
--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -198,7 +198,7 @@ stages:
         parameters:
           ArtifactName: $(PipelineArtifactsName)
           ArtifactPath: $(StagedArtifactsFolder)
-          CustomCondition: and(succeeded(), ne(variables['StagedArtifactsFolder'], ''))
+          CustomCondition: and(succeededOrFailed(), ne(variables['StagedArtifactsFolder'], ''))
 
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         - task: PowerShell@2

--- a/eng/tools/spec-gen-sdk-runner/src/commands.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/commands.ts
@@ -191,6 +191,14 @@ export async function generateSdkForBatchSpecs(batchType: string): Promise<numbe
   const commandInput: SpecGenSdkCmdInput = parseArguments();
   // Construct the spec-gen-sdk command
   const specGenSdkCommand = prepareSpecGenSdkCommand(commandInput);
+  if (
+    batchType === "all-typespecs" ||
+    batchType === "all-mgmtplane-typespecs" ||
+    batchType === "all-dataplane-typespecs"
+  ) {
+    specGenSdkCommand.push("--skip-sdk-gen-from-openapi", "true");
+  }
+
   // Get the spec paths based on the batch run type
   const specConfigsArray: SpecConfigs[] = getSpecPaths(batchType, commandInput.localSpecRepoPath);
 

--- a/eng/tools/spec-gen-sdk-runner/src/index.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/index.ts
@@ -13,16 +13,13 @@ export async function main() {
   const args: string[] = process.argv.slice(2);
   // Log the arguments to the console
   console.log("Arguments passed to the script:", args.join(" "));
-  console.log("Current working directory:", process.cwd());
   const batchType: string = getArgumentValue(args, "--batch-type", "");
   const pullRequestNumber: string = getArgumentValue(args, "--pr-number", "");
+  console.log("Current working directory:", process.cwd());
   const workingFolder: string = getArgumentValue(args, "--wf", path.join(process.cwd(), ".."));
   const logFolder = path.join(workingFolder, "out/logs");
   if (!existsSync(logFolder)) {
     mkdirSync(logFolder, { recursive: true });
-  }
-  if (existsSync(logFolder)) {
-    console.log(`Log folder exists: ${logFolder}`);
   }
   let statusCode = 0;
   if (batchType) {

--- a/eng/tools/spec-gen-sdk-runner/src/index.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/index.ts
@@ -1,4 +1,6 @@
 import { exit } from "node:process";
+import path from "node:path";
+import { existsSync, mkdirSync } from "node:fs";
 import { getArgumentValue } from "./utils.js";
 import {
   generateSdkForBatchSpecs,
@@ -11,8 +13,17 @@ export async function main() {
   const args: string[] = process.argv.slice(2);
   // Log the arguments to the console
   console.log("Arguments passed to the script:", args.join(" "));
+  console.log("Current working directory:", process.cwd());
   const batchType: string = getArgumentValue(args, "--batch-type", "");
   const pullRequestNumber: string = getArgumentValue(args, "--pr-number", "");
+  const workingFolder: string = getArgumentValue(args, "--wf", path.join(process.cwd(), ".."));
+  const logFolder = path.join(workingFolder, "out/logs");
+  if (!existsSync(logFolder)) {
+    mkdirSync(logFolder, { recursive: true });
+  }
+  if (existsSync(logFolder)) {
+    console.log(`Log folder exists: ${logFolder}`);
+  }
   let statusCode = 0;
   if (batchType) {
     statusCode = await generateSdkForBatchSpecs(batchType);

--- a/eng/tools/spec-gen-sdk-runner/src/spec-helpers.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/spec-helpers.ts
@@ -200,17 +200,6 @@ export function groupSpecConfigPaths(
   const safeTspConfigs = tspconfigs ?? emptyArray;
   const safeReadmes = readmes ?? emptyArray;
 
-  if (skipUnmatchedReadme) {
-    // Explicitly remove the specific readme file from the array
-    // as we don't want to include it for typespec related batch runs
-    const indexToRemove = safeReadmes.indexOf(
-      "specification/awsconnector/resource-manager/readme.md",
-    );
-    if (indexToRemove !== -1) {
-      safeReadmes.splice(indexToRemove, 1);
-    }
-  }
-
   // Quick return for simple cases
   if (safeTspConfigs.length === 0 && safeReadmes.length === 0) {
     return [];

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "azure-rest-api-specs",
       "devDependencies": {
         "@autorest/openapi-to-typespec": "0.11.1",
-        "@azure-tools/spec-gen-sdk": "~0.7.2",
+        "@azure-tools/spec-gen-sdk": "~0.8.0",
         "@azure-tools/specs-shared": "file:.github/shared",
         "@azure-tools/typespec-apiview": "0.7.2",
         "@azure-tools/typespec-autorest": "0.56.0",
@@ -1389,9 +1389,9 @@
       "link": true
     },
     "node_modules/@azure-tools/spec-gen-sdk": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@azure-tools/spec-gen-sdk/-/spec-gen-sdk-0.7.2.tgz",
-      "integrity": "sha512-LJ4ahVmGdktvxIQu58HkoF1mPgn8K+lV3HJn78IkAE06jdDmUozosOvXsmBaETNUnk8SC9E5giYtvaPI7W49Qg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/spec-gen-sdk/-/spec-gen-sdk-0.8.0.tgz",
+      "integrity": "sha512-SXGC2ezRqbUBgFzBLjRZtrMrIP0T9pxlmPDrHJd4fM5qHR9r2dW06p807qXh+qZvWWvnhTIVIWIKfxy1kUJkTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "azure-rest-api-specs",
   "devDependencies": {
-    "@azure-tools/spec-gen-sdk": "~0.7.2",
+    "@azure-tools/spec-gen-sdk": "~0.8.0",
     "@azure-tools/specs-shared": "file:.github/shared",
     "@azure-tools/typespec-apiview": "0.7.2",
     "@azure-tools/typespec-autorest": "0.56.0",


### PR DESCRIPTION
- Adopted new version of `spec-gen-sdk` tool to skip SDK generation from swaggers for `typespec` batch runs
- Created log folder in the runner to avoid errors in log publishing step when no specs changed in the PR
- Changed the condition for artifact publishing step to include failure cases, one of which will be batch run

[Test Run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4903437&view=ms.vss-build-web.run-extensions-tab)