### PR TITLE
Enabled auth for sdk breaking change label WF

### DIFF
--- a/.github/workflows/sdk-breaking-change-labels.yaml
+++ b/.github/workflows/sdk-breaking-change-labels.yaml
@@ -6,14 +6,15 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
+  id-token: write
 
 jobs:
   sdk-breaking-change-labels:
-    # Only run this job when the check run is from Azure Pipelines SDK Generation job in the azure-sdk/public(id: 29ec6040-b234-4e31-b139-33dc4287b756) project
+    # Only run this job when the check run is 'SDK Validation *'
     if: |
       github.event.check_run.check_suite.app.name == 'Azure Pipelines' &&
-      contains(github.event.check_run.name, 'SDK Validation') &&
-      endsWith(github.event.check_run.external_id, '29ec6040-b234-4e31-b139-33dc4287b756')
+      contains(github.event.check_run.name, 'SDK Validation')
     name: SDK Breaking Change Labels
     runs-on: ubuntu-24.04
     steps:
@@ -21,7 +22,23 @@ jobs:
         with:
           sparse-checkout: |
             .github
-      
+
+      # Only run the login and get token steps when the respository is azure-rest-api-specs-pr
+      - if: github.event.repository.name == 'azure-rest-api-specs-pr'
+        name: Azure Login with Workload Identity Federation
+        uses: azure/login@v2
+        with:
+          client-id: "936c56f0-298b-467f-b702-3ad5bf4b15c1"
+          tenant-id: "72f988bf-86f1-41af-91ab-2d7cd011db47"
+          allow-no-subscriptions: true
+
+      - if: github.event.repository.name == 'azure-rest-api-specs-pr'
+        name: Get ADO Token via Managed Identity
+        run: |
+          # Get token for Azure DevOps resource
+          ADO_TOKEN=$(az account get-access-token --resource "499b84ac-1321-427f-aa17-267ca6975798" --query "accessToken" -o tsv)
+          echo "ADO_TOKEN=$ADO_TOKEN" >> $GITHUB_ENV
+
       - name: Get label and action
         id: get-label-and-action
         uses: actions/github-script@v7
@@ -42,8 +59,9 @@ jobs:
           value: "${{ fromJson(steps.get-label-and-action.outputs.result).labelAction == 'add' }}"
 
       - if: |
-          (fromJson(steps.get-label-and-action.outputs.result).labelAction == 'add' ||
-          fromJson(steps.get-label-and-action.outputs.result).labelAction == 'remove')
+          ((fromJson(steps.get-label-and-action.outputs.result).labelAction == 'add' ||
+          fromJson(steps.get-label-and-action.outputs.result).labelAction == 'remove') &&
+          fromJson(steps.get-label-and-action.outputs.result).issueNumber > 0)
         name: Upload artifact with issue number
         uses: ./.github/actions/add-empty-artifact
         with:

