### PR TITLE
Update Microsoft.SecretsyncController API Spec

### DIFF
--- a/specification/ews/SecretSyncController.Management/examples/2024-08-21-preview/SecretSyncs_Update_MaximumSet_Gen.json
+++ b/specification/ews/SecretSyncController.Management/examples/2024-08-21-preview/SecretSyncs_Update_MaximumSet_Gen.json
@@ -13,7 +13,6 @@
       "properties": {
         "secretProviderClassName": "jttlpenhtpxfrrlxdsmqqvmvtmgqrficvqngkggjwciilrexenlstxncyvkqcydxrivkioujssncoaiysdklfouukczzdbxniipbyiqsarqaespuqrbbydwtdaulllostoomntkadklihemfpeffvuyvyilequiqewzspaootvkibrynbqrsbiptjdhywynvydaadprdc",
         "serviceAccountName": "fcldqfdfpktndlntuoxicsftelhefevovmlycflfwzckvamiqjnjugandqaqqeccsbzztfmmeunvhsafgerbcsdbnmsyqivygornebbkusuvphwghgouxvcbvmbydqjzoxextnyowsnyymadniwdrrxtogeveldpejixmsrzzfqkquaxdpzwvecevqwasxgxxchrfa",
-        "kubernetesSecretType": "Opaque",
         "objectSecretMapping": [
           {
             "sourcePath": "ssrzmbvdiomkvzrdsyilwlfzicfydnbjwjsnohrppkukjddrunfslkrnexunuckmghixdssposvndpiqchpqrkjuqbapoisvqdvgstvdonsmlpsmticfvuhqlofpaxfdg",

--- a/specification/ews/SecretSyncController.Management/secretsync.tsp
+++ b/specification/ews/SecretSyncController.Management/secretsync.tsp
@@ -37,6 +37,7 @@ model SecretSyncProperties {
   serviceAccountName: string;
 
   @doc("Type specifies the type of the Kubernetes secret object, e.g. \"Opaque\" or\"kubernetes.io/tls\". The controller must have permission to create secrets of the specified type.")
+  @visibility(Lifecycle.Read, Lifecycle.Create)
   kubernetesSecretType: KubernetesSecretType;
 
   @doc("ForceSynchronization can be used to force the secret synchronization. The secret synchronization is triggered by changing the value in this field. This field is not used to resolve synchronization conflicts.")
@@ -46,7 +47,7 @@ model SecretSyncProperties {
 
   @doc("An array of SecretObjectData that maps secret data from the external secret provider to the Kubernetes secret. Each entry specifies the source secret in the external provider and the corresponding key in the Kubernetes secret.")
   @minItems(1)
-  @identifiers(#[])
+  @identifiers(#["targetKey"])
   objectSecretMapping: KubernetesSecretObjectMapping[];
 
   @visibility(Lifecycle.Read)

--- a/specification/ews/resource-manager/Microsoft.SecretSyncController/preview/2024-08-21-preview/examples/SecretSyncs_Update_MaximumSet_Gen.json
+++ b/specification/ews/resource-manager/Microsoft.SecretSyncController/preview/2024-08-21-preview/examples/SecretSyncs_Update_MaximumSet_Gen.json
@@ -13,7 +13,6 @@
       "properties": {
         "secretProviderClassName": "jttlpenhtpxfrrlxdsmqqvmvtmgqrficvqngkggjwciilrexenlstxncyvkqcydxrivkioujssncoaiysdklfouukczzdbxniipbyiqsarqaespuqrbbydwtdaulllostoomntkadklihemfpeffvuyvyilequiqewzspaootvkibrynbqrsbiptjdhywynvydaadprdc",
         "serviceAccountName": "fcldqfdfpktndlntuoxicsftelhefevovmlycflfwzckvamiqjnjugandqaqqeccsbzztfmmeunvhsafgerbcsdbnmsyqivygornebbkusuvphwghgouxvcbvmbydqjzoxextnyowsnyymadniwdrrxtogeveldpejixmsrzzfqkquaxdpzwvecevqwasxgxxchrfa",
-        "kubernetesSecretType": "Opaque",
         "objectSecretMapping": [
           {
             "sourcePath": "ssrzmbvdiomkvzrdsyilwlfzicfydnbjwjsnohrppkukjddrunfslkrnexunuckmghixdssposvndpiqchpqrkjuqbapoisvqdvgstvdonsmlpsmticfvuhqlofpaxfdg",

--- a/specification/ews/resource-manager/Microsoft.SecretSyncController/preview/2024-08-21-preview/secretsynccontroller.json
+++ b/specification/ews/resource-manager/Microsoft.SecretSyncController/preview/2024-08-21-preview/secretsynccontroller.json
@@ -1120,7 +1120,11 @@
         },
         "kubernetesSecretType": {
           "$ref": "#/definitions/KubernetesSecretType",
-          "description": "Type specifies the type of the Kubernetes secret object, e.g. \"Opaque\" or\"kubernetes.io/tls\". The controller must have permission to create secrets of the specified type."
+          "description": "Type specifies the type of the Kubernetes secret object, e.g. \"Opaque\" or\"kubernetes.io/tls\". The controller must have permission to create secrets of the specified type.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         },
         "forceSynchronization": {
           "type": "string",
@@ -1135,7 +1139,9 @@
           "items": {
             "$ref": "#/definitions/KubernetesSecretObjectMapping"
           },
-          "x-ms-identifiers": []
+          "x-ms-identifiers": [
+            "targetKey"
+          ]
         },
         "status": {
           "$ref": "#/definitions/SecretSyncStatus",
@@ -1212,10 +1218,6 @@
           "maxLength": 253,
           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
         },
-        "kubernetesSecretType": {
-          "$ref": "#/definitions/KubernetesSecretType",
-          "description": "Type specifies the type of the Kubernetes secret object, e.g. \"Opaque\" or\"kubernetes.io/tls\". The controller must have permission to create secrets of the specified type."
-        },
         "forceSynchronization": {
           "type": "string",
           "description": "ForceSynchronization can be used to force the secret synchronization. The secret synchronization is triggered by changing the value in this field. This field is not used to resolve synchronization conflicts.",
@@ -1229,7 +1231,9 @@
           "items": {
             "$ref": "#/definitions/KubernetesSecretObjectMapping"
           },
-          "x-ms-identifiers": []
+          "x-ms-identifiers": [
+            "targetKey"
+          ]
         }
       }
     },


### PR DESCRIPTION
The kubernetesSecretType cannot be changed, so we update the lifecycle so that is can only be set on creation.

Set the targetKey as the primary key for kubernetesSecretObjectMapping as this value must be unique across the entire list.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
