### PR TITLE
Enable authentication support for private ADO in status check

### DIFF
--- a/.github/workflows/spec-gen-sdk-status.yml
+++ b/.github/workflows/spec-gen-sdk-status.yml
@@ -22,10 +22,8 @@ jobs:
           sparse-checkout: |
             .github
 
-      # Only run the login and get token steps when the check run is from azure-rest-api-specs-pr repository
-      - if: |
-          startsWith(github.event.check_run.html_url, 'https://github.com/') &&
-          contains(github.event.check_run.html_url, '/azure-rest-api-specs-pr/')
+      # Only run the login and get token steps when the respository is azure-rest-api-specs-pr
+      - if: github.event.repository.name == 'azure-rest-api-specs-pr'
         name: Azure Login with Workload Identity Federation
         uses: azure/login@v2
         with:
@@ -33,9 +31,7 @@ jobs:
           tenant-id: "72f988bf-86f1-41af-91ab-2d7cd011db47"
           allow-no-subscriptions: true
 
-      - if: |
-          startsWith(github.event.check_run.html_url, 'https://github.com/') &&
-          contains(github.event.check_run.html_url, '/azure-rest-api-specs-pr/')
+      - if: github.event.repository.name == 'azure-rest-api-specs-pr'
         name: Get ADO Token via Managed Identity
         run: |
           # Get token for Azure DevOps resource

--- a/.github/workflows/spec-gen-sdk-status.yml
+++ b/.github/workflows/spec-gen-sdk-status.yml
@@ -7,23 +7,47 @@ on:
 permissions:
   contents: read
   statuses: write
+  id-token: write
 
 jobs:
   sdk-validation-status:
     # Only run this job when the check run is from Azure Pipelines(SDK Validation) in the azure-sdk/public(id: 29ec6040-b234-4e31-b139-33dc4287b756) project
     if: |
       github.event.check_run.check_suite.app.name == 'Azure Pipelines' &&
-      contains(github.event.check_run.name, 'SDK Validation') &&
-      endsWith(github.event.check_run.external_id, '29ec6040-b234-4e31-b139-33dc4287b756')
-    name: "SDK Validation - Status"
+      contains(github.event.check_run.name, 'SDK Validation')
+    name: "SDK Validation Status"
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
           sparse-checkout: |
             .github
-      
-      - name: "SDK Validation - Status"
+
+      - name: Check Azure Credentials
+        id: check-creds
+        run: |
+          if [ -n "${{ secrets.AZURE_CLIENT_ID }}" ]; then
+            echo "has_creds=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_creds=false" >> $GITHUB_OUTPUT
+          fi
+
+      - if: steps.check-creds.outputs.has_creds == 'true'
+        name: Azure Login with Workload Identity Federation
+        uses: azure/login@v1
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
+      - if: steps.check-creds.outputs.has_creds == 'true'
+        name: Get ADO Token via Managed Identity
+        run: |
+          # Get token for Azure DevOps resource
+          ADO_TOKEN=$(az account get-access-token --resource "499b84ac-1321-427f-aa17-267ca6975798" --query "accessToken" -o tsv)
+          echo "ADO_TOKEN=$ADO_TOKEN" >> $GITHUB_ENV
+
+      - name: "SDK Validation Set Status"
         id: sdk-validation-status
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/spec-gen-sdk-status.yml
+++ b/.github/workflows/spec-gen-sdk-status.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  checks: read
   statuses: write
   id-token: write
 

--- a/.github/workflows/spec-gen-sdk-status.yml
+++ b/.github/workflows/spec-gen-sdk-status.yml
@@ -11,7 +11,6 @@ permissions:
 
 jobs:
   sdk-validation-status:
-    # Only run this job when the check run is from Azure Pipelines(SDK Validation) in the azure-sdk/public(id: 29ec6040-b234-4e31-b139-33dc4287b756) project
     if: |
       github.event.check_run.check_suite.app.name == 'Azure Pipelines' &&
       contains(github.event.check_run.name, 'SDK Validation')
@@ -23,24 +22,16 @@ jobs:
           sparse-checkout: |
             .github
 
-      - name: Check Azure Credentials
-        id: check-creds
-        run: |
-          if [ -n "${{ secrets.AZURE_CLIENT_ID }}" ]; then
-            echo "has_creds=true" >> $GITHUB_OUTPUT
-          else
-            echo "has_creds=false" >> $GITHUB_OUTPUT
-          fi
-
-      - if: steps.check-creds.outputs.has_creds == 'true'
+      # Only run this job when the check run is from Azure Pipelines(SDK Validation) in the azure-sdk/internal project
+      - if: endsWith(github.event.check_run.external_id, '590cfd2a-581c-4dcb-a12e-6568ce786175')
         name: Azure Login with Workload Identity Federation
