### PR TITLE
[SpecModel] Add backpointers, resolve paths against backpointers, move "new Swagger" from Readme to Tag

### DIFF
--- a/.github/shared/src/readme.js
+++ b/.github/shared/src/readme.js
@@ -153,9 +153,6 @@ export class Readme {
           throw new Error(message);
         }
 
-        // /** @type {Map<string, Swagger>} */
-        // const inputFiles = new Map();
-
         // It's possible for input-file to be a string or an array
         const inputFilePaths = Array.isArray(obj["input-file"])
           ? obj["input-file"]

--- a/.github/shared/src/readme.js
+++ b/.github/shared/src/readme.js
@@ -5,7 +5,6 @@ import yaml from "js-yaml";
 import { marked } from "marked";
 import { dirname, normalize, relative, resolve } from "path";
 import { mapAsync } from "./array.js";
-import { Swagger } from "./swagger.js";
 import { Tag } from "./tag.js";
 
 /**
@@ -154,31 +153,22 @@ export class Readme {
           throw new Error(message);
         }
 
-        /** @type {Map<string, Swagger>} */
-        const inputFiles = new Map();
-
-        const tag = new Tag(tagName, inputFiles, {
-          logger: this.#logger,
-          readme: this,
-        });
+        // /** @type {Map<string, Swagger>} */
+        // const inputFiles = new Map();
 
         // It's possible for input-file to be a string or an array
         const inputFilePaths = Array.isArray(obj["input-file"])
           ? obj["input-file"]
           : [obj["input-file"]];
