### PR TITLE
Updates for `oav-runner`

### DIFF
--- a/eng/tools/oav-runner/src/cli.ts
+++ b/eng/tools/oav-runner/src/cli.ts
@@ -8,7 +8,9 @@ import {
   ReportableOavError,
 } from "./formatting.js";
 
+import { resolve } from "path";
 import { parseArgs, ParseArgsConfig } from "node:util";
+import { exit } from "node:process";
 
 export async function main() {
   const config: ParseArgsConfig = {
@@ -19,6 +21,12 @@ export async function main() {
         multiple: false,
         default: process.cwd(),
       },
+      fileList: {
+        type: "string",
+        short: "f",
+        multiple: false,
+        default: undefined,
+      },
     },
     allowPositionals: true,
   };
@@ -27,6 +35,24 @@ export async function main() {
   // this option has a default value of process.cwd(), so we can assume it is always defined
   // just need to resolve that here to make ts aware of it
   const targetDirectory = opts.targetDirectory as string;
+
+  let fileList: string[] | undefined = undefined;
+  if (opts.fileList !== undefined) {
+    const fileListPath = resolve(opts.fileList as string);
+    try {
+      const fs = await import('node:fs/promises');
+      const fileContent = await fs.readFile(fileListPath, { encoding: 'utf-8' });
+      fileList = fileContent.split('\n')
+        .map(line => line.trim())
+        .filter(line => line.length > 0);
+      console.log(`Loaded ${fileList.length} files from ${opts.fileList}`);
+    } catch (error) {
+      console.error(`Error reading file list from ${opts.fileList}: ${error instanceof Error ? error.message : String(error)}`);
+      console.error('User provided file list thatis invalid or not found.');
+      console.error("Please ensure the file exists and is readable, or do not provide the option 'fileList'")
+      exit(1);
+    }
+  }
 
   // first positional is runType
   const [runType] = positionals;

--- a/eng/tools/oav-runner/src/cli.ts
+++ b/eng/tools/oav-runner/src/cli.ts
@@ -11,6 +11,7 @@ import {
 import { resolve } from "path";
 import { parseArgs, ParseArgsConfig } from "node:util";
 import { exit } from "node:process";
+import fs from "node:fs/promises";
 
 export async function main() {
   const config: ParseArgsConfig = {
@@ -40,7 +41,6 @@ export async function main() {
   if (opts.fileList !== undefined) {
     const fileListPath = resolve(opts.fileList as string);
     try {
-      const fs = await import('node:fs/promises');
       const fileContent = await fs.readFile(fileListPath, { encoding: 'utf-8' });
       fileList = fileContent.split('\n')
         .map(line => line.trim())

--- a/eng/tools/oav-runner/src/cli.ts
+++ b/eng/tools/oav-runner/src/cli.ts
@@ -73,11 +73,11 @@ export async function main() {
 
   if (runType === "specs") {
     [exitCode, scannedSwaggerFiles, errorList] =
-      await checkSpecs(targetDirectory);
+      await checkSpecs(targetDirectory, fileList);
     reportName = "Swagger SemanticValidation";
   } else if (runType === "examples") {
     [exitCode, scannedSwaggerFiles, errorList] =
-      await checkExamples(targetDirectory);
+      await checkExamples(targetDirectory, fileList);
     reportName = "Swagger ModelValidation";
   }
 

--- a/eng/tools/oav-runner/src/cli.ts
+++ b/eng/tools/oav-runner/src/cli.ts
@@ -48,7 +48,7 @@ export async function main() {
       console.log(`Loaded ${fileList.length} files from ${opts.fileList}`);
     } catch (error) {
       console.error(`Error reading file list from ${opts.fileList}: ${error instanceof Error ? error.message : String(error)}`);
-      console.error('User provided file list thatis invalid or not found.');
+      console.error('User provided file list that is not found.');
       console.error("Please ensure the file exists and is readable, or do not provide the option 'fileList'")
       exit(1);
     }

--- a/eng/tools/oav-runner/src/runner.ts
+++ b/eng/tools/oav-runner/src/runner.ts
@@ -12,9 +12,7 @@ import {
 import { ReportableOavError } from "./formatting.js";
 
 export async function preCheckFiltering(rootDirectory: string, fileList?: string[]): Promise<string[]> {
-  const changedFiles = fileList?.length
-    ? fileList
-    : await getChangedFiles({ cwd: rootDirectory });
+  const changedFiles = fileList ?? await getChangedFiles({ cwd: rootDirectory });
 
   const swaggerFiles = await processFilesToSpecificationList(
     rootDirectory,

--- a/eng/tools/oav-runner/src/runner.ts
+++ b/eng/tools/oav-runner/src/runner.ts
@@ -190,7 +190,7 @@ export async function processFilesToSpecificationList(
           );
           try {
             const exampleSwaggers = await swaggerModel.getExamples();
-            const examples = exampleSwaggers.keys()
+            const examples = [...exampleSwaggers.keys()]
             cachedSwaggerSpecs.set(swaggerFile, examples);
           }
           catch (e) {

--- a/eng/tools/oav-runner/src/runner.ts
+++ b/eng/tools/oav-runner/src/runner.ts
@@ -13,12 +13,13 @@ import { ReportableOavError } from "./formatting.js";
 
 export async function checkExamples(
   rootDirectory: string,
+  fileList?: string[]
 ): Promise<[number, string[], ReportableOavError[]]> {
   let errors: ReportableOavError[] = [];
 
-  const changedFiles = await getChangedFiles({
-    cwd: rootDirectory,
-  });
+  const changedFiles = fileList?.length
+    ? fileList
+    : await getChangedFiles({ cwd: rootDirectory });
 
   const swaggerFiles = await processFilesToSpecificationList(
     rootDirectory,
@@ -67,12 +68,16 @@ export async function checkExamples(
 
 export async function checkSpecs(
   rootDirectory: string,
+  fileList?: string[]
 ): Promise<[number, string[], ReportableOavError[]]> {
   let errors: ReportableOavError[] = [];
 
-  const changedFiles = await getChangedFiles({
-    cwd: rootDirectory,
-  });
+  const changedFiles = fileList?.length
+    ? fileList
+    : await getChangedFiles({ cwd: rootDirectory });
+
+  console.log('oav-runner is checking the following changed files:');
+  changedFiles.forEach(file => console.log(`- ${file}`));
 
   const swaggerFiles = await processFilesToSpecificationList(
     rootDirectory,

--- a/eng/tools/oav-runner/src/runner.ts
+++ b/eng/tools/oav-runner/src/runner.ts
@@ -190,7 +190,7 @@ export async function processFilesToSpecificationList(
           );
           try {
             const exampleSwaggers = await swaggerModel.getExamples();
-            const examples = [...exampleSwaggers].map((e) => e[1].path);
+            const examples = exampleSwaggers.keys()
             cachedSwaggerSpecs.set(swaggerFile, examples);
           }
           catch (e) {

--- a/eng/tools/oav-runner/src/runner.ts
+++ b/eng/tools/oav-runner/src/runner.ts
@@ -11,12 +11,7 @@ import {
 } from "@azure-tools/specs-shared/changed-files"; //getChangedFiles,
 import { ReportableOavError } from "./formatting.js";
 
-export async function checkExamples(
-  rootDirectory: string,
-  fileList?: string[]
-): Promise<[number, string[], ReportableOavError[]]> {
-  let errors: ReportableOavError[] = [];
-
+export async function preCheckFiltering(rootDirectory: string, fileList?: string[]): Promise<string[]> {
   const changedFiles = fileList?.length
     ? fileList
     : await getChangedFiles({ cwd: rootDirectory });
@@ -25,6 +20,20 @@ export async function checkExamples(
     rootDirectory,
     changedFiles,
   );
+
+  console.log('oav-runner is checking the following specification rooted files:');
+  swaggerFiles.forEach(file => console.log(`- ${file}`));
+
+  return swaggerFiles;
+}
+
+export async function checkExamples(
+  rootDirectory: string,
+  fileList?: string[]
+): Promise<[number, string[], ReportableOavError[]]> {
+  let errors: ReportableOavError[] = [];
+
+  const swaggerFiles = await preCheckFiltering(rootDirectory, fileList);
 
   for (const swaggerFile of swaggerFiles) {
     try {
@@ -72,17 +81,7 @@ export async function checkSpecs(
 ): Promise<[number, string[], ReportableOavError[]]> {
   let errors: ReportableOavError[] = [];
 
-  const changedFiles = fileList?.length
-    ? fileList
-    : await getChangedFiles({ cwd: rootDirectory });
-
-  const swaggerFiles = await processFilesToSpecificationList(
-    rootDirectory,
-    changedFiles,
-  );
-
-  console.log('oav-runner is checking the following specification rooted files:');
-  swaggerFiles.forEach(file => console.log(`- ${file}`));
+  const swaggerFiles = await preCheckFiltering(rootDirectory, fileList);
 
   for (const swaggerFile of swaggerFiles) {
     try {


### PR DESCRIPTION
- [x] No longer run against files that don't start with `specification/`
- [x] Add new option at startup to pass a file that contains a _list_ of files that were changed. (This is for easy repro)
- [x] Output the list of changed files before starting to parse. To allow easier diagnosis.

