### PR TITLE
[tools bugfix] handling head Empty sdk-suppressions files

### DIFF
--- a/eng/tools/sdk-suppressions/src/sdkSuppressions.ts
+++ b/eng/tools/sdk-suppressions/src/sdkSuppressions.ts
@@ -22,9 +22,15 @@ export type SdkPackageSuppressionsEntry = {
   "breaking-changes": string[];
 };
 
-function exitWithError(error: string): never {
+function errorResult(error: string): {
+  result: boolean;
+  message: string;
+} {
     console.error("Error:", error);
-    process.exit(1);
+    return {
+      result: false,
+      message: error,
+    };
 }
 
 export function validateSdkSuppressionsFile(
@@ -34,11 +40,11 @@ export function validateSdkSuppressionsFile(
   message: string;
 } {
   if (suppressionContent === null) {
-    exitWithError("This suppression file is a empty file");
+    return errorResult("This suppression file is a empty file");
   }
 
   if (!suppressionContent) {
-    exitWithError("This suppression file is not a valid yaml. Refer to https://aka.ms/azsdk/sdk-suppression for more information.");
+    return errorResult("This suppression file is not a valid yaml. Refer to https://aka.ms/azsdk/sdk-suppression for more information.");
   }
 
   const suppressionFileSchema = {
@@ -80,6 +86,6 @@ export function validateSdkSuppressionsFile(
       message: "This suppression file is a valid yaml.",
     };
   } else {
-    exitWithError("This suppression file is a valid yaml but the schema is wrong: " + suppressionAjv.errorsText(suppressionAjvCompile.errors, { separator: "\n" }));
+    return errorResult("This suppression file is a valid yaml but the schema is wrong: " + suppressionAjv.errorsText(suppressionAjvCompile.errors, { separator: "\n" }));
   }
 }

--- a/eng/tools/sdk-suppressions/src/updateSdkSuppressionsLabel.ts
+++ b/eng/tools/sdk-suppressions/src/updateSdkSuppressionsLabel.ts
@@ -52,8 +52,10 @@ export async function getSdkSuppressionsSdkNames(
       // if the head suppression file is present but anything is wrong like schema error with it return
       const validateSdkSuppressionsFileResult =
         validateSdkSuppressionsFile(headSuppressionContent).result;
+      // If the head suppression file is not valid or empty, we get _sdkNameList with [].
       if (!validateSdkSuppressionsFileResult) {
-        return [];
+        console.log(`Get sdk name after compare for ${suppressionFile} was empty because the head suppression file is not valid or empty.`);
+        continue;
       }
       // if base suppression file does not exist, set it to an empty object but has correct schema
       if (!baseSuppressionContent) {
@@ -67,10 +69,13 @@ export async function getSdkSuppressionsSdkNames(
           `${JSON.stringify(headSuppressionContent)} to get different SDK.`,
       );
 
-      sdkNameList = getSdkNamesWithChangedSuppressions(
+      let _sdkNameList = getSdkNamesWithChangedSuppressions(
         headSuppressionContent as SdkSuppressionsYml,
         baseSuppressionContent as SdkSuppressionsYml,
       );
+
+      console.log(`Get sdk name after compare for ${suppressionFile} was ${_sdkNameList.join(",")}`);
+      sdkNameList = [..._sdkNameList, ...sdkNameList];
     }
   }
 

--- a/eng/tools/sdk-suppressions/src/updateSdkSuppressionsLabel.ts
+++ b/eng/tools/sdk-suppressions/src/updateSdkSuppressionsLabel.ts
@@ -54,7 +54,7 @@ export async function getSdkSuppressionsSdkNames(
         validateSdkSuppressionsFile(headSuppressionContent).result;
       // If the head suppression file is not valid or empty, we get _sdkNameList with [].
       if (!validateSdkSuppressionsFileResult) {
-        console.log(`Get sdk name after compare for ${suppressionFile} was empty because the head suppression file is not valid or empty.`);
+        console.log(`Returned empty SDK name list — head suppression file at ${suppressionFile}/${headCommitHash} is invalid or empty.`);
         continue;
       }
       // if base suppression file does not exist, set it to an empty object but has correct schema
@@ -73,8 +73,7 @@ export async function getSdkSuppressionsSdkNames(
         headSuppressionContent as SdkSuppressionsYml,
         baseSuppressionContent as SdkSuppressionsYml,
       );
-
-      console.log(`Get sdk name after compare for ${suppressionFile} was ${_sdkNameList.join(",")}`);
+      console.log(`Retrieved SDK names after comparing suppression file ${suppressionFile}: [${_sdkNameList.join(",")}].`);
       sdkNameList = [..._sdkNameList, ...sdkNameList];
     }
   }

--- a/eng/tools/sdk-suppressions/test/updateSdkSuppressionsLabel.test.ts
+++ b/eng/tools/sdk-suppressions/test/updateSdkSuppressionsLabel.test.ts
@@ -57,37 +57,30 @@ test("test validateSdkSuppressionsFile for sdk-suppression file", () => {
 
 test("test validateSdkSuppressionsFile for empty file", () => {
   const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-  const mockProcessExit = vi.spyOn(process, "exit").mockImplementation(() => {
-    throw new Error("process.exit called"); // Prevent actual exit
-  });
 
-  expect(() => validateSdkSuppressionsFile(null)).toThrow("process.exit called");
+  expect(validateSdkSuppressionsFile(null)).toEqual({
+    result: false,
+    message: "This suppression file is a empty file",
+  });
   expect(consoleSpy).toHaveBeenCalledWith("Error:", "This suppression file is a empty file");
-  expect(mockProcessExit).toHaveBeenCalledWith(1);
 
   consoleSpy.mockRestore();
-  mockProcessExit.mockRestore();
 });
 
 test("test validateSdkSuppressionsFile for undefined file", () => {
   const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-  const mockProcessExit = vi.spyOn(process, "exit").mockImplementation(() => {
-    throw new Error("process.exit called"); // Prevent actual exit
-  });
 
-  expect(() => validateSdkSuppressionsFile(undefined)).toThrow("process.exit called");
+  expect(validateSdkSuppressionsFile(undefined)).toEqual({
+    message: "This suppression file is not a valid yaml. Refer to https://aka.ms/azsdk/sdk-suppression for more information.",
+    result: false,
+  });
   expect(consoleSpy).toHaveBeenCalledWith("Error:", "This suppression file is not a valid yaml. Refer to https://aka.ms/azsdk/sdk-suppression for more information.");
-  expect(mockProcessExit).toHaveBeenCalledWith(1);
 
   consoleSpy.mockRestore();
-  mockProcessExit.mockRestore();
 });
 
 test("test validateSdkSuppressionsFile for error structor file", () => {
   const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-  const mockProcessExit = vi.spyOn(process, "exit").mockImplementation(() => {
-    throw new Error("process.exit called"); // Prevent actual exit
-  });
 
   const suppressionContent = {
     "suppressions": {
@@ -107,12 +100,13 @@ test("test validateSdkSuppressionsFile for error structor file", () => {
     }
   };
 
-  expect(() => validateSdkSuppressionsFile(suppressionContent)).toThrow("process.exit called");
+  expect(validateSdkSuppressionsFile(suppressionContent)).toEqual({
+    message: "This suppression file is a valid yaml but the schema is wrong: data/suppressions/azure-sdk-for-go/0 must have required property 'breaking-changes'",
+    result: false,
+  });
   expect(consoleSpy).toHaveBeenCalledWith("Error:", "This suppression file is a valid yaml but the schema is wrong: data/suppressions/azure-sdk-for-go/0 must have required property 'breaking-changes'");
-  expect(mockProcessExit).toHaveBeenCalledWith(1);
 
   consoleSpy.mockRestore();
-  mockProcessExit.mockRestore();
 });
 
 test("test getSdkNamesWithChangedSuppressions", () => {


### PR DESCRIPTION
This pull request refactors the error-handling mechanism in the `sdk-suppressions` tools to replace `process.exit` calls with structured error results, improving testability and code maintainability. Additionally, it enhances logging and updates the test cases to align with the new approach.

### Refactoring error handling:
* Replaced the `exitWithError` function with a new `errorResult` function that returns structured error objects instead of terminating the process. This change was applied throughout the `validateSdkSuppressionsFile` function. (`eng/tools/sdk-suppressions/src/sdkSuppressions.ts`, [[1]](diffhunk://#diff-63106cc989ad055cf72709b811b00d4143f666adfde32e7fd03dcb23120724fdL25-R33) [[2]](diffhunk://#diff-63106cc989ad055cf72709b811b00d4143f666adfde32e7fd03dcb23120724fdL37-R47) [[3]](diffhunk://#diff-63106cc989ad055cf72709b811b00d4143f666adfde32e7fd03dcb23120724fdL83-R89)

### Enhancing logging:
* Added detailed log messages in the `getSdkSuppressionsSdkNames` function to provide better insights into processing results, particularly when suppression files are invalid or empty. (`eng/tools/sdk-suppressions/src/updateSdkSuppressionsLabel.ts`, [[1]](diffhunk://#diff-5f0746e3ab8be889b95054a19e9c7ec0520cf664effc8cb23c6d199b1ffcaae8R55-R58) [[2]](diffhunk://#diff-5f0746e3ab8be889b95054a19e9c7ec0520cf664effc8cb23c6d199b1ffcaae8L70-R78)

### Updating test cases:
* Refactored test cases for `validateSdkSuppressionsFile` to validate the new structured error results instead of expecting `process.exit` calls. This includes verifying the returned error objects and ensuring appropriate console error messages are logged. (`eng/tools/sdk-suppressions/test/updateSdkSuppressionsLabel.test.ts`, [[1]](diffhunk://#diff-4eceab6caa2d80e477afd79699fad50c5aeedb1133619bdbd7a7311651eb9e36L60-L90) [[2]](diffhunk://#diff-4eceab6caa2d80e477afd79699fad50c5aeedb1133619bdbd7a7311651eb9e36L110-L115)