### PR TITLE
Add resolution of repo root to `oav-runner`

### DIFF
--- a/eng/tools/oav-runner/src/cli.ts
+++ b/eng/tools/oav-runner/src/cli.ts
@@ -10,8 +10,22 @@ import {
 
 import { resolve } from "path";
 import { parseArgs, ParseArgsConfig } from "node:util";
-import { exit } from "node:process";
 import fs from "node:fs/promises";
+import { simpleGit } from "simple-git";
+
+export async function getRootFolder(inputPath: string): Promise<string> {
+  try {
+    const gitRoot = await simpleGit(inputPath).revparse("--show-toplevel");
+    return gitRoot.trim();
+  }
+  catch (error) {
+    console.error(
+      `Error: Unable to determine the root folder of the git repository.`,
+      `Please ensure you are running this command within a git repository OR providing a targeted directory that is within a git repo.`,
+    );
+    process.exit(1);
+  }
+}
 
 export async function main() {
   const config: ParseArgsConfig = {
@@ -37,6 +51,8 @@ export async function main() {
   // just need to resolve that here to make ts aware of it
   const targetDirectory = opts.targetDirectory as string;
 
+  const resolvedGitRoot = await getRootFolder(targetDirectory);
+
   let fileList: string[] | undefined = undefined;
   if (opts.fileList !== undefined) {
     const fileListPath = resolve(opts.fileList as string);
@@ -50,7 +66,7 @@ export async function main() {
       console.error(`Error reading file list from ${opts.fileList}: ${error instanceof Error ? error.message : String(error)}`);
       console.error('User provided file list that is not found.');
       console.error("Please ensure the file exists and is readable, or do not provide the option 'fileList'")
-      exit(1);
+      process.exit(1);
     }
   }
 
@@ -63,7 +79,7 @@ export async function main() {
   }
 
   console.log(
-    `Running oav-runner against ${runType} within ${targetDirectory}.`,
+    `Running oav-runner against ${runType} within ${resolvedGitRoot}.`,
   );
 
   let exitCode = 0;
@@ -73,11 +89,11 @@ export async function main() {
 
   if (runType === "specs") {
     [exitCode, scannedSwaggerFiles, errorList] =
-      await checkSpecs(targetDirectory, fileList);
+      await checkSpecs(resolvedGitRoot, fileList);
     reportName = "Swagger SemanticValidation";
   } else if (runType === "examples") {
     [exitCode, scannedSwaggerFiles, errorList] =
-      await checkExamples(targetDirectory, fileList);
+      await checkExamples(resolvedGitRoot, fileList);
     reportName = "Swagger ModelValidation";
   }
 

--- a/eng/tools/oav-runner/src/cli.ts
+++ b/eng/tools/oav-runner/src/cli.ts
@@ -16,7 +16,7 @@ import { simpleGit } from "simple-git";
 export async function getRootFolder(inputPath: string): Promise<string> {
   try {
     const gitRoot = await simpleGit(inputPath).revparse("--show-toplevel");
-    return gitRoot.trim();
+    return resolve(gitRoot.trim());
   }
   catch (error) {
     console.error(

--- a/eng/tools/oav-runner/test/cli.test.ts
+++ b/eng/tools/oav-runner/test/cli.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from "vitest";
+import { getRootFolder } from "../src/cli.js";
+import path from "path";
+
+const REPOROOT = path.resolve(__dirname, "..", "..", "..", "..");
+
+describe("invocation directory checks", () => {
+  it("Should return the same path when invoked from the root of a git repo.", async () => {
+    const result = await getRootFolder(REPOROOT);
+    expect(result).toBe(REPOROOT);
+  });
+
+  it("Should return a higher path when invoked from a path deep in a git repo.", async () => {
+    const result = await getRootFolder(path.join(REPOROOT, "eng", "tools", "oav-runner"));
+    expect(result).toBe(REPOROOT);
+  });
+
+  it("Should exit with error when invoked outside of a git directory.", async () => {
+    const pathOutsideRepo = path.resolve(path.join(REPOROOT, ".."));
+
+    const exitMock = vi
+      .spyOn(process, "exit")
+      .mockImplementation((code?: number) => {
+        throw new Error(`Exit ${code}`);
+      });
+
+    await expect(getRootFolder(pathOutsideRepo)).rejects.toThrow("Exit 1");
+
+    exitMock.mockRestore();
+  });
+});


### PR DESCRIPTION
Currently, one needs to implicitly be in the context of the root of the directory to allow the tool to properly locate changed swaggers. Let's add some resolution logic so that A) you have to run within a git directory and B) if you provide a deeper directory within the repo, we always resolve repo root.