### PR TITLE
[Storage] `set/get_tags`, `get_account_info` and `list_blobs` TypeSpec Changes

### DIFF
--- a/specification/storage/Microsoft.BlobStorage/routes.tsp
+++ b/specification/storage/Microsoft.BlobStorage/routes.tsp
@@ -579,8 +579,6 @@ namespace Storage.Blob {
         ...TimeoutParameter;
       },
       {
-        ...DateResponseHeader;
-
         /** The list of blobs in the container */
         @body
         enumerationResults: ListBlobsFlatSegmentResponse;
@@ -626,7 +624,6 @@ namespace Storage.Blob {
         ...TimeoutParameter;
       },
       {
-        ...DateResponseHeader;
         ...SkuNameResponseHeader;
         ...AccountKindResponseHeader;
         ...IsHierarchicalNamespaceEnabled;
@@ -1348,8 +1345,6 @@ namespace Storage.Blob {
           ...IfTagsParameter;
         },
         {
-          ...DateResponseHeader;
-
           /** The blob tags. */
           @body
           tags: BlobTags;
@@ -1375,10 +1370,7 @@ namespace Storage.Blob {
           @body
           tags: BlobTags;
         },
-        {
-          @statusCode statusCode: 204;
-          ...DateResponseHeader;
-        }
+        {}
       >;
 
       #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "Existing API. Storage API version parameter pre-dates current guidance."

--- a/specification/storage/Microsoft.BlobStorage/routes.tsp
+++ b/specification/storage/Microsoft.BlobStorage/routes.tsp
@@ -141,7 +141,6 @@ namespace Storage.Blob {
   op getAccountInfo is StorageOperation<
     TimeoutParameter,
     {
-      ...DateResponseHeader;
       ...SkuNameResponseHeader;
       ...AccountKindResponseHeader;
 
@@ -1322,7 +1321,6 @@ namespace Storage.Blob {
           ...TimeoutParameter;
         },
         {
-          ...DateResponseHeader;
           ...AccountKindResponseHeader;
           ...SkuNameResponseHeader;
           ...IsHierarchicalNamespaceEnabled;


### PR DESCRIPTION
This PR omits the following response headers:
Set/Get Tags:

- Date

GetAccountInfo

- Date

ListBlobs

- Date