### PR TITLE
Add Watch Jobs for `SemanticValidation` and `ModelValidation`

### DIFF
--- a/.github/workflows/watch-modelvalidation.yaml
+++ b/.github/workflows/watch-modelvalidation.yaml
@@ -1,0 +1,26 @@
+# Use ~ to sort the workflow to the bottom of the list
+name: "~Watch - Swagger ModelValidation"
+
+on:
+  # check_suite is preferred over check_run to avoid triggering on all check
+  # runs. In some cases, check_run must be used in testing environments.
+  check_suite:
+    types: completed
+
+  workflow_run:
+    types: completed
+    workflows:
+      - "\\[TEST-IGNORE\\] Swagger ModelValidation"
+
+permissions:
+  checks: read
+  contents: read
+
+jobs:
+  ModelValidationWatch:
+    name: Watch ModelValidation
+    uses: ./.github/workflows/_reusable-verify-run-status.yaml
+    with:
+      check_run_name: "Swagger ModelValidation"
+      workflow_name: "[TEST-IGNORE] Swagger ModelValidation"
+

--- a/.github/workflows/watch-semanticvalidation.yaml
+++ b/.github/workflows/watch-semanticvalidation.yaml
@@ -1,0 +1,25 @@
+# Use ~ to sort the workflow to the bottom of the list
+name: "~Watch - Swagger SemanticValidation"
+
+on:
+  # check_suite is preferred over check_run to avoid triggering on all check
+  # runs. In some cases, check_run must be used in testing environments.
+  check_suite:
+    types: completed
+
+  workflow_run:
+    types: completed
+    workflows:
+      - "\\[TEST-IGNORE\\] Swagger SemanticValidation"
+
+permissions:
+  checks: read
+  contents: read
+
+jobs:
+  SemanticValidationWatch:
+    name: Watch SemanticValidation
+    uses: ./.github/workflows/_reusable-verify-run-status.yaml
+    with:
+      check_run_name: "Swagger SemanticValidation"
+      workflow_name: "[TEST-IGNORE] Swagger SemanticValidation"


### PR DESCRIPTION
I originally combined these into a single workflow. When I did that, I maintained:

```
  workflow_run:
    types: completed
    workflows:
      - "\\[TEST-IGNORE\\] Swagger ModelValidation"
      - "\\[TEST-IGNORE\\] Swagger SemanticValidation"
```

But realized that would just result in this same workflow running twice and checking the difference in results for both `Swagger ModelValidation` and `Swagger SemanticValidation` on both. We'd be sacrificing wasted agent minutes for reducing the # of checks showing up on the PR by 1.