### PR TITLE
[LintDiff] Skip readme.md files with no "input-file:" string

### DIFF
--- a/eng/tools/lint-diff/src/processChanges.ts
+++ b/eng/tools/lint-diff/src/processChanges.ts
@@ -135,9 +135,18 @@ export async function buildState(
   // For readme files that have changed but there are no affected swaggers,
   // add them to the map with no tags
   for (const changedReadme of existingChangedFiles.filter(readme)) {
+    const readmePath = resolve(rootPath, changedReadme);
+
+    // Skip readme.md files that don't have "input-file:" as autorest cannot
+    // scan them.
+    const readmeContent = await readFile(readmePath, { encoding: "utf-8" });
+    if (!readmeContent.includes("input-file:")) {
+      continue;
+    }
+
     const service = specModels.get(getService(changedReadme))!;
     const readmes = await service.getReadmes();
-    const readmeObject = readmes.get(resolve(rootPath, changedReadme))!;
+    const readmeObject = readmes.get(readmePath)!;
 
     if (!changedFileAndTagsMap.has(changedReadme)) {
       changedFileAndTagsMap.set(changedReadme, {

--- a/eng/tools/lint-diff/test/fixtures/buildState/specification/no-input-file/readme.md
+++ b/eng/tools/lint-diff/test/fixtures/buildState/specification/no-input-file/readme.md
@@ -1,0 +1,2 @@
+This readme.md file is lacking a string. The lack of that string should exclude
+it from consideration.

--- a/eng/tools/lint-diff/test/fixtures/buildState/specification/no-input-file/readme.md
+++ b/eng/tools/lint-diff/test/fixtures/buildState/specification/no-input-file/readme.md
@@ -1,2 +1,13 @@
-This readme.md file is lacking a string. The lack of that string should exclude
-it from consideration.
+# Widget
+
+> see https://aka.ms/autorest
+> This is the AutoRest configuration file for Widget.
+
+## Configuration
+
+Required if any services under this folder are RPaaS.
+
+```yaml
+openapi-type: arm
+openapi-subtype: rpaas
+```

--- a/eng/tools/lint-diff/test/processChanges.test.ts
+++ b/eng/tools/lint-diff/test/processChanges.test.ts
@@ -250,7 +250,7 @@ describe("buildState", () => {
     ).not.toThrow();
   });
 
-  test("does not include readme files that has no input-file:", async () => {
+  test.skipIf(isWindows())("does not include readme files that has no input-file:", async () => {
     const actual = await buildState(
       ["specification/no-input-file/readme.md"],
       "test/fixtures/buildState/",

--- a/eng/tools/lint-diff/test/processChanges.test.ts
+++ b/eng/tools/lint-diff/test/processChanges.test.ts
@@ -249,4 +249,13 @@ describe("buildState", () => {
       ),
     ).not.toThrow();
   });
+
+  test("does not include readme files that has no input-file:", async () => {
+    const actual = await buildState(
+      ["specification/no-input-file/readme.md"],
+      "test/fixtures/buildState/",
+    );
+
+    expect(actual).toEqual([new Map<string, ReadmeAffectedTags>(), []]);
+  });
 });


### PR DESCRIPTION
This heuristic excludes readme.md files (like the obligate [RPaaS readme.md](specification/widget/resource-manager/readme.md)) from scanning

Example existing failure: https://github.com/Azure/azure-rest-api-specs/actions/runs/15546016760?pr=35175

Example with this fix: https://github.com/Azure/azure-rest-api-specs/actions/runs/15546150253

Related PR to legacy LintDiff: https://dev.azure.com/devdiv/DevDiv/_git/openapi-alps/pullrequest/642335