### PR TITLE
Removing some Go-specific renames

### DIFF
--- a/specification/eventgrid/Azure.Messaging.EventGrid.SystemEvents/propertyNameOverrideGo.tsp
+++ b/specification/eventgrid/Azure.Messaging.EventGrid.SystemEvents/propertyNameOverrideGo.tsp
@@ -380,10 +380,6 @@ using Microsoft.EventGrid.SystemEvents;
   "ACSMessageDeliveryStatusUpdatedEventData",
   "go"
 );
-@@clientName(AcsMessageDeliveryStatusUpdatedEventData.channelType,
-  "ChannelKind",
-  "go"
-);
 @@clientName(AcsMessageDeliveryStatusUpdatedEventData.receivedTimeStamp,
   "ReceivedTimestamp",
   "go"
@@ -414,7 +410,6 @@ using Microsoft.EventGrid.SystemEvents;
 @@clientName(AcsMessageMediaContent.id, "MediaID", "go");
 
 @@clientName(AcsMessageReceivedEventData, "ACSMessageReceivedEventData", "go");
-@@clientName(AcsMessageReceivedEventData.channelType, "ChannelKind", "go");
 @@clientName(AcsMessageReceivedEventData.interactive,
   "InteractiveContent",
   "go"
@@ -435,7 +430,7 @@ using Microsoft.EventGrid.SystemEvents;
   "go"
 );
 
-@@clientName(recordingChannelType, "ACSRecordingChannelKind", "go");
+@@clientName(recordingChannelType, "ACSRecordingChannelType", "go");
 @@clientName(recordingContentType, "ACSRecordingContentType", "go");
 @@clientName(recordingFormatType, "ACSRecordingFormatType", "go");
 @@clientName(KeyVaultAccessPolicyChangedEventData.NBF, "NBF", "go");
@@ -458,11 +453,6 @@ using Microsoft.EventGrid.SystemEvents;
 @@clientName(KeyVaultSecretNearExpiryEventData.EXP, "EXP", "go");
 @@clientName(KeyVaultSecretNewVersionCreatedEventData.NBF, "NBF", "go");
 @@clientName(KeyVaultSecretNewVersionCreatedEventData.EXP, "EXP", "go");
-
-@@clientName(AcsRecordingFileStatusUpdatedEventData.recordingChannelType,
-  "recordingChannelKind",
-  "go"
-);
 
 @@clientName(AcsRecordingStorageInfoProperties,
   "ACSRecordingStorageInfoProperties",


### PR DESCRIPTION
We had some renames that seemed arbitrary, and (worse) they deviate from the Typespec's name which makes discovery harder for no reason.