-        uses: azure/login@v1
+        uses: azure/login@v2
         with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          client-id: "936c56f0-298b-467f-b702-3ad5bf4b15c1"
+          tenant-id: "72f988bf-86f1-41af-91ab-2d7cd011db47"
           allow-no-subscriptions: true
 
-      - if: steps.check-creds.outputs.has_creds == 'true'
+      - if: endsWith(github.event.check_run.external_id, '590cfd2a-581c-4dcb-a12e-6568ce786175')
         name: Get ADO Token via Managed Identity
         run: |
           # Get token for Azure DevOps resource

--- a/.github/workflows/spec-gen-sdk-status.yml
+++ b/.github/workflows/spec-gen-sdk-status.yml
@@ -22,8 +22,10 @@ jobs:
           sparse-checkout: |
             .github
 
-      # Only run this job when the check run is from Azure Pipelines(SDK Validation) in the azure-sdk/internal project
-      - if: endsWith(github.event.check_run.external_id, '590cfd2a-581c-4dcb-a12e-6568ce786175')
+      # Only run the login and get token steps when the check run is from azure-rest-api-specs-pr repository
+      - if: |
+          startsWith(github.event.check_run.html_url, 'https://github.com/') &&
+          contains(github.event.check_run.html_url, '/azure-rest-api-specs-pr/')
         name: Azure Login with Workload Identity Federation
         uses: azure/login@v2
         with:
@@ -31,7 +33,9 @@ jobs:
           tenant-id: "72f988bf-86f1-41af-91ab-2d7cd011db47"
           allow-no-subscriptions: true
 
-      - if: endsWith(github.event.check_run.external_id, '590cfd2a-581c-4dcb-a12e-6568ce786175')
+      - if: |
+          startsWith(github.event.check_run.html_url, 'https://github.com/') &&
+          contains(github.event.check_run.html_url, '/azure-rest-api-specs-pr/')
         name: Get ADO Token via Managed Identity
         run: |
           # Get token for Azure DevOps resource

--- a/.github/workflows/src/spec-gen-sdk-status.js
+++ b/.github/workflows/src/spec-gen-sdk-status.js
@@ -16,6 +16,10 @@ import {
  * @returns {Promise<void>}
  */
 export default async function setSpecGenSdkStatus({ github, context, core }) {
+  const adoToken = process.env.ADO_TOKEN;
+  if (!adoToken) {
+    throw new Error("ADO_TOKEN environment variable is not set");
+  }
   const inputs = await extractInputs(github, context, core);
   const ado_build_id = inputs.ado_build_id;
   const ado_project_url = inputs.ado_project_url;
@@ -165,6 +169,7 @@ async function processResult({ checkRuns, core }) {
       artifactFileName,
       core,
       fallbackToFailedArtifact: true,
+      token: process.env.ADO_TOKEN,
     });
     // Parse the JSON data
     if (!result.artifactData) {

--- a/.github/workflows/src/spec-gen-sdk-status.js
+++ b/.github/workflows/src/spec-gen-sdk-status.js
@@ -16,10 +16,6 @@ import {
  * @returns {Promise<void>}
  */
 export default async function setSpecGenSdkStatus({ github, context, core }) {
-  const adoToken = process.env.ADO_TOKEN;
-  if (!adoToken) {
-    throw new Error("ADO_TOKEN environment variable is not set");
-  }
   const inputs = await extractInputs(github, context, core);
   const ado_build_id = inputs.ado_build_id;
   const ado_project_url = inputs.ado_project_url;


### PR DESCRIPTION
### Workflow Enhancements:
* [`.github/workflows/spec-gen-sdk-status.yml`] Added workload identity federation for Azure login, with steps to check for Azure credentials, log in using a managed identity, and fetch an Azure DevOps token. 

### Artifact Handling Improvements:
* `.github/workflows/src/artifacts.js`:
  * Added a `token` parameter to `getAzurePipelineArtifact` and `fetchFailedArtifact` functions to support passing Azure DevOps authorization tokens. 
  * Refactored API calls in both functions to include dynamic headers with optional authorization tokens. 
  * Updated retry logic for fetching artifacts to utilize these headers.

### Validation Script Updates:
* `.github/workflows/src/spec-gen-sdk-status.js`:
  * Added validation to ensure the `ADO_TOKEN` environment variable is set before proceeding.
  * Updated `processResult` to pass the `ADO_TOKEN` to artifact-fetching functions, ensuring secure API calls.

### Test PRs:
https://github.com/raych1/azure-rest-api-specs/pull/51