### PR TITLE
Support v2 folder structure

### DIFF
--- a/eng/tools/spec-gen-sdk-runner/src/command-helpers.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/command-helpers.ts
@@ -263,24 +263,21 @@ export function logIssuesToPipeline(logPath: string, specConfigDisplayText: stri
  * Process the breaking change label artifacts.
  *
  * @param executionReport - The spec-gen-sdk execution report.
- * @returns [flag of lable breaking change, breaking change label].
+ * @returns flag of lable breaking change.
  */
-export function getBreakingChangeInfo(executionReport: any): [boolean, string] {
-  let breakingChangeLabel = "";
+export function getBreakingChangeInfo(executionReport: any): boolean {
   for (const packageInfo of executionReport.packages) {
-    breakingChangeLabel = packageInfo.breakingChangeLabel;
     if (packageInfo.shouldLabelBreakingChange) {
-      return [true, breakingChangeLabel];
+      return true;
     }
   }
-  return [false, breakingChangeLabel];
+  return false;
 }
 
 /**
  * Generate the spec-gen-sdk artifacts.
  * @param commandInput - The command input.
  * @param result - The spec-gen-sdk execution result.
- * @param breakingChangeLabel - The breaking change label.
  * @param hasBreakingChange - A flag indicating whether there are breaking changes.
  * @param hasManagementPlaneSpecs - A flag indicating whether there are management plane specs.
  * @param stagedArtifactsFolder - The staged artifacts folder.
@@ -291,7 +288,6 @@ export function getBreakingChangeInfo(executionReport: any): [boolean, string] {
 export function generateArtifact(
   commandInput: SpecGenSdkCmdInput,
   result: string,
-  breakingChangeLabel: string,
   hasBreakingChange: boolean,
   hasManagementPlaneSpecs: boolean,
   stagedArtifactsFolder: string,
@@ -333,8 +329,6 @@ export function generateArtifact(
     setVsoVariable("SpecGenSdkArtifactName", specGenSdkArtifactName);
     setVsoVariable("SpecGenSdkArtifactPath", specGenSdkArtifactPath);
     setVsoVariable("StagedArtifactsFolder", stagedArtifactsFolder);
-    setVsoVariable("BreakingChangeLabelAction", hasBreakingChange ? "add" : "remove");
-    setVsoVariable("BreakingChangeLabel", breakingChangeLabel);
     setVsoVariable("HasAPIViewArtifact", apiViewRequestData.length > 0 ? "true" : "false");
   } catch (error) {
     logMessage("Runner: errors occurred while processing breaking change", LogLevel.Group);

--- a/eng/tools/spec-gen-sdk-runner/src/commands.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/commands.ts
@@ -84,7 +84,6 @@ export async function generateSdkForSpecPr(): Promise<number> {
 
   let statusCode = 0;
   let pushedSpecConfigCount;
-  let breakingChangeLabel = "";
   let executionReport;
   let changedSpecPathText = "";
   let hasManagementPlaneSpecs = false;
@@ -164,7 +163,7 @@ export async function generateSdkForSpecPr(): Promise<number> {
       if (overallExecutionResult !== "failed") {
         overallExecutionResult = currentExecutionResult;
       }
-      [currentRunHasBreakingChange, breakingChangeLabel] = getBreakingChangeInfo(executionReport);
+      currentRunHasBreakingChange = getBreakingChangeInfo(executionReport);
       overallRunHasBreakingChange = overallRunHasBreakingChange || currentRunHasBreakingChange;
       logMessage(`Runner command execution result:${currentExecutionResult}`);
     } catch (error) {
@@ -180,7 +179,6 @@ export async function generateSdkForSpecPr(): Promise<number> {
     generateArtifact(
       commandInput,
       overallExecutionResult,
-      breakingChangeLabel,
       overallRunHasBreakingChange,
       hasManagementPlaneSpecs,
       stagedArtifactsFolder,

--- a/eng/tools/spec-gen-sdk-runner/src/spec-helpers.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/spec-helpers.ts
@@ -18,22 +18,139 @@ export const readmeMdRegex = /^readme.md$/;
 export const typespecProjectRegex = /^tspconfig.yaml$/;
 export const typespecProjectSharedLibraryRegex = /[^/]+\.Shared/;
 
+/**
+ * Processes typespec projects that follow the resource-manager or data-plane folder structure
+ * and matches them with corresponding readme files if they exist in the same folder.
+ * @param readmeMDResult - Object mapping folder paths to readme file paths
+ * @param typespecProjectResult - Object mapping folder paths to typespec project file paths
+ * @returns An array of ChangedSpecs objects containing the paths to the readme and TypeSpec config files
+ */
+export function processTypeSpecProjectsV2FolderStructure(
+  readmeMDResult: { [folderPath: string]: string[] },
+  typespecProjectResult: { [folderPath: string]: string[] },
+): ChangedSpecs[] {
+  const changedSpecs: ChangedSpecs[] = [];
+
+  // Iterate through each typespec project folder
+  for (const folderPath of Object.keys(typespecProjectResult)) {
+    // Split the path into segments to check for specific components
+    const segments = folderPath.split(/[/\\]/);
+    // Check if the folder path contains resource-manager or data-plane segments
+    if (segments.includes("resource-manager") || segments.includes("data-plane")) {
+      const cs: ChangedSpecs = {
+        specs: [],
+      };
+
+      // Set the typespec project path
+      cs.typespecProject = path.join(folderPath, "tspconfig.yaml");
+      // Initialize the specs array with typespec project files
+      cs.specs = [...typespecProjectResult[folderPath]]; // Check if the same folder has a readme.md file
+      if (readmeMDResult[folderPath]) {
+        cs.readmeMd = path.join(folderPath, "readme.md");
+        // Merge the specs arrays, removing duplicates
+        cs.specs = [...new Set([...cs.specs, ...readmeMDResult[folderPath]])];
+        // Remove the processed entry from readmeMDResult
+        delete readmeMDResult[folderPath];
+      }
+
+      // Add the ChangedSpecs object to the result array
+      changedSpecs.push(cs);
+      // Remove the processed entry from typespecProjectResult
+      delete typespecProjectResult[folderPath];
+
+      // Delete readme entries that match specific folder structure patterns and are in the same parent folder hierarchy
+      // such as:
+      // "specification/service/data-plane"
+      // "specification/service/resource-manager"
+      // "specification/service/resource-manager/Microsoft.Service"
+      for (const readmePath of Object.keys(readmeMDResult)) {
+        // Split the paths into segments to work with path components rather than raw strings with separators
+        const folderSegments = folderPath.split(/[/\\]/); // Split on either / or \
+        const readmeSegments = readmePath.split(/[/\\]/);
+
+        // Find the position of "resource-manager" or "data-plane" in folder segments
+        const rmIndex = folderSegments.indexOf("resource-manager");
+        const dpIndex = folderSegments.indexOf("data-plane");
+
+        // For resource-manager paths
+        if (rmIndex !== -1) {
+          // Get the service path segments (everything before resource-manager)
+          const serviceSegments = folderSegments.slice(0, rmIndex);
+          // Check if readmePath shares the same service prefix
+          const isRelatedService = serviceSegments.every(
+            (segment, i) => i < readmeSegments.length && readmeSegments[i] === segment,
+          );
+
+          if (isRelatedService) {
+            // Case 1: Readme ends with resource-manager
+            // Example: specification/service/resource-manager
+            if (
+              readmeSegments.length === rmIndex + 1 &&
+              readmeSegments[rmIndex] === "resource-manager"
+            ) {
+              logMessage(`\t Removing related readme: ${readmePath} for folder: ${folderPath}`);
+              delete readmeMDResult[readmePath];
+              continue;
+            }
+
+            // Case 2: Readme is one level down from resource-manager
+            // Example: specification/service/resource-manager/Microsoft.Service
+            if (
+              readmeSegments.length === rmIndex + 2 &&
+              readmeSegments[rmIndex] === "resource-manager" &&
+              folderSegments.length > rmIndex + 1 &&
+              folderSegments[rmIndex + 1] === readmeSegments[rmIndex + 1]
+            ) {
+              logMessage(`\t Removing related readme: ${readmePath} for folder: ${folderPath}`);
+              delete readmeMDResult[readmePath];
+              continue;
+            }
+          }
+        }
+        // For data-plane paths
+        else if (dpIndex !== -1) {
+          // Get the service path segments (everything before data-plane)
+          const serviceSegments = folderSegments.slice(0, dpIndex);
+          // Check if readmePath shares the same service prefix and ends with data-plane
+          const isRelatedService = serviceSegments.every(
+            (segment, i) => i < readmeSegments.length && readmeSegments[i] === segment,
+          );
+
+          if (
+            isRelatedService &&
+            readmeSegments.length === dpIndex + 1 &&
+            readmeSegments[dpIndex] === "data-plane"
+          ) {
+            logMessage(`\t Removing related readme: ${readmePath} for folder: ${folderPath}`);
+            delete readmeMDResult[readmePath];
+          }
+        }
+      }
+    }
+  }
+
+  return changedSpecs;
+}
+
 export function detectChangedSpecConfigFiles(commandInput: SpecGenSdkCmdInput): ChangedSpecs[] {
   const prChangedFiles: string[] = getChangedFiles(commandInput.localSpecRepoPath) ?? [];
   if (prChangedFiles.length === 0) {
     logMessage("No files changed in the PR");
   }
-  logMessage(`Changed files in the PR: ${prChangedFiles.length}`);
-  for (const file of prChangedFiles) {
+  const normalizedChangedFiles = prChangedFiles.map((f) => f.replaceAll("\\", "/"));
+  logMessage(`Changed files in the PR: ${normalizedChangedFiles.length}`);
+  for (const file of normalizedChangedFiles) {
     logMessage(`\t${file}`);
   }
-  const fileList = prChangedFiles
+  const fileList = normalizedChangedFiles
     .filter((p) => p.startsWith("specification/"))
     .filter((p) => !p.includes("/scenarios/"));
 
   if (fileList.length === 0) {
     logMessage("No relevant files changed under 'specification' folder in the PR");
     return [];
+  } else {
+    // Continue with processing the files
   }
   logMessage(`Related readme.md and typespec project list:`);
   const changedSpecs: ChangedSpecs[] = [];
@@ -75,88 +192,105 @@ export function detectChangedSpecConfigFiles(commandInput: SpecGenSdkCmdInput): 
     }
   }
 
-  // Group paths by service
-  const serviceMap = groupPathsByService(readmeMDResult, typespecProjectResult);
+  // Process TypeSpec projects with the V2 folder structure
+  const newFolderStructureSpecs = processTypeSpecProjectsV2FolderStructure(
+    readmeMDResult,
+    typespecProjectResult,
+  );
 
-  const results: SpecResults = { readmeMDResult, typespecProjectResult };
+  if (newFolderStructureSpecs.length > 0) {
+    logMessage(`Found ${newFolderStructureSpecs.length} specs with the new folder structure`);
+    changedSpecs.push(...newFolderStructureSpecs);
+    for (const spec of newFolderStructureSpecs) {
+      logMessage(`\t\t tspconfig: ${spec.typespecProject}, readme: ${spec.readmeMd}`);
+    }
+  }
 
-  // Process each service
-  for (const [, info] of serviceMap) {
-    // Case: Resource Manager with .Management
-    if (info.managementPaths.length > 0) {
-      if (info.resourceManagerPaths.length === 1) {
-        // Single resource-manager path - match with all Management paths
-        const newSpecs = createCombinedSpecs(
-          info.resourceManagerPaths[0].path,
-          info.managementPaths,
-          results,
-        );
-        changedSpecs.push(...newSpecs);
-        logMessage(
-          `\t readme folders: ${info.resourceManagerPaths[0].path}, tspconfig folders: ${info.managementPaths}`,
-        );
-        for (const p of info.managementPaths) {
-          delete typespecProjectResult[p];
-        }
-        delete readmeMDResult[info.resourceManagerPaths[0].path];
-      } else {
-        // Multiple resource-manager paths - match by subfolder name
-        for (const rmPath of info.resourceManagerPaths) {
-          const matchingManagements = info.managementPaths.filter((mPath) => {
-            const rmSubPath = rmPath.subPath;
-            const managementName = getLastPathSegment(mPath).replace(".Management", "");
-            return rmSubPath && rmSubPath === managementName;
-          });
-          if (matchingManagements.length > 0) {
-            const newSpecs = createCombinedSpecs(rmPath.path, matchingManagements, results);
-            changedSpecs.push(...newSpecs);
-            logMessage(
-              `\t readme folders: ${rmPath.path}, tspconfig folders: ${matchingManagements}`,
-            );
-            for (const p of matchingManagements) {
-              delete typespecProjectResult[p];
+  // Process TypeSpec projects with the old folder structure
+  if (Object.keys(readmeMDResult).length > 0 && Object.keys(typespecProjectResult).length > 0) {
+    // Group paths by service
+    const serviceMap = groupPathsByService(readmeMDResult, typespecProjectResult);
+
+    const results: SpecResults = { readmeMDResult, typespecProjectResult };
+
+    // Process each service
+    for (const [, info] of serviceMap) {
+      // Case: Resource Manager with .Management
+      if (info.managementPaths.length > 0) {
+        if (info.resourceManagerPaths.length === 1) {
+          // Single resource-manager path - match with all Management paths
+          const newSpecs = createCombinedSpecs(
+            info.resourceManagerPaths[0].path,
+            info.managementPaths,
+            results,
+          );
+          changedSpecs.push(...newSpecs);
+          logMessage(
+            `\t readme folders: ${info.resourceManagerPaths[0].path}, tspconfig folders: ${info.managementPaths}`,
+          );
+          for (const p of info.managementPaths) {
+            delete typespecProjectResult[p];
+          }
+          delete readmeMDResult[info.resourceManagerPaths[0].path];
+        } else {
+          // Multiple resource-manager paths - match by subfolder name
+          for (const rmPath of info.resourceManagerPaths) {
+            const matchingManagements = info.managementPaths.filter((mPath) => {
+              const rmSubPath = rmPath.subPath;
+              const managementName = getLastPathSegment(mPath).replace(".Management", "");
+              return rmSubPath && rmSubPath === managementName;
+            });
+            if (matchingManagements.length > 0) {
+              const newSpecs = createCombinedSpecs(rmPath.path, matchingManagements, results);
+              changedSpecs.push(...newSpecs);
+              logMessage(
+                `\t readme folders: ${rmPath.path}, tspconfig folders: ${matchingManagements}`,
+              );
+              for (const p of matchingManagements) {
+                delete typespecProjectResult[p];
+              }
+              delete readmeMDResult[rmPath.path];
             }
-            delete readmeMDResult[rmPath.path];
           }
         }
       }
-    }
 
-    // Case: Data Plane matching
-    if (info.dataPlanePaths.length > 0 && info.otherTypeSpecPaths.length > 0) {
-      if (info.dataPlanePaths.length === 1) {
-        // Single data-plane path - match with all non-Management TypeSpec paths
-        const newSpecs = createCombinedSpecs(
-          info.dataPlanePaths[0].path,
-          info.otherTypeSpecPaths,
-          results,
-        );
-        changedSpecs.push(...newSpecs);
-        logMessage(
-          `\t readme folders: ${info.dataPlanePaths[0].path}, tspconfig folders: ${info.otherTypeSpecPaths}`,
-        );
-        for (const p of info.otherTypeSpecPaths) {
-          delete typespecProjectResult[p];
-        }
-        delete readmeMDResult[info.dataPlanePaths[0].path];
-      } else {
-        // Multiple data-plane paths - match by subfolder name
-        for (const dpPath of info.dataPlanePaths) {
-          const matchingTypeSpecs = info.otherTypeSpecPaths.filter((tsPath) => {
-            const dpSubFolder = dpPath.subFolder;
-            const tsLastSegment = getLastPathSegment(tsPath);
-            return dpSubFolder && dpSubFolder === tsLastSegment;
-          });
-          if (matchingTypeSpecs.length > 0) {
-            const newSpecs = createCombinedSpecs(dpPath.path, matchingTypeSpecs, results);
-            changedSpecs.push(...newSpecs);
-            logMessage(
-              `\t readme folders: ${dpPath.path}, tspconfig folders: ${matchingTypeSpecs}`,
-            );
-            for (const p of matchingTypeSpecs) {
-              delete typespecProjectResult[p];
+      // Case: Data Plane matching
+      if (info.dataPlanePaths.length > 0 && info.otherTypeSpecPaths.length > 0) {
+        if (info.dataPlanePaths.length === 1) {
+          // Single data-plane path - match with all non-Management TypeSpec paths
+          const newSpecs = createCombinedSpecs(
+            info.dataPlanePaths[0].path,
+            info.otherTypeSpecPaths,
+            results,
+          );
+          changedSpecs.push(...newSpecs);
+          logMessage(
+            `\t readme folders: ${info.dataPlanePaths[0].path}, tspconfig folders: ${info.otherTypeSpecPaths}`,
+          );
+          for (const p of info.otherTypeSpecPaths) {
+            delete typespecProjectResult[p];
+          }
+          delete readmeMDResult[info.dataPlanePaths[0].path];
+        } else {
+          // Multiple data-plane paths - match by subfolder name
+          for (const dpPath of info.dataPlanePaths) {
+            const matchingTypeSpecs = info.otherTypeSpecPaths.filter((tsPath) => {
+              const dpSubFolder = dpPath.subFolder;
+              const tsLastSegment = getLastPathSegment(tsPath);
+              return dpSubFolder && dpSubFolder === tsLastSegment;
+            });
+            if (matchingTypeSpecs.length > 0) {
+              const newSpecs = createCombinedSpecs(dpPath.path, matchingTypeSpecs, results);
+              changedSpecs.push(...newSpecs);
+              logMessage(
+                `\t readme folders: ${dpPath.path}, tspconfig folders: ${matchingTypeSpecs}`,
+              );
+              for (const p of matchingTypeSpecs) {
+                delete typespecProjectResult[p];
+              }
+              delete readmeMDResult[dpPath.path];
             }
-            delete readmeMDResult[dpPath.path];
           }
         }
       }

--- a/eng/tools/spec-gen-sdk-runner/src/spec-helpers.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/spec-helpers.ts
@@ -149,8 +149,6 @@ export function detectChangedSpecConfigFiles(commandInput: SpecGenSdkCmdInput): 
   if (fileList.length === 0) {
     logMessage("No relevant files changed under 'specification' folder in the PR");
     return [];
-  } else {
-    // Continue with processing the files
   }
   logMessage(`Related readme.md and typespec project list:`);
   const changedSpecs: ChangedSpecs[] = [];

--- a/eng/tools/spec-gen-sdk-runner/src/utils.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/utils.ts
@@ -223,7 +223,9 @@ export function findParentWithFile(
       return undefined;
     }
     currentPath = path.dirname(currentPath);
-    if (stopAtFolder && currentPath === stopAtFolder) {
+    // Check if we've reached the root of the path (stopAtFolder) or
+    // if we've reached '.' which prevents infinite loops with path.dirname('.')
+    if ((stopAtFolder && currentPath === stopAtFolder) || currentPath === ".") {
       return undefined;
     }
   }

--- a/eng/tools/spec-gen-sdk-runner/test/command-helpers.test.ts
+++ b/eng/tools/spec-gen-sdk-runner/test/command-helpers.test.ts
@@ -368,22 +368,22 @@ describe("commands.ts", () => {
   describe("getBreakingChangeInfo", () => {
     test("should return breaking change info if applicable", () => {
       const mockExecutionReport = {
-        packages: [{ shouldLabelBreakingChange: true, breakingChangeLabel: "breaking-change" }],
+        packages: [{ shouldLabelBreakingChange: true }],
       };
 
       const result = getBreakingChangeInfo(mockExecutionReport);
 
-      expect(result).toEqual([true, "breaking-change"]);
+      expect(result).toBe(true);
     });
 
     test("should return no breaking change info if not applicable", () => {
       const mockExecutionReport = {
-        packages: [{ shouldLabelBreakingChange: false, breakingChangeLabel: "" }],
+        packages: [{ shouldLabelBreakingChange: false }],
       };
 
       const result = getBreakingChangeInfo(mockExecutionReport);
 
-      expect(result).toEqual([false, ""]);
+      expect(result).toBe(false);
     });
 
     test("should return no breaking change info if not executionReport", () => {
@@ -393,7 +393,7 @@ describe("commands.ts", () => {
 
       const result = getBreakingChangeInfo(mockExecutionReport);
 
-      expect(result).toEqual([false, ""]);
+      expect(result).toBe(false);
     });
   });
 
@@ -426,7 +426,6 @@ describe("commands.ts", () => {
         specRepoHttpsUrl: "",
       };
       const mockResult = "succeeded";
-      const mockBreakingchangeLabel = "breaking-change";
       const mockhasBreakingChange = false;
       const mockhasManagementPlaneSpecs = false;
       const mockStagedArtifactsFolder = "mockStagedArtifactsFolder";
@@ -434,7 +433,6 @@ describe("commands.ts", () => {
       const result = generateArtifact(
         mockCommandInput,
         mockResult,
-        mockBreakingchangeLabel,
         mockhasBreakingChange,
         mockhasManagementPlaneSpecs,
         mockStagedArtifactsFolder,
@@ -478,8 +476,6 @@ describe("commands.ts", () => {
         "StagedArtifactsFolder",
         "mockStagedArtifactsFolder",
       );
-      expect(log.setVsoVariable).toHaveBeenCalledWith("BreakingChangeLabelAction", "remove");
-      expect(log.setVsoVariable).toHaveBeenCalledWith("BreakingChangeLabel", "breaking-change");
       expect(log.setVsoVariable).toHaveBeenCalledWith("HasAPIViewArtifact", "false");
     });
 
@@ -507,7 +503,6 @@ describe("commands.ts", () => {
       };
 
       const mockResult = "failed";
-      const mockBreakingchangeLabel = "breaking-change";
       const mockhasBreakingChange = false;
       const mockhasManagementPlaneSpecs = false;
       const mockStagedArtifactsFolder = "";
@@ -515,7 +510,6 @@ describe("commands.ts", () => {
       const result = generateArtifact(
         mockCommandInput,
         mockResult,
-        mockBreakingchangeLabel,
         mockhasBreakingChange,
         mockhasManagementPlaneSpecs,
         mockStagedArtifactsFolder,
@@ -553,7 +547,6 @@ describe("commands.ts", () => {
         specRepoHttpsUrl: "",
       };
       const mockResult = "succeeded";
-      const mockBreakingchangeLabel = "breaking-change";
       const mockhasBreakingChange = false;
       // Using true for hasManagementPlaneSpecs, which would normally make isSpecGenSdkCheckRequired=true
       // for Go SDK (as tested in the getRequiredSettingValue tests)
@@ -565,7 +558,6 @@ describe("commands.ts", () => {
       const result = generateArtifact(
         mockCommandInput,
         mockResult,
-        mockBreakingchangeLabel,
         mockhasBreakingChange,
         mockhasManagementPlaneSpecs,
         mockStagedArtifactsFolder,

--- a/eng/tools/spec-gen-sdk-runner/test/commands.test.ts
+++ b/eng/tools/spec-gen-sdk-runner/test/commands.test.ts
@@ -209,7 +209,7 @@ describe("generateSdkForSpecPr", () => {
     vi.spyOn(utils, "resetGitRepo").mockResolvedValue(undefined);
     vi.spyOn(utils, "runSpecGenSdkCommand").mockResolvedValue(undefined);
     vi.spyOn(commandHelpers, "getExecutionReport").mockReturnValue(mockExecutionReport);
-    vi.spyOn(commandHelpers, "getBreakingChangeInfo").mockReturnValue([false, ""]);
+    vi.spyOn(commandHelpers, "getBreakingChangeInfo").mockReturnValue(false);
     vi.spyOn(commandHelpers, "generateArtifact").mockReturnValue(0);
     vi.spyOn(commandHelpers, "logIssuesToPipeline").mockImplementation(() => {
       // mock implementation intentionally left blank
@@ -239,7 +239,6 @@ describe("generateSdkForSpecPr", () => {
     expect(commandHelpers.generateArtifact).toHaveBeenCalledWith(
       mockCommandInput,
       "succeeded", // overallExecutionResult
-      "", // breakingChangeLabel
       false, // overallRunHasBreakingChange
       true, // hasManagementPlaneSpecs
       "", // stagedArtifactsFolder
@@ -282,7 +281,6 @@ describe("generateSdkForSpecPr", () => {
     expect(generateArtifactSpy).toHaveBeenCalledWith(
       mockCommandInput,
       "succeeded", // overallExecutionResult should be set to "succeeded"
-      "", // breakingChangeLabel
       false, // overallRunHasBreakingChange
       false, // hasManagementPlaneSpecs
       "", // stagedArtifactsFolder
@@ -321,7 +319,6 @@ describe("generateSdkForSpecPr", () => {
     expect(commandHelpers.generateArtifact).toHaveBeenCalledWith(
       mockCommandInput,
       "", // overallExecutionResult is empty because no spec was actually processed
-      "", // breakingChangeLabel
       false, // overallRunHasBreakingChange
       false, // hasManagementPlaneSpecs
       "", // stagedArtifactsFolder

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/data-plane/widget/client.tsp
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/data-plane/widget/client.tsp
@@ -1,0 +1,7 @@
+import "./main.tsp";
+import "@azure-tools/typespec-client-generator-core";
+
+using Widget;
+using Azure.ClientGenerator.Core;
+
+@@clientName(Widgets, "AzureWidgets", "csharp");

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/data-plane/widget/examples/2022-12-01/Widgets_CreateOrUpdateWidgetSample.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/data-plane/widget/examples/2022-12-01/Widgets_CreateOrUpdateWidgetSample.json
@@ -1,0 +1,37 @@
+{
+  "title": "Widgets_CreateOrUpdateWidget",
+  "operationId": "Widgets_CreateOrUpdateWidget",
+  "parameters": {
+    "widgetName": "name1",
+    "api-version": "2022-12-01",
+    "resource": {
+      "manufacturerId": "manufacturer id1",
+      "sharedModel": {
+        "tag": "tag1",
+        "createdAt": "2023-01-09T02:12:25.689Z"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "name1",
+        "manufacturerId": "manufacturer id1",
+        "sharedModel": {
+          "tag": "tag1",
+          "createdAt": "2023-01-09T02:12:25.689Z"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "name1",
+        "manufacturerId": "manufacturer id1",
+        "sharedModel": {
+          "tag": "tag1",
+          "createdAt": "2023-01-09T02:12:25.689Z"
+        }
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/data-plane/widget/examples/2022-12-01/Widgets_DeleteWidgetSample.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/data-plane/widget/examples/2022-12-01/Widgets_DeleteWidgetSample.json
@@ -1,0 +1,29 @@
+{
+  "operationId": "Widgets_DeleteWidget",
+  "title": "Delete widget by widget name using long-running operation.",
+  "parameters": {
+    "api-version": "2022-12-01",
+    "widgetName": "searchbox"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contosowidgetmanager.azure.com/operations/00000000-0000-0000-0000-000000000123/result?api-version=2022-12-01",
+        "operation-location": "https://contosowidgetmanager.azure.com/operations/00000000-0000-0000-0000-000000000123?api-version=2022-12-01"
+      },
+      "body": {
+        "id": "id1",
+        "status": "deleted"
+      }
+    },
+    "default": {
+      "body": {
+        "error": {
+          "code": "Error code",
+          "message": "Error message",
+          "details": []
+        }
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/data-plane/widget/examples/2022-12-01/Widgets_GetWidgetOperationStatusSample.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/data-plane/widget/examples/2022-12-01/Widgets_GetWidgetOperationStatusSample.json
@@ -1,0 +1,45 @@
+{
+  "title": "Widgets_GetWidgetOperationStatus",
+  "operationId": "Widgets_GetWidgetOperationStatus",
+  "parameters": {
+    "widgetName": "name1",
+    "operationId": "opreation id1",
+    "api-version": "2022-12-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "opreation id1",
+        "status": "InProgress",
+        "error": {
+          "code": "Error code",
+          "message": "Error message",
+          "target": "op1",
+          "details": [
+            {
+              "code": "code1",
+              "message": "message1",
+              "target": "op1",
+              "details": [],
+              "innererror": {
+                "code": "code1"
+              }
+            }
+          ],
+          "innererror": {
+            "code": "code1"
+          }
+        },
+        "result": {
+          "name": "bingsearch",
+          "manufacturerId": "manufacturer Id1",
+          "sharedModel": {
+            "tag": "tag1",
+            "createdAt": "2023-01-09T02:12:25.689Z"
+          }
+        },
+        "widgetName": "rfazvwnfwwomiwrh"
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/data-plane/widget/examples/2022-12-01/Widgets_GetWidgetSample.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/data-plane/widget/examples/2022-12-01/Widgets_GetWidgetSample.json
@@ -1,0 +1,25 @@
+{
+  "operationId": "Widgets_GetWidget",
+  "title": "Get widget by widget name.",
+  "parameters": {
+    "api-version": "2022-12-01",
+    "widgetName": "searchbox"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "bingsearch",
+        "manufacturerId": "a-22-01"
+      }
+    },
+    "default": {
+      "body": {
+        "error": {
+          "code": "Error code",
+          "message": "Error message",
+          "details": []
+        }
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/data-plane/widget/examples/2022-12-01/Widgets_ListWidgetsSample.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/data-plane/widget/examples/2022-12-01/Widgets_ListWidgetsSample.json
@@ -1,0 +1,27 @@
+{
+  "title": "Widgets_ListWidgets",
+  "operationId": "Widgets_ListWidgets",
+  "parameters": {
+    "top": 8,
+    "skip": 15,
+    "maxpagesize": 27,
+    "api-version": "2022-12-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "bingsearch",
+            "manufacturerId": "manufacturer Id1",
+            "sharedModel": {
+              "tag": "tag1",
+              "createdAt": "2023-01-09T02:12:25.689Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/data-plane/widget/main.tsp
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/data-plane/widget/main.tsp
@@ -1,0 +1,61 @@
+import "@typespec/http";
+import "@typespec/rest";
+import "@typespec/versioning";
+import "@azure-tools/typespec-azure-core";
+import "./shared.tsp";
+
+using TypeSpec.Http;
+using TypeSpec.Rest;
+using TypeSpec.Versioning;
+using Azure.Core;
+
+@useAuth(AadOauth2Auth<["https://azure.com/.default"]>)
+@service(#{ title: "Widget" })
+@versioned(Widget.Versions)
+namespace Widget;
+
+@doc("Versions info.")
+enum Versions {
+  @doc("The 2022-12-01 version.")
+  @useDependency(Azure.Core.Versions.v1_0_Preview_1)
+  v2022_12_01: "2022-12-01",
+}
+
+@doc("A widget.")
+@resource("widgets")
+model WidgetSuite {
+  @key("widgetName")
+  @doc("The widget name.")
+  @visibility(Lifecycle.Read)
+  name: string;
+
+  @doc("The ID of the widget's manufacturer.")
+  manufacturerId: string;
+
+  @doc("The faked shared model.")
+  sharedModel?: FakedSharedModel;
+}
+
+interface Widgets {
+  @doc("Fetch a Widget by name.")
+  getWidget is ResourceRead<WidgetSuite>;
+
+  @doc("Gets status of a Widget operation.")
+  getWidgetOperationStatus is GetResourceOperationStatus<WidgetSuite>;
+
+  @doc("Creates or updates a Widget asynchronously.")
+  @pollingOperation(Widgets.getWidgetOperationStatus)
+  createOrUpdateWidget is StandardResourceOperations.LongRunningResourceCreateOrUpdate<WidgetSuite>;
+
+  @doc("Delete a Widget asynchronously.")
+  @pollingOperation(Widgets.getWidgetOperationStatus)
+  deleteWidget is LongRunningResourceDelete<WidgetSuite>;
+
+  @doc("List Widget resources")
+  listWidgets is ResourceList<
+    WidgetSuite,
+    {
+      parameters: StandardListQueryParameters;
+    }
+  >;
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/data-plane/widget/readme.md
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/data-plane/widget/readme.md
@@ -1,0 +1,78 @@
+# Widget
+
+> see https://aka.ms/autorest
+
+This is the AutoRest configuration file for Widget.
+
+## Configuration
+
+### Basic Information
+
+This is a TypeSpec project so we only want to readme to default the default tag and point to the outputted swagger file.
+This is used for some tools such as doc generation and swagger apiview generation it isn't used for SDK code gen as we
+use the native TypeSpec code generation configured in the tspconfig.yaml file.
+
+```yaml
+openapi-type: data-plane
+tag: package-2022-12-01
+```
+
+### Tag: package-2022-12-01
+
+These settings apply only when `--tag=package-2022-12-01` is specified on the command line.
+
+```yaml $(tag) == 'package-2022-12-01'
+input-file:
+  - stable/2022-12-01/widgets.json
+```
+
+### Suppress non-TypeSpec SDK related linting rules
+
+These set of linting rules aren't applicable to the new TypeSpec SDK code generators so suppressing them here. Eventually we will
+opt-out these rules from running in the linting tools for TypeSpec generated swagger files.
+
+```yaml
+suppressions:
+  - code: AvoidAnonymousTypes
+  - code: PatchInOperationName
+  - code: OperationIdNounVerb
+  - code: RequiredReadOnlyProperties
+  - code: SchemaNamesConvention
+  - code: SchemaDescriptionOrTitle
+```
+
+### Tag: package-2022-11-01-preview
+
+These settings apply only when `--tag=package-2022-11-01-preview` is specified on the command line.
+
+```yaml $(tag) == 'package-2022-11-01-preview'
+input-file:
+  - preview/2022-11-01-preview/widgets.json
+```
+
+### Suppress non-TypeSpec SDK related linting rules
+
+These set of linting rules aren't applicable to the new TypeSpec SDK code generators so suppressing them here. Eventually we will
+opt-out these rules from running in the linting tools for TypeSpec generated swagger files.
+
+```yaml
+suppressions:
+  - code: AvoidAnonymousTypes
+  - code: PatchInOperationName
+  - code: OperationIdNounVerb
+  - code: RequiredReadOnlyProperties
+  - code: SchemaNamesConvention
+  - code: SchemaDescriptionOrTitle
+```
+
+### Suppress rules that might be fixed
+
+These set of linting rules we expect to fixed in typespec-autorest emitter but for now suppressing.
+Github issue filed at https://github.com/Azure/typespec-azure/issues/2762
+
+```yaml
+suppressions:
+  - code: LroExtension
+  - code: SchemaTypeAndFormat
+  - code: PathParameterSchema
+```

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/data-plane/widget/shared.tsp
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/data-plane/widget/shared.tsp
@@ -1,0 +1,8 @@
+@doc("Faked shared model")
+model FakedSharedModel {
+  @doc("The tag.")
+  tag: string;
+
+  @doc("The created date.")
+  createdAt: utcDateTime;
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/data-plane/widget/stable/2022-12-01/examples/Widgets_CreateOrUpdateWidgetSample.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/data-plane/widget/stable/2022-12-01/examples/Widgets_CreateOrUpdateWidgetSample.json
@@ -1,0 +1,37 @@
+{
+  "title": "Widgets_CreateOrUpdateWidget",
+  "operationId": "Widgets_CreateOrUpdateWidget",
+  "parameters": {
+    "widgetName": "name1",
+    "api-version": "2022-12-01",
+    "resource": {
+      "manufacturerId": "manufacturer id1",
+      "sharedModel": {
+        "tag": "tag1",
+        "createdAt": "2023-01-09T02:12:25.689Z"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "name1",
+        "manufacturerId": "manufacturer id1",
+        "sharedModel": {
+          "tag": "tag1",
+          "createdAt": "2023-01-09T02:12:25.689Z"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "name1",
+        "manufacturerId": "manufacturer id1",
+        "sharedModel": {
+          "tag": "tag1",
+          "createdAt": "2023-01-09T02:12:25.689Z"
+        }
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/data-plane/widget/stable/2022-12-01/examples/Widgets_DeleteWidgetSample.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/data-plane/widget/stable/2022-12-01/examples/Widgets_DeleteWidgetSample.json
@@ -1,0 +1,29 @@
+{
+  "operationId": "Widgets_DeleteWidget",
+  "title": "Delete widget by widget name using long-running operation.",
+  "parameters": {
+    "api-version": "2022-12-01",
+    "widgetName": "searchbox"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contosowidgetmanager.azure.com/operations/00000000-0000-0000-0000-000000000123/result?api-version=2022-12-01",
+        "operation-location": "https://contosowidgetmanager.azure.com/operations/00000000-0000-0000-0000-000000000123?api-version=2022-12-01"
+      },
+      "body": {
+        "id": "id1",
+        "status": "deleted"
+      }
+    },
+    "default": {
+      "body": {
+        "error": {
+          "code": "Error code",
+          "message": "Error message",
+          "details": []
+        }
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/data-plane/widget/stable/2022-12-01/examples/Widgets_GetWidgetOperationStatusSample.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/data-plane/widget/stable/2022-12-01/examples/Widgets_GetWidgetOperationStatusSample.json
@@ -1,0 +1,45 @@
+{
+  "title": "Widgets_GetWidgetOperationStatus",
+  "operationId": "Widgets_GetWidgetOperationStatus",
+  "parameters": {
+    "widgetName": "name1",
+    "operationId": "opreation id1",
+    "api-version": "2022-12-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "opreation id1",
+        "status": "InProgress",
+        "error": {
+          "code": "Error code",
+          "message": "Error message",
+          "target": "op1",
+          "details": [
+            {
+              "code": "code1",
+              "message": "message1",
+              "target": "op1",
+              "details": [],
+              "innererror": {
+                "code": "code1"
+              }
+            }
+          ],
+          "innererror": {
+            "code": "code1"
+          }
+        },
+        "result": {
+          "name": "bingsearch",
+          "manufacturerId": "manufacturer Id1",
+          "sharedModel": {
+            "tag": "tag1",
+            "createdAt": "2023-01-09T02:12:25.689Z"
+          }
+        },
+        "widgetName": "rfazvwnfwwomiwrh"
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/data-plane/widget/stable/2022-12-01/examples/Widgets_GetWidgetSample.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/data-plane/widget/stable/2022-12-01/examples/Widgets_GetWidgetSample.json
@@ -1,0 +1,25 @@
+{
+  "operationId": "Widgets_GetWidget",
+  "title": "Get widget by widget name.",
+  "parameters": {
+    "api-version": "2022-12-01",
+    "widgetName": "searchbox"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "bingsearch",
+        "manufacturerId": "a-22-01"
+      }
+    },
+    "default": {
+      "body": {
+        "error": {
+          "code": "Error code",
+          "message": "Error message",
+          "details": []
+        }
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/data-plane/widget/stable/2022-12-01/examples/Widgets_ListWidgetsSample.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/data-plane/widget/stable/2022-12-01/examples/Widgets_ListWidgetsSample.json
@@ -1,0 +1,27 @@
+{
+  "title": "Widgets_ListWidgets",
+  "operationId": "Widgets_ListWidgets",
+  "parameters": {
+    "top": 8,
+    "skip": 15,
+    "maxpagesize": 27,
+    "api-version": "2022-12-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "bingsearch",
+            "manufacturerId": "manufacturer Id1",
+            "sharedModel": {
+              "tag": "tag1",
+              "createdAt": "2023-01-09T02:12:25.689Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/data-plane/widget/stable/2022-12-01/widget.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/data-plane/widget/stable/2022-12-01/widget.json
@@ -1,0 +1,550 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Widget",
+    "version": "2022-12-01",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "AadOauth2Auth": [
+        "https://azure.com/.default"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "AadOauth2Auth": {
+      "type": "oauth2",
+      "description": "The Azure Active Directory OAuth2 Flow",
+      "flow": "accessCode",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "https://azure.com/.default": ""
+      },
+      "tokenUrl": "https://login.microsoftonline.com/common/oauth2/token"
+    }
+  },
+  "tags": [],
+  "paths": {
+    "/widgets": {
+      "get": {
+        "operationId": "Widgets_ListWidgets",
+        "description": "List Widget resources",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/PagedWidgetSuite"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Widgets_ListWidgets": {
+            "$ref": "./examples/Widgets_ListWidgetsSample.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/widgets/{widgetName}": {
+      "get": {
+        "operationId": "Widgets_GetWidget",
+        "description": "Fetch a Widget by name.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "widgetName",
+            "in": "path",
+            "description": "The widget name.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/WidgetSuite"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get widget by widget name.": {
+            "$ref": "./examples/Widgets_GetWidgetSample.json"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "Widgets_CreateOrUpdateWidget",
+        "description": "Creates or updates a Widget asynchronously.",
+        "consumes": [
+          "application/merge-patch+json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "widgetName",
+            "in": "path",
+            "description": "The widget name.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "The resource instance.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WidgetSuiteCreateOrUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/WidgetSuite"
+            },
+            "headers": {
+              "Operation-Location": {
+                "type": "string",
+                "format": "uri",
+                "description": "The location for monitoring the operation state."
+              }
+            }
+          },
+          "201": {
+            "description": "The request has succeeded and a new resource has been created as a result.",
+            "schema": {
+              "$ref": "#/definitions/WidgetSuite"
+            },
+            "headers": {
+              "Operation-Location": {
+                "type": "string",
+                "format": "uri",
+                "description": "The location for monitoring the operation state."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Widgets_CreateOrUpdateWidget": {
+            "$ref": "./examples/Widgets_CreateOrUpdateWidgetSample.json"
+          }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "Widgets_DeleteWidget",
+        "description": "Delete a Widget asynchronously.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "widgetName",
+            "in": "path",
+            "description": "The widget name.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "type": "object",
+              "description": "Provides status details for long running operations.",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "The unique ID of the operation."
+                },
+                "status": {
+                  "$ref": "#/definitions/Azure.Core.Foundations.OperationState",
+                  "description": "The status of the operation"
+                },
+                "error": {
+                  "$ref": "#/definitions/Azure.Core.Foundations.Error",
+                  "description": "Error object that describes the error when status is \"Failed\"."
+                }
+              },
+              "required": [
+                "id",
+                "status"
+              ]
+            },
+            "headers": {
+              "Operation-Location": {
+                "type": "string",
+                "format": "uri",
+                "description": "The location for monitoring the operation state."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete widget by widget name using long-running operation.": {
+            "$ref": "./examples/Widgets_DeleteWidgetSample.json"
+          }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/widgets/{widgetName}/operations/{operationId}": {
+      "get": {
+        "operationId": "Widgets_GetWidgetOperationStatus",
+        "description": "Gets status of a Widget operation.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "widgetName",
+            "in": "path",
+            "description": "The widget name.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "operationId",
+            "in": "path",
+            "description": "The unique ID of the operation.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "type": "object",
+              "description": "Provides status details for long running operations.",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "The unique ID of the operation."
+                },
+                "status": {
+                  "$ref": "#/definitions/Azure.Core.Foundations.OperationState",
+                  "description": "The status of the operation"
+                },
+                "error": {
+                  "$ref": "#/definitions/Azure.Core.Foundations.Error",
+                  "description": "Error object that describes the error when status is \"Failed\"."
+                },
+                "result": {
+                  "$ref": "#/definitions/WidgetSuite",
+                  "description": "The result of the operation."
+                }
+              },
+              "required": [
+                "id",
+                "status"
+              ]
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Widgets_GetWidgetOperationStatus": {
+            "$ref": "./examples/Widgets_GetWidgetOperationStatusSample.json"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Azure.Core.Foundations.Error": {
+      "type": "object",
+      "description": "The error object.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "One of a server-defined set of error codes."
+        },
+        "message": {
+          "type": "string",
+          "description": "A human-readable representation of the error."
+        },
+        "target": {
+          "type": "string",
+          "description": "The target of the error."
+        },
+        "details": {
+          "type": "array",
+          "description": "An array of details about specific errors that led to this reported error.",
+          "items": {
+            "$ref": "#/definitions/Azure.Core.Foundations.Error"
+          },
+          "x-ms-identifiers": []
+        },
+        "innererror": {
+          "$ref": "#/definitions/Azure.Core.Foundations.InnerError",
+          "description": "An object containing more specific information than the current object about the error."
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ]
+    },
+    "Azure.Core.Foundations.ErrorResponse": {
+      "type": "object",
+      "description": "A response containing error details.",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/Azure.Core.Foundations.Error",
+          "description": "The error object."
+        }
+      },
+      "required": [
+        "error"
+      ]
+    },
+    "Azure.Core.Foundations.InnerError": {
+      "type": "object",
+      "description": "An object containing more specific information about the error. As per Microsoft One API guidelines - https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md#handling-errors.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "One of a server-defined set of error codes."
+        },
+        "innererror": {
+          "$ref": "#/definitions/Azure.Core.Foundations.InnerError",
+          "description": "Inner error."
+        }
+      }
+    },
+    "Azure.Core.Foundations.OperationState": {
+      "type": "string",
+      "description": "Enum describing allowed operation states.",
+      "enum": [
+        "NotStarted",
+        "Running",
+        "Succeeded",
+        "Failed",
+        "Canceled"
+      ],
+      "x-ms-enum": {
+        "name": "OperationState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "NotStarted",
+            "value": "NotStarted",
+            "description": "The operation has not started."
+          },
+          {
+            "name": "Running",
+            "value": "Running",
+            "description": "The operation is in progress."
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "The operation has completed successfully."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "The operation has failed."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "The operation has been canceled by the user."
+          }
+        ]
+      }
+    },
+    "FakedSharedModel": {
+      "type": "object",
+      "description": "Faked shared model",
+      "properties": {
+        "tag": {
+          "type": "string",
+          "description": "The tag."
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The created date."
+        }
+      },
+      "required": [
+        "tag",
+        "createdAt"
+      ]
+    },
+    "FakedSharedModelCreateOrUpdate": {
+      "type": "object",
+      "description": "Faked shared model",
+      "properties": {
+        "tag": {
+          "type": "string",
+          "description": "The tag."
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The created date."
+        }
+      }
+    },
+    "PagedWidgetSuite": {
+      "type": "object",
+      "description": "Paged collection of WidgetSuite items",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The WidgetSuite items on this page",
+          "items": {
+            "$ref": "#/definitions/WidgetSuite"
+          },
+          "x-ms-identifiers": []
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "WidgetSuite": {
+      "type": "object",
+      "description": "A widget.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The widget name.",
+          "readOnly": true
+        },
+        "manufacturerId": {
+          "type": "string",
+          "description": "The ID of the widget's manufacturer."
+        },
+        "sharedModel": {
+          "$ref": "#/definitions/FakedSharedModel",
+          "description": "The faked shared model."
+        }
+      },
+      "required": [
+        "name",
+        "manufacturerId"
+      ]
+    },
+    "WidgetSuiteCreateOrUpdate": {
+      "type": "object",
+      "description": "A widget.",
+      "properties": {
+        "manufacturerId": {
+          "type": "string",
+          "description": "The ID of the widget's manufacturer."
+        },
+        "sharedModel": {
+          "$ref": "#/definitions/FakedSharedModelCreateOrUpdate",
+          "description": "The faked shared model."
+        }
+      }
+    }
+  },
+  "parameters": {
+    "Azure.Core.Foundations.ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "description": "The API version to use for this operation.",
+      "required": true,
+      "type": "string",
+      "minLength": 1,
+      "x-ms-parameter-location": "method",
+      "x-ms-client-name": "apiVersion"
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/data-plane/widget/tspconfig.yaml
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/data-plane/widget/tspconfig.yaml
@@ -1,0 +1,47 @@
+parameters:
+  "service-dir":
+    default: "sdk/widget"
+  "dependencies":
+    default: ""
+emit:
+  - "@azure-tools/typespec-autorest"
+linter:
+  extends:
+    - "@azure-tools/typespec-azure-rulesets/data-plane"
+options:
+  "@azure-tools/typespec-autorest":
+    # TODO: Does anything need this set, if it's not used in output-file?
+    azure-resource-provider-folder: "data-plane"
+    emit-lro-options: "none"
+    emitter-output-dir: "{project-root}"
+    output-file: "{version-status}/{version}/widgets.json"
+  "@azure-tools/typespec-python":
+    package-dir: "azure-widget"
+    namespace: "azure.widget"
+    generate-test: true
+    generate-sample: true
+    flavor: azure
+  "@azure-tools/typespec-csharp":
+    package-dir: "Azure.Widget"
+    clear-output-folder: true
+    model-namespace: false
+    namespace: "{package-dir}"
+    flavor: azure
+  "@azure-tools/typespec-ts":
+    package-dir: "widget-rest"
+    package-details:
+      name: "@azure-rest/azure-widget"
+    flavor: azure
+  "@azure-tools/typespec-java":
+    package-dir: "azure-widget"
+    namespace: com.azure.widget
+    flavor: azure
+  "@azure-tools/typespec-go":
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/{package-dir}"
+    service-dir: "sdk/widget"
+    package-dir: "azmanager"
+    module-version: "0.0.1"
+    generate-fakes: true
+    inject-spans: true
+    single-client: true
+    slice-elements-byval: true

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/employee.tsp
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/employee.tsp
@@ -1,0 +1,63 @@
+import "@typespec/rest";
+import "@typespec/http";
+import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-azure-resource-manager";
+
+using TypeSpec.Rest;
+using TypeSpec.Http;
+using Azure.Core;
+using Azure.ResourceManager;
+
+namespace WidgetManagement;
+
+/** Employee resource */
+model Employee is TrackedResource<EmployeeProperties> {
+  ...ResourceNameParameter<Employee>;
+}
+
+/** Employee properties */
+model EmployeeProperties {
+  /** Age of employee */
+  age?: int32;
+
+  /** City of employee */
+  city?: string;
+
+  /** Profile of employee */
+  @encode("base64url")
+  profile?: bytes;
+
+  /** The status of the last operation. */
+  @visibility(Lifecycle.Read)
+  provisioningState?: ProvisioningState;
+}
+
+/** The resource provisioning state. */
+@lroStatus
+union ProvisioningState {
+  ResourceProvisioningState,
+
+  /** The resource is being provisioned */
+  Provisioning: "Provisioning",
+
+  /** The resource is updating */
+  Updating: "Updating",
+
+  /** The resource is being deleted */
+  Deleting: "Deleting",
+
+  /** The resource create request has been accepted */
+  Accepted: "Accepted",
+
+  string,
+}
+
+@armResourceOperations
+interface Employees {
+  get is ArmResourceRead<Employee>;
+  createOrUpdate is ArmResourceCreateOrReplaceAsync<Employee>;
+  update is ArmResourcePatchSync<Employee, EmployeeProperties>;
+  delete is ArmResourceDeleteWithoutOkAsync<Employee>;
+  listByResourceGroup is ArmResourceListByParent<Employee>;
+  listBySubscription is ArmListBySubscription<Employee>;
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/examples/2021-11-01/Employees_CreateOrUpdate.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/examples/2021-11-01/Employees_CreateOrUpdate.json
@@ -1,0 +1,76 @@
+{
+  "title": "Employees_CreateOrUpdate",
+  "operationId": "Employees_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2021-11-01",
+    "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
+    "resourceGroupName": "rgopenapi",
+    "employeeName": "9KF-f-8b",
+    "resource": {
+      "properties": {
+        "age": 30,
+        "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+        "profile": "ms"
+      },
+      "tags": {
+        "key2913": "urperxmkkhhkp"
+      },
+      "location": "itajgxyqozseoygnl"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "age": 30,
+          "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+          "profile": "ms",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "key2913": "urperxmkkhhkp"
+        },
+        "location": "itajgxyqozseoygnl",
+        "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/rgopenapi/providers/Microsoft.Contoso/employees/le-8MU--J3W6q8D386p3-iT3",
+        "name": "xepyxhpb",
+        "type": "svvamxrdnnv",
+        "systemData": {
+          "createdBy": "iewyxsnriqktsvp",
+          "createdByType": "User",
+          "createdAt": "2023-05-19T00:28:48.610Z",
+          "lastModifiedBy": "xrchbnnuzierzpxw",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-05-19T00:28:48.610Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+      },
+      "body": {
+        "properties": {
+          "age": 30,
+          "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+          "profile": "ms",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "key2913": "urperxmkkhhkp"
+        },
+        "location": "itajgxyqozseoygnl",
+        "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/rgopenapi/providers/Microsoft.Contoso/employees/9KF-f-8b",
+        "name": "xepyxhpb",
+        "type": "svvamxrdnnv",
+        "systemData": {
+          "createdBy": "iewyxsnriqktsvp",
+          "createdByType": "User",
+          "createdAt": "2023-05-19T00:28:48.610Z",
+          "lastModifiedBy": "xrchbnnuzierzpxw",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-05-19T00:28:48.610Z"
+        }
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/examples/2021-11-01/Employees_Delete.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/examples/2021-11-01/Employees_Delete.json
@@ -1,0 +1,19 @@
+{
+  "title": "Employees_Delete",
+  "operationId": "Employees_Delete",
+  "parameters": {
+    "api-version": "2021-11-01",
+    "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
+    "resourceGroupName": "rgopenapi",
+    "employeeName": "5vX--BxSu3ux48rI4O9OQ569"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Retry-After": 30,
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/examples/2021-11-01/Employees_Get.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/examples/2021-11-01/Employees_Get.json
@@ -1,0 +1,37 @@
+{
+  "title": "Employees_Get",
+  "operationId": "Employees_Get",
+  "parameters": {
+    "api-version": "2021-11-01",
+    "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
+    "resourceGroupName": "rgopenapi",
+    "employeeName": "le-8MU--J3W6q8D386p3-iT3"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "age": 30,
+          "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+          "profile": "ms",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "key2913": "urperxmkkhhkp"
+        },
+        "location": "itajgxyqozseoygnl",
+        "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/rgopenapi/providers/Microsoft.Contoso/employees/le-8MU--J3W6q8D386p3-iT3",
+        "name": "xepyxhpb",
+        "type": "svvamxrdnnv",
+        "systemData": {
+          "createdBy": "iewyxsnriqktsvp",
+          "createdByType": "User",
+          "createdAt": "2023-05-19T00:28:48.610Z",
+          "lastModifiedBy": "xrchbnnuzierzpxw",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-05-19T00:28:48.610Z"
+        }
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/examples/2021-11-01/Employees_ListByResourceGroup.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/examples/2021-11-01/Employees_ListByResourceGroup.json
@@ -1,0 +1,41 @@
+{
+  "title": "Employees_ListByResourceGroup",
+  "operationId": "Employees_ListByResourceGroup",
+  "parameters": {
+    "api-version": "2021-11-01",
+    "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
+    "resourceGroupName": "rgopenapi"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "age": 30,
+              "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+              "profile": "ms",
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "key2913": "urperxmkkhhkp"
+            },
+            "location": "itajgxyqozseoygnl",
+            "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/rgopenapi/providers/Microsoft.Contoso/employees/test",
+            "name": "xepyxhpb",
+            "type": "svvamxrdnnv",
+            "systemData": {
+              "createdBy": "iewyxsnriqktsvp",
+              "createdByType": "User",
+              "createdAt": "2023-05-19T00:28:48.610Z",
+              "lastModifiedBy": "xrchbnnuzierzpxw",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2023-05-19T00:28:48.610Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/examples/2021-11-01/Employees_ListBySubscription.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/examples/2021-11-01/Employees_ListBySubscription.json
@@ -1,0 +1,40 @@
+{
+  "title": "Employees_ListBySubscription",
+  "operationId": "Employees_ListBySubscription",
+  "parameters": {
+    "api-version": "2021-11-01",
+    "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "age": 30,
+              "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+              "profile": "ms",
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "key2913": "urperxmkkhhkp"
+            },
+            "location": "itajgxyqozseoygnl",
+            "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/rgopenapi/providers/Microsoft.Contoso/employees/test",
+            "name": "xepyxhpb",
+            "type": "svvamxrdnnv",
+            "systemData": {
+              "createdBy": "iewyxsnriqktsvp",
+              "createdByType": "User",
+              "createdAt": "2023-05-19T00:28:48.610Z",
+              "lastModifiedBy": "xrchbnnuzierzpxw",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2023-05-19T00:28:48.610Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/examples/2021-11-01/Employees_Update.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/examples/2021-11-01/Employees_Update.json
@@ -1,0 +1,47 @@
+{
+  "title": "Employees_Update",
+  "operationId": "Employees_Update",
+  "parameters": {
+    "api-version": "2021-11-01",
+    "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
+    "resourceGroupName": "rgopenapi",
+    "employeeName": "-XhyNJ--",
+    "properties": {
+      "tags": {
+        "key7952": "no"
+      },
+      "properties": {
+        "age": 24,
+        "city": "uyfg",
+        "profile": "oapgijcswfkruiuuzbwco"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "age": 30,
+          "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+          "profile": "ms",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "key2913": "urperxmkkhhkp"
+        },
+        "location": "itajgxyqozseoygnl",
+        "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/contoso/providers/Microsoft.Contoso/employees/test",
+        "name": "xepyxhpb",
+        "type": "svvamxrdnnv",
+        "systemData": {
+          "createdBy": "iewyxsnriqktsvp",
+          "createdByType": "User",
+          "createdAt": "2023-05-19T00:28:48.610Z",
+          "lastModifiedBy": "xrchbnnuzierzpxw",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-05-19T00:28:48.610Z"
+        }
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/examples/2021-11-01/Operations_List.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/examples/2021-11-01/Operations_List.json
@@ -1,0 +1,28 @@
+{
+  "title": "Operations_List",
+  "operationId": "Operations_List",
+  "parameters": {
+    "api-version": "2021-11-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "ymeow",
+            "isDataAction": true,
+            "display": {
+              "provider": "qxyznq",
+              "resource": "bqfwkox",
+              "operation": "td",
+              "description": "yvgkhsuwartgxb"
+            },
+            "origin": "user",
+            "actionType": "Internal"
+          }
+        ],
+        "nextLink": "https://sample.com/nextLink"
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/main.tsp
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/main.tsp
@@ -1,0 +1,35 @@
+import "@typespec/http";
+import "@typespec/rest";
+import "@typespec/versioning";
+import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-azure-resource-manager";
+import "./employee.tsp";
+
+using TypeSpec.Http;
+using TypeSpec.Rest;
+using TypeSpec.Versioning;
+using Azure.Core;
+using Azure.ResourceManager;
+
+/** Microsoft.Contoso Resource Provider management API. */
+@armProviderNamespace
+@service(#{ title: "WidgetManagement" })
+@versioned(WidgetManagement.Versions)
+namespace WidgetManagement;
+
+/** The available API versions. */
+enum Versions {
+  /** 2021-10-01-preview version */
+  @useDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
+  @useDependency(Azure.Core.Versions.v1_0_Preview_2)
+  @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v5)
+  v2021_10_01_preview: "2021-10-01-preview",
+
+  /** 2021-11-01 version */
+  @useDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
+  @useDependency(Azure.Core.Versions.v1_0_Preview_2)
+  @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v5)
+  v2021_11_01: "2021-11-01",
+}
+
+interface Operations extends Azure.ResourceManager.Operations {}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/readme.md
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/readme.md
@@ -1,0 +1,42 @@
+# WidgetManagement
+
+> see https://aka.ms/autorest
+> This is the AutoRest configuration file for WidgetManagement.
+
+## Getting Started
+
+To build the SDKs for My API, simply install AutoRest via `npm` (`npm install -g autorest`) and then run:
+
+> `autorest readme.md`
+> To see additional help and options, run:
+
+> `autorest --help`
+> For other options on installation see [Installing AutoRest](https://aka.ms/autorest/install) on the AutoRest github page.
+
+---
+
+## Configuration
+
+### Basic Information
+
+These are the global settings.
+
+```yaml
+openapi-type: arm
+openapi-subtype: rpaas
+tag: package-2021-11-01
+```
+
+### Tag: package-2021-11-01
+
+These settings apply only when `--tag=package-2021-11-01` is specified on the command line.
+
+```yaml $(tag) == 'package-2021-11-01'
+input-file:
+  - stable/2021-11-01/widgetmanagement.json
+suppressions:
+  - code: PathContainsResourceType
+  - code: PathResourceProviderMatchNamespace
+```
+
+---

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/shared.tsp
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/shared.tsp
@@ -1,0 +1,8 @@
+@doc("Faked shared model")
+model FakedSharedModel {
+  @doc("The tag.")
+  tag: string;
+
+  @doc("The created date.")
+  createdAt: utcDateTime;
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/stable/2021-11-01/examples/Employees_CreateOrUpdate.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/stable/2021-11-01/examples/Employees_CreateOrUpdate.json
@@ -1,0 +1,76 @@
+{
+  "title": "Employees_CreateOrUpdate",
+  "operationId": "Employees_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2021-11-01",
+    "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
+    "resourceGroupName": "rgopenapi",
+    "employeeName": "9KF-f-8b",
+    "resource": {
+      "properties": {
+        "age": 30,
+        "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+        "profile": "ms"
+      },
+      "tags": {
+        "key2913": "urperxmkkhhkp"
+      },
+      "location": "itajgxyqozseoygnl"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "age": 30,
+          "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+          "profile": "ms",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "key2913": "urperxmkkhhkp"
+        },
+        "location": "itajgxyqozseoygnl",
+        "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/rgopenapi/providers/Microsoft.Contoso/employees/le-8MU--J3W6q8D386p3-iT3",
+        "name": "xepyxhpb",
+        "type": "svvamxrdnnv",
+        "systemData": {
+          "createdBy": "iewyxsnriqktsvp",
+          "createdByType": "User",
+          "createdAt": "2023-05-19T00:28:48.610Z",
+          "lastModifiedBy": "xrchbnnuzierzpxw",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-05-19T00:28:48.610Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+      },
+      "body": {
+        "properties": {
+          "age": 30,
+          "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+          "profile": "ms",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "key2913": "urperxmkkhhkp"
+        },
+        "location": "itajgxyqozseoygnl",
+        "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/rgopenapi/providers/Microsoft.Contoso/employees/9KF-f-8b",
+        "name": "xepyxhpb",
+        "type": "svvamxrdnnv",
+        "systemData": {
+          "createdBy": "iewyxsnriqktsvp",
+          "createdByType": "User",
+          "createdAt": "2023-05-19T00:28:48.610Z",
+          "lastModifiedBy": "xrchbnnuzierzpxw",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-05-19T00:28:48.610Z"
+        }
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/stable/2021-11-01/examples/Employees_Delete.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/stable/2021-11-01/examples/Employees_Delete.json
@@ -1,0 +1,19 @@
+{
+  "title": "Employees_Delete",
+  "operationId": "Employees_Delete",
+  "parameters": {
+    "api-version": "2021-11-01",
+    "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
+    "resourceGroupName": "rgopenapi",
+    "employeeName": "5vX--BxSu3ux48rI4O9OQ569"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Retry-After": 30,
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/stable/2021-11-01/examples/Employees_Get.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/stable/2021-11-01/examples/Employees_Get.json
@@ -1,0 +1,37 @@
+{
+  "title": "Employees_Get",
+  "operationId": "Employees_Get",
+  "parameters": {
+    "api-version": "2021-11-01",
+    "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
+    "resourceGroupName": "rgopenapi",
+    "employeeName": "le-8MU--J3W6q8D386p3-iT3"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "age": 30,
+          "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+          "profile": "ms",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "key2913": "urperxmkkhhkp"
+        },
+        "location": "itajgxyqozseoygnl",
+        "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/rgopenapi/providers/Microsoft.Contoso/employees/le-8MU--J3W6q8D386p3-iT3",
+        "name": "xepyxhpb",
+        "type": "svvamxrdnnv",
+        "systemData": {
+          "createdBy": "iewyxsnriqktsvp",
+          "createdByType": "User",
+          "createdAt": "2023-05-19T00:28:48.610Z",
+          "lastModifiedBy": "xrchbnnuzierzpxw",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-05-19T00:28:48.610Z"
+        }
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/stable/2021-11-01/examples/Employees_ListByResourceGroup.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/stable/2021-11-01/examples/Employees_ListByResourceGroup.json
@@ -1,0 +1,41 @@
+{
+  "title": "Employees_ListByResourceGroup",
+  "operationId": "Employees_ListByResourceGroup",
+  "parameters": {
+    "api-version": "2021-11-01",
+    "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
+    "resourceGroupName": "rgopenapi"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "age": 30,
+              "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+              "profile": "ms",
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "key2913": "urperxmkkhhkp"
+            },
+            "location": "itajgxyqozseoygnl",
+            "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/rgopenapi/providers/Microsoft.Contoso/employees/test",
+            "name": "xepyxhpb",
+            "type": "svvamxrdnnv",
+            "systemData": {
+              "createdBy": "iewyxsnriqktsvp",
+              "createdByType": "User",
+              "createdAt": "2023-05-19T00:28:48.610Z",
+              "lastModifiedBy": "xrchbnnuzierzpxw",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2023-05-19T00:28:48.610Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/stable/2021-11-01/examples/Employees_ListBySubscription.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/stable/2021-11-01/examples/Employees_ListBySubscription.json
@@ -1,0 +1,40 @@
+{
+  "title": "Employees_ListBySubscription",
+  "operationId": "Employees_ListBySubscription",
+  "parameters": {
+    "api-version": "2021-11-01",
+    "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "age": 30,
+              "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+              "profile": "ms",
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "key2913": "urperxmkkhhkp"
+            },
+            "location": "itajgxyqozseoygnl",
+            "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/rgopenapi/providers/Microsoft.Contoso/employees/test",
+            "name": "xepyxhpb",
+            "type": "svvamxrdnnv",
+            "systemData": {
+              "createdBy": "iewyxsnriqktsvp",
+              "createdByType": "User",
+              "createdAt": "2023-05-19T00:28:48.610Z",
+              "lastModifiedBy": "xrchbnnuzierzpxw",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2023-05-19T00:28:48.610Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/stable/2021-11-01/examples/Employees_Update.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/stable/2021-11-01/examples/Employees_Update.json
@@ -1,0 +1,47 @@
+{
+  "title": "Employees_Update",
+  "operationId": "Employees_Update",
+  "parameters": {
+    "api-version": "2021-11-01",
+    "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
+    "resourceGroupName": "rgopenapi",
+    "employeeName": "-XhyNJ--",
+    "properties": {
+      "tags": {
+        "key7952": "no"
+      },
+      "properties": {
+        "age": 24,
+        "city": "uyfg",
+        "profile": "oapgijcswfkruiuuzbwco"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "age": 30,
+          "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+          "profile": "ms",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "key2913": "urperxmkkhhkp"
+        },
+        "location": "itajgxyqozseoygnl",
+        "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/contoso/providers/Microsoft.Contoso/employees/test",
+        "name": "xepyxhpb",
+        "type": "svvamxrdnnv",
+        "systemData": {
+          "createdBy": "iewyxsnriqktsvp",
+          "createdByType": "User",
+          "createdAt": "2023-05-19T00:28:48.610Z",
+          "lastModifiedBy": "xrchbnnuzierzpxw",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-05-19T00:28:48.610Z"
+        }
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/stable/2021-11-01/examples/Operations_List.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/stable/2021-11-01/examples/Operations_List.json
@@ -1,0 +1,28 @@
+{
+  "title": "Operations_List",
+  "operationId": "Operations_List",
+  "parameters": {
+    "api-version": "2021-11-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "ymeow",
+            "isDataAction": true,
+            "display": {
+              "provider": "qxyznq",
+              "resource": "bqfwkox",
+              "operation": "td",
+              "description": "yvgkhsuwartgxb"
+            },
+            "origin": "user",
+            "actionType": "Internal"
+          }
+        ],
+        "nextLink": "https://sample.com/nextLink"
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/stable/2021-11-01/widgetmanagement.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/stable/2021-11-01/widgetmanagement.json
@@ -1,0 +1,557 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "WidgetManagement",
+    "version": "2021-11-01",
+    "description": "Microsoft.Contoso Resource Provider management API.",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Operations"
+    },
+    {
+      "name": "Employees"
+    }
+  ],
+  "paths": {
+    "/providers/WidgetManagement/operations": {
+      "get": {
+        "operationId": "Operations_List",
+        "tags": [
+          "Operations"
+        ],
+        "description": "List the operations for the provider",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/OperationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Operations_List": {
+            "$ref": "./examples/Operations_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/WidgetManagement/employees": {
+      "get": {
+        "operationId": "Employees_ListBySubscription",
+        "tags": [
+          "Employees"
+        ],
+        "description": "List Employee resources by subscription ID",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EmployeeListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Employees_ListBySubscription": {
+            "$ref": "./examples/Employees_ListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/WidgetManagement/employees": {
+      "get": {
+        "operationId": "Employees_ListByResourceGroup",
+        "tags": [
+          "Employees"
+        ],
+        "description": "List Employee resources by resource group",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EmployeeListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Employees_ListByResourceGroup": {
+            "$ref": "./examples/Employees_ListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/WidgetManagement/employees/{employeeName}": {
+      "get": {
+        "operationId": "Employees_Get",
+        "tags": [
+          "Employees"
+        ],
+        "description": "Get a Employee",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "employeeName",
+            "in": "path",
+            "description": "The name of the Employee",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Employee"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Employees_Get": {
+            "$ref": "./examples/Employees_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Employees_CreateOrUpdate",
+        "tags": [
+          "Employees"
+        ],
+        "description": "Create a Employee",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "employeeName",
+            "in": "path",
+            "description": "The name of the Employee",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Employee"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Employee' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Employee"
+            }
+          },
+          "201": {
+            "description": "Resource 'Employee' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Employee"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Employees_CreateOrUpdate": {
+            "$ref": "./examples/Employees_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "Employees_Update",
+        "tags": [
+          "Employees"
+        ],
+        "description": "Update a Employee",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "employeeName",
+            "in": "path",
+            "description": "The name of the Employee",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EmployeeUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Employee"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Employees_Update": {
+            "$ref": "./examples/Employees_Update.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Employees_Delete",
+        "tags": [
+          "Employees"
+        ],
+        "description": "Delete a Employee",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "employeeName",
+            "in": "path",
+            "description": "The name of the Employee",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Employees_Delete": {
+            "$ref": "./examples/Employees_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    }
+  },
+  "definitions": {
+    "Azure.ResourceManager.CommonTypes.TrackedResourceUpdate": {
+      "type": "object",
+      "title": "Tracked Resource",
+      "description": "The resource model definition for an Azure Resource Manager tracked top level resource which has 'tags' and a 'location'",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/Resource"
+        }
+      ]
+    },
+    "Employee": {
+      "type": "object",
+      "description": "Employee resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/EmployeeProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "EmployeeListResult": {
+      "type": "object",
+      "description": "The response of a Employee list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Employee items on this page",
+          "items": {
+            "$ref": "#/definitions/Employee"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "EmployeeProperties": {
+      "type": "object",
+      "description": "Employee properties",
+      "properties": {
+        "age": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Age of employee"
+        },
+        "city": {
+          "type": "string",
+          "description": "City of employee"
+        },
+        "profile": {
+          "type": "string",
+          "format": "base64url",
+          "description": "Profile of employee"
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "The status of the last operation.",
+          "readOnly": true
+        }
+      }
+    },
+    "EmployeeUpdate": {
+      "type": "object",
+      "description": "Employee resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/EmployeeProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Azure.ResourceManager.CommonTypes.TrackedResourceUpdate"
+        }
+      ]
+    },
+    "ProvisioningState": {
+      "type": "string",
+      "description": "The resource provisioning state.",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Provisioning",
+        "Updating",
+        "Deleting",
+        "Accepted"
+      ],
+      "x-ms-enum": {
+        "name": "ProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Resource has been created."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Resource creation failed."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Resource creation was canceled."
+          },
+          {
+            "name": "Provisioning",
+            "value": "Provisioning",
+            "description": "The resource is being provisioned"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "The resource is updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "The resource is being deleted"
+          },
+          {
+            "name": "Accepted",
+            "value": "Accepted",
+            "description": "The resource create request has been accepted"
+          }
+        ]
+      },
+      "readOnly": true
+    }
+  },
+  "parameters": {}
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/tspconfig.yaml
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/tspconfig.yaml
@@ -1,0 +1,49 @@
+parameters:
+  "service-dir":
+    default: "sdk/widgetmanagement"
+emit:
+  - "@azure-tools/typespec-autorest"
+options:
+  "@azure-tools/typespec-autorest":
+    use-read-only-status-schema: true
+    emitter-output-dir: "{project-root}"
+    # TODO: Does anything need this set, if it's not used in output-file?  Currently required by TSV.
+    azure-resource-provider-folder: "resource-manager"
+    output-file: "{version-status}/{version}/widgetmanagement.json"
+    arm-types-dir: "{project-root}/../../../../common-types/resource-management"
+  "@azure-tools/typespec-csharp":
+    flavor: azure
+    package-dir: "Azure.ResourceManager.Widget"
+    clear-output-folder: true
+    model-namespace: true
+    namespace: "{package-dir}"
+  "@azure-tools/typespec-python":
+    package-dir: "azure-mgmt-widget"
+    namespace: "azure.mgmt.widget"
+    generate-test: true
+    generate-sample: true
+    flavor: "azure"
+  "@azure-tools/typespec-java":
+    package-dir: "azure-resourcemanager-widget"
+    namespace: "com.azure.resourcemanager.widget"
+    service-name: "Widget" # human-readable service name, whitespace allowed
+    flavor: azure
+  "@azure-tools/typespec-ts":
+    package-dir: "arm-widget"
+    flavor: azure
+    experimental-extensible-enums: true
+    package-details:
+      name: "@azure/arm-widget"
+  "@azure-tools/typespec-go":
+    service-dir: "sdk/resourcemanager/widget"
+    package-dir: "armwidget"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/{package-dir}"
+    fix-const-stuttering: true
+    flavor: "azure"
+    generate-samples: true
+    generate-fakes: true
+    head-as-boolean: true
+    inject-spans: true
+linter:
+  extends:
+    - "@azure-tools/typespec-azure-rulesets/resource-manager"

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/data-plane/widget2/client.tsp
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/data-plane/widget2/client.tsp
@@ -1,0 +1,7 @@
+import "./main.tsp";
+import "@azure-tools/typespec-client-generator-core";
+
+using Widget;
+using Azure.ClientGenerator.Core;
+
+@@clientName(Widgets, "AzureWidgets", "csharp");

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/data-plane/widget2/examples/2022-12-01/Widgets_CreateOrUpdateWidgetSample.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/data-plane/widget2/examples/2022-12-01/Widgets_CreateOrUpdateWidgetSample.json
@@ -1,0 +1,37 @@
+{
+  "title": "Widgets_CreateOrUpdateWidget",
+  "operationId": "Widgets_CreateOrUpdateWidget",
+  "parameters": {
+    "widgetName": "name1",
+    "api-version": "2022-12-01",
+    "resource": {
+      "manufacturerId": "manufacturer id1",
+      "sharedModel": {
+        "tag": "tag1",
+        "createdAt": "2023-01-09T02:12:25.689Z"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "name1",
+        "manufacturerId": "manufacturer id1",
+        "sharedModel": {
+          "tag": "tag1",
+          "createdAt": "2023-01-09T02:12:25.689Z"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "name1",
+        "manufacturerId": "manufacturer id1",
+        "sharedModel": {
+          "tag": "tag1",
+          "createdAt": "2023-01-09T02:12:25.689Z"
+        }
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/data-plane/widget2/examples/2022-12-01/Widgets_DeleteWidgetSample.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/data-plane/widget2/examples/2022-12-01/Widgets_DeleteWidgetSample.json
@@ -1,0 +1,29 @@
+{
+  "operationId": "Widgets_DeleteWidget",
+  "title": "Delete widget by widget name using long-running operation.",
+  "parameters": {
+    "api-version": "2022-12-01",
+    "widgetName": "searchbox"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contosowidgetmanager.azure.com/operations/00000000-0000-0000-0000-000000000123/result?api-version=2022-12-01",
+        "operation-location": "https://contosowidgetmanager.azure.com/operations/00000000-0000-0000-0000-000000000123?api-version=2022-12-01"
+      },
+      "body": {
+        "id": "id1",
+        "status": "deleted"
+      }
+    },
+    "default": {
+      "body": {
+        "error": {
+          "code": "Error code",
+          "message": "Error message",
+          "details": []
+        }
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/data-plane/widget2/examples/2022-12-01/Widgets_GetWidgetOperationStatusSample.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/data-plane/widget2/examples/2022-12-01/Widgets_GetWidgetOperationStatusSample.json
@@ -1,0 +1,45 @@
+{
+  "title": "Widgets_GetWidgetOperationStatus",
+  "operationId": "Widgets_GetWidgetOperationStatus",
+  "parameters": {
+    "widgetName": "name1",
+    "operationId": "opreation id1",
+    "api-version": "2022-12-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "opreation id1",
+        "status": "InProgress",
+        "error": {
+          "code": "Error code",
+          "message": "Error message",
+          "target": "op1",
+          "details": [
+            {
+              "code": "code1",
+              "message": "message1",
+              "target": "op1",
+              "details": [],
+              "innererror": {
+                "code": "code1"
+              }
+            }
+          ],
+          "innererror": {
+            "code": "code1"
+          }
+        },
+        "result": {
+          "name": "bingsearch",
+          "manufacturerId": "manufacturer Id1",
+          "sharedModel": {
+            "tag": "tag1",
+            "createdAt": "2023-01-09T02:12:25.689Z"
+          }
+        },
+        "widgetName": "rfazvwnfwwomiwrh"
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/data-plane/widget2/examples/2022-12-01/Widgets_GetWidgetSample.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/data-plane/widget2/examples/2022-12-01/Widgets_GetWidgetSample.json
@@ -1,0 +1,25 @@
+{
+  "operationId": "Widgets_GetWidget",
+  "title": "Get widget by widget name.",
+  "parameters": {
+    "api-version": "2022-12-01",
+    "widgetName": "searchbox"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "bingsearch",
+        "manufacturerId": "a-22-01"
+      }
+    },
+    "default": {
+      "body": {
+        "error": {
+          "code": "Error code",
+          "message": "Error message",
+          "details": []
+        }
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/data-plane/widget2/examples/2022-12-01/Widgets_ListWidgetsSample.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/data-plane/widget2/examples/2022-12-01/Widgets_ListWidgetsSample.json
@@ -1,0 +1,27 @@
+{
+  "title": "Widgets_ListWidgets",
+  "operationId": "Widgets_ListWidgets",
+  "parameters": {
+    "top": 8,
+    "skip": 15,
+    "maxpagesize": 27,
+    "api-version": "2022-12-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "bingsearch",
+            "manufacturerId": "manufacturer Id1",
+            "sharedModel": {
+              "tag": "tag1",
+              "createdAt": "2023-01-09T02:12:25.689Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/data-plane/widget2/main.tsp
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/data-plane/widget2/main.tsp
@@ -1,0 +1,61 @@
+import "@typespec/http";
+import "@typespec/rest";
+import "@typespec/versioning";
+import "@azure-tools/typespec-azure-core";
+import "./shared.tsp";
+
+using TypeSpec.Http;
+using TypeSpec.Rest;
+using TypeSpec.Versioning;
+using Azure.Core;
+
+@useAuth(AadOauth2Auth<["https://azure.com/.default"]>)
+@service(#{ title: "Widget" })
+@versioned(Widget.Versions)
+namespace Widget;
+
+@doc("Versions info.")
+enum Versions {
+  @doc("The 2022-12-01 version.")
+  @useDependency(Azure.Core.Versions.v1_0_Preview_1)
+  v2022_12_01: "2022-12-01",
+}
+
+@doc("A widget.")
+@resource("widgets")
+model WidgetSuite {
+  @key("widgetName")
+  @doc("The widget name.")
+  @visibility(Lifecycle.Read)
+  name: string;
+
+  @doc("The ID of the widget's manufacturer.")
+  manufacturerId: string;
+
+  @doc("The faked shared model.")
+  sharedModel?: FakedSharedModel;
+}
+
+interface Widgets {
+  @doc("Fetch a Widget by name.")
+  getWidget is ResourceRead<WidgetSuite>;
+
+  @doc("Gets status of a Widget operation.")
+  getWidgetOperationStatus is GetResourceOperationStatus<WidgetSuite>;
+
+  @doc("Creates or updates a Widget asynchronously.")
+  @pollingOperation(Widgets.getWidgetOperationStatus)
+  createOrUpdateWidget is StandardResourceOperations.LongRunningResourceCreateOrUpdate<WidgetSuite>;
+
+  @doc("Delete a Widget asynchronously.")
+  @pollingOperation(Widgets.getWidgetOperationStatus)
+  deleteWidget is LongRunningResourceDelete<WidgetSuite>;
+
+  @doc("List Widget resources")
+  listWidgets is ResourceList<
+    WidgetSuite,
+    {
+      parameters: StandardListQueryParameters;
+    }
+  >;
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/data-plane/widget2/readme.md
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/data-plane/widget2/readme.md
@@ -1,0 +1,78 @@
+# Widget
+
+> see https://aka.ms/autorest
+
+This is the AutoRest configuration file for Widget.
+
+## Configuration
+
+### Basic Information
+
+This is a TypeSpec project so we only want to readme to default the default tag and point to the outputted swagger file.
+This is used for some tools such as doc generation and swagger apiview generation it isn't used for SDK code gen as we
+use the native TypeSpec code generation configured in the tspconfig.yaml file.
+
+```yaml
+openapi-type: data-plane
+tag: package-2022-12-01
+```
+
+### Tag: package-2022-12-01
+
+These settings apply only when `--tag=package-2022-12-01` is specified on the command line.
+
+```yaml $(tag) == 'package-2022-12-01'
+input-file:
+  - stable/2022-12-01/widgets.json
+```
+
+### Suppress non-TypeSpec SDK related linting rules
+
+These set of linting rules aren't applicable to the new TypeSpec SDK code generators so suppressing them here. Eventually we will
+opt-out these rules from running in the linting tools for TypeSpec generated swagger files.
+
+```yaml
+suppressions:
+  - code: AvoidAnonymousTypes
+  - code: PatchInOperationName
+  - code: OperationIdNounVerb
+  - code: RequiredReadOnlyProperties
+  - code: SchemaNamesConvention
+  - code: SchemaDescriptionOrTitle
+```
+
+### Tag: package-2022-11-01-preview
+
+These settings apply only when `--tag=package-2022-11-01-preview` is specified on the command line.
+
+```yaml $(tag) == 'package-2022-11-01-preview'
+input-file:
+  - preview/2022-11-01-preview/widgets.json
+```
+
+### Suppress non-TypeSpec SDK related linting rules
+
+These set of linting rules aren't applicable to the new TypeSpec SDK code generators so suppressing them here. Eventually we will
+opt-out these rules from running in the linting tools for TypeSpec generated swagger files.
+
+```yaml
+suppressions:
+  - code: AvoidAnonymousTypes
+  - code: PatchInOperationName
+  - code: OperationIdNounVerb
+  - code: RequiredReadOnlyProperties
+  - code: SchemaNamesConvention
+  - code: SchemaDescriptionOrTitle
+```
+
+### Suppress rules that might be fixed
+
+These set of linting rules we expect to fixed in typespec-autorest emitter but for now suppressing.
+Github issue filed at https://github.com/Azure/typespec-azure/issues/2762
+
+```yaml
+suppressions:
+  - code: LroExtension
+  - code: SchemaTypeAndFormat
+  - code: PathParameterSchema
+```

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/data-plane/widget2/shared.tsp
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/data-plane/widget2/shared.tsp
@@ -1,0 +1,8 @@
+@doc("Faked shared model")
+model FakedSharedModel {
+  @doc("The tag.")
+  tag: string;
+
+  @doc("The created date.")
+  createdAt: utcDateTime;
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/data-plane/widget2/stable/2022-12-01/examples/Widgets_CreateOrUpdateWidgetSample.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/data-plane/widget2/stable/2022-12-01/examples/Widgets_CreateOrUpdateWidgetSample.json
@@ -1,0 +1,37 @@
+{
+  "title": "Widgets_CreateOrUpdateWidget",
+  "operationId": "Widgets_CreateOrUpdateWidget",
+  "parameters": {
+    "widgetName": "name1",
+    "api-version": "2022-12-01",
+    "resource": {
+      "manufacturerId": "manufacturer id1",
+      "sharedModel": {
+        "tag": "tag1",
+        "createdAt": "2023-01-09T02:12:25.689Z"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "name1",
+        "manufacturerId": "manufacturer id1",
+        "sharedModel": {
+          "tag": "tag1",
+          "createdAt": "2023-01-09T02:12:25.689Z"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "name1",
+        "manufacturerId": "manufacturer id1",
+        "sharedModel": {
+          "tag": "tag1",
+          "createdAt": "2023-01-09T02:12:25.689Z"
+        }
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/data-plane/widget2/stable/2022-12-01/examples/Widgets_DeleteWidgetSample.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/data-plane/widget2/stable/2022-12-01/examples/Widgets_DeleteWidgetSample.json
@@ -1,0 +1,29 @@
+{
+  "operationId": "Widgets_DeleteWidget",
+  "title": "Delete widget by widget name using long-running operation.",
+  "parameters": {
+    "api-version": "2022-12-01",
+    "widgetName": "searchbox"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contosowidgetmanager.azure.com/operations/00000000-0000-0000-0000-000000000123/result?api-version=2022-12-01",
+        "operation-location": "https://contosowidgetmanager.azure.com/operations/00000000-0000-0000-0000-000000000123?api-version=2022-12-01"
+      },
+      "body": {
+        "id": "id1",
+        "status": "deleted"
+      }
+    },
+    "default": {
+      "body": {
+        "error": {
+          "code": "Error code",
+          "message": "Error message",
+          "details": []
+        }
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/data-plane/widget2/stable/2022-12-01/examples/Widgets_GetWidgetOperationStatusSample.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/data-plane/widget2/stable/2022-12-01/examples/Widgets_GetWidgetOperationStatusSample.json
@@ -1,0 +1,45 @@
+{
+  "title": "Widgets_GetWidgetOperationStatus",
+  "operationId": "Widgets_GetWidgetOperationStatus",
+  "parameters": {
+    "widgetName": "name1",
+    "operationId": "opreation id1",
+    "api-version": "2022-12-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "opreation id1",
+        "status": "InProgress",
+        "error": {
+          "code": "Error code",
+          "message": "Error message",
+          "target": "op1",
+          "details": [
+            {
+              "code": "code1",
+              "message": "message1",
+              "target": "op1",
+              "details": [],
+              "innererror": {
+                "code": "code1"
+              }
+            }
+          ],
+          "innererror": {
+            "code": "code1"
+          }
+        },
+        "result": {
+          "name": "bingsearch",
+          "manufacturerId": "manufacturer Id1",
+          "sharedModel": {
+            "tag": "tag1",
+            "createdAt": "2023-01-09T02:12:25.689Z"
+          }
+        },
+        "widgetName": "rfazvwnfwwomiwrh"
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/data-plane/widget2/stable/2022-12-01/examples/Widgets_GetWidgetSample.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/data-plane/widget2/stable/2022-12-01/examples/Widgets_GetWidgetSample.json
@@ -1,0 +1,25 @@
+{
+  "operationId": "Widgets_GetWidget",
+  "title": "Get widget by widget name.",
+  "parameters": {
+    "api-version": "2022-12-01",
+    "widgetName": "searchbox"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "bingsearch",
+        "manufacturerId": "a-22-01"
+      }
+    },
+    "default": {
+      "body": {
+        "error": {
+          "code": "Error code",
+          "message": "Error message",
+          "details": []
+        }
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/data-plane/widget2/stable/2022-12-01/examples/Widgets_ListWidgetsSample.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/data-plane/widget2/stable/2022-12-01/examples/Widgets_ListWidgetsSample.json
@@ -1,0 +1,27 @@
+{
+  "title": "Widgets_ListWidgets",
+  "operationId": "Widgets_ListWidgets",
+  "parameters": {
+    "top": 8,
+    "skip": 15,
+    "maxpagesize": 27,
+    "api-version": "2022-12-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "bingsearch",
+            "manufacturerId": "manufacturer Id1",
+            "sharedModel": {
+              "tag": "tag1",
+              "createdAt": "2023-01-09T02:12:25.689Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/data-plane/widget2/stable/2022-12-01/widget.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/data-plane/widget2/stable/2022-12-01/widget.json
@@ -1,0 +1,550 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Widget",
+    "version": "2022-12-01",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "AadOauth2Auth": [
+        "https://azure.com/.default"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "AadOauth2Auth": {
+      "type": "oauth2",
+      "description": "The Azure Active Directory OAuth2 Flow",
+      "flow": "accessCode",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "https://azure.com/.default": ""
+      },
+      "tokenUrl": "https://login.microsoftonline.com/common/oauth2/token"
+    }
+  },
+  "tags": [],
+  "paths": {
+    "/widgets": {
+      "get": {
+        "operationId": "Widgets_ListWidgets",
+        "description": "List Widget resources",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/PagedWidgetSuite"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Widgets_ListWidgets": {
+            "$ref": "./examples/Widgets_ListWidgetsSample.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/widgets/{widgetName}": {
+      "get": {
+        "operationId": "Widgets_GetWidget",
+        "description": "Fetch a Widget by name.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "widgetName",
+            "in": "path",
+            "description": "The widget name.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/WidgetSuite"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get widget by widget name.": {
+            "$ref": "./examples/Widgets_GetWidgetSample.json"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "Widgets_CreateOrUpdateWidget",
+        "description": "Creates or updates a Widget asynchronously.",
+        "consumes": [
+          "application/merge-patch+json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "widgetName",
+            "in": "path",
+            "description": "The widget name.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "The resource instance.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WidgetSuiteCreateOrUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/WidgetSuite"
+            },
+            "headers": {
+              "Operation-Location": {
+                "type": "string",
+                "format": "uri",
+                "description": "The location for monitoring the operation state."
+              }
+            }
+          },
+          "201": {
+            "description": "The request has succeeded and a new resource has been created as a result.",
+            "schema": {
+              "$ref": "#/definitions/WidgetSuite"
+            },
+            "headers": {
+              "Operation-Location": {
+                "type": "string",
+                "format": "uri",
+                "description": "The location for monitoring the operation state."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Widgets_CreateOrUpdateWidget": {
+            "$ref": "./examples/Widgets_CreateOrUpdateWidgetSample.json"
+          }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "Widgets_DeleteWidget",
+        "description": "Delete a Widget asynchronously.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "widgetName",
+            "in": "path",
+            "description": "The widget name.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "type": "object",
+              "description": "Provides status details for long running operations.",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "The unique ID of the operation."
+                },
+                "status": {
+                  "$ref": "#/definitions/Azure.Core.Foundations.OperationState",
+                  "description": "The status of the operation"
+                },
+                "error": {
+                  "$ref": "#/definitions/Azure.Core.Foundations.Error",
+                  "description": "Error object that describes the error when status is \"Failed\"."
+                }
+              },
+              "required": [
+                "id",
+                "status"
+              ]
+            },
+            "headers": {
+              "Operation-Location": {
+                "type": "string",
+                "format": "uri",
+                "description": "The location for monitoring the operation state."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete widget by widget name using long-running operation.": {
+            "$ref": "./examples/Widgets_DeleteWidgetSample.json"
+          }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/widgets/{widgetName}/operations/{operationId}": {
+      "get": {
+        "operationId": "Widgets_GetWidgetOperationStatus",
+        "description": "Gets status of a Widget operation.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "widgetName",
+            "in": "path",
+            "description": "The widget name.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "operationId",
+            "in": "path",
+            "description": "The unique ID of the operation.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "type": "object",
+              "description": "Provides status details for long running operations.",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "The unique ID of the operation."
+                },
+                "status": {
+                  "$ref": "#/definitions/Azure.Core.Foundations.OperationState",
+                  "description": "The status of the operation"
+                },
+                "error": {
+                  "$ref": "#/definitions/Azure.Core.Foundations.Error",
+                  "description": "Error object that describes the error when status is \"Failed\"."
+                },
+                "result": {
+                  "$ref": "#/definitions/WidgetSuite",
+                  "description": "The result of the operation."
+                }
+              },
+              "required": [
+                "id",
+                "status"
+              ]
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Widgets_GetWidgetOperationStatus": {
+            "$ref": "./examples/Widgets_GetWidgetOperationStatusSample.json"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Azure.Core.Foundations.Error": {
+      "type": "object",
+      "description": "The error object.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "One of a server-defined set of error codes."
+        },
+        "message": {
+          "type": "string",
+          "description": "A human-readable representation of the error."
+        },
+        "target": {
+          "type": "string",
+          "description": "The target of the error."
+        },
+        "details": {
+          "type": "array",
+          "description": "An array of details about specific errors that led to this reported error.",
+          "items": {
+            "$ref": "#/definitions/Azure.Core.Foundations.Error"
+          },
+          "x-ms-identifiers": []
+        },
+        "innererror": {
+          "$ref": "#/definitions/Azure.Core.Foundations.InnerError",
+          "description": "An object containing more specific information than the current object about the error."
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ]
+    },
+    "Azure.Core.Foundations.ErrorResponse": {
+      "type": "object",
+      "description": "A response containing error details.",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/Azure.Core.Foundations.Error",
+          "description": "The error object."
+        }
+      },
+      "required": [
+        "error"
+      ]
+    },
+    "Azure.Core.Foundations.InnerError": {
+      "type": "object",
+      "description": "An object containing more specific information about the error. As per Microsoft One API guidelines - https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md#handling-errors.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "One of a server-defined set of error codes."
+        },
+        "innererror": {
+          "$ref": "#/definitions/Azure.Core.Foundations.InnerError",
+          "description": "Inner error."
+        }
+      }
+    },
+    "Azure.Core.Foundations.OperationState": {
+      "type": "string",
+      "description": "Enum describing allowed operation states.",
+      "enum": [
+        "NotStarted",
+        "Running",
+        "Succeeded",
+        "Failed",
+        "Canceled"
+      ],
+      "x-ms-enum": {
+        "name": "OperationState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "NotStarted",
+            "value": "NotStarted",
+            "description": "The operation has not started."
+          },
+          {
+            "name": "Running",
+            "value": "Running",
+            "description": "The operation is in progress."
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "The operation has completed successfully."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "The operation has failed."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "The operation has been canceled by the user."
+          }
+        ]
+      }
+    },
+    "FakedSharedModel": {
+      "type": "object",
+      "description": "Faked shared model",
+      "properties": {
+        "tag": {
+          "type": "string",
+          "description": "The tag."
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The created date."
+        }
+      },
+      "required": [
+        "tag",
+        "createdAt"
+      ]
+    },
+    "FakedSharedModelCreateOrUpdate": {
+      "type": "object",
+      "description": "Faked shared model",
+      "properties": {
+        "tag": {
+          "type": "string",
+          "description": "The tag."
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The created date."
+        }
+      }
+    },
+    "PagedWidgetSuite": {
+      "type": "object",
+      "description": "Paged collection of WidgetSuite items",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The WidgetSuite items on this page",
+          "items": {
+            "$ref": "#/definitions/WidgetSuite"
+          },
+          "x-ms-identifiers": []
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "WidgetSuite": {
+      "type": "object",
+      "description": "A widget.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The widget name.",
+          "readOnly": true
+        },
+        "manufacturerId": {
+          "type": "string",
+          "description": "The ID of the widget's manufacturer."
+        },
+        "sharedModel": {
+          "$ref": "#/definitions/FakedSharedModel",
+          "description": "The faked shared model."
+        }
+      },
+      "required": [
+        "name",
+        "manufacturerId"
+      ]
+    },
+    "WidgetSuiteCreateOrUpdate": {
+      "type": "object",
+      "description": "A widget.",
+      "properties": {
+        "manufacturerId": {
+          "type": "string",
+          "description": "The ID of the widget's manufacturer."
+        },
+        "sharedModel": {
+          "$ref": "#/definitions/FakedSharedModelCreateOrUpdate",
+          "description": "The faked shared model."
+        }
+      }
+    }
+  },
+  "parameters": {
+    "Azure.Core.Foundations.ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "description": "The API version to use for this operation.",
+      "required": true,
+      "type": "string",
+      "minLength": 1,
+      "x-ms-parameter-location": "method",
+      "x-ms-client-name": "apiVersion"
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/data-plane/widget2/tspconfig.yaml
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/data-plane/widget2/tspconfig.yaml
@@ -1,0 +1,47 @@
+parameters:
+  "service-dir":
+    default: "sdk/widget"
+  "dependencies":
+    default: ""
+emit:
+  - "@azure-tools/typespec-autorest"
+linter:
+  extends:
+    - "@azure-tools/typespec-azure-rulesets/data-plane"
+options:
+  "@azure-tools/typespec-autorest":
+    # TODO: Does anything need this set, if it's not used in output-file?
+    azure-resource-provider-folder: "data-plane"
+    emit-lro-options: "none"
+    emitter-output-dir: "{project-root}"
+    output-file: "{version-status}/{version}/widgets.json"
+  "@azure-tools/typespec-python":
+    package-dir: "azure-widget"
+    namespace: "azure.widget"
+    generate-test: true
+    generate-sample: true
+    flavor: azure
+  "@azure-tools/typespec-csharp":
+    package-dir: "Azure.Widget"
+    clear-output-folder: true
+    model-namespace: false
+    namespace: "{package-dir}"
+    flavor: azure
+  "@azure-tools/typespec-ts":
+    package-dir: "widget-rest"
+    package-details:
+      name: "@azure-rest/azure-widget"
+    flavor: azure
+  "@azure-tools/typespec-java":
+    package-dir: "azure-widget"
+    namespace: com.azure.widget
+    flavor: azure
+  "@azure-tools/typespec-go":
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/{package-dir}"
+    service-dir: "sdk/widget"
+    package-dir: "azmanager"
+    module-version: "0.0.1"
+    generate-fakes: true
+    inject-spans: true
+    single-client: true
+    slice-elements-byval: true

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/employee.tsp
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/employee.tsp
@@ -1,0 +1,63 @@
+import "@typespec/rest";
+import "@typespec/http";
+import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-azure-resource-manager";
+
+using TypeSpec.Rest;
+using TypeSpec.Http;
+using Azure.Core;
+using Azure.ResourceManager;
+
+namespace WidgetManagement;
+
+/** Employee resource */
+model Employee is TrackedResource<EmployeeProperties> {
+  ...ResourceNameParameter<Employee>;
+}
+
+/** Employee properties */
+model EmployeeProperties {
+  /** Age of employee */
+  age?: int32;
+
+  /** City of employee */
+  city?: string;
+
+  /** Profile of employee */
+  @encode("base64url")
+  profile?: bytes;
+
+  /** The status of the last operation. */
+  @visibility(Lifecycle.Read)
+  provisioningState?: ProvisioningState;
+}
+
+/** The resource provisioning state. */
+@lroStatus
+union ProvisioningState {
+  ResourceProvisioningState,
+
+  /** The resource is being provisioned */
+  Provisioning: "Provisioning",
+
+  /** The resource is updating */
+  Updating: "Updating",
+
+  /** The resource is being deleted */
+  Deleting: "Deleting",
+
+  /** The resource create request has been accepted */
+  Accepted: "Accepted",
+
+  string,
+}
+
+@armResourceOperations
+interface Employees {
+  get is ArmResourceRead<Employee>;
+  createOrUpdate is ArmResourceCreateOrReplaceAsync<Employee>;
+  update is ArmResourcePatchSync<Employee, EmployeeProperties>;
+  delete is ArmResourceDeleteWithoutOkAsync<Employee>;
+  listByResourceGroup is ArmResourceListByParent<Employee>;
+  listBySubscription is ArmListBySubscription<Employee>;
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/examples/2021-11-01/Employees_CreateOrUpdate.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/examples/2021-11-01/Employees_CreateOrUpdate.json
@@ -1,0 +1,76 @@
+{
+  "title": "Employees_CreateOrUpdate",
+  "operationId": "Employees_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2021-11-01",
+    "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
+    "resourceGroupName": "rgopenapi",
+    "employeeName": "9KF-f-8b",
+    "resource": {
+      "properties": {
+        "age": 30,
+        "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+        "profile": "ms"
+      },
+      "tags": {
+        "key2913": "urperxmkkhhkp"
+      },
+      "location": "itajgxyqozseoygnl"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "age": 30,
+          "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+          "profile": "ms",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "key2913": "urperxmkkhhkp"
+        },
+        "location": "itajgxyqozseoygnl",
+        "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/rgopenapi/providers/Microsoft.Contoso/employees/le-8MU--J3W6q8D386p3-iT3",
+        "name": "xepyxhpb",
+        "type": "svvamxrdnnv",
+        "systemData": {
+          "createdBy": "iewyxsnriqktsvp",
+          "createdByType": "User",
+          "createdAt": "2023-05-19T00:28:48.610Z",
+          "lastModifiedBy": "xrchbnnuzierzpxw",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-05-19T00:28:48.610Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+      },
+      "body": {
+        "properties": {
+          "age": 30,
+          "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+          "profile": "ms",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "key2913": "urperxmkkhhkp"
+        },
+        "location": "itajgxyqozseoygnl",
+        "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/rgopenapi/providers/Microsoft.Contoso/employees/9KF-f-8b",
+        "name": "xepyxhpb",
+        "type": "svvamxrdnnv",
+        "systemData": {
+          "createdBy": "iewyxsnriqktsvp",
+          "createdByType": "User",
+          "createdAt": "2023-05-19T00:28:48.610Z",
+          "lastModifiedBy": "xrchbnnuzierzpxw",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-05-19T00:28:48.610Z"
+        }
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/examples/2021-11-01/Employees_Delete.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/examples/2021-11-01/Employees_Delete.json
@@ -1,0 +1,19 @@
+{
+  "title": "Employees_Delete",
+  "operationId": "Employees_Delete",
+  "parameters": {
+    "api-version": "2021-11-01",
+    "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
+    "resourceGroupName": "rgopenapi",
+    "employeeName": "5vX--BxSu3ux48rI4O9OQ569"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Retry-After": 30,
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/examples/2021-11-01/Employees_Get.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/examples/2021-11-01/Employees_Get.json
@@ -1,0 +1,37 @@
+{
+  "title": "Employees_Get",
+  "operationId": "Employees_Get",
+  "parameters": {
+    "api-version": "2021-11-01",
+    "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
+    "resourceGroupName": "rgopenapi",
+    "employeeName": "le-8MU--J3W6q8D386p3-iT3"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "age": 30,
+          "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+          "profile": "ms",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "key2913": "urperxmkkhhkp"
+        },
+        "location": "itajgxyqozseoygnl",
+        "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/rgopenapi/providers/Microsoft.Contoso/employees/le-8MU--J3W6q8D386p3-iT3",
+        "name": "xepyxhpb",
+        "type": "svvamxrdnnv",
+        "systemData": {
+          "createdBy": "iewyxsnriqktsvp",
+          "createdByType": "User",
+          "createdAt": "2023-05-19T00:28:48.610Z",
+          "lastModifiedBy": "xrchbnnuzierzpxw",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-05-19T00:28:48.610Z"
+        }
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/examples/2021-11-01/Employees_ListByResourceGroup.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/examples/2021-11-01/Employees_ListByResourceGroup.json
@@ -1,0 +1,41 @@
+{
+  "title": "Employees_ListByResourceGroup",
+  "operationId": "Employees_ListByResourceGroup",
+  "parameters": {
+    "api-version": "2021-11-01",
+    "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
+    "resourceGroupName": "rgopenapi"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "age": 30,
+              "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+              "profile": "ms",
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "key2913": "urperxmkkhhkp"
+            },
+            "location": "itajgxyqozseoygnl",
+            "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/rgopenapi/providers/Microsoft.Contoso/employees/test",
+            "name": "xepyxhpb",
+            "type": "svvamxrdnnv",
+            "systemData": {
+              "createdBy": "iewyxsnriqktsvp",
+              "createdByType": "User",
+              "createdAt": "2023-05-19T00:28:48.610Z",
+              "lastModifiedBy": "xrchbnnuzierzpxw",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2023-05-19T00:28:48.610Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/examples/2021-11-01/Employees_ListBySubscription.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/examples/2021-11-01/Employees_ListBySubscription.json
@@ -1,0 +1,40 @@
+{
+  "title": "Employees_ListBySubscription",
+  "operationId": "Employees_ListBySubscription",
+  "parameters": {
+    "api-version": "2021-11-01",
+    "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "age": 30,
+              "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+              "profile": "ms",
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "key2913": "urperxmkkhhkp"
+            },
+            "location": "itajgxyqozseoygnl",
+            "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/rgopenapi/providers/Microsoft.Contoso/employees/test",
+            "name": "xepyxhpb",
+            "type": "svvamxrdnnv",
+            "systemData": {
+              "createdBy": "iewyxsnriqktsvp",
+              "createdByType": "User",
+              "createdAt": "2023-05-19T00:28:48.610Z",
+              "lastModifiedBy": "xrchbnnuzierzpxw",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2023-05-19T00:28:48.610Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/examples/2021-11-01/Employees_Update.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/examples/2021-11-01/Employees_Update.json
@@ -1,0 +1,47 @@
+{
+  "title": "Employees_Update",
+  "operationId": "Employees_Update",
+  "parameters": {
+    "api-version": "2021-11-01",
+    "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
+    "resourceGroupName": "rgopenapi",
+    "employeeName": "-XhyNJ--",
+    "properties": {
+      "tags": {
+        "key7952": "no"
+      },
+      "properties": {
+        "age": 24,
+        "city": "uyfg",
+        "profile": "oapgijcswfkruiuuzbwco"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "age": 30,
+          "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+          "profile": "ms",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "key2913": "urperxmkkhhkp"
+        },
+        "location": "itajgxyqozseoygnl",
+        "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/contoso/providers/Microsoft.Contoso/employees/test",
+        "name": "xepyxhpb",
+        "type": "svvamxrdnnv",
+        "systemData": {
+          "createdBy": "iewyxsnriqktsvp",
+          "createdByType": "User",
+          "createdAt": "2023-05-19T00:28:48.610Z",
+          "lastModifiedBy": "xrchbnnuzierzpxw",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-05-19T00:28:48.610Z"
+        }
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/examples/2021-11-01/Operations_List.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/examples/2021-11-01/Operations_List.json
@@ -1,0 +1,28 @@
+{
+  "title": "Operations_List",
+  "operationId": "Operations_List",
+  "parameters": {
+    "api-version": "2021-11-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "ymeow",
+            "isDataAction": true,
+            "display": {
+              "provider": "qxyznq",
+              "resource": "bqfwkox",
+              "operation": "td",
+              "description": "yvgkhsuwartgxb"
+            },
+            "origin": "user",
+            "actionType": "Internal"
+          }
+        ],
+        "nextLink": "https://sample.com/nextLink"
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/main.tsp
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/main.tsp
@@ -1,0 +1,35 @@
+import "@typespec/http";
+import "@typespec/rest";
+import "@typespec/versioning";
+import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-azure-resource-manager";
+import "./employee.tsp";
+
+using TypeSpec.Http;
+using TypeSpec.Rest;
+using TypeSpec.Versioning;
+using Azure.Core;
+using Azure.ResourceManager;
+
+/** Microsoft.Contoso Resource Provider management API. */
+@armProviderNamespace
+@service(#{ title: "WidgetManagement" })
+@versioned(WidgetManagement.Versions)
+namespace WidgetManagement;
+
+/** The available API versions. */
+enum Versions {
+  /** 2021-10-01-preview version */
+  @useDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
+  @useDependency(Azure.Core.Versions.v1_0_Preview_2)
+  @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v5)
+  v2021_10_01_preview: "2021-10-01-preview",
+
+  /** 2021-11-01 version */
+  @useDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
+  @useDependency(Azure.Core.Versions.v1_0_Preview_2)
+  @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v5)
+  v2021_11_01: "2021-11-01",
+}
+
+interface Operations extends Azure.ResourceManager.Operations {}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/readme.md
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/readme.md
@@ -1,0 +1,42 @@
+# WidgetManagement
+
+> see https://aka.ms/autorest
+> This is the AutoRest configuration file for WidgetManagement.
+
+## Getting Started
+
+To build the SDKs for My API, simply install AutoRest via `npm` (`npm install -g autorest`) and then run:
+
+> `autorest readme.md`
+> To see additional help and options, run:
+
+> `autorest --help`
+> For other options on installation see [Installing AutoRest](https://aka.ms/autorest/install) on the AutoRest github page.
+
+---
+
+## Configuration
+
+### Basic Information
+
+These are the global settings.
+
+```yaml
+openapi-type: arm
+openapi-subtype: rpaas
+tag: package-2021-11-01
+```
+
+### Tag: package-2021-11-01
+
+These settings apply only when `--tag=package-2021-11-01` is specified on the command line.
+
+```yaml $(tag) == 'package-2021-11-01'
+input-file:
+  - stable/2021-11-01/widgetmanagement.json
+suppressions:
+  - code: PathContainsResourceType
+  - code: PathResourceProviderMatchNamespace
+```
+
+---

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/shared.tsp
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/shared.tsp
@@ -1,0 +1,8 @@
+@doc("Faked shared model")
+model FakedSharedModel {
+  @doc("The tag.")
+  tag: string;
+
+  @doc("The created date.")
+  createdAt: utcDateTime;
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/stable/2021-11-01/examples/Employees_CreateOrUpdate.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/stable/2021-11-01/examples/Employees_CreateOrUpdate.json
@@ -1,0 +1,76 @@
+{
+  "title": "Employees_CreateOrUpdate",
+  "operationId": "Employees_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2021-11-01",
+    "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
+    "resourceGroupName": "rgopenapi",
+    "employeeName": "9KF-f-8b",
+    "resource": {
+      "properties": {
+        "age": 30,
+        "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+        "profile": "ms"
+      },
+      "tags": {
+        "key2913": "urperxmkkhhkp"
+      },
+      "location": "itajgxyqozseoygnl"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "age": 30,
+          "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+          "profile": "ms",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "key2913": "urperxmkkhhkp"
+        },
+        "location": "itajgxyqozseoygnl",
+        "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/rgopenapi/providers/Microsoft.Contoso/employees/le-8MU--J3W6q8D386p3-iT3",
+        "name": "xepyxhpb",
+        "type": "svvamxrdnnv",
+        "systemData": {
+          "createdBy": "iewyxsnriqktsvp",
+          "createdByType": "User",
+          "createdAt": "2023-05-19T00:28:48.610Z",
+          "lastModifiedBy": "xrchbnnuzierzpxw",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-05-19T00:28:48.610Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+      },
+      "body": {
+        "properties": {
+          "age": 30,
+          "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+          "profile": "ms",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "key2913": "urperxmkkhhkp"
+        },
+        "location": "itajgxyqozseoygnl",
+        "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/rgopenapi/providers/Microsoft.Contoso/employees/9KF-f-8b",
+        "name": "xepyxhpb",
+        "type": "svvamxrdnnv",
+        "systemData": {
+          "createdBy": "iewyxsnriqktsvp",
+          "createdByType": "User",
+          "createdAt": "2023-05-19T00:28:48.610Z",
+          "lastModifiedBy": "xrchbnnuzierzpxw",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-05-19T00:28:48.610Z"
+        }
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/stable/2021-11-01/examples/Employees_Delete.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/stable/2021-11-01/examples/Employees_Delete.json
@@ -1,0 +1,19 @@
+{
+  "title": "Employees_Delete",
+  "operationId": "Employees_Delete",
+  "parameters": {
+    "api-version": "2021-11-01",
+    "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
+    "resourceGroupName": "rgopenapi",
+    "employeeName": "5vX--BxSu3ux48rI4O9OQ569"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Retry-After": 30,
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/stable/2021-11-01/examples/Employees_Get.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/stable/2021-11-01/examples/Employees_Get.json
@@ -1,0 +1,37 @@
+{
+  "title": "Employees_Get",
+  "operationId": "Employees_Get",
+  "parameters": {
+    "api-version": "2021-11-01",
+    "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
+    "resourceGroupName": "rgopenapi",
+    "employeeName": "le-8MU--J3W6q8D386p3-iT3"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "age": 30,
+          "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+          "profile": "ms",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "key2913": "urperxmkkhhkp"
+        },
+        "location": "itajgxyqozseoygnl",
+        "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/rgopenapi/providers/Microsoft.Contoso/employees/le-8MU--J3W6q8D386p3-iT3",
+        "name": "xepyxhpb",
+        "type": "svvamxrdnnv",
+        "systemData": {
+          "createdBy": "iewyxsnriqktsvp",
+          "createdByType": "User",
+          "createdAt": "2023-05-19T00:28:48.610Z",
+          "lastModifiedBy": "xrchbnnuzierzpxw",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-05-19T00:28:48.610Z"
+        }
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/stable/2021-11-01/examples/Employees_ListByResourceGroup.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/stable/2021-11-01/examples/Employees_ListByResourceGroup.json
@@ -1,0 +1,41 @@
+{
+  "title": "Employees_ListByResourceGroup",
+  "operationId": "Employees_ListByResourceGroup",
+  "parameters": {
+    "api-version": "2021-11-01",
+    "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
+    "resourceGroupName": "rgopenapi"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "age": 30,
+              "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+              "profile": "ms",
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "key2913": "urperxmkkhhkp"
+            },
+            "location": "itajgxyqozseoygnl",
+            "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/rgopenapi/providers/Microsoft.Contoso/employees/test",
+            "name": "xepyxhpb",
+            "type": "svvamxrdnnv",
+            "systemData": {
+              "createdBy": "iewyxsnriqktsvp",
+              "createdByType": "User",
+              "createdAt": "2023-05-19T00:28:48.610Z",
+              "lastModifiedBy": "xrchbnnuzierzpxw",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2023-05-19T00:28:48.610Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/stable/2021-11-01/examples/Employees_ListBySubscription.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/stable/2021-11-01/examples/Employees_ListBySubscription.json
@@ -1,0 +1,40 @@
+{
+  "title": "Employees_ListBySubscription",
+  "operationId": "Employees_ListBySubscription",
+  "parameters": {
+    "api-version": "2021-11-01",
+    "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "age": 30,
+              "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+              "profile": "ms",
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "key2913": "urperxmkkhhkp"
+            },
+            "location": "itajgxyqozseoygnl",
+            "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/rgopenapi/providers/Microsoft.Contoso/employees/test",
+            "name": "xepyxhpb",
+            "type": "svvamxrdnnv",
+            "systemData": {
+              "createdBy": "iewyxsnriqktsvp",
+              "createdByType": "User",
+              "createdAt": "2023-05-19T00:28:48.610Z",
+              "lastModifiedBy": "xrchbnnuzierzpxw",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2023-05-19T00:28:48.610Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/stable/2021-11-01/examples/Employees_Update.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/stable/2021-11-01/examples/Employees_Update.json
@@ -1,0 +1,47 @@
+{
+  "title": "Employees_Update",
+  "operationId": "Employees_Update",
+  "parameters": {
+    "api-version": "2021-11-01",
+    "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
+    "resourceGroupName": "rgopenapi",
+    "employeeName": "-XhyNJ--",
+    "properties": {
+      "tags": {
+        "key7952": "no"
+      },
+      "properties": {
+        "age": 24,
+        "city": "uyfg",
+        "profile": "oapgijcswfkruiuuzbwco"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "age": 30,
+          "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+          "profile": "ms",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "key2913": "urperxmkkhhkp"
+        },
+        "location": "itajgxyqozseoygnl",
+        "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/contoso/providers/Microsoft.Contoso/employees/test",
+        "name": "xepyxhpb",
+        "type": "svvamxrdnnv",
+        "systemData": {
+          "createdBy": "iewyxsnriqktsvp",
+          "createdByType": "User",
+          "createdAt": "2023-05-19T00:28:48.610Z",
+          "lastModifiedBy": "xrchbnnuzierzpxw",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-05-19T00:28:48.610Z"
+        }
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/stable/2021-11-01/examples/Operations_List.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/stable/2021-11-01/examples/Operations_List.json
@@ -1,0 +1,28 @@
+{
+  "title": "Operations_List",
+  "operationId": "Operations_List",
+  "parameters": {
+    "api-version": "2021-11-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "ymeow",
+            "isDataAction": true,
+            "display": {
+              "provider": "qxyznq",
+              "resource": "bqfwkox",
+              "operation": "td",
+              "description": "yvgkhsuwartgxb"
+            },
+            "origin": "user",
+            "actionType": "Internal"
+          }
+        ],
+        "nextLink": "https://sample.com/nextLink"
+      }
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/stable/2021-11-01/widgetmanagement.json
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/stable/2021-11-01/widgetmanagement.json
@@ -1,0 +1,557 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "WidgetManagement",
+    "version": "2021-11-01",
+    "description": "Microsoft.Contoso Resource Provider management API.",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Operations"
+    },
+    {
+      "name": "Employees"
+    }
+  ],
+  "paths": {
+    "/providers/WidgetManagement/operations": {
+      "get": {
+        "operationId": "Operations_List",
+        "tags": [
+          "Operations"
+        ],
+        "description": "List the operations for the provider",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/OperationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Operations_List": {
+            "$ref": "./examples/Operations_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/WidgetManagement/employees": {
+      "get": {
+        "operationId": "Employees_ListBySubscription",
+        "tags": [
+          "Employees"
+        ],
+        "description": "List Employee resources by subscription ID",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EmployeeListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Employees_ListBySubscription": {
+            "$ref": "./examples/Employees_ListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/WidgetManagement/employees": {
+      "get": {
+        "operationId": "Employees_ListByResourceGroup",
+        "tags": [
+          "Employees"
+        ],
+        "description": "List Employee resources by resource group",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EmployeeListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Employees_ListByResourceGroup": {
+            "$ref": "./examples/Employees_ListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/WidgetManagement/employees/{employeeName}": {
+      "get": {
+        "operationId": "Employees_Get",
+        "tags": [
+          "Employees"
+        ],
+        "description": "Get a Employee",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "employeeName",
+            "in": "path",
+            "description": "The name of the Employee",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Employee"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Employees_Get": {
+            "$ref": "./examples/Employees_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Employees_CreateOrUpdate",
+        "tags": [
+          "Employees"
+        ],
+        "description": "Create a Employee",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "employeeName",
+            "in": "path",
+            "description": "The name of the Employee",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Employee"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Employee' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Employee"
+            }
+          },
+          "201": {
+            "description": "Resource 'Employee' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Employee"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Employees_CreateOrUpdate": {
+            "$ref": "./examples/Employees_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "Employees_Update",
+        "tags": [
+          "Employees"
+        ],
+        "description": "Update a Employee",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "employeeName",
+            "in": "path",
+            "description": "The name of the Employee",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EmployeeUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Employee"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Employees_Update": {
+            "$ref": "./examples/Employees_Update.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Employees_Delete",
+        "tags": [
+          "Employees"
+        ],
+        "description": "Delete a Employee",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "employeeName",
+            "in": "path",
+            "description": "The name of the Employee",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Employees_Delete": {
+            "$ref": "./examples/Employees_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    }
+  },
+  "definitions": {
+    "Azure.ResourceManager.CommonTypes.TrackedResourceUpdate": {
+      "type": "object",
+      "title": "Tracked Resource",
+      "description": "The resource model definition for an Azure Resource Manager tracked top level resource which has 'tags' and a 'location'",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/Resource"
+        }
+      ]
+    },
+    "Employee": {
+      "type": "object",
+      "description": "Employee resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/EmployeeProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "EmployeeListResult": {
+      "type": "object",
+      "description": "The response of a Employee list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Employee items on this page",
+          "items": {
+            "$ref": "#/definitions/Employee"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "EmployeeProperties": {
+      "type": "object",
+      "description": "Employee properties",
+      "properties": {
+        "age": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Age of employee"
+        },
+        "city": {
+          "type": "string",
+          "description": "City of employee"
+        },
+        "profile": {
+          "type": "string",
+          "format": "base64url",
+          "description": "Profile of employee"
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "The status of the last operation.",
+          "readOnly": true
+        }
+      }
+    },
+    "EmployeeUpdate": {
+      "type": "object",
+      "description": "Employee resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/EmployeeProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Azure.ResourceManager.CommonTypes.TrackedResourceUpdate"
+        }
+      ]
+    },
+    "ProvisioningState": {
+      "type": "string",
+      "description": "The resource provisioning state.",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Provisioning",
+        "Updating",
+        "Deleting",
+        "Accepted"
+      ],
+      "x-ms-enum": {
+        "name": "ProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Resource has been created."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Resource creation failed."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Resource creation was canceled."
+          },
+          {
+            "name": "Provisioning",
+            "value": "Provisioning",
+            "description": "The resource is being provisioned"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "The resource is updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "The resource is being deleted"
+          },
+          {
+            "name": "Accepted",
+            "value": "Accepted",
+            "description": "The resource create request has been accepted"
+          }
+        ]
+      },
+      "readOnly": true
+    }
+  },
+  "parameters": {}
+}

--- a/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/tspconfig.yaml
+++ b/eng/tools/spec-gen-sdk-runner/test/fixtures/specification/service2/resource-manager/Microsoft.Service2/WidgetManagement2/tspconfig.yaml
@@ -1,0 +1,49 @@
+parameters:
+  "service-dir":
+    default: "sdk/widgetmanagement"
+emit:
+  - "@azure-tools/typespec-autorest"
+options:
+  "@azure-tools/typespec-autorest":
+    use-read-only-status-schema: true
+    emitter-output-dir: "{project-root}"
+    # TODO: Does anything need this set, if it's not used in output-file?  Currently required by TSV.
+    azure-resource-provider-folder: "resource-manager"
+    output-file: "{version-status}/{version}/widgetmanagement.json"
+    arm-types-dir: "{project-root}/../../../../common-types/resource-management"
+  "@azure-tools/typespec-csharp":
+    flavor: azure
+    package-dir: "Azure.ResourceManager.Widget"
+    clear-output-folder: true
+    model-namespace: true
+    namespace: "{package-dir}"
+  "@azure-tools/typespec-python":
+    package-dir: "azure-mgmt-widget"
+    namespace: "azure.mgmt.widget"
+    generate-test: true
+    generate-sample: true
+    flavor: "azure"
+  "@azure-tools/typespec-java":
+    package-dir: "azure-resourcemanager-widget"
+    namespace: "com.azure.resourcemanager.widget"
+    service-name: "Widget" # human-readable service name, whitespace allowed
+    flavor: azure
+  "@azure-tools/typespec-ts":
+    package-dir: "arm-widget"
+    flavor: azure
+    experimental-extensible-enums: true
+    package-details:
+      name: "@azure/arm-widget"
+  "@azure-tools/typespec-go":
+    service-dir: "sdk/resourcemanager/widget"
+    package-dir: "armwidget"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/{package-dir}"
+    fix-const-stuttering: true
+    flavor: "azure"
+    generate-samples: true
+    generate-fakes: true
+    head-as-boolean: true
+    inject-spans: true
+linter:
+  extends:
+    - "@azure-tools/typespec-azure-rulesets/resource-manager"

--- a/eng/tools/spec-gen-sdk-runner/test/spec-helpers.test.ts
+++ b/eng/tools/spec-gen-sdk-runner/test/spec-helpers.test.ts
@@ -1,5 +1,9 @@
 import { describe, test, expect, vi, beforeEach } from "vitest";
-import { detectChangedSpecConfigFiles, groupSpecConfigPaths } from "../src/spec-helpers.js";
+import {
+  detectChangedSpecConfigFiles,
+  groupSpecConfigPaths,
+  processTypeSpecProjectsV2FolderStructure,
+} from "../src/spec-helpers.js";
 import { SpecGenSdkCmdInput } from "../src/types.js";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
@@ -182,6 +186,189 @@ describe("detectChangedSpecConfigFiles", () => {
       ],
       readmeMd: "specification/contosowidgetmanager/data-plane/readme.md",
       typespecProject: "specification/contosowidgetmanager/Contoso.WidgetManager/tspconfig.yaml",
+    });
+  });
+
+  test("case with V2 folder structure - resource-manager", () => {
+    vi.mocked(getChangedFiles).mockReturnValue([
+      "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/tspconfig.yaml",
+      "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/main.tsp",
+      "specification/service1/resource-manager/readme.md",
+    ]);
+
+    const result = detectChangedSpecConfigFiles(mockCommandInput);
+
+    expect(result).toHaveLength(1);
+    const normalizedResult = normalizeResultItem(result[0]);
+
+    // In V2 structure, the TypeSpec project should be correctly associated with the readme
+    expect(normalizedResult).toEqual({
+      specs: [
+        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/tspconfig.yaml",
+        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/main.tsp",
+      ],
+      readmeMd:
+        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/readme.md",
+      typespecProject:
+        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/tspconfig.yaml",
+    });
+  });
+
+  test("case with V2 folder structure - data-plane", () => {
+    vi.mocked(getChangedFiles).mockReturnValue([
+      "specification/service1/data-plane/widget/tspconfig.yaml",
+      "specification/service1/data-plane/widget/main.tsp",
+      "specification/service1/data-plane/readme.md",
+    ]);
+
+    const result = detectChangedSpecConfigFiles(mockCommandInput);
+
+    expect(result).toHaveLength(1);
+    const normalizedResult = normalizeResultItem(result[0]);
+
+    // In V2 structure, the TypeSpec project should be correctly associated with the readme
+    expect(normalizedResult).toEqual({
+      specs: [
+        "specification/service1/data-plane/widget/tspconfig.yaml",
+        "specification/service1/data-plane/widget/main.tsp",
+      ],
+      readmeMd: "specification/service1/data-plane/widget/readme.md",
+      typespecProject: "specification/service1/data-plane/widget/tspconfig.yaml",
+    });
+  });
+
+  test("case with V2 folder structure - nested subfolders", () => {
+    vi.mocked(getChangedFiles).mockReturnValue([
+      "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/examples/2025-05-05/create.json",
+      "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/stable/2025-05-05/servicecontrol.json",
+      "specification/service1/resource-manager/Microsoft.Service1/readme.md",
+      "specification/service1/resource-manager/readme.md",
+    ]);
+
+    const result = detectChangedSpecConfigFiles(mockCommandInput);
+
+    expect(result).toHaveLength(1);
+    const normalizedResult = normalizeResultItem(result[0]);
+
+    // The deepest TypeSpec project should be used, and both readme files should be cleaned up
+    expect(normalizedResult).toEqual({
+      specs: [
+        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/examples/2025-05-05/create.json",
+        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/stable/2025-05-05/servicecontrol.json",
+      ],
+      readmeMd:
+        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/readme.md",
+      typespecProject:
+        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/tspconfig.yaml",
+    });
+  });
+
+  test("case with V2 folder structure mixed with old structure", () => {
+    vi.mocked(getChangedFiles).mockReturnValue([
+      // V2 folder structure
+      "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/tspconfig.yaml",
+      "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/main.tsp",
+      "specification/service1/resource-manager/readme.md",
+      // Old folder structure
+      "specification/contosowidgetmanager/Contoso.WidgetManager/client.tsp",
+      "specification/contosowidgetmanager/Contoso.WidgetManager/tspconfig.yaml",
+      "specification/contosowidgetmanager/data-plane/readme.md",
+    ]);
+
+    const result = detectChangedSpecConfigFiles(mockCommandInput);
+
+    expect(result).toHaveLength(2);
+
+    // First result should be for the V2 structure
+    const normalizedV2Result = normalizeResultItem(result[0]);
+    expect(normalizedV2Result).toEqual({
+      specs: [
+        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/tspconfig.yaml",
+        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/main.tsp",
+      ],
+      readmeMd:
+        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/readme.md",
+      typespecProject:
+        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/tspconfig.yaml",
+    });
+
+    // Second result should be for the old structure
+    const normalizedOldResult = normalizeResultItem(result[1]);
+    expect(normalizedOldResult).toEqual({
+      specs: [
+        "specification/contosowidgetmanager/data-plane/readme.md",
+        "specification/contosowidgetmanager/Contoso.WidgetManager/client.tsp",
+        "specification/contosowidgetmanager/Contoso.WidgetManager/tspconfig.yaml",
+      ],
+      readmeMd: "specification/contosowidgetmanager/data-plane/readme.md",
+      typespecProject: "specification/contosowidgetmanager/Contoso.WidgetManager/tspconfig.yaml",
+    });
+  });
+
+  test("case with multiple V2 folder structures", () => {
+    vi.mocked(getChangedFiles).mockReturnValue([
+      // First service
+      "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/tspconfig.yaml",
+      "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/main.tsp",
+      "specification/service1/resource-manager/readme.md",
+      // Second service
+      "specification/service2/data-plane/widget2/tspconfig.yaml",
+      "specification/service2/data-plane/widget2/main.tsp",
+      "specification/service2/data-plane/readme.md",
+    ]);
+
+    const result = detectChangedSpecConfigFiles(mockCommandInput);
+
+    expect(result).toHaveLength(2);
+
+    // Results for both services should be properly processed with V2 structure
+    const service1Result = result.find((r) => r.typespecProject?.includes("service1"));
+    const service2Result = result.find((r) => r.typespecProject?.includes("service2"));
+
+    expect(normalizeResultItem(service1Result!)).toEqual({
+      specs: [
+        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/tspconfig.yaml",
+        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/main.tsp",
+      ],
+      readmeMd:
+        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/readme.md",
+      typespecProject:
+        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/tspconfig.yaml",
+    });
+
+    expect(normalizeResultItem(service2Result!)).toEqual({
+      specs: [
+        "specification/service2/data-plane/widget2/tspconfig.yaml",
+        "specification/service2/data-plane/widget2/main.tsp",
+      ],
+      readmeMd: "specification/service2/data-plane/widget2/readme.md",
+      typespecProject: "specification/service2/data-plane/widget2/tspconfig.yaml",
+    });
+  });
+
+  test("case with V2 folder structure - cross-platform path separators", () => {
+    // Mock getChangedFiles to return paths with both forward and backslashes
+    vi.mocked(getChangedFiles).mockReturnValue([
+      String.raw`specification\service1\resource-manager\Microsoft.Service1\servicecontrol\tspconfig.yaml`,
+      "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/main.tsp",
+      String.raw`specification\service1\resource-manager\readme.md`,
+    ]);
+
+    const result = detectChangedSpecConfigFiles(mockCommandInput);
+
+    expect(result).toHaveLength(1);
+    const normalizedResult = normalizeResultItem(result[0]);
+
+    // The function should handle mixed path separators correctly
+    expect(normalizedResult).toEqual({
+      specs: [
+        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/tspconfig.yaml",
+        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/main.tsp",
+      ],
+      readmeMd:
+        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/readme.md",
+      typespecProject:
+        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/tspconfig.yaml",
     });
   });
 });
@@ -393,5 +580,158 @@ describe("groupSpecConfigPaths", () => {
       (r) => r.readmePath === "specification/compute/data-plane/readme.md",
     );
     expect(computeDpResult).toBeUndefined();
+  });
+});
+
+describe("processTypeSpecProjectsV2FolderStructure", () => {
+  test("should process resource-manager structure and return ChangedSpecs with correct paths", () => {
+    // Setup test data
+    const readmeMDResult = {
+      "specification/service/resource-manager": [
+        "specification/service/resource-manager/readme.md",
+      ],
+      "specification/service/resource-manager/Microsoft.Service": [
+        "specification/service/resource-manager/Microsoft.Service/readme.md",
+      ],
+    };
+
+    const typespecProjectResult = {
+      "specification/service/resource-manager/Microsoft.Service": [
+        "specification/service/resource-manager/Microsoft.Service/tspconfig.yaml",
+        "specification/service/resource-manager/Microsoft.Service/main.tsp",
+      ],
+    };
+
+    // Run the function
+    const result = processTypeSpecProjectsV2FolderStructure(readmeMDResult, typespecProjectResult);
+
+    // Normalize results for comparison
+    const normalizedResults = result.map((item) => normalizeResultItem(item));
+
+    // Verify results
+    expect(normalizedResults).toHaveLength(1);
+
+    // Check structure of the returned ChangedSpecs object
+    const spec = normalizedResults[0];
+    expect(spec.typespecProject).toBe(
+      normalizePath("specification/service/resource-manager/Microsoft.Service/tspconfig.yaml"),
+    );
+    expect(spec.readmeMd).toBe(
+      normalizePath("specification/service/resource-manager/Microsoft.Service/readme.md"),
+    );
+    expect(spec.specs).toContain(
+      normalizePath("specification/service/resource-manager/Microsoft.Service/tspconfig.yaml"),
+    );
+    expect(spec.specs).toContain(
+      normalizePath("specification/service/resource-manager/Microsoft.Service/main.tsp"),
+    );
+    expect(spec.specs).toContain(
+      normalizePath("specification/service/resource-manager/Microsoft.Service/readme.md"),
+    );
+
+    // Verify the readmeMDResult was modified as expected
+    expect(readmeMDResult).not.toHaveProperty("specification/service/resource-manager");
+    expect(readmeMDResult).not.toHaveProperty(
+      "specification/service/resource-manager/Microsoft.Service",
+    );
+
+    // Verify the typespecProjectResult was modified as expected
+    expect(typespecProjectResult).not.toHaveProperty(
+      "specification/service/resource-manager/Microsoft.Service",
+    );
+  });
+
+  test("should process data-plane structure and clean related readme entries", () => {
+    // Setup test data
+    const readmeMDResult = {
+      "specification/service/data-plane": ["specification/service/data-plane/readme.md"],
+      "specification/otherservice/data-plane": ["specification/otherservice/data-plane/readme.md"],
+    };
+
+    const typespecProjectResult = {
+      "specification/service/data-plane/client": [
+        "specification/service/data-plane/client/tspconfig.yaml",
+        "specification/service/data-plane/client/main.tsp",
+      ],
+    };
+
+    // Run the function
+    const result = processTypeSpecProjectsV2FolderStructure(readmeMDResult, typespecProjectResult);
+
+    // Normalize results for comparison
+    const normalizedResults = result.map((item) => normalizeResultItem(item));
+
+    // Verify results
+    expect(normalizedResults).toHaveLength(1);
+
+    // Check that the data-plane structure was processed correctly
+    const spec = normalizedResults[0];
+    expect(spec.typespecProject).toBe(
+      normalizePath("specification/service/data-plane/client/tspconfig.yaml"),
+    );
+    expect(spec.readmeMd).toBeUndefined(); // No direct readme in the client folder
+    expect(spec.specs).toContain(
+      normalizePath("specification/service/data-plane/client/tspconfig.yaml"),
+    );
+    expect(spec.specs).toContain(normalizePath("specification/service/data-plane/client/main.tsp"));
+
+    // Verify related readme was removed
+    expect(readmeMDResult).not.toHaveProperty("specification/service/data-plane");
+
+    // Verify unrelated readme remains
+    expect(readmeMDResult).toHaveProperty("specification/otherservice/data-plane");
+
+    // Verify the typespecProjectResult was cleaned
+    expect(typespecProjectResult).not.toHaveProperty("specification/service/data-plane/client");
+  });
+
+  test("should handle multiple levels in the folder structure", () => {
+    // Setup test data with nested structure
+    const readmeMDResult = {
+      "specification/service/resource-manager": [
+        "specification/service/resource-manager/readme.md",
+      ],
+      "specification/service/resource-manager/Microsoft.Service": [
+        "specification/service/resource-manager/Microsoft.Service/readme.md",
+      ],
+      "specification/service/resource-manager/Microsoft.Service/nested/subfolder": [
+        "specification/service/resource-manager/Microsoft.Service/nested/subfolder/readme.md",
+      ],
+    };
+
+    const typespecProjectResult = {
+      "specification/service/resource-manager/Microsoft.Service/nested/subfolder": [
+        "specification/service/resource-manager/Microsoft.Service/nested/subfolder/tspconfig.yaml",
+        "specification/service/resource-manager/Microsoft.Service/nested/subfolder/main.tsp",
+      ],
+    };
+
+    // Run the function
+    const result = processTypeSpecProjectsV2FolderStructure(readmeMDResult, typespecProjectResult);
+
+    // Normalize results for comparison
+    const normalizedResults = result.map((item) => normalizeResultItem(item));
+
+    // Verify results
+    expect(normalizedResults).toHaveLength(1);
+
+    // Check that the deeply nested structure was processed correctly
+    const spec = normalizedResults[0];
+    expect(spec.readmeMd).toBe(
+      normalizePath(
+        "specification/service/resource-manager/Microsoft.Service/nested/subfolder/readme.md",
+      ),
+    );
+
+    // Verify parent readme entries were removed
+    expect(readmeMDResult).not.toHaveProperty("specification/service/resource-manager");
+    expect(readmeMDResult).not.toHaveProperty(
+      "specification/service/resource-manager/Microsoft.Service",
+    );
+  });
+
+  test("should handle empty inputs", () => {
+    const result = processTypeSpecProjectsV2FolderStructure({}, {});
+    expect(result).toHaveLength(0);
   });
 });

--- a/eng/tools/spec-gen-sdk-runner/test/spec-helpers.test.ts
+++ b/eng/tools/spec-gen-sdk-runner/test/spec-helpers.test.ts
@@ -191,8 +191,8 @@ describe("detectChangedSpecConfigFiles", () => {
 
   test("case with V2 folder structure - resource-manager", () => {
     vi.mocked(getChangedFiles).mockReturnValue([
-      "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/tspconfig.yaml",
-      "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/main.tsp",
+      "specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/tspconfig.yaml",
+      "specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/main.tsp",
       "specification/service1/resource-manager/readme.md",
     ]);
 
@@ -204,13 +204,13 @@ describe("detectChangedSpecConfigFiles", () => {
     // In V2 structure, the TypeSpec project should be correctly associated with the readme
     expect(normalizedResult).toEqual({
       specs: [
-        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/tspconfig.yaml",
-        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/main.tsp",
+        "specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/tspconfig.yaml",
+        "specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/main.tsp",
       ],
       readmeMd:
-        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/readme.md",
+        "specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/readme.md",
       typespecProject:
-        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/tspconfig.yaml",
+        "specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/tspconfig.yaml",
     });
   });
 
@@ -239,8 +239,8 @@ describe("detectChangedSpecConfigFiles", () => {
 
   test("case with V2 folder structure - nested subfolders", () => {
     vi.mocked(getChangedFiles).mockReturnValue([
-      "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/examples/2025-05-05/create.json",
-      "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/stable/2025-05-05/servicecontrol.json",
+      "specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/examples/2021-11-01/create.json",
+      "specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/stable/2021-11-01/servicecontrol.json",
       "specification/service1/resource-manager/Microsoft.Service1/readme.md",
       "specification/service1/resource-manager/readme.md",
     ]);
@@ -253,21 +253,21 @@ describe("detectChangedSpecConfigFiles", () => {
     // The deepest TypeSpec project should be used, and both readme files should be cleaned up
     expect(normalizedResult).toEqual({
       specs: [
-        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/examples/2025-05-05/create.json",
-        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/stable/2025-05-05/servicecontrol.json",
+        "specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/examples/2021-11-01/create.json",
+        "specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/stable/2021-11-01/servicecontrol.json",
       ],
       readmeMd:
-        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/readme.md",
+        "specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/readme.md",
       typespecProject:
-        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/tspconfig.yaml",
+        "specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/tspconfig.yaml",
     });
   });
 
   test("case with V2 folder structure mixed with old structure", () => {
     vi.mocked(getChangedFiles).mockReturnValue([
       // V2 folder structure
-      "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/tspconfig.yaml",
-      "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/main.tsp",
+      "specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/tspconfig.yaml",
+      "specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/main.tsp",
       "specification/service1/resource-manager/readme.md",
       // Old folder structure
       "specification/contosowidgetmanager/Contoso.WidgetManager/client.tsp",
@@ -283,13 +283,13 @@ describe("detectChangedSpecConfigFiles", () => {
     const normalizedV2Result = normalizeResultItem(result[0]);
     expect(normalizedV2Result).toEqual({
       specs: [
-        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/tspconfig.yaml",
-        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/main.tsp",
+        "specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/tspconfig.yaml",
+        "specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/main.tsp",
       ],
       readmeMd:
-        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/readme.md",
+        "specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/readme.md",
       typespecProject:
-        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/tspconfig.yaml",
+        "specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/tspconfig.yaml",
     });
 
     // Second result should be for the old structure
@@ -308,8 +308,8 @@ describe("detectChangedSpecConfigFiles", () => {
   test("case with multiple V2 folder structures", () => {
     vi.mocked(getChangedFiles).mockReturnValue([
       // First service
-      "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/tspconfig.yaml",
-      "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/main.tsp",
+      "specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/tspconfig.yaml",
+      "specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/main.tsp",
       "specification/service1/resource-manager/readme.md",
       // Second service
       "specification/service2/data-plane/widget2/tspconfig.yaml",
@@ -327,13 +327,13 @@ describe("detectChangedSpecConfigFiles", () => {
 
     expect(normalizeResultItem(service1Result!)).toEqual({
       specs: [
-        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/tspconfig.yaml",
-        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/main.tsp",
+        "specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/tspconfig.yaml",
+        "specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/main.tsp",
       ],
       readmeMd:
-        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/readme.md",
+        "specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/readme.md",
       typespecProject:
-        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/tspconfig.yaml",
+        "specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/tspconfig.yaml",
     });
 
     expect(normalizeResultItem(service2Result!)).toEqual({
@@ -349,8 +349,8 @@ describe("detectChangedSpecConfigFiles", () => {
   test("case with V2 folder structure - cross-platform path separators", () => {
     // Mock getChangedFiles to return paths with both forward and backslashes
     vi.mocked(getChangedFiles).mockReturnValue([
-      String.raw`specification\service1\resource-manager\Microsoft.Service1\servicecontrol\tspconfig.yaml`,
-      "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/main.tsp",
+      String.raw`specification\service1\resource-manager\Microsoft.Service1\WidgetManagement\tspconfig.yaml`,
+      "specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/main.tsp",
       String.raw`specification\service1\resource-manager\readme.md`,
     ]);
 
@@ -362,13 +362,13 @@ describe("detectChangedSpecConfigFiles", () => {
     // The function should handle mixed path separators correctly
     expect(normalizedResult).toEqual({
       specs: [
-        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/tspconfig.yaml",
-        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/main.tsp",
+        "specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/tspconfig.yaml",
+        "specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/main.tsp",
       ],
       readmeMd:
-        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/readme.md",
+        "specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/readme.md",
       typespecProject:
-        "specification/service1/resource-manager/Microsoft.Service1/servicecontrol/tspconfig.yaml",
+        "specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/tspconfig.yaml",
     });
   });
 });

--- a/eng/tools/spec-gen-sdk-runner/test/utils/findParentWithFile.test.ts
+++ b/eng/tools/spec-gen-sdk-runner/test/utils/findParentWithFile.test.ts
@@ -27,6 +27,11 @@ describe("findParentWithFile", () => {
     expect(result).toBe("specification/contosowidgetmanager/Contoso.WidgetManager");
   });
 
+  test("handles single segment path", () => {
+    const result = findParentWithFile(".", typespecProjectRegex, repoRoot);
+    expect(result).toBeUndefined();
+  });
+
   test("stops at specified boundary", () => {
     const result = findParentWithFile(
       "specification/contosowidgetmanager/Contoso.WidgetManager",


### PR DESCRIPTION
This pull request introduces several changes to streamline the handling of breaking change labels, improve TypeSpec project processing, and enhance test coverage. The key updates include simplifying the `getBreakingChangeInfo` function, adding support for processing TypeSpec projects with a new folder structure, and updating related tests to reflect these changes.

### Breaking Change Label Simplification:
* Refactored the `getBreakingChangeInfo` function to return a boolean instead of a tuple, eliminating the need to handle a breaking change label string. (`eng/tools/spec-gen-sdk-runner/src/command-helpers.ts`, [[1]](diffhunk://#diff-d292e56953349ba449b6a945620041b82cb4b7a32a76ea96b87839f91884d1cbL266-L283) [[2]](diffhunk://#diff-d292e56953349ba449b6a945620041b82cb4b7a32a76ea96b87839f91884d1cbL294) [[3]](diffhunk://#diff-d292e56953349ba449b6a945620041b82cb4b7a32a76ea96b87839f91884d1cbL336-L337) [[4]](diffhunk://#diff-d7be89bc13d39990960756a431e7e422649175ec72b22237a9ebabf6b41c7e4eL87) [[5]](diffhunk://#diff-d7be89bc13d39990960756a431e7e422649175ec72b22237a9ebabf6b41c7e4eL167-R166) [[6]](diffhunk://#diff-d7be89bc13d39990960756a431e7e422649175ec72b22237a9ebabf6b41c7e4eL183).

### TypeSpec Project Processing Enhancements:
* Introduced the `processTypeSpecProjectsV2FolderStructure` function to handle TypeSpec projects with the new resource-manager or data-plane folder structure. This function matches TypeSpec projects with corresponding `readme.md` files and removes redundant entries (`eng/tools/spec-gen-sdk-runner/src/spec-helpers.ts`, [[1]](diffhunk://#diff-d2dd0ed10cc0304aa7f41fc5e798710ac2f205df116e2a65ab9c81628629f3cfR21-R153) [[2]](diffhunk://#diff-d2dd0ed10cc0304aa7f41fc5e798710ac2f205df116e2a65ab9c81628629f3cfR195-R210) [[3]](diffhunk://#diff-d2dd0ed10cc0304aa7f41fc5e798710ac2f205df116e2a65ab9c81628629f3cfR298).

### Test Updates:
* Updated unit tests to reflect the changes in `getBreakingChangeInfo`, ensuring it now validates boolean outputs instead of tuples (`eng/tools/spec-gen-sdk-runner/test/command-helpers.test.ts`, [[1]](diffhunk://#diff-a33d0528b53032959617c4f452c5bca75f42ae4dc508ba35a6945a229118fe84L371-R386) [[2]](diffhunk://#diff-a33d0528b53032959617c4f452c5bca75f42ae4dc508ba35a6945a229118fe84L396-R396).
* Adjusted tests for `generateArtifact` to remove references to the breaking change label parameter (`eng/tools/spec-gen-sdk-runner/test/command-helpers.test.ts`, [[1]](diffhunk://#diff-a33d0528b53032959617c4f452c5bca75f42ae4dc508ba35a6945a229118fe84L429-L437) [[2]](diffhunk://#diff-a33d0528b53032959617c4f452c5bca75f42ae4dc508ba35a6945a229118fe84L481-L482) [[3]](diffhunk://#diff-a33d0528b53032959617c4f452c5bca75f42ae4dc508ba35a6945a229118fe84L510-L518) [[4]](diffhunk://#diff-a33d0528b53032959617c4f452c5bca75f42ae4dc508ba35a6945a229118fe84L556) [[5]](diffhunk://#diff-a33d0528b53032959617c4f452c5bca75f42ae4dc508ba35a6945a229118fe84L568).
* Updated tests for `generateSdkForSpecPr` to align with the simplified handling of breaking change information (`eng/tools/spec-gen-sdk-runner/test/commands.test.ts`, [[1]](diffhunk://#diff-7aceaf61a99c9cc94f36cc49d8c6a6c23c9d645b963e7fc4ada30c8d48bc4e68L212-R212) [[2]](diffhunk://#diff-7aceaf61a99c9cc94f36cc49d8c6a6c23c9d645b963e7fc4ada30c8d48bc4e68L242) [[3]](diffhunk://#diff-7aceaf61a99c9cc94f36cc49d8c6a6c23c9d645b963e7fc4ada30c8d48bc4e68L285) [[4]](diffhunk://#diff-7aceaf61a99c9cc94f36cc49d8c6a6c23c9d645b963e7fc4ada30c8d48bc4e68L324).

### Utility Improvement:
* Enhanced the `findParentWithFile` utility function to prevent infinite loops by adding a check for the current path reaching `'.'` (`eng/tools/spec-gen-sdk-runner/src/utils.ts`, [eng/tools/spec-gen-sdk-runner/src/utils.tsL226-R228](diffhunk://#diff-cc8e463308ef97c86ca0651b6703b4c6a895b0104288d56017244dad18053e16L226-R228)).

### Test PRs
[old folder structure](https://github.com/raych1/azure-rest-api-specs/pull/63)
[V2 folder structure](https://github.com/raych1/azure-rest-api-specs/pull/62)

@mikeharder could you review this PR?