### PR TITLE
[Storage] Fix extraneous `?<BlobType>` in RequestURI TypeSpec Changes

### DIFF
--- a/specification/storage/Microsoft.BlobStorage/routes.tsp
+++ b/specification/storage/Microsoft.BlobStorage/routes.tsp
@@ -1388,7 +1388,7 @@ namespace Storage.Blob {
         #suppress "@azure-tools/typespec-azure-core/no-response-body" "Existing API"
         @put
         @sharedRoute
-        @route("{blobName}?PageBlob")
+        @route("{blobName}")
         op create is StorageOperationNoBody<
           {
             ...MetadataHeaders;
@@ -1729,7 +1729,7 @@ namespace Storage.Blob {
         #suppress "@azure-tools/typespec-azure-core/no-response-body" "Existing API"
         @put
         @sharedRoute
-        @route("{blobName}?AppendBlob")
+        @route("{blobName}")
         op create is StorageOperationNoBody<
           {
             ...MetadataHeaders;

--- a/specification/storage/Microsoft.BlobStorage/routes.tsp
+++ b/specification/storage/Microsoft.BlobStorage/routes.tsp
@@ -1903,7 +1903,7 @@ namespace Storage.Blob {
         #suppress "@azure-tools/typespec-azure-core/byos" "Existing API"
         @put
         @sharedRoute
-        @route("{blobName}?BlockBlob")
+        @route("{blobName}")
         op upload is StorageOperation<
           {
             ...MetadataHeaders;


### PR DESCRIPTION
This PR fixes extraneous information found in the RequestURI. Examples:

```xml
PUT http://ruststoragedev.blob.core.windows.net/containerksmy1voe/blob25jpbmjd?PageBlob
PUT https://ruststoragedev.blob.core.windows.net/containerilxvr34i/blob5ekapyoy?AppendBlob
"RequestUri": "https://Sanitized.blob.core.windows.net/container6bwl244t/blobnwl7kbkb?BlockBlob",
      "RequestMethod": "PUT",
```

Fixes issue 2 in https://github.com/Azure/typespec-rust/issues/444