### PR TITLE
Added Dedicated backend connection and certificate validation option

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2024-10-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2024-10-01/applicationGateway.json
@@ -1879,6 +1879,24 @@
           "type": "string",
           "description": "Path which should be used as a prefix for all HTTP requests. Null means no path will be prefixed. Default value is null."
         },
+        "dedicatedBackendConnection": {
+          "type": "boolean",
+          "description": "Whether Dedicated backend connection Support is enabled or not. Default value is false."
+        },
+        "validateCertChainAndExpiry": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether to validate cert chain and Expiry of the Backend Cert for Https protocol. Default value is true."
+        },
+        "validateSNI": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether to validate SNI Name of the Backend Cert for Https protocol. Default value is true."
+        },
+        "sniName": {
+          "type": "string",
+          "description": "Custom Server name indication to be sent to the backend servers for Https protocol. Default value is null"
+        },
         "provisioningState": {
           "readOnly": true,
           "$ref": "./network.json#/definitions/ProvisioningState",


### PR DESCRIPTION
Added Dedicated backend connection and certificate validation options in template for application Gateway.
Following are the 4 properties that will be added in Backend HTTP Settings for Application Gateway Resource.
1. dedicatedBackendConnection
2. validateCertChainAndExpiry
3. validateSNI
4. sniName
Changes will be tied to NRP 186 - API version: 202# Choose a PR Template

https://github.com/Azure/azure-rest-api-specs-pr/pull/20934
Properties were already reviewed few months back and were checked in Private Branch Already as shared in above Link. Hence only now this approval is needed

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