--- a/.github/workflows/src/artifacts.js
+++ b/.github/workflows/src/artifacts.js
@@ -188,7 +188,14 @@ export async function fetchFailedArtifact({
     .filter((artifact) => artifact.name.includes(artifactName))
     .sort((a, b) => b.name.localeCompare(a.name)); // Descending order (Z to A)
   if (artifactsList.length === 0) {
-    throw new Error(`No artifacts found with name containing ${artifactName}`);
+    const message = `No artifacts found with name containing ${artifactName}`;
+    core.warning(message);
+    // Return a Response-like object using the global Response constructor
+    return new Response(message, {
+      status: 404,
+      statusText: message,
+      headers: { "Content-Type": "text/plain" },
+    });
   }
   artifactName = artifactsList[0].name;
   apiUrl = `${ado_project_url}/_apis/build/builds/${ado_build_id}/artifacts?artifactName=${artifactName}&api-version=7.0`;

--- a/.github/workflows/src/spec-gen-sdk-status.js
+++ b/.github/workflows/src/spec-gen-sdk-status.js
@@ -17,12 +17,11 @@ import {
  */
 export default async function setSpecGenSdkStatus({ github, context, core }) {
   const inputs = await extractInputs(github, context, core);
-  const ado_build_id = inputs.ado_build_id;
-  const ado_project_url = inputs.ado_project_url;
   const head_sha = inputs.head_sha;
-  if (!ado_build_id || !ado_project_url || !head_sha) {
+  const details_url = inputs.details_url;
+  if (!details_url || !head_sha) {
     throw new Error(
-      `Required inputs are not valid: ado_build_id:${ado_build_id}, ado_project_url:${ado_project_url}, head_sha:${head_sha}`,
+      `Required inputs are not valid: details_url:${details_url}, head_sha:${head_sha}`,
     );
   }
   const owner = inputs.owner;

--- a/.github/workflows/test/artifacts.test.js
+++ b/.github/workflows/test/artifacts.test.js
@@ -703,7 +703,7 @@ describe("fetchFailedArtifact function", () => {
     expect(response).toBe(mockFetchResponse);
   });
 
-  it("should throw an error when no matching artifacts are found", async () => {
+  it("should return 404 when no matching artifacts are found", async () => {
     // Mock response with no matching artifacts
     const mockListResponse = {
       ok: true,
@@ -725,8 +725,11 @@ describe("fetchFailedArtifact function", () => {
 
     global.fetch.mockResolvedValue(mockListResponse);
 
-    // Call the function and expect it to throw
-    await expect(fetchFailedArtifact(defaultParams)).rejects.toThrow(
+    // Call the function and expect it to return a 404 response
+    const response = await fetchFailedArtifact(defaultParams);
+    expect(response.ok).toBe(false);
+    expect(response.status).toBe(404);
+    expect(response.statusText).toBe(
       `No artifacts found with name containing ${defaultParams.artifactName}`,
     );
   });

--- a/.github/workflows/test/context.test.js
+++ b/.github/workflows/test/context.test.js
@@ -469,8 +469,8 @@ describe("extractInputs", () => {
       issue_number: NaN,
       head_sha: "abc123",
       run_id: NaN,
-      ado_build_id: "56789",
-      ado_project_url: "https://dev.azure.com/abc/123-456",
+      details_url:
+        "https://dev.azure.com/abc/123-456/_build/results?buildId=56789",
     });
   });
 
@@ -481,25 +481,17 @@ describe("extractInputs", () => {
       payload: {
         action: "completed",
         check_run: {
-          details_url: "https://debc/123-456/_build/result/buildId=56789",
+          details_url:
+            "https://dev.azure.com/abc/123-456/_build/results?buildId=56789",
           head_sha: "abc123",
         },
         repository: {
-          name: "TestRepoName",
           owner: {
             login: "TestRepoOwnerLogin",
           },
         },
       },
     };
-
-    await expect(
-      extractInputs(github, context, createMockCore()),
-    ).rejects.toThrow("from check run details URL");
-
-    context.payload.check_run.details_url =
-      "https://dev.azure.com/abc/123-456/_build/results?buildId=56789";
-    delete context.payload.repository.name;
 
     await expect(
       extractInputs(github, context, createMockCore()),

--- a/.github/workflows/test/sdk-breaking-change-labels.test.js
+++ b/.github/workflows/test/sdk-breaking-change-labels.test.js
@@ -33,8 +33,8 @@ describe("sdk-breaking-change-labels", () => {
     it("should extract inputs and call getLabelAndActionImpl", async () => {
       // Mock extracted inputs
       const mockInputs = {
-        ado_build_id: "12345",
-        ado_project_url: "https://dev.azure.com/project",
+        details_url:
+          "https://dev.azure.com/project/_build/results?buildId=12345",
         head_sha: "abc123",
       };
 
@@ -62,17 +62,10 @@ describe("sdk-breaking-change-labels", () => {
           JSON.stringify({
             labelAction: true,
             language,
+            prNumber: "123",
           }),
         ),
       };
-
-      // Mock PR search results
-      mockGithub.rest.search.issuesAndPullRequests.mockResolvedValue({
-        data: {
-          total_count: 1,
-          items: [{ number: 123, html_url: "https://github.com/pr/123" }],
-        },
-      });
 
       // Setup fetch to return different responses for each call
       global.fetch.mockImplementation((url) => {
@@ -96,19 +89,12 @@ describe("sdk-breaking-change-labels", () => {
         labelAction: LabelAction.Add,
         issueNumber: 123,
       });
-
-      // Verify mocks were called correctly
-      expect(mockGithub.rest.search.issuesAndPullRequests).toHaveBeenCalledWith(
-        {
-          q: `sha:abc123 type:pr state:open`,
-        },
-      );
     });
     it("should correctly set labelAction to Remove", async () => {
       // Setup inputs
       const inputs = {
-        ado_build_id: "12345",
-        ado_project_url: "https://dev.azure.com/project",
+        details_url:
+          "https://dev.azure.com/project/_build/results?buildId=12345",
         head_sha: "abc123",
       };
 
@@ -133,6 +119,7 @@ describe("sdk-breaking-change-labels", () => {
           JSON.stringify({
             labelAction: false,
             language,
+            prNumber: "123",
           }),
         ),
       };
@@ -144,14 +131,6 @@ describe("sdk-breaking-change-labels", () => {
         } else {
           return mockContentResponse;
         }
-      });
-
-      // Mock PR search
-      mockGithub.rest.search.issuesAndPullRequests.mockResolvedValue({
-        data: {
-          total_count: 1,
-          items: [{ number: 123, html_url: "https://github.com/pr/123" }],
-        },
       });
 
       // Call function
@@ -171,8 +150,7 @@ describe("sdk-breaking-change-labels", () => {
     it("should throw error with invalid inputs", async () => {
       // Setup inputs
       const inputs = {
-        ado_build_id: "",
-        ado_project_url: "https://dev.azure.com/project",
+        details_url: "",
         head_sha: "abc123",
       };
 
@@ -195,8 +173,8 @@ describe("sdk-breaking-change-labels", () => {
     it("should handle API failure", async () => {
       // Setup inputs
       const inputs = {
-        ado_build_id: "12345",
-        ado_project_url: "https://dev.azure.com/project",
+        details_url:
+          "https://dev.azure.com/project/_build/results?buildId=12345",
         head_sha: "abc123",
       };
 
@@ -208,18 +186,9 @@ describe("sdk-breaking-change-labels", () => {
         text: vi.fn().mockResolvedValue("Artifact not found"),
       });
 
-      // Mock PR search success
-      mockGithub.rest.search.issuesAndPullRequests.mockResolvedValue({
-        data: {
-          total_count: 1,
-          items: [{ number: 123, html_url: "https://github.com/pr/123" }],
-        },
-      });
-
       // Call function
       const result = await getLabelAndActionImpl({
-        ado_build_id: inputs.ado_build_id,
-        ado_project_url: inputs.ado_project_url,
+        details_url: inputs.details_url,
         head_sha: inputs.head_sha,
         github: mockGithub,
         core: mockCore,
@@ -241,31 +210,60 @@ describe("sdk-breaking-change-labels", () => {
     it("should complete without op when artifact does not exist", async () => {
       // Setup inputs
       const inputs = {
-        ado_build_id: "12345",
-        ado_project_url: "https://dev.azure.com/project",
+        details_url:
+          "https://dev.azure.com/project/_build/results?buildId=12345",
         head_sha: "abc123",
       };
 
-      // Mock fetch failure
-      global.fetch.mockResolvedValue({
-        ok: false,
-        status: 404,
-        statusText: "Not Found",
-        text: vi.fn().mockResolvedValue("Artifact not found"),
-      });
-
-      // Mock PR search success
-      mockGithub.rest.search.issuesAndPullRequests.mockResolvedValue({
-        data: {
-          total_count: 1,
-          items: [{ number: 123, html_url: "https://github.com/pr/123" }],
-        },
+      // Mock fetch to handle the artifact URL with 404 error and fallback behavior
+      global.fetch.mockImplementation((url) => {
+        if (url.includes("artifacts?artifactName=spec-gen-sdk-artifact")) {
+          // Initial fetch for the specific artifact returns 404
+          return Promise.resolve({
+            ok: false,
+            status: 404,
+            statusText: "Not Found",
+            text: vi.fn().mockResolvedValue("Artifact not found"),
+          });
+        } else if (
+          url.includes("artifacts?api-version=7.0") &&
+          !url.includes("artifactName=")
+        ) {
+          // List artifacts API call (used by fetchFailedArtifact)
+          return Promise.resolve({
+            ok: true,
+            json: vi.fn().mockResolvedValue({
+              value: [
+                {
+                  name: "spec-gen-sdk-artifact-failed",
+                  id: "12345",
+                  resource: {
+                    downloadUrl:
+                      "https://dev.azure.com/download-failed?format=zip",
+                  },
+                },
+              ],
+            }),
+          });
+        } else if (url.includes("artifactName=spec-gen-sdk-artifact-failed")) {
+          // Fetch for the failed artifact version returns 404 too
+          return Promise.resolve({
+            ok: false,
+            status: 404,
+            statusText: "Not Found",
+            text: vi.fn().mockResolvedValue("Failed artifact not found either"),
+          });
+        }
+        // Default response for other URLs
+        return Promise.resolve({
+          ok: true,
+          text: vi.fn().mockResolvedValue("{}"),
+        });
       });
 
       // Call function
       const result = await getLabelAndActionImpl({
-        ado_build_id: inputs.ado_build_id,
-        ado_project_url: inputs.ado_project_url,
+        details_url: inputs.details_url,
         head_sha: inputs.head_sha,
         github: mockGithub,
         core: mockCore,
@@ -282,8 +280,8 @@ describe("sdk-breaking-change-labels", () => {
     it("should throw error if resource is empty from the artifact api response", async () => {
       // Setup inputs
       const inputs = {
-        ado_build_id: "12345",
-        ado_project_url: "https://dev.azure.com/project",
+        details_url:
+          "https://dev.azure.com/project/_build/results?buildId=12345",
         head_sha: "abc123",
       };
 
@@ -303,8 +301,7 @@ describe("sdk-breaking-change-labels", () => {
       // Call function and expect it to throw
       await expect(
         getLabelAndActionImpl({
-          ado_build_id: inputs.ado_build_id,
-          ado_project_url: inputs.ado_project_url,
+          details_url: inputs.details_url,
           head_sha: inputs.head_sha,
           github: mockGithub,
           core: mockCore,
@@ -315,8 +312,8 @@ describe("sdk-breaking-change-labels", () => {
     it("should throw error if missing download url from the artifact api response", async () => {
       // Setup inputs
       const inputs = {
-        ado_build_id: "12345",
-        ado_project_url: "https://dev.azure.com/project",
+        details_url:
+          "https://dev.azure.com/project/_build/results?buildId=12345",
         head_sha: "abc123",
       };
 
@@ -338,8 +335,7 @@ describe("sdk-breaking-change-labels", () => {
       // Call function and expect it to throw
       await expect(
         getLabelAndActionImpl({
-          ado_build_id: inputs.ado_build_id,
-          ado_project_url: inputs.ado_project_url,
+          details_url: inputs.details_url,
           head_sha: inputs.head_sha,
           github: mockGithub,
           core: mockCore,
@@ -350,8 +346,8 @@ describe("sdk-breaking-change-labels", () => {
     it("should throw error when fail to fetch artifact content", async () => {
       // Setup inputs
       const inputs = {
-        ado_build_id: "12345",
-        ado_project_url: "https://dev.azure.com/project",
+        details_url:
+          "https://dev.azure.com/project/_build/results?buildId=12345",
         head_sha: "abc123",
       };
 
@@ -387,8 +383,7 @@ describe("sdk-breaking-change-labels", () => {
       // Call function and expect it to throw
       await expect(
         getLabelAndActionImpl({
-          ado_build_id: inputs.ado_build_id,
-          ado_project_url: inputs.ado_project_url,
+          details_url: inputs.details_url,
           head_sha: inputs.head_sha,
           github: mockGithub,
           core: mockCore,
@@ -399,8 +394,8 @@ describe("sdk-breaking-change-labels", () => {
     it("should handle exception during processing", async () => {
       // Setup inputs
       const inputs = {
-        ado_build_id: "12345",
-        ado_project_url: "https://dev.azure.com/project",
+        details_url:
+          "https://dev.azure.com/project/_build/results?buildId=12345",
         head_sha: "abc123",
       };
 
@@ -409,18 +404,9 @@ describe("sdk-breaking-change-labels", () => {
         throw new Error("Network error");
       });
 
-      // Mock PR search success
-      mockGithub.rest.search.issuesAndPullRequests.mockResolvedValue({
-        data: {
-          total_count: 1,
-          items: [{ number: 123, html_url: "https://github.com/pr/123" }],
-        },
-      });
-
       // Start the async operation that will retry
       const promise = getLabelAndActionImpl({
-        ado_build_id: inputs.ado_build_id,
-        ado_project_url: inputs.ado_project_url,
+        details_url: inputs.details_url,
         head_sha: inputs.head_sha,
         github: mockGithub,
         core: mockCore,

--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -200,64 +200,35 @@ stages:
           ArtifactPath: $(StagedArtifactsFolder)
           CustomCondition: and(succeededOrFailed(), ne(variables['StagedArtifactsFolder'], ''))
 
-      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+      - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(parameters.SkipPullRequestCreation, false), ne(variables['Build.Reason'], 'PullRequest')) }}:
+        - template: /eng/common/pipelines/templates/steps/git-push-changes.yml
+          parameters:
+            BaseRepoBranch: $(PrBranch)-$(Build.BuildId)
+            BaseRepoOwner: azure-sdk
+            CommitMsg: $(GeneratedSDKInformation)
+            TargetRepoOwner: $(SdkRepoOwner)
+            TargetRepoName: $(SdkRepoName)
+            PushArgs: "--force"
+            WorkingDirectory: $(SdkRepoDirectory)
+            ScriptDirectory: $(SdkRepoDirectory)/eng/common/scripts
+
         - task: PowerShell@2
-          displayName: Add label to the spec PR
-          condition: and(eq(variables['Build.Reason'], 'PullRequest'), ne(variables['BreakingChangeLabel'], ''), eq(variables['BreakingChangeLabelAction'], 'add'))
+          displayName: Create pull request
+          condition: and(succeeded(), eq(variables['HasChanges'], 'true'), ne(variables['Build.Reason'], 'PullRequest'), not(endsWith(variables['SdkRepoName'], '-pr')))
           inputs:
             pwsh: true
             workingDirectory: $(SdkRepoDirectory)
-            filePath: $(SdkRepoDirectory)/eng/common/scripts/Add-IssueLabels.ps1
+            filePath: $(SdkRepoDirectory)/eng/common/scripts/Submit-PullRequest.ps1
             arguments: >
-              -RepoOwner $(SpecRepoOwner)
-              -RepoName $(SpecRepoName)
-              -IssueNumber "$(System.PullRequest.PullRequestNumber)"
-              -Labels $(BreakingChangeLabel)
+              -RepoOwner "$(SdkRepoOwner)"
+              -RepoName "$(SdkRepoName)"
+              -BaseBranch "main"
+              -PROwner "azure-sdk"
+              -PRBranch "$(PrBranch)-$(Build.BuildId)"
               -AuthToken "$(azuresdk-github-pat)"
-
-        - task: PowerShell@2
-          displayName: Remove label from the spec PR
-          condition: and(eq(variables['Build.Reason'], 'PullRequest'), ne(variables['BreakingChangeLabel'], ''), eq(variables['BreakingChangeLabelAction'], 'remove'))
-          inputs:
-            pwsh: true
-            workingDirectory: $(SdkRepoDirectory)
-            filePath: $(SdkRepoDirectory)/eng/common/scripts/Remove-IssueLabel.ps1
-            arguments: >
-              -RepoOwner $(SpecRepoOwner)
-              -RepoName $(SpecRepoName)
-              -IssueNumber "$(System.PullRequest.PullRequestNumber)"
-              -LabelName $(BreakingChangeLabel)
-              -AuthToken "$(azuresdk-github-pat)"
-
-        - ${{ if and(eq(parameters.SkipPullRequestCreation, false), ne(variables['Build.Reason'], 'PullRequest')) }}:
-          - template: /eng/common/pipelines/templates/steps/git-push-changes.yml
-            parameters:
-              BaseRepoBranch: $(PrBranch)-$(Build.BuildId)
-              BaseRepoOwner: azure-sdk
-              CommitMsg: $(GeneratedSDKInformation)
-              TargetRepoOwner: $(SdkRepoOwner)
-              TargetRepoName: $(SdkRepoName)
-              PushArgs: "--force"
-              WorkingDirectory: $(SdkRepoDirectory)
-              ScriptDirectory: $(SdkRepoDirectory)/eng/common/scripts
-
-          - task: PowerShell@2
-            displayName: Create pull request
-            condition: and(succeeded(), eq(variables['HasChanges'], 'true'), ne(variables['Build.Reason'], 'PullRequest'), not(endsWith(variables['SdkRepoName'], '-pr')))
-            inputs:
-              pwsh: true
-              workingDirectory: $(SdkRepoDirectory)
-              filePath: $(SdkRepoDirectory)/eng/common/scripts/Submit-PullRequest.ps1
-              arguments: >
-                -RepoOwner "$(SdkRepoOwner)"
-                -RepoName "$(SdkRepoName)"
-                -BaseBranch "main"
-                -PROwner "azure-sdk"
-                -PRBranch "$(PrBranch)-$(Build.BuildId)"
-                -AuthToken "$(azuresdk-github-pat)"
-                -PRTitle "$(PrTitle)-generated-from-$(Build.DefinitionName)-$(Build.BuildId)"
-                -PRBody "$(GeneratedSDKInformation)"
-                -OpenAsDraft $true
+              -PRTitle "$(PrTitle)-generated-from-$(Build.DefinitionName)-$(Build.BuildId)"
+              -PRBody "$(GeneratedSDKInformation)"
+              -OpenAsDraft $true
 
       - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
         - pwsh: |

--- a/eng/tools/spec-gen-sdk-runner/src/command-helpers.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/command-helpers.ts
@@ -309,6 +309,7 @@ export function generateArtifact(
     const artifactInfo: SpecGenSdkArtifactInfo = {
       language: commandInput.sdkLanguage,
       result,
+      prNumber: commandInput.prNumber,
       labelAction: hasBreakingChange,
       isSpecGenSdkCheckRequired:
         hasManagementPlaneSpecs && SpecGenSdkRequiredSettings[commandInput.sdkLanguage as SdkName],

--- a/eng/tools/spec-gen-sdk-runner/src/types.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/types.ts
@@ -44,6 +44,7 @@ export type VsoLogs = Map<
 export interface SpecGenSdkArtifactInfo {
   language: string;
   result: string;
+  prNumber?: string;
   labelAction?: boolean;
   isSpecGenSdkCheckRequired: boolean;
   apiViewRequestData: APIViewRequestData [];


### PR DESCRIPTION
### Workflow Updates and Permissions:
* [`.github/workflows/sdk-breaking-change-labels.yaml`](diffhunk://#diff-23bc6e5f25d3869907a8ffc24b2075b505d5ef979872870aab04f32bef22efc7R9-R17): Updated job conditions to use `details_url` for artifact retrieval and added Azure login steps for repositories named `azure-rest-api-specs-pr`. Permissions for `pull-requests` (read) and `id-token` (write) were added. [[1]](diffhunk://#diff-23bc6e5f25d3869907a8ffc24b2075b505d5ef979872870aab04f32bef22efc7R9-R17) [[2]](diffhunk://#diff-23bc6e5f25d3869907a8ffc24b2075b505d5ef979872870aab04f32bef22efc7R26-R41) [[3]](diffhunk://#diff-23bc6e5f25d3869907a8ffc24b2075b505d5ef979872870aab04f32bef22efc7L45-R64)

### Artifact Handling Improvements:
* [`.github/workflows/src/artifacts.js`](diffhunk://#diff-ad37fc4583fc8403c4564c02a8a19b2d23ba7dce63143a4db4dc45a569a17e44L191-R198): Modified `fetchFailedArtifact` to return a `Response` object with a 404 status instead of throwing an error when no artifacts are found.
* [`.github/workflows/src/sdk-breaking-change-labels.js`](diffhunk://#diff-c9180d75de7c58c051b1960509620d68e751c1cde55d2da4bf880d93c25e39f3R3-L6): Refactored artifact retrieval logic to use `getAzurePipelineArtifact`, removing direct API calls and redundant fetch logic. Introduced `getAdoBuildInfoFromUrl` to extract build information from `details_url`. [[1]](diffhunk://#diff-c9180d75de7c58c051b1960509620d68e751c1cde55d2da4bf880d93c25e39f3R3-L6) [[2]](diffhunk://#diff-c9180d75de7c58c051b1960509620d68e751c1cde55d2da4bf880d93c25e39f3L28-L60) [[3]](diffhunk://#diff-c9180d75de7c58c051b1960509620d68e751c1cde55d2da4bf880d93c25e39f3R61-R94) [[4]](diffhunk://#diff-c9180d75de7c58c051b1960509620d68e751c1cde55d2da4bf880d93c25e39f3L141-R106)
* Migrated code to use common function to parse the Azure DevOps build details from URLs

### Runner Part
* Output prNumber to `spec-gen-sdk-artifact` which will be consumed by github workflows directly so that we could save the calls to GitHub search API to query the PR number

### Others
* Updated related tests accordingly

### Test PRs
[add-breaking-change-label-to-PR](https://github.com/test-repo-billy/azure-rest-api-specs-pr/pull/1)