### PR TITLE
[CODEOWNERS] Remove owners for readme.*.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -282,10 +282,6 @@
 # PRLabel: %Profile
 /profile/ @shahabhijeet
 
-/specification/**/resource-manager/**/readme.typescript.md @qiaozha
-/specification/**/resource-manager/**/readme.go.md @tadelesh
-/specification/**/resource-manager/**/readme.python.md @msyyc
-
 /specification/contosowidgetmanager/ @mikeharder @raych1 @maririos
 
 ###########


### PR DESCRIPTION
- Not appropriate to block all spec PRs changing `readme.*.md` files on code review from a single person
- If we want to block PRs until `readme.*.md` changes are reviewed, we will need a reliable process with SLAs on review times