-        for (const swaggerPath of inputFilePaths) {
-          const swaggerPathNormalized =
-            Readme.#normalizeSwaggerPath(swaggerPath);
-          const swaggerPathResolved = resolve(
-            dirname(this.#path),
-            swaggerPathNormalized,
-          );
-          const swagger = new Swagger(swaggerPathResolved, {
-            logger: this.#logger,
-            tag,
-          });
-          inputFiles.set(swagger.path, swagger);
-        }
+
+        const swaggerPathsResolved = inputFilePaths
+          .map((p) => Readme.#normalizeSwaggerPath(p))
+          .map((p) => resolve(dirname(this.#path), p));
+
+        const tag = new Tag(tagName, swaggerPathsResolved, {
+          logger: this.#logger,
+          readme: this,
+        });
 
         tags.set(tag.name, tag);
       }

--- a/.github/shared/src/readme.js
+++ b/.github/shared/src/readme.js
@@ -48,7 +48,8 @@ export class Readme {
    * @param {SpecModel} [options.specModel]
    */
   constructor(path, options) {
-    this.#path = resolve(path);
+    this.#path = resolve(options?.specModel?.folder ?? "", path);
+
     this.#content = options?.content;
     this.#logger = options?.logger;
     this.#specModel = options?.specModel;

--- a/.github/shared/src/readme.js
+++ b/.github/shared/src/readme.js
@@ -36,15 +36,15 @@ export class Readme {
   #path;
 
   /**
-   * backpointer to owning SpecModel
+   * SpecModel that contains this Readme
    * @type {SpecModel | undefined}
    */
   #specModel;
 
   /**
-   * @param {string} path
+   * @param {string} path Used for content, unless options.content is specified
    * @param {Object} [options]
-   * @param {string} [options.content]
+   * @param {string} [options.content] If specified, is used instead of reading path from disk
    * @param {import('./logger.js').ILogger} [options.logger]
    * @param {SpecModel} [options.specModel]
    */
@@ -175,7 +175,10 @@ export class Readme {
           inputFiles.set(swagger.path, swagger);
         }
 
-        const tag = new Tag(tagName, inputFiles, { logger: this.#logger });
+        const tag = new Tag(tagName, inputFiles, {
+          logger: this.#logger,
+          readme: this,
+        });
 
         tags.set(tag.name, tag);
       }
@@ -208,6 +211,13 @@ export class Readme {
    */
   get path() {
     return this.#path;
+  }
+
+  /**
+   * @returns {SpecModel | undefined} SpecModel that contains this Readme
+   */
+  get specModel() {
+    return this.#specModel;
   }
 
   /**

--- a/.github/shared/src/readme.js
+++ b/.github/shared/src/readme.js
@@ -157,6 +157,11 @@ export class Readme {
         /** @type {Map<string, Swagger>} */
         const inputFiles = new Map();
 
+        const tag = new Tag(tagName, inputFiles, {
+          logger: this.#logger,
+          readme: this,
+        });
+
         // It's possible for input-file to be a string or an array
         const inputFilePaths = Array.isArray(obj["input-file"])
           ? obj["input-file"]
@@ -170,15 +175,10 @@ export class Readme {
           );
           const swagger = new Swagger(swaggerPathResolved, {
             logger: this.#logger,
-            specModel: this.#specModel,
+            tag,
           });
           inputFiles.set(swagger.path, swagger);
         }
-
-        const tag = new Tag(tagName, inputFiles, {
-          logger: this.#logger,
-          readme: this,
-        });
 
         tags.set(tag.name, tag);
       }

--- a/.github/shared/src/spec-model-error.js
+++ b/.github/shared/src/spec-model-error.js
@@ -24,9 +24,9 @@ export class SpecModelError extends Error {
    * @param {string} message
    * @param {Object} [options]
    * @param {Error} [options.cause]
-   * @param {string} [options.source]
-   * @param {string} [options.readme]
-   * @param {string} [options.tag]
+   * @param {string} [options.source] Path to file that caused the error
+   * @param {string} [options.readme] Path to readme that caused the error (if known)
+   * @param {string} [options.tag] Name of tag that caused the error (if known)
    */
   constructor(message, options) {
     super(message, { cause: options?.cause });

--- a/.github/shared/src/spec-model.js
+++ b/.github/shared/src/spec-model.js
@@ -4,7 +4,6 @@ import { readdir } from "fs/promises";
 import { resolve } from "path";
 import { mapAsync } from "./array.js";
 import { Readme } from "./readme.js";
-import { SpecModelError } from "./spec-model-error.js";
 
 /**
  * @typedef {Object} ToJSONOptions
@@ -66,18 +65,7 @@ export class SpecModel {
             continue;
           }
 
-          let refs;
-          try {
-            refs = await inputFile.getRefs();
-          } catch (error) {
-            if (error instanceof SpecModelError) {
-              error.readme = readme.path;
-              error.tag = tag.name;
-            }
-
-            throw error;
-          }
-
+          const refs = await inputFile.getRefs();
           if (refs.get(swaggerPathResolved)) {
             /** @type {Map<string, Tag>} */
             const tags = affectedReadmeTags.get(readme.path) ?? new Map();

--- a/.github/shared/src/swagger.js
+++ b/.github/shared/src/swagger.js
@@ -48,7 +48,7 @@ export class Swagger {
    * @param {Tag} [options.tag]
    */
   constructor(path, options) {
-    this.#path = resolve(path);
+    this.#path = resolve(options?.tag?.readme?.path ?? "", path);
     this.#logger = options?.logger;
     this.#tag = options?.tag;
   }

--- a/.github/shared/src/swagger.js
+++ b/.github/shared/src/swagger.js
@@ -2,7 +2,7 @@
 
 import $RefParser, { ResolverError } from "@apidevtools/json-schema-ref-parser";
 import { readFile } from "fs/promises";
-import { relative, resolve } from "path";
+import { dirname, relative, resolve } from "path";
 import { mapAsync } from "./array.js";
 import { SpecModelError } from "./spec-model-error.js";
 
@@ -48,7 +48,8 @@ export class Swagger {
    * @param {Tag} [options.tag]
    */
   constructor(path, options) {
-    this.#path = resolve(options?.tag?.readme?.path ?? "", path);
+    const rootDir = dirname(options?.tag?.readme?.path ?? "");
+    this.#path = resolve(rootDir, path);
     this.#logger = options?.logger;
     this.#tag = options?.tag;
   }

--- a/.github/shared/src/swagger.js
+++ b/.github/shared/src/swagger.js
@@ -70,6 +70,8 @@ export class Swagger {
             {
               cause: error,
               source: error.source,
+              tag: this.#tag?.name,
+              readme: this.#tag?.readme?.path,
             },
           );
         }

--- a/.github/shared/src/swagger.js
+++ b/.github/shared/src/swagger.js
@@ -7,7 +7,7 @@ import { mapAsync } from "./array.js";
 import { SpecModelError } from "./spec-model-error.js";
 
 /**
- * @typedef {import('./spec-model.js').SpecModel} SpecModel
+ * @typedef {import('./spec-model.js').Tag} Tag
  * @typedef {import('./spec-model.js').ToJSONOptions} ToJSONOptions
  */
 
@@ -38,19 +38,19 @@ export class Swagger {
   /** @type {Map<string, Swagger> | undefined} */
   #refs;
 
-  /** @type {SpecModel | undefined} backpointer to owning SpecModel */
-  #specModel;
+  /** @type {Tag | undefined} Tag that contains this Swagger */
+  #tag;
 
   /**
    * @param {string} path
    * @param {Object} [options]
    * @param {import('./logger.js').ILogger} [options.logger]
-   * @param {SpecModel} [options.specModel]
+   * @param {Tag} [options.tag]
    */
   constructor(path, options) {
     this.#path = resolve(path);
     this.#logger = options?.logger;
-    this.#specModel = options?.specModel;
+    this.#tag = options?.tag;
   }
 
   /**
@@ -88,7 +88,7 @@ export class Swagger {
         refPaths.map((p) => {
           const swagger = new Swagger(p, {
             logger: this.#logger,
-            specModel: this.#specModel,
+            tag: this.#tag,
           });
           return [swagger.path, swagger];
         }),
@@ -106,14 +106,21 @@ export class Swagger {
   }
 
   /**
+   * @returns {Tag | undefined} Tag that contains this Swagger
+   */
+  get tag() {
+    return this.#tag;
+  }
+
+  /**
    * @param {ToJSONOptions} [options]
    * @returns {Promise<Object>}
    */
   async toJSONAsync(options) {
     return {
       path:
-        options?.relativePaths && this.#specModel
-          ? relative(this.#specModel.folder, this.#path)
+        options?.relativePaths && this.#tag?.readme?.specModel
+          ? relative(this.#tag?.readme?.specModel.folder, this.#path)
           : this.#path,
       refs: options?.includeRefs
         ? await mapAsync(

--- a/.github/shared/src/tag.js
+++ b/.github/shared/src/tag.js
@@ -3,6 +3,7 @@
 import { mapAsync } from "./array.js";
 
 /**
+ * @typedef {import('./readme.js').Readme} Readme
  * @typedef {import('./swagger.js').Swagger} Swagger
  * @typedef {import('./spec-model.js').ToJSONOptions} ToJSONOptions
  */
@@ -18,15 +19,23 @@ export class Tag {
   #name;
 
   /**
+   * Readme that contains this Tag
+   * @type {Readme | undefined}
+   */
+  #readme;
+
+  /**
    * @param {string} name
    * @param {Map<string, Swagger>} inputFiles
    * @param {Object} [options]
    * @param {import('./logger.js').ILogger} [options.logger]
+   * @param {Readme} [options.readme]
    */
   constructor(name, inputFiles, options) {
     this.#name = name;
     this.#inputFiles = inputFiles;
     this.#logger = options?.logger;
+    this.#readme = options?.readme;
   }
 
   /**
@@ -41,6 +50,13 @@ export class Tag {
    */
   get name() {
     return this.#name;
+  }
+
+  /**
+   * @returns {Readme | undefined} Readme that contains this Tag
+   */
+  get readme() {
+    return this.#readme;
   }
 
   /**

--- a/.github/shared/src/tag.js
+++ b/.github/shared/src/tag.js
@@ -1,10 +1,10 @@
 // @ts-check
 
 import { mapAsync } from "./array.js";
+import { Swagger } from "./swagger.js";
 
 /**
  * @typedef {import('./readme.js').Readme} Readme
- * @typedef {import('./swagger.js').Swagger} Swagger
  * @typedef {import('./spec-model.js').ToJSONOptions} ToJSONOptions
  */
 
@@ -26,16 +26,22 @@ export class Tag {
 
   /**
    * @param {string} name
-   * @param {Map<string, Swagger>} inputFiles
+   * @param {string[]} inputFilePaths
    * @param {Object} [options]
    * @param {import('./logger.js').ILogger} [options.logger]
    * @param {Readme} [options.readme]
    */
-  constructor(name, inputFiles, options) {
+  constructor(name, inputFilePaths, options) {
     this.#name = name;
-    this.#inputFiles = inputFiles;
     this.#logger = options?.logger;
     this.#readme = options?.readme;
+
+    this.#inputFiles = new Map(
+      inputFilePaths.map((p) => {
+        let swagger = new Swagger(p, { logger: this.#logger, tag: this });
+        return [swagger.path, swagger];
+      }),
+    );
   }
 
   /**

--- a/.github/shared/test/readme.test.js
+++ b/.github/shared/test/readme.test.js
@@ -25,7 +25,7 @@ describe("readme", () => {
     const readme = new Readme("readme.md", {
       specModel: new SpecModel("/specs/foo"),
     });
-    expect(readme.path).toBe("/specs/foo/readme.md");
+    expect(readme.path).toBe(resolve("/specs/foo/readme.md"));
   });
 
   // TODO: Test that path is resolved against backpointer

--- a/.github/shared/test/readme.test.js
+++ b/.github/shared/test/readme.test.js
@@ -4,6 +4,7 @@ import { resolve } from "path";
 import { describe, expect, it } from "vitest";
 import { ConsoleLogger } from "../src/logger.js";
 import { Readme } from "../src/readme.js";
+import { SpecModel } from "../src/spec-model.js";
 import { contosoReadme } from "./examples.js";
 
 const options = { logger: new ConsoleLogger(/*debug*/ true) };
@@ -19,6 +20,15 @@ describe("readme", () => {
 
     expect(readme.specModel).toBeUndefined();
   });
+
+  it("resolves path against SpecModel", async () => {
+    const readme = new Readme("readme.md", {
+      specModel: new SpecModel("/specs/foo"),
+    });
+    expect(readme.path).toBe("/specs/foo/readme.md");
+  });
+
+  // TODO: Test that path is resolved against backpointer
 
   it("can be created with string content", async () => {
     const folder = "/fake";

--- a/.github/shared/test/readme.test.js
+++ b/.github/shared/test/readme.test.js
@@ -16,6 +16,8 @@ describe("readme", () => {
     await expect(readme.getTags()).rejects.toThrowError(
       /no such file or directory/i,
     );
+
+    expect(readme.specModel).toBeUndefined();
   });
 
   it("can be created with string content", async () => {

--- a/.github/shared/test/spec-model.test.js
+++ b/.github/shared/test/spec-model.test.js
@@ -52,6 +52,7 @@ describe("SpecModel", () => {
 
     expect(tags[0].toString()).toContain("Tag");
     expect(tags[0].name).toBe("package-2021-10-01-preview");
+    expect(tags[0].readme).toBe(readme);
 
     const inputFiles0 = [...tags[0].inputFiles.values()];
     expect(inputFiles0.length).toBe(1);

--- a/.github/shared/test/spec-model.test.js
+++ b/.github/shared/test/spec-model.test.js
@@ -77,6 +77,7 @@ describe("SpecModel", () => {
         "../../../../../common-types/resource-management/v5/types.json",
       ),
     );
+    expect(refs0[0].tag).toBe(tags[0]);
 
     expect(tags[1].name).toBe("package-2021-11-01");
     const inputFiles1 = [...tags[1].inputFiles.values()];

--- a/.github/shared/test/spec-model.test.js
+++ b/.github/shared/test/spec-model.test.js
@@ -85,6 +85,7 @@ describe("SpecModel", () => {
     expect(inputFiles1[0].path).toBe(
       resolve(folder, "Microsoft.Contoso/stable/2021-11-01/contoso.json"),
     );
+    expect(inputFiles1[0].tag).toBe(tags[1]);
 
     const jsonDefault = await specModel.toJSONAsync();
     const readmePathDefault = jsonDefault.readmes[0].path;

--- a/.github/shared/test/spec-model.test.js
+++ b/.github/shared/test/spec-model.test.js
@@ -63,6 +63,7 @@ describe("SpecModel", () => {
         "Microsoft.Contoso/preview/2021-10-01-preview/contoso.json",
       ),
     );
+    expect(inputFiles0[0].tag).toBe(tags[0]);
 
     const refs0 = [...(await inputFiles0[0].getRefs()).values()].sort((a, b) =>
       a.path.localeCompare(b.path),

--- a/.github/shared/test/spec-model.test.js
+++ b/.github/shared/test/spec-model.test.js
@@ -37,6 +37,7 @@ describe("SpecModel", () => {
     const readme = readmes[0];
     expect(readme.toString()).toContain("Readme");
     expect(readme.path).toBe(resolve(folder, "readme.md"));
+    expect(readme.specModel).toBe(specModel);
 
     expect(readme.getGlobalConfig()).resolves.toEqual({
       "openapi-type": "arm",

--- a/.github/shared/test/swagger.test.js
+++ b/.github/shared/test/swagger.test.js
@@ -25,7 +25,7 @@ describe("Swagger", () => {
     const tag = new Tag("2025-01-01", [], { readme });
     const swagger = new Swagger("test.json", { tag });
 
-    expect(swagger.path).toBe("/specs/foo/test.json");
+    expect(swagger.path).toBe(resolve("/specs/foo/test.json"));
   });
 
   // TODO: Test that path is resolved against backpointer

--- a/.github/shared/test/swagger.test.js
+++ b/.github/shared/test/swagger.test.js
@@ -5,6 +5,8 @@ import { describe, expect, it } from "vitest";
 import { Swagger } from "../src/swagger.js";
 
 import { fileURLToPath } from "url";
+import { Readme } from "../src/readme.js";
+import { Tag } from "../src/tag.js";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 describe("Swagger", () => {
@@ -17,6 +19,16 @@ describe("Swagger", () => {
       /Failed to resolve file for swagger/i,
     );
   });
+
+  it("resolves path against Tag.readme", async () => {
+    const readme = new Readme("/specs/foo/readme.md");
+    const tag = new Tag("2025-01-01", [], { readme });
+    const swagger = new Swagger("test.json", { tag });
+
+    expect(swagger.path).toBe("/specs/foo/test.json");
+  });
+
+  // TODO: Test that path is resolved against backpointer
 
   it("excludes example files", async () => {
     const swagger = new Swagger(

--- a/.github/shared/test/swagger.test.js
+++ b/.github/shared/test/swagger.test.js
@@ -11,6 +11,7 @@ describe("Swagger", () => {
   it("can be created with mock path", async () => {
     const swagger = new Swagger("bar");
     expect(swagger.path).toBe(resolve("bar"));
+    expect(swagger.tag).toBeUndefined();
 
     await expect(swagger.getRefs()).rejects.toThrowError(
       /Failed to resolve file for swagger/i,

--- a/.github/shared/test/tag.test.js
+++ b/.github/shared/test/tag.test.js
@@ -8,11 +8,16 @@ import { Tag } from "../src/tag.js";
 
 describe("Tag", () => {
   it("can be created with mock swaggers", async () => {
-    const tag = new Tag("tag", new Set([new Swagger("swagger")]));
-    expect(tag.name).toBe("tag");
-    expect(tag.inputFiles.size).toBe(1);
+    const inputSwagger = new Swagger("swagger");
+    const inputFiles = new Map([[inputSwagger.path, inputSwagger]]);
 
-    const swagger = [...tag.inputFiles][0];
+    const tag = new Tag("tag", inputFiles);
+
+    expect(tag.name).toBe("tag");
+    expect(tag.readme).toBeUndefined();
+
+    expect(tag.inputFiles.size).toBe(1);
+    const swagger = [...tag.inputFiles.values()][0];
     expect(swagger.path).toBe(resolve("swagger"));
 
     await expect(swagger.getRefs()).rejects.toThrowError(

--- a/.github/shared/test/tag.test.js
+++ b/.github/shared/test/tag.test.js
@@ -3,15 +3,11 @@
 import { describe, expect, it } from "vitest";
 
 import { resolve } from "path";
-import { Swagger } from "../src/swagger.js";
 import { Tag } from "../src/tag.js";
 
 describe("Tag", () => {
   it("can be created with mock swaggers", async () => {
-    const inputSwagger = new Swagger("swagger");
-    const inputFiles = new Map([[inputSwagger.path, inputSwagger]]);
-
-    const tag = new Tag("tag", inputFiles);
+    const tag = new Tag("tag", ["swagger"]);
 
     expect(tag.name).toBe("tag");
     expect(tag.readme).toBeUndefined();

--- a/.github/workflows/typespec-validation-all.yaml
+++ b/.github/workflows/typespec-validation-all.yaml
@@ -19,13 +19,14 @@ on:
       - package.json
       - tsconfig.json
       - eng/**
-      - '!eng/common/**'
+      - "!eng/common/**"
       - specification/suppressions.yaml
       - specification/common-types/**
 
       # Workflow and workflow dependencies
-      - .github/workflows/typespec-validation-all.yaml
       - .github/actions/setup-node-npm-ci/**
+      - .github/shared/**
+      - .github/workflows/typespec-validation-all.yaml
 
   schedule:
     # Run 4x/day


### PR DESCRIPTION
- move code calling "new Swagger()" from Readme to Tag to align responsibility
- main benefit of backpointers is calling code doesn't need to try/catch/enhance/throw to add error context
- may be useful in the future for additional exceptions, logging, etc.
- properties are optional and backwards-compatible
