### PR TITLE
[Az.DataProtection] Added optional restore param for data protection blob workload

### DIFF
--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/dataprotection.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/dataprotection.json
@@ -1,0 +1,8562 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "2025-02-01",
+    "title": "DataProtectionBackupClient",
+    "x-ms-code-generation-settings": {
+      "internalConstructors": false
+    }
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.DataProtection/backupVaults": {
+      "get": {
+        "tags": [
+          "BackupVaults"
+        ],
+        "description": "Returns resource collection belonging to a subscription.",
+        "operationId": "BackupVaults_GetInSubscription",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/BackupVaultResourceList"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "Get BackupVaults in Subscription": {
+            "$ref": "./examples/VaultCRUD/GetBackupVaultsInSubscription.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.DataProtection/locations/{location}/operationResults/{operationId}": {
+      "get": {
+        "tags": [
+          "GetOperationResult"
+        ],
+        "description": "Gets the operation result for a resource",
+        "operationId": "OperationResult_Get",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "operationId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "location",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Accepted",
+            "headers": {
+              "Location": {
+                "description": "The URL of the resource used to check the status of the asynchronous operation.",
+                "type": "string"
+              },
+              "Azure-AsyncOperation": {
+                "description": "The URL of the resource used to check the status of the asynchronous operation.",
+                "type": "string"
+              },
+              "Retry-After": {
+                "description": "Suggested delay to check the status of the asynchronous operation. The value is an integer that represents the seconds.",
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          "200": {
+            "description": "Contains additional information like job Id",
+            "schema": {
+              "$ref": "#/definitions/OperationJobExtendedInfo"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "summary": "Gets the operation status for a resource.",
+        "x-ms-examples": {
+          "Get OperationResult": {
+            "$ref": "./examples/GetOperationResult.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.DataProtection/locations/{location}/operationStatus/{operationId}": {
+      "get": {
+        "tags": [
+          "OperationStatus"
+        ],
+        "summary": "Gets the operation status for a resource.",
+        "operationId": "OperationStatus_Get",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "location",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "operationId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OperationResource"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get OperationStatus": {
+            "$ref": "./examples/GetOperationStatus.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/operationStatus/{operationId}": {
+      "get": {
+        "tags": [
+          "OperationStatus"
+        ],
+        "summary": "Gets the operation status for an operation over a BackupVault's context.",
+        "operationId": "OperationStatusBackupVaultContext_Get",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          },
+          {
+            "name": "operationId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OperationResource"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get OperationStatus": {
+            "$ref": "./examples/GetOperationStatusVaultContext.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/operationStatus/{operationId}": {
+      "get": {
+        "tags": [
+          "OperationStatus"
+        ],
+        "summary": "Gets the operation status for an operation over a ResourceGroup's context.",
+        "operationId": "OperationStatusResourceGroupContext_Get",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "operationId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OperationResource"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get OperationStatus": {
+            "$ref": "./examples/GetOperationStatusRGContext.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults": {
+      "get": {
+        "tags": [
+          "BackupVaults"
+        ],
+        "description": "Returns resource collection belonging to a resource group.",
+        "operationId": "BackupVaults_GetInResourceGroup",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/BackupVaultResourceList"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "Get BackupVaults in ResourceGroup": {
+            "$ref": "./examples/VaultCRUD/GetBackupVaultsInResourceGroup.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}": {
+      "get": {
+        "tags": [
+          "BackupVaults"
+        ],
+        "description": "Returns a resource belonging to a resource group.",
+        "operationId": "BackupVaults_Get",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/BackupVaultResource"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get BackupVault": {
+            "$ref": "./examples/VaultCRUD/GetBackupVault.json"
+          },
+          "Get BackupVault With MSI": {
+            "$ref": "./examples/VaultCRUD/GetBackupVaultWithMSI.json"
+          },
+          "Get BackupVault With CMK": {
+            "$ref": "./examples/VaultCRUD/GetBackupVaultWithCMK.json"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "BackupVaults"
+        ],
+        "description": "Creates or updates a BackupVault resource belonging to a resource group.",
+        "operationId": "BackupVaults_CreateOrUpdate",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Request body for operation",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/BackupVaultResource"
+            }
+          },
+          {
+            "name": "x-ms-authorization-auxiliary",
+            "in": "header",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/BackupVaultResource"
+            }
+          },
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/BackupVaultResource"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create BackupVault": {
+            "$ref": "./examples/VaultCRUD/PutBackupVault.json"
+          },
+          "Create BackupVault With MSI": {
+            "$ref": "./examples/VaultCRUD/PutBackupVaultWithMSI.json"
+          },
+          "Create BackupVault With CMK": {
+            "$ref": "./examples/VaultCRUD/PutBackupVaultWithCMK.json"
+          }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "tags": [
+          "BackupVaults"
+        ],
+        "description": "Deletes a BackupVault resource from the resource group.",
+        "operationId": "BackupVaults_Delete",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "202": {
+            "description": "Accepted"
+          },
+          "204": {
+            "description": "NoContent"
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete BackupVault": {
+            "$ref": "./examples/VaultCRUD/DeleteBackupVault.json"
+          }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "tags": [
+          "BackupVaults"
+        ],
+        "description": "Updates a BackupVault resource belonging to a resource group. For example, updating tags for a resource.",
+        "operationId": "BackupVaults_Update",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Request body for operation",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PatchResourceRequestInput"
+            }
+          },
+          {
+            "name": "x-ms-authorization-auxiliary",
+            "in": "header",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/BackupVaultResource"
+            }
+          },
+          "202": {
+            "description": "Accepted"
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-examples": {
+          "Patch BackupVault": {
+            "$ref": "./examples/VaultCRUD/PatchBackupVault.json"
+          },
+          "Patch BackupVault with CMK": {
+            "$ref": "./examples/VaultCRUD/PatchBackupVaultWithCMK.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/operationResults/{operationId}": {
+      "get": {
+        "tags": [
+          "Resources"
+        ],
+        "operationId": "BackupVaultOperationResults_Get",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          },
+          {
+            "name": "operationId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/BackupVaultResource"
+            }
+          },
+          "202": {
+            "description": "Accepted",
+            "headers": {
+              "Location": {
+                "description": "The URL of the resource used to check the status of the asynchronous operation.",
+                "type": "string"
+              },
+              "Azure-AsyncOperation": {
+                "description": "The URL of the resource used to check the status of the asynchronous operation.",
+                "type": "string"
+              },
+              "Retry-After": {
+                "description": "Suggested delay to check the status of the asynchronous operation. The value is an integer that represents the seconds.",
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetOperationResult Patch": {
+            "$ref": "./examples/VaultCRUD/GetOperationResultPatch.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/locations/{location}/checkNameAvailability": {
+      "post": {
+        "tags": [
+          "BackupVaults"
+        ],
+        "summary": "API to check for resource name availability",
+        "operationId": "BackupVaults_CheckNameAvailability",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "location",
+            "in": "path",
+            "description": "The location in which uniqueness will be verified.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Check name availability request",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CheckNameAvailabilityRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/CheckNameAvailabilityResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Check BackupVaults name availability": {
+            "$ref": "./examples/VaultCRUD/CheckBackupVaultsNameAvailability.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.DataProtection/locations/{location}/checkFeatureSupport": {
+      "post": {
+        "tags": [
+          "DppFeatureSupport"
+        ],
+        "summary": "Validates if a feature is supported",
+        "operationId": "DataProtection_CheckFeatureSupport",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "location",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Feature support request object",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FeatureValidationRequestBase"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/FeatureValidationResponseBase"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Check Azure Vm Backup Feature Support": {
+            "$ref": "./examples/CheckfeatureSupport.json"
+          }
+        }
+      }
+    },
+    "/providers/Microsoft.DataProtection/operations": {
+      "get": {
+        "tags": [
+          "Operations"
+        ],
+        "description": "Returns the list of available operations.",
+        "operationId": "DataProtectionOperations_List",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ClientDiscoveryResponse"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink",
+          "itemName": "value"
+        },
+        "x-ms-examples": {
+          "Returns the list of supported REST operations.": {
+            "$ref": "./examples/Operations/List.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/backupPolicies": {
+      "get": {
+        "tags": [
+          "BackupPolicies"
+        ],
+        "description": "Returns list of backup policies belonging to a backup vault",
+        "operationId": "BackupPolicies_List",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/BaseBackupPolicyResourceList"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "List BackupPolicy": {
+            "$ref": "./examples/PolicyCRUD/ListBackupPolicy.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/backupPolicies/{backupPolicyName}": {
+      "get": {
+        "tags": [
+          "BackupPolicies"
+        ],
+        "operationId": "BackupPolicies_Get",
+        "description": "Gets a backup policy belonging to a backup vault",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          },
+          {
+            "name": "backupPolicyName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/BaseBackupPolicyResource"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "summary": "Gets a backup policy belonging to a backup vault",
+        "x-ms-examples": {
+          "Get BackupPolicy": {
+            "$ref": "./examples/PolicyCRUD/GetBackupPolicy.json"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "BackupPolicies"
+        ],
+        "operationId": "BackupPolicies_CreateOrUpdate",
+        "summary": "Creates or Updates a backup policy belonging to a backup vault",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          },
+          {
+            "name": "backupPolicyName",
+            "description": "Name of the policy",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Request body for operation",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/BaseBackupPolicyResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/BaseBackupPolicyResource"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "CreateOrUpdate BackupPolicy": {
+            "$ref": "./examples/PolicyCRUD/CreateOrUpdateBackupPolicy.json"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "BackupPolicies"
+        ],
+        "operationId": "BackupPolicies_Delete",
+        "summary": "Deletes a backup policy belonging to a backup vault",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          },
+          {
+            "name": "backupPolicyName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "204": {
+            "description": "NoContent"
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete BackupPolicy": {
+            "$ref": "./examples/PolicyCRUD/DeleteBackupPolicy.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/backupInstances": {
+      "get": {
+        "tags": [
+          "BackupInstances"
+        ],
+        "description": "Gets a backup instances belonging to a backup vault",
+        "operationId": "BackupInstances_List",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/BackupInstanceResourceList"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "List BackupInstances in a Vault": {
+            "$ref": "./examples/BackupInstanceOperations/ListBackupInstances.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/backupInstances/{backupInstanceName}": {
+      "get": {
+        "tags": [
+          "BackupInstances"
+        ],
+        "description": "Gets a backup instance with name in a backup vault",
+        "operationId": "BackupInstances_Get",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          },
+          {
+            "$ref": "#/parameters/BackupInstanceName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/BackupInstanceResource"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get BackupInstance": {
+            "$ref": "./examples/BackupInstanceOperations/GetBackupInstance.json"
+          },
+          "Get BackupInstance for ADLS Blob": {
+            "$ref": "./examples/BackupInstanceOperations/GetBackupInstance_ADLSBlobBackupDatasourceParameters.json"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "BackupInstances"
+        ],
+        "description": "Create or update a backup instance in a backup vault",
+        "operationId": "BackupInstances_CreateOrUpdate",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          },
+          {
+            "$ref": "#/parameters/BackupInstanceName"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Request body for operation",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/BackupInstanceResource"
+            }
+          },
+          {
+            "name": "x-ms-authorization-auxiliary",
+            "in": "header",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/BackupInstanceResource"
+            }
+          },
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/BackupInstanceResource"
+            }
+          },
+          "202": {
+            "description": "Accepted",
+            "headers": {
+              "Location": {
+                "description": "The URL of the resource used to check the status of the asynchronous operation.",
+                "type": "string"
+              },
+              "Azure-AsyncOperation": {
+                "description": "The URL of the resource used to check the status of the asynchronous operation.",
+                "type": "string"
+              }
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create BackupInstance": {
+            "$ref": "./examples/BackupInstanceOperations/PutBackupInstance.json"
+          },
+          "Create BackupInstance to perform critical operation With MUA": {
+            "$ref": "./examples/BackupInstanceOperations/PutBackupInstance_ResourceGuardEnabled.json"
+          },
+          "Create BackupInstance With KubernetesClusterBackupDatasourceParameters": {
+            "$ref": "./examples/BackupInstanceOperations/PutBackupInstance_KubernetesClusterBackupDatasourceParameters.json"
+          },
+          "Create BackupInstance With ADLSBlobBackupDatasourceParameters": {
+            "$ref": "./examples/BackupInstanceOperations/PutBackupInstance_ADLSBlobBackupDatasourceParameters.json"
+          }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "tags": [
+          "BackupInstances"
+        ],
+        "description": "Delete a backup instance in a backup vault",
+        "operationId": "BackupInstances_Delete",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          },
+          {
+            "$ref": "#/parameters/BackupInstanceName"
+          },
+          {
+            "name": "x-ms-authorization-auxiliary",
+            "in": "header",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "The operation will be completed asynchronously.",
+            "headers": {
+              "Location": {
+                "description": "The URL of the resource used to check the status of the asynchronous operation.",
+                "type": "string"
+              },
+              "Azure-AsyncOperation": {
+                "description": "The URL of the resource used to check the status of the asynchronous operation.",
+                "type": "string"
+              },
+              "Retry-After": {
+                "description": "Suggested delay to check the status of the asynchronous operation. The value is an integer that represents the seconds.",
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          "204": {
+            "description": "NoContent"
+          },
+          "200": {
+            "description": "Ok"
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete BackupInstance": {
+            "$ref": "./examples/BackupInstanceOperations/DeleteBackupInstance.json"
+          }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/backupInstances/{backupInstanceName}/backup": {
+      "post": {
+        "tags": [
+          "BackupInstances"
+        ],
+        "description": "Trigger adhoc backup ",
+        "operationId": "BackupInstances_AdhocBackup",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          },
+          {
+            "$ref": "#/parameters/BackupInstanceName"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Request body for operation",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/TriggerBackupRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Contains additional information like job Id",
+            "schema": {
+              "$ref": "#/definitions/OperationJobExtendedInfo"
+            }
+          },
+          "202": {
+            "description": "The operation will be completed asynchronously.",
+            "headers": {
+              "Location": {
+                "description": "The URL of the resource used to check the status of the asynchronous operation.",
+                "type": "string"
+              },
+              "Azure-AsyncOperation": {
+                "description": "The URL of the resource used to check the status of the asynchronous operation.",
+                "type": "string"
+              },
+              "Retry-After": {
+                "description": "Suggested delay to check the status of the asynchronous operation. The value is an integer that represents the seconds.",
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Trigger Adhoc Backup": {
+            "$ref": "./examples/BackupInstanceOperations/TriggerBackup.json"
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/validateForBackup": {
+      "post": {
+        "tags": [
+          "BackupInstances"
+        ],
+        "description": "Validate whether adhoc backup will be successful or not",
+        "operationId": "BackupInstances_ValidateForBackup",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Request body for operation",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ValidateForBackupRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Contains additional information like job Id and Operation Job Extended Info of the asynchronous operation to track the status.",
+            "schema": {
+              "$ref": "#/definitions/OperationJobExtendedInfo"
+            }
+          },
+          "202": {
+            "description": "The operation will be completed asynchronously.",
+            "headers": {
+              "Location": {
+                "description": "The URL of the resource used to check the status of the asynchronous operation.",
+                "type": "string"
+              },
+              "Azure-AsyncOperation": {
+                "description": "The URL of the resource used to check the status of the asynchronous operation.",
+                "type": "string"
+              },
+              "Retry-After": {
+                "description": "Suggested delay to check the status of the asynchronous operation. The value is an integer that represents the seconds.",
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Validate For Backup": {
+            "$ref": "./examples/BackupInstanceOperations/ValidateForBackup.json"
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/backupInstances/{backupInstanceName}/validateForModifyBackup": {
+      "post": {
+        "tags": [
+          "BackupInstances"
+        ],
+        "description": "Validate whether update for backup instance will be successful or not",
+        "operationId": "BackupInstances_ValidateForModifyBackup",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/RestrictedVaultName"
+          },
+          {
+            "$ref": "#/parameters/BackupInstanceName"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Request body for operation",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ValidateForModifyBackupRequest"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "The operation will be completed asynchronously.",
+            "headers": {
+              "Location": {
+                "description": "The URL of the resource used to check the status of the asynchronous operation.",
+                "type": "string"
+              },
+              "Azure-AsyncOperation": {
+                "description": "The URL of the resource used to check the status of the asynchronous operation.",
+                "type": "string"
+              },
+              "Retry-After": {
+                "description": "Suggested delay to check the status of the asynchronous operation. The value is an integer that represents the seconds.",
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Validate For Modify Backup": {
+            "$ref": "./examples/BackupInstanceOperations/ValidateForModifyBackup.json"
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/OperationJobExtendedInfo"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/backupInstances/{backupInstanceName}/operationResults/{operationId}": {
+      "get": {
+        "tags": [
+          "BackupInstances"
+        ],
+        "description": "Get result of backup instance creation operation",
+        "operationId": "BackupInstances_GetBackupInstanceOperationResult",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          },
+          {
+            "$ref": "#/parameters/BackupInstanceName"
+          },
+          {
+            "name": "operationId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/BackupInstanceResource"
+            }
+          },
+          "202": {
+            "description": "Accepted"
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get BackupInstanceOperationResult": {
+            "$ref": "./examples/BackupInstanceOperations/GetBackupInstanceOperationResult.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/backupInstances/{backupInstanceName}/recoveryPoints": {
+      "get": {
+        "tags": [
+          "RecoveryPoint"
+        ],
+        "description": "Returns a list of Recovery Points for a DataSource in a vault.",
+        "operationId": "RecoveryPoints_List",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          },
+          {
+            "$ref": "#/parameters/BackupInstanceName"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "OData filter options.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "skipToken Filter.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/AzureBackupRecoveryPointResourceList"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-odata": "#/definitions/RecoveryPointsFilters",
+        "x-ms-examples": {
+          "List Recovery Points in a Vault": {
+            "$ref": "./examples/BackupInstanceOperations/ListRecoveryPoints.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/backupInstances/{backupInstanceName}/recoveryPoints/{recoveryPointId}": {
+      "get": {
+        "tags": [
+          "RecoveryPoint"
+        ],
+        "description": "Gets a Recovery Point using recoveryPointId for a Datasource.",
+        "operationId": "RecoveryPoints_Get",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          },
+          {
+            "$ref": "#/parameters/BackupInstanceName"
+          },
+          {
+            "name": "recoveryPointId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/AzureBackupRecoveryPointResource"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Recovery Point": {
+            "$ref": "./examples/BackupInstanceOperations/GetRecoveryPoint.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/locations/{location}/fetchSecondaryRecoveryPoints": {
+      "post": {
+        "tags": [
+          "FetchSecondaryRecoveryPoints"
+        ],
+        "description": "Returns a list of Secondary Recovery Points for a DataSource in a vault, that can be used for Cross Region Restore.",
+        "operationId": "FetchSecondaryRecoveryPoints_List",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Request body for operation",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FetchSecondaryRPsRequestParameters"
+            }
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "OData filter options.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "skipToken Filter.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/AzureBackupRecoveryPointResourceList"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-odata": "#/definitions/RecoveryPointsFilters",
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "Fetch SecondaryRPs": {
+            "$ref": "./examples/CrossRegionRestore/FetchSecondaryRPs.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/locations/{location}/crossRegionRestore": {
+      "post": {
+        "tags": [
+          "BackupInstances"
+        ],
+        "description": "Triggers Cross Region Restore for BackupInstance.",
+        "operationId": "BackupInstances_TriggerCrossRegionRestore",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Request body for trigger CRR operation",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CrossRegionRestoreRequestObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Contains additional information like job Id",
+            "schema": {
+              "$ref": "#/definitions/OperationJobExtendedInfo"
+            }
+          },
+          "202": {
+            "description": "The operation will be completed asynchronously.",
+            "headers": {
+              "Location": {
+                "description": "The URL of the resource used to check the status of the asynchronous operation.",
+                "type": "string"
+              },
+              "Azure-AsyncOperation": {
+                "description": "The URL of the resource used to check the status of the asynchronous operation.",
+                "type": "string"
+              },
+              "Retry-After": {
+                "description": "Suggested delay to check the status of the asynchronous operation. The value is an integer that represents the seconds.",
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-examples": {
+          "Trigger Cross Region Restore": {
+            "$ref": "./examples/CrossRegionRestore/TriggerCrossRegionRestore.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/locations/{location}/validateCrossRegionRestore": {
+      "post": {
+        "tags": [
+          "BackupInstances"
+        ],
+        "description": "Validates whether Cross Region Restore can be triggered for DataSource.",
+        "operationId": "BackupInstances_ValidateCrossRegionRestore",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Request body for operation",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ValidateCrossRegionRestoreRequestObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Contains additional information like job Id",
+            "schema": {
+              "$ref": "#/definitions/OperationJobExtendedInfo"
+            }
+          },
+          "202": {
+            "description": "The operation will be completed asynchronously.",
+            "headers": {
+              "Location": {
+                "description": "The URL of the resource used to check the status of the asynchronous operation.",
+                "type": "string"
+              },
+              "Azure-AsyncOperation": {
+                "description": "The URL of the resource used to check the status of the asynchronous operation.",
+                "type": "string"
+              },
+              "Retry-After": {
+                "description": "Suggested delay to check the status of the asynchronous operation. The value is an integer that represents the seconds.",
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-examples": {
+          "Validate Cross Region Restore": {
+            "$ref": "./examples/CrossRegionRestore/ValidateCrossRegionRestore.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/locations/{location}/fetchCrossRegionRestoreJob": {
+      "post": {
+        "tags": [
+          "DppJob"
+        ],
+        "description": "Fetches the Cross Region Restore Job",
+        "operationId": "FetchCrossRegionRestoreJob_Get",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Request body for operation",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CrossRegionRestoreJobRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Details about a Cross Region Restore Job",
+            "schema": {
+              "$ref": "#/definitions/AzureBackupJobResource"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Cross Region Restore Job": {
+            "$ref": "./examples/CrossRegionRestore/FetchCrossRegionRestoreJob.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/locations/{location}/fetchCrossRegionRestoreJobs": {
+      "post": {
+        "tags": [
+          "DppJob"
+        ],
+        "description": "Fetches list of Cross Region Restore job belonging to the vault",
+        "operationId": "FetchCrossRegionRestoreJobs_List",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "OData filter options.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Request body for operation",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CrossRegionRestoreJobsRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of Cross Region Restore Jobs",
+            "schema": {
+              "$ref": "#/definitions/AzureBackupJobResourceList"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "List Cross Region Restore Jobs": {
+            "$ref": "./examples/CrossRegionRestore/FetchCrossRegionRestoreJobs.json"
+          }
+        }
+      }
+    },
+    "/{resourceId}/providers/Microsoft.DataProtection/backupInstances": {
+      "get": {
+        "tags": [
+          "BackupInstancesExtensionRouting"
+        ],
+        "description": "Gets a list of backup instances associated with a tracked resource",
+        "operationId": "BackupInstancesExtensionRouting_List",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/BackupInstanceResourceList"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "List BackupInstances associated with an azure resource": {
+            "$ref": "./examples/BackupInstanceOperations/ListBackupInstancesExtensionRouting.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/backupInstances/{backupInstanceName}/rehydrate": {
+      "post": {
+        "description": "rehydrate recovery point for restore for a BackupInstance",
+        "operationId": "BackupInstances_TriggerRehydrate",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          },
+          {
+            "description": "Request body for operation",
+            "in": "body",
+            "name": "parameters",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AzureBackupRehydrationRequest"
+            }
+          },
+          {
+            "$ref": "#/parameters/BackupInstanceName"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "202": {
+            "description": "The operation will be completed asynchronously.",
+            "headers": {
+              "Location": {
+                "description": "The URL of the resource used to check the status of the asynchronous operation.",
+                "type": "string"
+              },
+              "Azure-AsyncOperation": {
+                "description": "The URL of the resource used to check the status of the asynchronous operation.",
+                "type": "string"
+              },
+              "Retry-After": {
+                "description": "Suggested delay to check the status of the asynchronous operation. The value is an integer that represents the seconds.",
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          "204": {
+            "description": "NoContent"
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "tags": [
+          "BackupInstances"
+        ],
+        "x-ms-examples": {
+          "Trigger Rehydrate": {
+            "$ref": "./examples/BackupInstanceOperations/TriggerRehydrate.json"
+          }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/backupInstances/{backupInstanceName}/restore": {
+      "post": {
+        "tags": [
+          "BackupInstances"
+        ],
+        "description": "Triggers restore for a BackupInstance",
+        "operationId": "BackupInstances_TriggerRestore",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          },
+          {
+            "$ref": "#/parameters/BackupInstanceName"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Request body for operation",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AzureBackupRestoreRequest"
+            }
+          },
+          {
+            "name": "x-ms-authorization-auxiliary",
+            "in": "header",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Contains additional information like job Id",
+            "schema": {
+              "$ref": "#/definitions/OperationJobExtendedInfo"
+            }
+          },
+          "202": {
+            "description": "The operation will be completed asynchronously.",
+            "headers": {
+              "Location": {
+                "description": "The URL of the resource used to check the status of the asynchronous operation.",
+                "type": "string"
+              },
+              "Azure-AsyncOperation": {
+                "description": "The URL of the resource used to check the status of the asynchronous operation.",
+                "type": "string"
+              },
+              "Retry-After": {
+                "description": "Suggested delay to check the status of the asynchronous operation. The value is an integer that represents the seconds.",
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-examples": {
+          "Trigger Restore": {
+            "$ref": "./examples/BackupInstanceOperations/TriggerRestore.json"
+          },
+          "Trigger Restore As Files": {
+            "$ref": "./examples/BackupInstanceOperations/TriggerRestoreAsFiles.json"
+          },
+          "Trigger Restore With Rehydration": {
+            "$ref": "./examples/BackupInstanceOperations/TriggerRestoreWithRehydration.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/backupInstances/{backupInstanceName}/resumeBackups": {
+      "post": {
+        "tags": [
+          "BackupInstances"
+        ],
+        "description": "This operation will resume backups for backup instance",
+        "operationId": "BackupInstances_ResumeBackups",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          },
+          {
+            "$ref": "#/parameters/BackupInstanceName"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "202": {
+            "description": "The operation will be completed asynchronously.",
+            "headers": {
+              "Location": {
+                "description": "The URL of the resource used to check the status of the asynchronous operation.",
+                "type": "string"
+              },
+              "Azure-AsyncOperation": {
+                "description": "The URL of the resource used to check the status of the asynchronous operation.",
+                "type": "string"
+              },
+              "Retry-After": {
+                "description": "Suggested delay to check the status of the asynchronous operation. The value is an integer that represents the seconds.",
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-examples": {
+          "ResumeBackups": {
+            "$ref": "./examples/BackupInstanceOperations/ResumeBackups.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/backupInstances/{backupInstanceName}/resumeProtection": {
+      "post": {
+        "tags": [
+          "BackupInstances"
+        ],
+        "description": "This operation will resume protection for a stopped backup instance",
+        "operationId": "BackupInstances_ResumeProtection",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          },
+          {
+            "$ref": "#/parameters/BackupInstanceName"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "202": {
+            "description": "The operation will be completed asynchronously.",
+            "headers": {
+              "Location": {
+                "description": "The URL of the resource used to check the status of the asynchronous operation.",
+                "type": "string"
+              },
+              "Azure-AsyncOperation": {
+                "description": "The URL of the resource used to check the status of the asynchronous operation.",
+                "type": "string"
+              },
+              "Retry-After": {
+                "description": "Suggested delay to check the status of the asynchronous operation. The value is an integer that represents the seconds.",
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-examples": {
+          "ResumeProtection": {
+            "$ref": "./examples/BackupInstanceOperations/ResumeProtection.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/backupInstances/{backupInstanceName}/stopProtection": {
+      "post": {
+        "tags": [
+          "BackupInstances"
+        ],
+        "description": "This operation will stop protection of a backup instance and data will be held forever",
+        "operationId": "BackupInstances_StopProtection",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          },
+          {
+            "$ref": "#/parameters/BackupInstanceName"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Request body for operation",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/StopProtectionRequest"
+            }
+          },
+          {
+            "name": "x-ms-authorization-auxiliary",
+            "in": "header",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "202": {
+            "description": "The operation will be completed asynchronously.",
+            "headers": {
+              "Location": {
+                "description": "The URL of the resource used to check the status of the asynchronous operation.",
+                "type": "string"
+              },
+              "Azure-AsyncOperation": {
+                "description": "The URL of the resource used to check the status of the asynchronous operation.",
+                "type": "string"
+              },
+              "Retry-After": {
+                "description": "Suggested delay to check the status of the asynchronous operation. The value is an integer that represents the seconds.",
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-examples": {
+          "StopProtection": {
+            "$ref": "./examples/BackupInstanceOperations/StopProtection.json"
+          },
+          "StopProtection with MUA": {
+            "$ref": "./examples/BackupInstanceOperations/StopProtection_ResourceGuardEnabled.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/backupInstances/{backupInstanceName}/suspendBackups": {
+      "post": {
+        "tags": [
+          "BackupInstances"
+        ],
+        "description": "This operation will stop backup for a backup instance and retains the backup data as per the policy (except latest Recovery point, which will be retained forever)",
+        "operationId": "BackupInstances_SuspendBackups",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          },
+          {
+            "$ref": "#/parameters/BackupInstanceName"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Request body for operation",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/SuspendBackupRequest"
+            }
+          },
+          {
+            "name": "x-ms-authorization-auxiliary",
+            "in": "header",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "202": {
+            "description": "The operation will be completed asynchronously.",
+            "headers": {
+              "Location": {
+                "description": "The URL of the resource used to check the status of the asynchronous operation.",
+                "type": "string"
+              },
+              "Azure-AsyncOperation": {
+                "description": "The URL of the resource used to check the status of the asynchronous operation.",
+                "type": "string"
+              },
+              "Retry-After": {
+                "description": "Suggested delay to check the status of the asynchronous operation. The value is an integer that represents the seconds.",
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-examples": {
+          "SuspendBackups": {
+            "$ref": "./examples/BackupInstanceOperations/SuspendBackups.json"
+          },
+          "SuspendBackups with MUA": {
+            "$ref": "./examples/BackupInstanceOperations/SuspendBackup_ResourceGuardEnabled.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/backupInstances/{backupInstanceName}/sync": {
+      "post": {
+        "tags": [
+          "BackupInstances"
+        ],
+        "description": "Sync backup instance again in case of failure\r\nThis action will retry last failed operation and will bring backup instance to valid state",
+        "operationId": "BackupInstances_SyncBackupInstance",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          },
+          {
+            "$ref": "#/parameters/BackupInstanceName"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Request body for operation",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SyncBackupInstanceRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "202": {
+            "description": "The operation will be completed asynchronously.",
+            "headers": {
+              "Location": {
+                "description": "The URL of the resource used to check the status of the asynchronous operation.",
+                "type": "string"
+              },
+              "Azure-AsyncOperation": {
+                "description": "The URL of the resource used to check the status of the asynchronous operation.",
+                "type": "string"
+              },
+              "Retry-After": {
+                "description": "Suggested delay to check the status of the asynchronous operation. The value is an integer that represents the seconds.",
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-examples": {
+          "Sync BackupInstance": {
+            "$ref": "./examples/BackupInstanceOperations/SyncBackupInstance.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/backupInstances/{backupInstanceName}/validateRestore": {
+      "post": {
+        "tags": [
+          "BackupInstances"
+        ],
+        "description": "Validates if Restore can be triggered for a DataSource",
+        "operationId": "BackupInstances_ValidateForRestore",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          },
+          {
+            "$ref": "#/parameters/BackupInstanceName"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Request body for operation",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ValidateRestoreRequestObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Contains additional information like job Id",
+            "schema": {
+              "$ref": "#/definitions/OperationJobExtendedInfo"
+            }
+          },
+          "202": {
+            "description": "The operation will be completed asynchronously.",
+            "headers": {
+              "Location": {
+                "description": "The URL of the resource used to check the status of the asynchronous operation.",
+                "type": "string"
+              },
+              "Azure-AsyncOperation": {
+                "description": "The URL of the resource used to check the status of the asynchronous operation.",
+                "type": "string"
+              },
+              "Retry-After": {
+                "description": "Suggested delay to check the status of the asynchronous operation. The value is an integer that represents the seconds.",
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-examples": {
+          "Validate Restore": {
+            "$ref": "./examples/BackupInstanceOperations/ValidateRestore.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/backupJobs": {
+      "get": {
+        "tags": [
+          "AzureBackupJobs"
+        ],
+        "description": "Returns list of jobs belonging to a backup vault",
+        "operationId": "Jobs_List",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/AzureBackupJobResourceList"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "Get Jobs": {
+            "$ref": "./examples/JobCRUD/ListJobs.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/backupInstances/{backupInstanceName}/findRestorableTimeRanges": {
+      "post": {
+        "tags": [
+          "FindRestorableTimeRanges"
+        ],
+        "operationId": "RestorableTimeRanges_Find",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          },
+          {
+            "$ref": "#/parameters/BackupInstanceName"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Request body for operation",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AzureBackupFindRestorableTimeRangesRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/AzureBackupFindRestorableTimeRangesResponseResource"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Find Restorable Time Ranges": {
+            "$ref": "./examples/BackupInstanceOperations/FindRestorableTimeRanges.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/backupJobs/{jobId}": {
+      "get": {
+        "tags": [
+          "AzureBackupJob"
+        ],
+        "description": "Gets a job with id in a backup vault",
+        "operationId": "Jobs_Get",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          },
+          {
+            "name": "jobId",
+            "description": "The Job ID. This is a GUID-formatted string (e.g. 00000000-0000-0000-0000-000000000000).",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/AzureBackupJobResource"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Job": {
+            "$ref": "./examples/JobCRUD/GetJob.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/exportBackupJobs": {
+      "post": {
+        "tags": [
+          "AzureBackupJob"
+        ],
+        "description": "Triggers export of jobs and returns an OperationID to track.",
+        "operationId": "ExportJobs_Trigger",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Accepted",
+            "headers": {
+              "Location": {
+                "description": "The URL of the resource used to check the status of the asynchronous operation.",
+                "type": "string"
+              },
+              "Retry-After": {
+                "description": "Suggested delay to check the status of the asynchronous operation. The value is an integer that represents the seconds.",
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          "204": {
+            "description": "NoContent"
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-examples": {
+          "Trigger Export Jobs": {
+            "$ref": "./examples/JobCRUD/TriggerExportJobs.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/backupJobs/operations/{operationId}": {
+      "get": {
+        "tags": [
+          "AzureBackupJob"
+        ],
+        "description": "Gets the operation result of operation triggered by Export Jobs API. If the operation is successful, then it also contains URL of a Blob and a SAS key to access the same. The blob contains exported jobs in JSON serialized format.",
+        "operationId": "ExportJobsOperationResult_Get",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          },
+          {
+            "name": "operationId",
+            "description": "OperationID which represents the export job.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ExportJobsResult"
+            }
+          },
+          "202": {
+            "description": "Accepted"
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Export Jobs Operation Result": {
+            "$ref": "./examples/JobCRUD/GetExportJobsOperationResult.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/deletedBackupInstances": {
+      "get": {
+        "tags": [
+          "DeletedBackupInstances"
+        ],
+        "description": "Gets deleted backup instances belonging to a backup vault",
+        "operationId": "DeletedBackupInstances_List",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/DeletedBackupInstanceResourceList"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "List DeletedBackupInstances in a Vault": {
+            "$ref": "./examples/DeletedBackupInstanceOperations/ListDeletedBackupInstances.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/deletedBackupInstances/{backupInstanceName}": {
+      "get": {
+        "tags": [
+          "DeletedBackupInstances"
+        ],
+        "description": "Gets a deleted backup instance with name in a backup vault",
+        "operationId": "DeletedBackupInstances_Get",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          },
+          {
+            "name": "backupInstanceName",
+            "description": "The name of the deleted backup instance",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/DeletedBackupInstanceResource"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get DeletedBackupInstance": {
+            "$ref": "./examples/DeletedBackupInstanceOperations/GetDeletedBackupInstance.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/deletedBackupInstances/{backupInstanceName}/undelete": {
+      "post": {
+        "tags": [
+          "DeletedBackupInstances"
+        ],
+        "operationId": "DeletedBackupInstances_Undelete",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          },
+          {
+            "name": "backupInstanceName",
+            "description": "The name of the deleted backup instance",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "202": {
+            "description": "Accepted"
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-examples": {
+          "Undelete Deleted BackupInstance": {
+            "$ref": "./examples/DeletedBackupInstanceOperations/UndeleteDeletedBackupInstance.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.DataProtection/resourceGuards": {
+      "get": {
+        "tags": [
+          "ResourceGuards"
+        ],
+        "summary": "Returns ResourceGuards collection belonging to a subscription.",
+        "operationId": "ResourceGuards_GetResourcesInSubscription",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResourceGuardResourceList"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "Get ResourceGuards in Subscription": {
+            "$ref": "./examples/ResourceGuardCRUD/GetResourceGuardsInSubscription.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/resourceGuards": {
+      "get": {
+        "tags": [
+          "ResourceGuards"
+        ],
+        "summary": "Returns ResourceGuards collection belonging to a ResourceGroup.",
+        "operationId": "ResourceGuards_GetResourcesInResourceGroup",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResourceGuardResourceList"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "Get ResourceGuards in ResourceGroup": {
+            "$ref": "./examples/ResourceGuardCRUD/GetResourceGuardsInResourceGroup.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/resourceGuards/{resourceGuardsName}": {
+      "put": {
+        "tags": [
+          "ResourceGuards"
+        ],
+        "summary": "Creates or updates a ResourceGuard resource belonging to a resource group.",
+        "operationId": "ResourceGuards_Put",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "resourceGuardsName",
+            "in": "path",
+            "description": "The name of ResourceGuard",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Request body for operation",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ResourceGuardResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResourceGuardResource"
+            }
+          },
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/ResourceGuardResource"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create ResourceGuard": {
+            "$ref": "./examples/ResourceGuardCRUD/PutResourceGuard.json"
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "ResourceGuards"
+        ],
+        "summary": "Returns a ResourceGuard belonging to a resource group.",
+        "operationId": "ResourceGuards_Get",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "resourceGuardsName",
+            "in": "path",
+            "description": "The name of ResourceGuard",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResourceGuardResource"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get ResourceGuard": {
+            "$ref": "./examples/ResourceGuardCRUD/GetResourceGuard.json"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "ResourceGuards"
+        ],
+        "summary": "Deletes a ResourceGuard resource from the resource group.",
+        "operationId": "ResourceGuards_Delete",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "resourceGuardsName",
+            "in": "path",
+            "description": "The name of ResourceGuard",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "204": {
+            "description": "NoContent"
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete ResourceGuard": {
+            "$ref": "./examples/ResourceGuardCRUD/DeleteResourceGuard.json"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "ResourceGuards"
+        ],
+        "summary": "Updates a ResourceGuard resource belonging to a resource group. For example, updating tags for a resource.",
+        "operationId": "ResourceGuards_Patch",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "resourceGuardsName",
+            "in": "path",
+            "description": "The name of ResourceGuard",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Request body for operation",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PatchResourceGuardInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResourceGuardResource"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Patch ResourceGuard": {
+            "$ref": "./examples/ResourceGuardCRUD/PatchResourceGuard.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/resourceGuards/{resourceGuardsName}/disableSoftDeleteRequests": {
+      "get": {
+        "tags": [
+          "ResourceGuards"
+        ],
+        "summary": "Returns collection of operation request objects for a critical operation protected by the given ResourceGuard resource.",
+        "operationId": "ResourceGuards_GetDisableSoftDeleteRequestsObjects",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "resourceGuardsName",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/DppBaseResourceList"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "List OperationsRequestObject": {
+            "$ref": "./examples/ResourceGuardCRUD/ListDisableSoftDeleteRequests.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/resourceGuards/{resourceGuardsName}/deleteResourceGuardProxyRequests": {
+      "get": {
+        "tags": [
+          "ResourceGuards"
+        ],
+        "summary": "Returns collection of operation request objects for a critical operation protected by the given ResourceGuard resource.",
+        "operationId": "ResourceGuards_GetDeleteResourceGuardProxyRequestsObjects",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "resourceGuardsName",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/DppBaseResourceList"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "List OperationsRequestObject": {
+            "$ref": "./examples/ResourceGuardCRUD/ListDeleteResourceGuardProxyRequests.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/resourceGuards/{resourceGuardsName}/getBackupSecurityPINRequests": {
+      "get": {
+        "tags": [
+          "ResourceGuards"
+        ],
+        "summary": "Returns collection of operation request objects for a critical operation protected by the given ResourceGuard resource.",
+        "operationId": "ResourceGuards_GetBackupSecurityPINRequestsObjects",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "resourceGuardsName",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/DppBaseResourceList"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "List OperationsRequestObject": {
+            "$ref": "./examples/ResourceGuardCRUD/ListBackupSecurityPINRequests.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/resourceGuards/{resourceGuardsName}/deleteProtectedItemRequests": {
+      "get": {
+        "tags": [
+          "ResourceGuards"
+        ],
+        "summary": "Returns collection of operation request objects for a critical operation protected by the given ResourceGuard resource.",
+        "operationId": "ResourceGuards_GetDeleteProtectedItemRequestsObjects",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "resourceGuardsName",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/DppBaseResourceList"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "List OperationsRequestObject": {
+            "$ref": "./examples/ResourceGuardCRUD/ListDeleteProtectedItemRequests.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/resourceGuards/{resourceGuardsName}/updateProtectionPolicyRequests": {
+      "get": {
+        "tags": [
+          "ResourceGuards"
+        ],
+        "summary": "Returns collection of operation request objects for a critical operation protected by the given ResourceGuard resource.",
+        "operationId": "ResourceGuards_GetUpdateProtectionPolicyRequestsObjects",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "resourceGuardsName",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/DppBaseResourceList"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "List OperationsRequestObject": {
+            "$ref": "./examples/ResourceGuardCRUD/ListUpdateProtectionPolicyRequests.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/resourceGuards/{resourceGuardsName}/updateProtectedItemRequests": {
+      "get": {
+        "tags": [
+          "ResourceGuards"
+        ],
+        "summary": "Returns collection of operation request objects for a critical operation protected by the given ResourceGuard resource.",
+        "operationId": "ResourceGuards_GetUpdateProtectedItemRequestsObjects",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "resourceGuardsName",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/DppBaseResourceList"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "List OperationsRequestObject": {
+            "$ref": "./examples/ResourceGuardCRUD/ListUpdateProtectedItemRequests.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/resourceGuards/{resourceGuardsName}/disableSoftDeleteRequests/{requestName}": {
+      "get": {
+        "tags": [
+          "ResourceGuards"
+        ],
+        "summary": "Returns collection of operation request objects for a critical operation protected by the given ResourceGuard resource.",
+        "operationId": "ResourceGuards_GetDefaultDisableSoftDeleteRequestsObject",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "resourceGuardsName",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "requestName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/DppBaseResource"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get DefaultOperationsRequestObject": {
+            "$ref": "./examples/ResourceGuardCRUD/GetDefaultDisableSoftDeleteRequests.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/resourceGuards/{resourceGuardsName}/deleteResourceGuardProxyRequests/{requestName}": {
+      "get": {
+        "tags": [
+          "ResourceGuards"
+        ],
+        "summary": "Returns collection of operation request objects for a critical operation protected by the given ResourceGuard resource.",
+        "operationId": "ResourceGuards_GetDefaultDeleteResourceGuardProxyRequestsObject",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "resourceGuardsName",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "requestName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/DppBaseResource"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get DefaultOperationsRequestObject": {
+            "$ref": "./examples/ResourceGuardCRUD/GetDefaultDeleteResourceGuardProxyRequests.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/resourceGuards/{resourceGuardsName}/getBackupSecurityPINRequests/{requestName}": {
+      "get": {
+        "tags": [
+          "ResourceGuards"
+        ],
+        "summary": "Returns collection of operation request objects for a critical operation protected by the given ResourceGuard resource.",
+        "operationId": "ResourceGuards_GetDefaultBackupSecurityPINRequestsObject",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "resourceGuardsName",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "requestName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/DppBaseResource"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get DefaultOperationsRequestObject": {
+            "$ref": "./examples/ResourceGuardCRUD/GetDefaultBackupSecurityPINRequests.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/resourceGuards/{resourceGuardsName}/deleteProtectedItemRequests/{requestName}": {
+      "get": {
+        "tags": [
+          "ResourceGuards"
+        ],
+        "summary": "Returns collection of operation request objects for a critical operation protected by the given ResourceGuard resource.",
+        "operationId": "ResourceGuards_GetDefaultDeleteProtectedItemRequestsObject",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "resourceGuardsName",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "requestName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/DppBaseResource"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get DefaultOperationsRequestObject": {
+            "$ref": "./examples/ResourceGuardCRUD/GetDefaultDeleteProtectedItemRequests.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/resourceGuards/{resourceGuardsName}/updateProtectionPolicyRequests/{requestName}": {
+      "get": {
+        "tags": [
+          "ResourceGuards"
+        ],
+        "summary": "Returns collection of operation request objects for a critical operation protected by the given ResourceGuard resource.",
+        "operationId": "ResourceGuards_GetDefaultUpdateProtectionPolicyRequestsObject",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "resourceGuardsName",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "requestName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/DppBaseResource"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get DefaultOperationsRequestObject": {
+            "$ref": "./examples/ResourceGuardCRUD/GetDefaultUpdateProtectionPolicyRequests.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/resourceGuards/{resourceGuardsName}/updateProtectedItemRequests/{requestName}": {
+      "get": {
+        "tags": [
+          "ResourceGuards"
+        ],
+        "summary": "Returns collection of operation request objects for a critical operation protected by the given ResourceGuard resource.",
+        "operationId": "ResourceGuards_GetDefaultUpdateProtectedItemRequestsObject",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "resourceGuardsName",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "requestName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/DppBaseResource"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get DefaultOperationsRequestObject": {
+            "$ref": "./examples/ResourceGuardCRUD/GetDefaultUpdateProtectedItemRequests.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/backupResourceGuardProxies": {
+      "get": {
+        "tags": [
+          "DppResourceGuardProxies"
+        ],
+        "summary": "Returns the list of ResourceGuardProxies associated with the vault",
+        "operationId": "DppResourceGuardProxy_List",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResourceGuardProxyBaseResourceList"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "Get ResourceGuardProxies": {
+            "$ref": "./examples/ResourceGuardProxyCRUD/ListResourceGuardProxy.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/backupResourceGuardProxies/{resourceGuardProxyName}": {
+      "get": {
+        "tags": [
+          "DppResourceGuardProxies"
+        ],
+        "summary": "Returns the ResourceGuardProxy object associated with the vault, and that matches the name in the request",
+        "operationId": "DppResourceGuardProxy_Get",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          },
+          {
+            "name": "resourceGuardProxyName",
+            "description": "name of the resource guard proxy",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": "^[A-Za-z0-9]*$"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResourceGuardProxyBaseResource"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get ResourceGuardProxy": {
+            "$ref": "./examples/ResourceGuardProxyCRUD/GetResourceGuardProxy.json"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "DppResourceGuardProxies"
+        ],
+        "summary": "Creates or Updates a ResourceGuardProxy",
+        "operationId": "DppResourceGuardProxy_CreateOrUpdate",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          },
+          {
+            "name": "resourceGuardProxyName",
+            "description": "name of the resource guard proxy",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": "^[A-Za-z0-9]*$"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Request body for operation",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ResourceGuardProxyBaseResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResourceGuardProxyBaseResource"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create ResourceGuardProxy": {
+            "$ref": "./examples/ResourceGuardProxyCRUD/PutResourceGuardProxy.json"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "DppResourceGuardProxies"
+        ],
+        "summary": "Deletes the ResourceGuardProxy",
+        "operationId": "DppResourceGuardProxy_Delete",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          },
+          {
+            "name": "resourceGuardProxyName",
+            "description": "name of the resource guard proxy",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": "^[A-Za-z0-9]*$"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "204": {
+            "description": "NoContent"
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete ResourceGuardProxy": {
+            "$ref": "./examples/ResourceGuardProxyCRUD/DeleteResourceGuardProxy.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataProtection/backupVaults/{vaultName}/backupResourceGuardProxies/{resourceGuardProxyName}/unlockDelete": {
+      "post": {
+        "tags": [
+          "DppResourceGuardProxies"
+        ],
+        "summary": "UnlockDelete call for ResourceGuardProxy, executed before one can delete it",
+        "operationId": "DppResourceGuardProxy_UnlockDelete",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/VaultName"
+          },
+          {
+            "name": "resourceGuardProxyName",
+            "description": "name of the resource guard proxy",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": "^[A-Za-z0-9]*$"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v4/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Request body for operation",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UnlockDeleteRequest"
+            }
+          },
+          {
+            "name": "x-ms-authorization-auxiliary",
+            "in": "header",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/UnlockDeleteResponse"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "UnlockDelete ResourceGuardProxy": {
+            "$ref": "./examples/ResourceGuardProxyCRUD/UnlockDeleteResourceGuardProxy.json"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "AbsoluteDeleteOption": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/DeleteOption"
+        }
+      ],
+      "description": "Delete option with duration",
+      "required": [
+        "duration",
+        "objectType"
+      ],
+      "title": "AbsoluteDeleteOption",
+      "type": "object",
+      "x-ms-discriminator-value": "AbsoluteDeleteOption"
+    },
+    "RecoveryPointsFilters": {
+      "type": "object",
+      "properties": {
+        "restorePointDataStoreId": {
+          "type": "string"
+        },
+        "isVisible": {
+          "type": "boolean"
+        },
+        "startDate": {
+          "type": "string"
+        },
+        "endDate": {
+          "type": "string"
+        },
+        "extendedInfo": {
+          "type": "boolean"
+        },
+        "restorePointState": {
+          "type": "string"
+        }
+      }
+    },
+    "AdHocBackupRuleOptions": {
+      "description": "Adhoc backup rules",
+      "properties": {
+        "ruleName": {
+          "type": "string"
+        },
+        "triggerOption": {
+          "$ref": "#/definitions/AdhocBackupTriggerOption"
+        }
+      },
+      "required": [
+        "ruleName",
+        "triggerOption"
+      ],
+      "title": "AdHocBackupRuleOptions",
+      "type": "object"
+    },
+    "AdhocBackupTriggerOption": {
+      "description": "Adhoc backup trigger option",
+      "properties": {
+        "retentionTagOverride": {
+          "type": "string"
+        }
+      },
+      "title": "AdhocBackupTriggerOption",
+      "type": "object"
+    },
+    "AdhocBasedTaggingCriteria": {
+      "description": "Adhoc backup tagging criteria",
+      "properties": {
+        "tagInfo": {
+          "$ref": "#/definitions/RetentionTag",
+          "description": "Retention tag information"
+        }
+      },
+      "title": "AdhocBasedTaggingCriteria",
+      "type": "object"
+    },
+    "AdhocBasedTriggerContext": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/TriggerContext"
+        }
+      ],
+      "description": "Adhoc trigger context",
+      "properties": {
+        "taggingCriteria": {
+          "$ref": "#/definitions/AdhocBasedTaggingCriteria",
+          "description": "Tagging Criteria containing retention tag for adhoc backup."
+        }
+      },
+      "required": [
+        "objectType",
+        "taggingCriteria"
+      ],
+      "title": "AdhocBasedTriggerContext",
+      "type": "object",
+      "x-ms-discriminator-value": "AdhocBasedTriggerContext"
+    },
+    "AuthCredentials": {
+      "description": "Base class for different types of authentication credentials.",
+      "required": [
+        "objectType"
+      ],
+      "type": "object",
+      "properties": {
+        "objectType": {
+          "description": "Type of the specific object - used for deserializing",
+          "type": "string",
+          "readOnly": false
+        }
+      },
+      "discriminator": "objectType"
+    },
+    "AzureBackupDiscreteRecoveryPoint": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureBackupRecoveryPoint"
+        }
+      ],
+      "description": "Azure backup discrete RecoveryPoint",
+      "properties": {
+        "friendlyName": {
+          "type": "string"
+        },
+        "recoveryPointDataStoresDetails": {
+          "items": {
+            "$ref": "#/definitions/RecoveryPointDataStoreDetails"
+          },
+          "type": "array"
+        },
+        "recoveryPointTime": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "policyName": {
+          "type": "string"
+        },
+        "policyVersion": {
+          "type": "string"
+        },
+        "recoveryPointId": {
+          "type": "string"
+        },
+        "recoveryPointType": {
+          "type": "string"
+        },
+        "retentionTagName": {
+          "type": "string"
+        },
+        "retentionTagVersion": {
+          "type": "string"
+        },
+        "expiryTime": {
+          "format": "date-time",
+          "type": "string",
+          "readOnly": true
+        },
+        "recoveryPointState": {
+          "description": "Specifies recovery point completeness. Partial (i.e., only some of the intended items were backed up), or Completed (i.e., ALL intended items were backed up).",
+          "enum": [
+            "Completed",
+            "Partial"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "RecoveryPointCompletionState",
+            "modelAsString": true
+          }
+        }
+      },
+      "required": [
+        "recoveryPointTime"
+      ],
+      "title": "AzureBackupDiscreteRecoveryPoint",
+      "type": "object",
+      "x-ms-discriminator-value": "AzureBackupDiscreteRecoveryPoint"
+    },
+    "AzureBackupFindRestorableTimeRangesRequest": {
+      "description": "List Restore Ranges Request",
+      "required": [
+        "sourceDataStoreType"
+      ],
+      "type": "object",
+      "properties": {
+        "sourceDataStoreType": {
+          "description": "Gets or sets the type of the source data store.",
+          "enum": [
+            "OperationalStore",
+            "VaultStore",
+            "ArchiveStore"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "RestoreSourceDataStoreType",
+            "modelAsString": true
+          }
+        },
+        "startTime": {
+          "description": "Start time for the List Restore Ranges request. ISO 8601 format.",
+          "type": "string"
+        },
+        "endTime": {
+          "description": "End time for the List Restore Ranges request. ISO 8601 format.",
+          "type": "string"
+        }
+      }
+    },
+    "AzureBackupFindRestorableTimeRangesRequestResource": {
+      "description": "List Restore Ranges Request",
+      "allOf": [
+        {
+          "$ref": "#/definitions/DppWorkerRequest"
+        }
+      ],
+      "properties": {
+        "content": {
+          "$ref": "#/definitions/AzureBackupFindRestorableTimeRangesRequest",
+          "description": "AzureBackupFindRestorableTimeRangesRequestResource content"
+        }
+      }
+    },
+    "AzureBackupFindRestorableTimeRangesResponse": {
+      "description": "List Restore Ranges Response",
+      "type": "object",
+      "properties": {
+        "restorableTimeRanges": {
+          "description": "Returns the Restore Ranges available on the Backup Instance.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RestorableTimeRange"
+          },
+          "x-ms-identifiers": []
+        },
+        "objectType": {
+          "type": "string"
+        }
+      }
+    },
+    "AzureBackupFindRestorableTimeRangesResponseResource": {
+      "description": "List Restore Ranges Response",
+      "allOf": [
+        {
+          "$ref": "#/definitions/DppResource"
+        }
+      ],
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AzureBackupFindRestorableTimeRangesResponse",
+          "description": "AzureBackupFindRestorableTimeRangesResponseResource properties"
+        }
+      }
+    },
+    "AzureBackupJob": {
+      "description": "AzureBackup Job Class",
+      "properties": {
+        "activityID": {
+          "description": "Job Activity Id",
+          "type": "string"
+        },
+        "backupInstanceFriendlyName": {
+          "description": "Name of the Backup Instance",
+          "type": "string"
+        },
+        "backupInstanceId": {
+          "description": "ARM ID of the Backup Instance",
+          "readOnly": true,
+          "type": "string"
+        },
+        "dataSourceId": {
+          "description": "ARM ID of the DataSource",
+          "type": "string"
+        },
+        "dataSourceLocation": {
+          "description": "Location of the DataSource",
+          "type": "string"
+        },
+        "dataSourceName": {
+          "description": "User Friendly Name of the DataSource",
+          "type": "string"
+        },
+        "dataSourceSetName": {
+          "description": "Data Source Set Name of the DataSource",
+          "type": "string"
+        },
+        "dataSourceType": {
+          "description": "Type of DataSource",
+          "type": "string"
+        },
+        "duration": {
+          "description": "Total run time of the job. ISO 8601 format.",
+          "type": "string"
+        },
+        "endTime": {
+          "description": "EndTime of the job(in UTC)",
+          "format": "date-time",
+          "readOnly": true,
+          "type": "string"
+        },
+        "errorDetails": {
+          "description": "A List, detailing the errors related to the job",
+          "items": {
+            "$ref": "#/definitions/UserFacingError"
+          },
+          "x-ms-identifiers": [],
+          "readOnly": true,
+          "type": "array"
+        },
+        "extendedInfo": {
+          "$ref": "#/definitions/JobExtendedInfo",
+          "description": "Extended Information about the job",
+          "readOnly": true
+        },
+        "isUserTriggered": {
+          "description": "Indicated that whether the job is adhoc(true) or scheduled(false)",
+          "type": "boolean"
+        },
+        "operation": {
+          "description": "It indicates the type of Job i.e. Backup:full/log/diff ;Restore:ALR/OLR; Tiering:Backup/Archive ; Management:ConfigureProtection/UnConfigure",
+          "type": "string"
+        },
+        "operationCategory": {
+          "description": "It indicates the type of Job i.e. Backup/Restore/Tiering/Management",
+          "type": "string"
+        },
+        "policyId": {
+          "description": "ARM ID of the policy",
+          "readOnly": true,
+          "type": "string"
+        },
+        "policyName": {
+          "description": "Name of the policy",
+          "readOnly": true,
+          "type": "string"
+        },
+        "progressEnabled": {
+          "description": "Indicated whether progress is enabled for the job",
+          "type": "boolean"
+        },
+        "progressUrl": {
+          "description": "Url which contains job's progress",
+          "readOnly": true,
+          "type": "string"
+        },
+        "rehydrationPriority": {
+          "description": "Priority to be used for rehydration",
+          "readOnly": true,
+          "type": "string"
+        },
+        "restoreType": {
+          "description": "It indicates the sub type of operation i.e. in case of Restore it can be ALR/OLR",
+          "readOnly": true,
+          "type": "string"
+        },
+        "sourceResourceGroup": {
+          "description": "Resource Group Name of the Datasource",
+          "type": "string"
+        },
+        "sourceSubscriptionID": {
+          "description": "SubscriptionId corresponding to the DataSource",
+          "type": "string"
+        },
+        "startTime": {
+          "description": "StartTime of the job(in UTC)",
+          "format": "date-time",
+          "type": "string"
+        },
+        "status": {
+          "description": "Status of the job like InProgress/Completed/Failed/Cancelled/CompletedWithWarnings/Cancelling/Paused",
+          "type": "string"
+        },
+        "subscriptionId": {
+          "description": "Subscription Id of the corresponding backup vault",
+          "type": "string"
+        },
+        "supportedActions": {
+          "description": "List of supported actions",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "vaultName": {
+          "description": "Name of the vault",
+          "type": "string"
+        },
+        "etag": {
+          "type": "string"
+        },
+        "sourceDataStoreName": {
+          "type": "string"
+        },
+        "destinationDataStoreName": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "activityID",
+        "subscriptionId",
+        "dataSourceId",
+        "vaultName",
+        "backupInstanceFriendlyName",
+        "sourceResourceGroup",
+        "dataSourceName",
+        "progressEnabled",
+        "sourceSubscriptionID",
+        "dataSourceLocation",
+        "startTime",
+        "dataSourceType",
+        "operationCategory",
+        "operation",
+        "status",
+        "isUserTriggered",
+        "supportedActions"
+      ],
+      "type": "object"
+    },
+    "CrossRegionRestoreJobRequest": {
+      "description": "Details of CRR Job to be fetched",
+      "required": [
+        "sourceRegion",
+        "sourceBackupVaultId",
+        "jobId"
+      ],
+      "type": "object",
+      "properties": {
+        "sourceRegion": {
+          "type": "string"
+        },
+        "sourceBackupVaultId": {
+          "type": "string"
+        },
+        "jobId": {
+          "type": "string"
+        }
+      }
+    },
+    "CrossRegionRestoreJobsRequest": {
+      "description": "Details of Backup Vault for which CRR Jobs are to be fetched",
+      "required": [
+        "sourceRegion",
+        "sourceBackupVaultId"
+      ],
+      "type": "object",
+      "properties": {
+        "sourceRegion": {
+          "type": "string"
+        },
+        "sourceBackupVaultId": {
+          "type": "string"
+        }
+      }
+    },
+    "AzureBackupJobResource": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/DppResource"
+        }
+      ],
+      "description": "AzureBackup Job Resource Class",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AzureBackupJob",
+          "description": "AzureBackupJobResource properties",
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "AzureBackupJobResourceList": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/DppResourceList"
+        }
+      ],
+      "description": "List of AzureBackup Job resources",
+      "properties": {
+        "value": {
+          "description": "List of resources.",
+          "items": {
+            "$ref": "#/definitions/AzureBackupJobResource"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "AzureBackupParams": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/BackupParameters"
+        }
+      ],
+      "description": "Azure backup parameters",
+      "properties": {
+        "backupType": {
+          "description": "BackupType ; Full/Incremental etc",
+          "type": "string"
+        }
+      },
+      "required": [
+        "backupType",
+        "objectType"
+      ],
+      "title": "AzureBackupParams",
+      "type": "object",
+      "x-ms-discriminator-value": "AzureBackupParams"
+    },
+    "AzureBackupRecoveryPoint": {
+      "description": "Azure backup recoveryPoint",
+      "discriminator": "objectType",
+      "properties": {
+        "objectType": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "objectType"
+      ],
+      "title": "AzureBackupRecoveryPoint",
+      "type": "object"
+    },
+    "AzureBackupRecoveryPointBasedRestoreRequest": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureBackupRestoreRequest"
+        }
+      ],
+      "description": "Azure backup recoveryPoint based restore request",
+      "properties": {
+        "recoveryPointId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "recoveryPointId"
+      ],
+      "title": "AzureBackupRecoveryPointBasedRestoreRequest",
+      "type": "object",
+      "x-ms-discriminator-value": "AzureBackupRecoveryPointBasedRestoreRequest"
+    },
+    "AzureBackupRecoveryPointResource": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/DppResource"
+        }
+      ],
+      "description": "Azure backup recoveryPoint resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AzureBackupRecoveryPoint",
+          "description": "AzureBackupRecoveryPointResource properties"
+        }
+      },
+      "title": "AzureBackupRecoveryPointResource"
+    },
+    "AzureBackupRecoveryPointResourceList": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/DppResourceList"
+        }
+      ],
+      "description": "Azure backup recoveryPoint resource list",
+      "properties": {
+        "value": {
+          "description": "List of resources.",
+          "items": {
+            "$ref": "#/definitions/AzureBackupRecoveryPointResource"
+          },
+          "type": "array"
+        }
+      },
+      "title": "AzureBackupRecoveryPointResourceList",
+      "type": "object"
+    },
+    "AzureBackupRehydrationRequest": {
+      "description": "Azure Backup Rehydrate Request",
+      "properties": {
+        "recoveryPointId": {
+          "description": "Id of the recovery point to be recovered",
+          "type": "string"
+        },
+        "rehydrationPriority": {
+          "description": "Priority to be used for rehydration. Values High or Standard",
+          "$ref": "#/definitions/RehydrationPriority"
+        },
+        "rehydrationRetentionDuration": {
+          "description": "Retention duration in ISO 8601 format i.e P10D .",
+          "type": "string"
+        }
+      },
+      "required": [
+        "recoveryPointId",
+        "rehydrationRetentionDuration"
+      ],
+      "title": "AzureBackupRehydrationRequest",
+      "type": "object"
+    },
+    "AzureBackupRestoreRequest": {
+      "description": "Azure backup restore request",
+      "discriminator": "objectType",
+      "properties": {
+        "objectType": {
+          "type": "string"
+        },
+        "restoreTargetInfo": {
+          "$ref": "#/definitions/RestoreTargetInfoBase",
+          "description": "Gets or sets the restore target information."
+        },
+        "sourceDataStoreType": {
+          "description": "Gets or sets the type of the source data store.",
+          "enum": [
+            "ArchiveStore",
+            "SnapshotStore",
+            "OperationalStore",
+            "VaultStore"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "modelAsString": true,
+            "name": "SourceDataStoreType"
+          }
+        },
+        "sourceResourceId": {
+          "description": "Fully qualified Azure Resource Manager ID of the datasource which is being recovered.",
+          "type": "string"
+        },
+        "resourceGuardOperationRequests": {
+          "description": "ResourceGuardOperationRequests on which LAC check will be performed",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "identityDetails": {
+          "$ref": "#/definitions/IdentityDetails",
+          "description": "Contains information of the Identity Details for the BI.\r\nIf it is null, default will be considered as System Assigned."
+        }
+      },
+      "required": [
+        "objectType",
+        "restoreTargetInfo",
+        "sourceDataStoreType"
+      ],
+      "title": "AzureBackupRestoreRequest",
+      "type": "object"
+    },
+    "IdentityDetails": {
+      "type": "object",
+      "properties": {
+        "useSystemAssignedIdentity": {
+          "description": "Specifies if the BI is protected by System Identity.",
+          "type": "boolean"
+        },
+        "userAssignedIdentityArmUrl": {
+          "description": "ARM URL for User Assigned Identity.",
+          "type": "string"
+        }
+      }
+    },
+    "AzureBackupRestoreWithRehydrationRequest": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureBackupRecoveryPointBasedRestoreRequest"
+        }
+      ],
+      "description": "AzureBackup Restore with Rehydration Request",
+      "properties": {
+        "rehydrationPriority": {
+          "description": "Priority to be used for rehydration. Values High or Standard",
+          "$ref": "#/definitions/RehydrationPriority"
+        },
+        "rehydrationRetentionDuration": {
+          "description": "Retention duration in ISO 8601 format i.e P10D .",
+          "type": "string"
+        }
+      },
+      "required": [
+        "rehydrationPriority",
+        "rehydrationRetentionDuration"
+      ],
+      "title": "AzureBackupRestoreWithRehydrationRequest",
+      "type": "object",
+      "x-ms-discriminator-value": "AzureBackupRestoreWithRehydrationRequest"
+    },
+    "AzureBackupRecoveryTimeBasedRestoreRequest": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureBackupRestoreRequest"
+        }
+      ],
+      "description": "AzureBackup RecoveryPointTime Based Restore Request",
+      "properties": {
+        "recoveryPointTime": {
+          "description": "The recovery time in ISO 8601 format example - 2020-08-14T17:30:00.0000000Z.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "recoveryPointTime"
+      ],
+      "title": "AzureBackupRecoveryTimeBasedRestoreRequest",
+      "type": "object",
+      "x-ms-discriminator-value": "AzureBackupRecoveryTimeBasedRestoreRequest"
+    },
+    "AzureBackupRule": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/BasePolicyRule"
+        }
+      ],
+      "description": "Azure backup rule",
+      "properties": {
+        "backupParameters": {
+          "$ref": "#/definitions/BackupParameters"
+        },
+        "dataStore": {
+          "$ref": "#/definitions/DataStoreInfoBase"
+        },
+        "trigger": {
+          "$ref": "#/definitions/TriggerContext"
+        }
+      },
+      "required": [
+        "dataStore",
+        "name",
+        "objectType",
+        "trigger"
+      ],
+      "title": "AzureBackupRule",
+      "type": "object",
+      "x-ms-discriminator-value": "AzureBackupRule"
+    },
+    "AzureMonitorAlertSettings": {
+      "type": "object",
+      "description": "Settings for Azure Monitor based alerts",
+      "properties": {
+        "alertsForAllJobFailures": {
+          "enum": [
+            "Enabled",
+            "Disabled"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "AlertsState",
+            "modelAsString": true
+          }
+        }
+      }
+    },
+    "AzureOperationalStoreParameters": {
+      "description": "Parameters for Operational-Tier DataStore",
+      "required": [
+        "objectType",
+        "dataStoreType"
+      ],
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/DataStoreParameters"
+        }
+      ],
+      "properties": {
+        "resourceGroupId": {
+          "description": "Gets or sets the Snapshot Resource Group Uri.",
+          "type": "string"
+        }
+      },
+      "x-ms-discriminator-value": "AzureOperationalStoreParameters"
+    },
+    "KubernetesClusterBackupDatasourceParameters": {
+      "description": "Parameters for Kubernetes Cluster Backup Datasource",
+      "required": [
+        "snapshotVolumes",
+        "includeClusterScopeResources"
+      ],
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/BackupDatasourceParameters"
+        }
+      ],
+      "properties": {
+        "snapshotVolumes": {
+          "description": "Gets or sets the volume snapshot property. This property if enabled will take volume snapshots during backup.",
+          "type": "boolean"
+        },
+        "includedVolumeTypes": {
+          "description": "Gets or sets the include volume types property. This property sets the volume types to be included during backup.",
+          "items": {
+            "enum": [
+              "AzureDisk",
+              "AzureFileShareSMB"
+            ],
+            "type": "string",
+            "x-ms-enum": {
+              "modelAsString": true,
+              "name": "AKSVolumeTypes"
+            }
+          },
+          "type": "array"
+        },
+        "includeClusterScopeResources": {
+          "description": "Gets or sets the include cluster resources property. This property if enabled will include cluster scope resources during backup.",
+          "type": "boolean"
+        },
+        "includedNamespaces": {
+          "description": "Gets or sets the include namespaces property. This property sets the namespaces to be included during backup.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "excludedNamespaces": {
+          "description": "Gets or sets the exclude namespaces property. This property sets the namespaces to be excluded during backup.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "includedResourceTypes": {
+          "description": "Gets or sets the include resource types property. This property sets the resource types to be included during backup.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "excludedResourceTypes": {
+          "description": "Gets or sets the exclude resource types property. This property sets the resource types to be excluded during backup.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "labelSelectors": {
+          "description": "Gets or sets the LabelSelectors property. This property sets the resource with such label selectors to be included during backup.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "backupHookReferences": {
+          "description": "Gets or sets the backup hook references. This property sets the hook reference to be executed during backup.",
+          "items": {
+            "$ref": "#/definitions/NamespacedNameResource"
+          },
+          "x-ms-identifiers": [],
+          "type": "array"
+        }
+      },
+      "x-ms-discriminator-value": "KubernetesClusterBackupDatasourceParameters"
+    },
+    "BlobBackupDatasourceParameters": {
+      "description": "Parameters to be used during configuration of backup of blobs",
+      "required": [
+        "containersList",
+        "objectType"
+      ],
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/BackupDatasourceParameters"
+        }
+      ],
+      "properties": {
+        "containersList": {
+          "description": "List of containers to be backed up during configuration of backup of blobs",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "x-ms-discriminator-value": "BlobBackupDatasourceParameters"
+    },
+    "AdlsBlobBackupDatasourceParameters": {
+      "description": "Parameters to be used during configuration of backup of azure data lake storage account blobs",
+      "required": [
+        "containersList",
+        "objectType"
+      ],
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/BlobBackupDatasourceParameters"
+        }
+      ],
+      "x-ms-discriminator-value": "AdlsBlobBackupDatasourceParameters"
+    },
+    "AzureRetentionRule": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/BasePolicyRule"
+        }
+      ],
+      "description": "Azure retention rule",
+      "properties": {
+        "isDefault": {
+          "type": "boolean"
+        },
+        "lifecycles": {
+          "items": {
+            "$ref": "#/definitions/SourceLifeCycle"
+          },
+          "x-ms-identifiers": [],
+          "type": "array"
+        }
+      },
+      "required": [
+        "lifecycles",
+        "name",
+        "objectType"
+      ],
+      "title": "AzureRetentionRule",
+      "type": "object",
+      "x-ms-discriminator-value": "AzureRetentionRule"
+    },
+    "BackupCriteria": {
+      "description": "BackupCriteria base class",
+      "discriminator": "objectType",
+      "properties": {
+        "objectType": {
+          "description": "Type of the specific object - used for deserializing",
+          "type": "string"
+        }
+      },
+      "required": [
+        "objectType"
+      ],
+      "title": "BackupCriteria",
+      "type": "object"
+    },
+    "BackupInstance": {
+      "description": "Backup Instance",
+      "required": [
+        "dataSourceInfo",
+        "policyInfo",
+        "objectType"
+      ],
+      "type": "object",
+      "properties": {
+        "friendlyName": {
+          "description": "Gets or sets the Backup Instance friendly name.",
+          "type": "string"
+        },
+        "dataSourceInfo": {
+          "$ref": "#/definitions/Datasource",
+          "description": "Gets or sets the data source information."
+        },
+        "dataSourceSetInfo": {
+          "$ref": "#/definitions/DatasourceSet",
+          "description": "Gets or sets the data source set information."
+        },
+        "policyInfo": {
+          "$ref": "#/definitions/PolicyInfo",
+          "description": "Gets or sets the policy information."
+        },
+        "resourceGuardOperationRequests": {
+          "description": "ResourceGuardOperationRequests on which LAC check will be performed",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "protectionStatus": {
+          "$ref": "#/definitions/ProtectionStatusDetails",
+          "description": "Specifies the protection status of the resource",
+          "readOnly": true
+        },
+        "currentProtectionState": {
+          "description": "Specifies the current protection state of the resource",
+          "enum": [
+            "Invalid",
+            "NotProtected",
+            "ConfiguringProtection",
+            "ProtectionConfigured",
+            "BackupSchedulesSuspended",
+            "RetentionSchedulesSuspended",
+            "ProtectionStopped",
+            "ProtectionError",
+            "ConfiguringProtectionFailed",
+            "SoftDeleting",
+            "SoftDeleted",
+            "UpdatingProtection"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "CurrentProtectionState",
+            "modelAsString": true
+          }
+        },
+        "protectionErrorDetails": {
+          "$ref": "#/definitions/UserFacingError",
+          "description": "Specifies the protection error of the resource",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "description": "Specifies the provisioning state of the resource i.e. provisioning/updating/Succeeded/Failed",
+          "type": "string",
+          "readOnly": true
+        },
+        "datasourceAuthCredentials": {
+          "$ref": "#/definitions/AuthCredentials",
+          "description": "Credentials to use to authenticate with data source provider."
+        },
+        "validationType": {
+          "description": "Specifies the type of validation. In case of DeepValidation, all validations from /validateForBackup API will run again.",
+          "enum": [
+            "ShallowValidation",
+            "DeepValidation"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "ValidationType",
+            "modelAsString": true
+          }
+        },
+        "identityDetails": {
+          "$ref": "#/definitions/IdentityDetails",
+          "description": "Contains information of the Identity Details for the BI.\r\nIf it is null, default will be considered as System Assigned."
+        },
+        "objectType": {
+          "type": "string"
+        }
+      }
+    },
+    "BackupInstanceResource": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/DppProxyResource"
+        }
+      ],
+      "description": "BackupInstance Resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/BackupInstance",
+          "description": "BackupInstanceResource properties"
+        }
+      },
+      "title": "BackupInstanceResource"
+    },
+    "BackupInstanceResourceList": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/DppResourceList"
+        }
+      ],
+      "description": "BackupInstance Resource list response",
+      "properties": {
+        "value": {
+          "description": "List of resources.",
+          "items": {
+            "$ref": "#/definitions/BackupInstanceResource"
+          },
+          "type": "array"
+        }
+      },
+      "title": "BackupInstanceResourceList",
+      "type": "object"
+    },
+    "BackupParameters": {
+      "description": "BackupParameters base",
+      "discriminator": "objectType",
+      "properties": {
+        "objectType": {
+          "description": "Type of the specific object - used for deserializing",
+          "type": "string"
+        }
+      },
+      "required": [
+        "objectType"
+      ],
+      "title": "BackupParameters",
+      "type": "object"
+    },
+    "BackupPolicy": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/BaseBackupPolicy"
+        }
+      ],
+      "description": "Rule based backup policy",
+      "properties": {
+        "policyRules": {
+          "description": "Policy rule dictionary that contains rules for each backuptype i.e Full/Incremental/Logs etc",
+          "items": {
+            "$ref": "#/definitions/BasePolicyRule"
+          },
+          "x-ms-identifiers": [],
+          "type": "array"
+        }
+      },
+      "required": [
+        "datasourceTypes",
+        "policyRules"
+      ],
+      "title": "BackupPolicy",
+      "type": "object",
+      "x-ms-discriminator-value": "BackupPolicy"
+    },
+    "BackupSchedule": {
+      "description": "Schedule for backup",
+      "properties": {
+        "repeatingTimeIntervals": {
+          "description": "ISO 8601 repeating time interval format",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "timeZone": {
+          "description": "Time zone for a schedule. Example: Pacific Standard Time",
+          "type": "string"
+        }
+      },
+      "required": [
+        "repeatingTimeIntervals"
+      ],
+      "title": "BackupSchedule",
+      "type": "object"
+    },
+    "BackupVault": {
+      "description": "Backup Vault",
+      "properties": {
+        "monitoringSettings": {
+          "$ref": "#/definitions/MonitoringSettings",
+          "description": "Monitoring Settings"
+        },
+        "provisioningState": {
+          "description": "Provisioning state of the BackupVault resource",
+          "enum": [
+            "Failed",
+            "Provisioning",
+            "Succeeded",
+            "Unknown",
+            "Updating"
+          ],
+          "readOnly": true,
+          "type": "string",
+          "x-ms-enum": {
+            "modelAsString": true,
+            "name": "ProvisioningState"
+          }
+        },
+        "resourceMoveState": {
+          "description": "Resource move state for backup vault",
+          "enum": [
+            "Unknown",
+            "InProgress",
+            "PrepareFailed",
+            "CommitFailed",
+            "Failed",
+            "PrepareTimedout",
+            "CommitTimedout",
+            "CriticalFailure",
+            "PartialSuccess",
+            "MoveSucceeded"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "ResourceMoveState",
+            "modelAsString": true
+          }
+        },
+        "resourceMoveDetails": {
+          "$ref": "#/definitions/ResourceMoveDetails",
+          "description": "Resource move details for backup vault",
+          "readOnly": true
+        },
+        "securitySettings": {
+          "$ref": "#/definitions/SecuritySettings",
+          "description": "Security Settings"
+        },
+        "storageSettings": {
+          "description": "Storage Settings",
+          "items": {
+            "$ref": "#/definitions/StorageSetting"
+          },
+          "x-ms-identifiers": [],
+          "type": "array"
+        },
+        "isVaultProtectedByResourceGuard": {
+          "description": "Is vault protected by resource guard",
+          "type": "boolean",
+          "readOnly": true
+        },
+        "featureSettings": {
+          "$ref": "#/definitions/FeatureSettings",
+          "description": "Feature Settings"
+        },
+        "secureScore": {
+          "description": "Secure Score of Backup Vault",
+          "enum": [
+            "None",
+            "Minimum",
+            "Adequate",
+            "Maximum",
+            "NotSupported"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "SecureScoreLevel",
+            "modelAsString": true
+          }
+        },
+        "bcdrSecurityLevel": {
+          "description": "Security Level of Backup Vault",
+          "enum": [
+            "Poor",
+            "Fair",
+            "Good",
+            "Excellent",
+            "NotSupported"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "BCDRSecurityLevel",
+            "modelAsString": true
+          }
+        },
+        "resourceGuardOperationRequests": {
+          "description": "ResourceGuardOperationRequests on which LAC check will be performed",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "replicatedRegions": {
+          "description": "List of replicated regions for Backup Vault",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "storageSettings"
+      ],
+      "title": "BackupVault",
+      "type": "object"
+    },
+    "BackupVaultResource": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/DppTrackedResource"
+        }
+      ],
+      "description": "Backup Vault Resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/BackupVault",
+          "description": "BackupVaultResource properties"
+        }
+      },
+      "required": [
+        "location",
+        "properties"
+      ],
+      "title": "BackupVault Resource"
+    },
+    "BackupVaultResourceList": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/DppResourceList"
+        }
+      ],
+      "description": "List of BackupVault resources",
+      "properties": {
+        "value": {
+          "description": "List of resources.",
+          "items": {
+            "$ref": "#/definitions/BackupVaultResource"
+          },
+          "type": "array"
+        }
+      },
+      "title": "BackupVaultResourceList",
+      "type": "object"
+    },
+    "BaseBackupPolicy": {
+      "description": "BackupPolicy base",
+      "discriminator": "objectType",
+      "properties": {
+        "datasourceTypes": {
+          "description": "Type of datasource for the backup management",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "objectType": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "datasourceTypes",
+        "objectType"
+      ],
+      "title": "BaseBackupPolicy",
+      "type": "object"
+    },
+    "BaseBackupPolicyResource": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/DppResource"
+        }
+      ],
+      "description": "BaseBackupPolicy resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/BaseBackupPolicy",
+          "description": "BaseBackupPolicyResource properties"
+        }
+      },
+      "title": "BaseBackupPolicyResource"
+    },
+    "BaseBackupPolicyResourceList": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/DppResourceList"
+        }
+      ],
+      "description": "List of BaseBackupPolicy resources",
+      "properties": {
+        "value": {
+          "description": "List of resources.",
+          "items": {
+            "$ref": "#/definitions/BaseBackupPolicyResource"
+          },
+          "type": "array"
+        }
+      },
+      "title": "BaseBackupPolicyResourceList",
+      "type": "object"
+    },
+    "BasePolicyRule": {
+      "description": "BasePolicy Rule",
+      "discriminator": "objectType",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "objectType": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "objectType"
+      ],
+      "title": "BasePolicyRule",
+      "type": "object"
+    },
+    "BaseResourceProperties": {
+      "description": "Properties which are specific to datasource/datasourceSets",
+      "required": [
+        "objectType"
+      ],
+      "type": "object",
+      "properties": {
+        "objectType": {
+          "description": "Type of the specific object - used for deserializing",
+          "type": "string",
+          "readOnly": false,
+          "enum": [
+            "DefaultResourceProperties"
+          ],
+          "x-ms-enum": {
+            "name": "ResourcePropertiesObjectType",
+            "modelAsString": true
+          }
+        }
+      },
+      "discriminator": "objectType"
+    },
+    "CheckNameAvailabilityRequest": {
+      "description": "CheckNameAvailability Request",
+      "properties": {
+        "name": {
+          "description": "Resource name for which availability needs to be checked",
+          "type": "string"
+        },
+        "type": {
+          "description": "Describes the Resource type: Microsoft.DataProtection/BackupVaults",
+          "type": "string"
+        }
+      },
+      "title": "CheckNameAvailabilityRequest",
+      "type": "object"
+    },
+    "CheckNameAvailabilityResult": {
+      "description": "CheckNameAvailability Result",
+      "properties": {
+        "message": {
+          "description": "Gets or sets the message.",
+          "type": "string"
+        },
+        "nameAvailable": {
+          "description": "Gets or sets a value indicating whether [name available].",
+          "type": "boolean"
+        },
+        "reason": {
+          "description": "Gets or sets the reason.",
+          "type": "string"
+        }
+      },
+      "title": "CheckNameAvailabilityResult",
+      "type": "object"
+    },
+    "ClientDiscoveryDisplay": {
+      "description": "Localized display information of an operation.",
+      "properties": {
+        "description": {
+          "description": "Description of the operation having details of what operation is about.",
+          "type": "string"
+        },
+        "operation": {
+          "description": "Operations Name itself.",
+          "type": "string"
+        },
+        "provider": {
+          "description": "Name of the provider for display purposes",
+          "type": "string"
+        },
+        "resource": {
+          "description": "ResourceType for which this Operation can be performed.",
+          "type": "string"
+        }
+      },
+      "title": "ClientDiscoveryDisplay",
+      "type": "object"
+    },
+    "ClientDiscoveryForLogSpecification": {
+      "description": "Class to represent shoebox log specification in json client discovery.",
+      "properties": {
+        "blobDuration": {
+          "description": "blob duration of shoebox log specification",
+          "type": "string"
+        },
+        "displayName": {
+          "description": "Localized display name",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name for shoebox log specification.",
+          "type": "string"
+        }
+      },
+      "title": "ClientDiscoveryForLogSpecification",
+      "type": "object"
+    },
+    "ClientDiscoveryForProperties": {
+      "description": "Class to represent shoebox properties in json client discovery.",
+      "properties": {
+        "serviceSpecification": {
+          "$ref": "#/definitions/ClientDiscoveryForServiceSpecification",
+          "description": "Operation properties."
+        }
+      },
+      "title": "ClientDiscoveryForProperties",
+      "type": "object"
+    },
+    "ClientDiscoveryForServiceSpecification": {
+      "description": "Class to represent shoebox service specification in json client discovery.",
+      "properties": {
+        "logSpecifications": {
+          "description": "List of log specifications of this operation.",
+          "items": {
+            "$ref": "#/definitions/ClientDiscoveryForLogSpecification"
+          },
+          "x-ms-identifiers": [],
+          "type": "array"
+        }
+      },
+      "title": "ClientDiscoveryForServiceSpecification",
+      "type": "object"
+    },
+    "ClientDiscoveryResponse": {
+      "description": "Operations List response which contains list of available APIs.",
+      "properties": {
+        "nextLink": {
+          "description": "Link to the next chunk of Response.",
+          "type": "string"
+        },
+        "value": {
+          "description": "List of available operations.",
+          "items": {
+            "$ref": "#/definitions/ClientDiscoveryValueForSingleApi"
+          },
+          "x-ms-identifiers": [],
+          "type": "array"
+        }
+      },
+      "title": "ClientDiscoveryResponse",
+      "type": "object"
+    },
+    "ClientDiscoveryValueForSingleApi": {
+      "description": "Available operation details.",
+      "properties": {
+        "display": {
+          "$ref": "#/definitions/ClientDiscoveryDisplay",
+          "description": "Contains the localized display information for this particular operation"
+        },
+        "name": {
+          "description": "Name of the Operation.",
+          "type": "string"
+        },
+        "isDataAction": {
+          "description": "Indicates whether the operation is a data action",
+          "type": "boolean"
+        },
+        "origin": {
+          "description": "The intended executor of the operation;governs the display of the operation in the RBAC UX and the audit logs UX",
+          "type": "string"
+        },
+        "properties": {
+          "$ref": "#/definitions/ClientDiscoveryForProperties",
+          "description": "Properties for the given operation."
+        }
+      },
+      "title": "ClientDiscoveryValueForSingleApi",
+      "type": "object"
+    },
+    "FetchSecondaryRPsRequestParameters": {
+      "description": "Information about BI whose secondary RecoveryPoints are requested\r\nSource region and\r\nBI ARM path",
+      "type": "object",
+      "properties": {
+        "sourceRegion": {
+          "description": "Source region in which BackupInstance is located",
+          "type": "string"
+        },
+        "sourceBackupInstanceId": {
+          "description": "ARM Path of BackupInstance",
+          "type": "string"
+        }
+      }
+    },
+    "CloudError": {
+      "description": "An error response from Azure Backup.",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/Error"
+        }
+      },
+      "title": "CloudError",
+      "x-ms-external": true
+    },
+    "CmkKeyVaultProperties": {
+      "type": "object",
+      "description": "The properties of the Key Vault which hosts CMK",
+      "properties": {
+        "keyUri": {
+          "description": "The key uri of the Customer Managed Key",
+          "type": "string"
+        }
+      }
+    },
+    "CmkKekIdentity": {
+      "type": "object",
+      "description": "The details of the managed identity used for CMK",
+      "properties": {
+        "identityType": {
+          "type": "string",
+          "description": "The identity type. 'SystemAssigned' and 'UserAssigned' are mutually exclusive. 'SystemAssigned' will use implicitly created managed identity.",
+          "enum": [
+            "SystemAssigned",
+            "UserAssigned"
+          ],
+          "x-ms-enum": {
+            "name": "IdentityType",
+            "modelAsString": true
+          }
+        },
+        "identityId": {
+          "type": "string",
+          "description": "The managed identity to be used which has access permissions to the Key Vault. Provide a value here in case identity types: 'UserAssigned' only."
+        }
+      }
+    },
+    "CopyOnExpiryOption": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopyOption"
+        }
+      ],
+      "description": "Copy on Expiry Option",
+      "required": [
+        "objectType"
+      ],
+      "title": "CopyOnExpiryOption",
+      "type": "object",
+      "x-ms-discriminator-value": "CopyOnExpiryOption"
+    },
+    "CopyOption": {
+      "description": "Options to copy",
+      "discriminator": "objectType",
+      "properties": {
+        "objectType": {
+          "description": "Type of the specific object - used for deserializing",
+          "type": "string"
+        }
+      },
+      "required": [
+        "objectType"
+      ],
+      "title": "CopyOption",
+      "type": "object"
+    },
+    "CrossRegionRestoreSettings": {
+      "type": "object",
+      "properties": {
+        "state": {
+          "description": "CrossRegionRestore state",
+          "enum": [
+            "Disabled",
+            "Enabled"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "CrossRegionRestoreState",
+            "modelAsString": true
+          }
+        }
+      }
+    },
+    "CrossSubscriptionRestoreSettings": {
+      "description": "CrossSubscriptionRestore Settings",
+      "type": "object",
+      "properties": {
+        "state": {
+          "description": "CrossSubscriptionRestore state",
+          "enum": [
+            "Disabled",
+            "PermanentlyDisabled",
+            "Enabled"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "CrossSubscriptionRestoreState",
+            "modelAsString": true
+          }
+        }
+      }
+    },
+    "CustomCopyOption": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopyOption"
+        }
+      ],
+      "description": "Duration based custom options to copy",
+      "properties": {
+        "duration": {
+          "description": "Data copied after given timespan",
+          "type": "string"
+        }
+      },
+      "required": [
+        "objectType"
+      ],
+      "title": "CustomCopyOption",
+      "type": "object",
+      "x-ms-discriminator-value": "CustomCopyOption"
+    },
+    "Datasource": {
+      "description": "Datasource to be backed up",
+      "properties": {
+        "datasourceType": {
+          "description": "DatasourceType of the resource.",
+          "type": "string"
+        },
+        "objectType": {
+          "description": "Type of Datasource object, used to initialize the right inherited type",
+          "type": "string"
+        },
+        "resourceID": {
+          "description": "Full ARM ID of the resource. For azure resources, this is ARM ID. For non azure resources, this will be the ID created by backup service via Fabric/Vault.",
+          "type": "string"
+        },
+        "resourceLocation": {
+          "description": "Location of datasource.",
+          "type": "string"
+        },
+        "resourceName": {
+          "description": "Unique identifier of the resource in the context of parent.",
+          "type": "string"
+        },
+        "resourceType": {
+          "description": "Resource Type of Datasource.",
+          "type": "string"
+        },
+        "resourceUri": {
+          "description": "Uri of the resource.",
+          "type": "string"
+        },
+        "resourceProperties": {
+          "$ref": "#/definitions/BaseResourceProperties",
+          "description": "Properties specific to data source"
+        }
+      },
+      "required": [
+        "resourceID"
+      ],
+      "title": "Datasource",
+      "type": "object"
+    },
+    "DatasourceSet": {
+      "description": "DatasourceSet details of datasource to be backed up",
+      "properties": {
+        "datasourceType": {
+          "description": "DatasourceType of the resource.",
+          "type": "string"
+        },
+        "objectType": {
+          "description": "Type of Datasource object, used to initialize the right inherited type",
+          "type": "string"
+        },
+        "resourceID": {
+          "description": "Full ARM ID of the resource. For azure resources, this is ARM ID. For non azure resources, this will be the ID created by backup service via Fabric/Vault.",
+          "type": "string"
+        },
+        "resourceLocation": {
+          "description": "Location of datasource.",
+          "type": "string"
+        },
+        "resourceName": {
+          "description": "Unique identifier of the resource in the context of parent.",
+          "type": "string"
+        },
+        "resourceType": {
+          "description": "Resource Type of Datasource.",
+          "type": "string"
+        },
+        "resourceUri": {
+          "description": "Uri of the resource.",
+          "type": "string"
+        },
+        "resourceProperties": {
+          "$ref": "#/definitions/BaseResourceProperties",
+          "description": "Properties specific to data source set"
+        }
+      },
+      "required": [
+        "resourceID"
+      ],
+      "title": "DatasourceSet",
+      "type": "object"
+    },
+    "DataStoreInfoBase": {
+      "description": "DataStoreInfo base",
+      "properties": {
+        "dataStoreType": {
+          "description": "type of datastore; Operational/Vault/Archive",
+          "enum": [
+            "OperationalStore",
+            "VaultStore",
+            "ArchiveStore"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "modelAsString": true,
+            "name": "DataStoreTypes"
+          }
+        },
+        "objectType": {
+          "description": "Type of Datasource object, used to initialize the right inherited type",
+          "readOnly": false,
+          "type": "string"
+        }
+      },
+      "required": [
+        "dataStoreType",
+        "objectType"
+      ],
+      "title": "DataStoreInfoBase",
+      "type": "object"
+    },
+    "DataStoreParameters": {
+      "description": "Parameters for DataStore",
+      "required": [
+        "objectType",
+        "dataStoreType"
+      ],
+      "type": "object",
+      "properties": {
+        "objectType": {
+          "description": "Type of the specific object - used for deserializing",
+          "type": "string",
+          "readOnly": false
+        },
+        "dataStoreType": {
+          "description": "type of datastore; Operational/Vault/Archive",
+          "enum": [
+            "OperationalStore",
+            "VaultStore",
+            "ArchiveStore"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "DataStoreTypes",
+            "modelAsString": true
+          }
+        }
+      },
+      "discriminator": "objectType"
+    },
+    "BackupDatasourceParameters": {
+      "description": "Parameters for Backup Datasource",
+      "required": [
+        "objectType"
+      ],
+      "type": "object",
+      "properties": {
+        "objectType": {
+          "description": "Type of the specific object - used for deserializing",
+          "type": "string",
+          "readOnly": false
+        }
+      },
+      "discriminator": "objectType"
+    },
+    "Day": {
+      "description": "Day of the week",
+      "properties": {
+        "date": {
+          "description": "Date of the month",
+          "format": "int32",
+          "type": "integer"
+        },
+        "isLast": {
+          "description": "Whether Date is last date of month",
+          "type": "boolean"
+        }
+      },
+      "title": "Day",
+      "type": "object"
+    },
+    "DeletedBackupInstance": {
+      "description": "Deleted Backup Instance",
+      "required": [
+        "dataSourceInfo",
+        "policyInfo"
+      ],
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/BackupInstance"
+        }
+      ],
+      "properties": {
+        "deletionInfo": {
+          "$ref": "#/definitions/DeletionInfo",
+          "description": "Deletion info of Backup Instance",
+          "readOnly": true
+        }
+      }
+    },
+    "DefaultResourceProperties": {
+      "description": "Default source properties",
+      "required": [
+        "objectType"
+      ],
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/BaseResourceProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "DefaultResourceProperties"
+    },
+    "DeletedBackupInstanceResource": {
+      "description": "Deleted Backup Instance",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/DppResource"
+        }
+      ],
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/DeletedBackupInstance",
+          "description": "DeletedBackupInstanceResource properties"
+        }
+      }
+    },
+    "DeletedBackupInstanceResourceList": {
+      "description": "List of DeletedBackupInstance resources",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/DppResourceList"
+        }
+      ],
+      "properties": {
+        "value": {
+          "description": "List of resources.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DeletedBackupInstanceResource"
+          }
+        }
+      }
+    },
+    "DeletionInfo": {
+      "description": "Deletion Info",
+      "type": "object",
+      "properties": {
+        "deletionTime": {
+          "description": "Specifies time of deletion",
+          "type": "string",
+          "readOnly": true
+        },
+        "billingEndDate": {
+          "description": "Specifies billing end date",
+          "type": "string",
+          "readOnly": true
+        },
+        "scheduledPurgeTime": {
+          "description": "Specifies purge time",
+          "type": "string",
+          "readOnly": true
+        },
+        "deleteActivityID": {
+          "description": "Delete activity ID for troubleshooting purpose",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "DeleteOption": {
+      "description": "Delete Option",
+      "discriminator": "objectType",
+      "properties": {
+        "duration": {
+          "description": "Duration of deletion after given timespan",
+          "type": "string"
+        },
+        "objectType": {
+          "description": "Type of the specific object - used for deserializing",
+          "type": "string"
+        }
+      },
+      "required": [
+        "duration",
+        "objectType"
+      ],
+      "title": "DeleteOption",
+      "type": "object"
+    },
+    "DppIdentityDetails": {
+      "description": "Identity details",
+      "properties": {
+        "principalId": {
+          "description": "The object ID of the service principal object for the managed identity that is used to grant role-based access to an Azure resource.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "tenantId": {
+          "description": "A Globally Unique Identifier (GUID) that represents the Azure AD tenant where the resource is now a member.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "type": {
+          "description": "The identityType which can be either SystemAssigned, UserAssigned, 'SystemAssigned,UserAssigned' or None",
+          "type": "string"
+        },
+        "userAssignedIdentities": {
+          "description": "Gets or sets the user assigned identities.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "../../../../../common-types/resource-management/v4/managedidentity.json#/definitions/UserAssignedIdentity"
+          }
+        }
+      },
+      "title": "DppIdentityDetails",
+      "type": "object"
+    },
+    "DppBaseResourceList": {
+      "description": "Base for all lists of V2 resources.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "List of Dpp resources.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DppBaseResource"
+          }
+        },
+        "nextLink": {
+          "description": "The uri to fetch the next page of resources. Call ListNext() fetches next page of resources.",
+          "type": "string"
+        }
+      }
+    },
+    "DppBaseResource": {
+      "type": "object",
+      "description": "Base resource under Microsoft.DataProtection provider namespace",
+      "properties": {
+        "id": {
+          "description": "Resource Id represents the complete path to the resource.",
+          "type": "string",
+          "readOnly": true
+        },
+        "name": {
+          "description": "Resource name associated with the resource.",
+          "type": "string",
+          "readOnly": true
+        },
+        "type": {
+          "description": "Resource type represents the complete path of the form Namespace/ResourceType/ResourceType/...",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "DppResource": {
+      "description": "Resource class",
+      "properties": {
+        "id": {
+          "description": "Resource Id represents the complete path to the resource.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "name": {
+          "description": "Resource name associated with the resource.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "type": {
+          "description": "Resource type represents the complete path of the form Namespace/ResourceType/ResourceType/...",
+          "readOnly": true,
+          "type": "string"
+        },
+        "systemData": {
+          "$ref": "../../../../../common-types/resource-management/v4/types.json#/definitions/systemData"
+        }
+      },
+      "title": "DppResource",
+      "type": "object",
+      "x-ms-azure-resource": true
+    },
+    "DppResourceList": {
+      "description": "ListResource",
+      "properties": {
+        "nextLink": {
+          "description": "The uri to fetch the next page of resources. Call ListNext() fetches next page of resources.",
+          "type": "string"
+        }
+      },
+      "title": "List Resource",
+      "type": "object"
+    },
+    "DppBaseTrackedResource": {
+      "properties": {
+        "eTag": {
+          "description": "Optional ETag.",
+          "type": "string"
+        },
+        "id": {
+          "description": "Resource Id represents the complete path to the resource.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "location": {
+          "description": "Resource location.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Resource name associated with the resource.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "tags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Resource tags.",
+          "type": "object"
+        },
+        "type": {
+          "description": "Resource type represents the complete path of the form Namespace/ResourceType/ResourceType/...",
+          "readOnly": true,
+          "type": "string"
+        },
+        "systemData": {
+          "$ref": "../../../../../common-types/resource-management/v4/types.json#/definitions/systemData"
+        }
+      },
+      "type": "object",
+      "x-ms-azure-resource": true
+    },
+    "DppTrackedResource": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/DppBaseTrackedResource"
+        }
+      ],
+      "properties": {
+        "identity": {
+          "$ref": "#/definitions/DppIdentityDetails",
+          "description": "Input Managed Identity Details"
+        }
+      },
+      "type": "object",
+      "x-ms-azure-resource": true
+    },
+    "ImmutabilitySettings": {
+      "description": "Immutability Settings at vault level",
+      "type": "object",
+      "properties": {
+        "state": {
+          "description": "Immutability state",
+          "enum": [
+            "Disabled",
+            "Unlocked",
+            "Locked"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "ImmutabilityState",
+            "modelAsString": true
+          }
+        }
+      }
+    },
+    "DppProxyResource": {
+      "properties": {
+        "id": {
+          "description": "Proxy Resource Id represents the complete path to the resource.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "name": {
+          "description": "Proxy Resource name associated with the resource.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "type": {
+          "description": "Proxy Resource type represents the complete path of the form Namespace/ResourceType/ResourceType/...",
+          "readOnly": true,
+          "type": "string"
+        },
+        "tags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Proxy Resource tags.",
+          "type": "object"
+        },
+        "systemData": {
+          "$ref": "../../../../../common-types/resource-management/v4/types.json#/definitions/systemData"
+        }
+      },
+      "type": "object",
+      "x-ms-azure-resource": true
+    },
+    "DppTrackedResourceList": {
+      "properties": {
+        "nextLink": {
+          "description": "The uri to fetch the next page of resources. Call ListNext() fetches next page of resources.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "DppWorkerRequest": {
+      "type": "object",
+      "properties": {
+        "subscriptionId": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "supportedGroupVersions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "cultureInfo": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "httpMethod": {
+          "type": "string"
+        }
+      }
+    },
+    "encryptionSettings": {
+      "description": "Customer Managed Key details of the resource.",
+      "type": "object",
+      "properties": {
+        "state": {
+          "description": "Encryption state of the Backup Vault.",
+          "type": "string",
+          "enum": [
+            "Enabled",
+            "Disabled",
+            "Inconsistent"
+          ],
+          "x-ms-enum": {
+            "name": "EncryptionState",
+            "modelAsString": true,
+            "values": [
+              {
+                "description": "CMK encryption is enabled on the Backup Vault",
+                "value": "Enabled"
+              },
+              {
+                "description": "CMK encryption is disabled on the Backup Vault. User can not set this state once Encryption State is 'Enabled'.",
+                "value": "Disabled"
+              },
+              {
+                "description": "CMK encryption is in inconsistent state on the Backup Vault. This state indicates that user needs to retry the encryption settings operation immediately to correct the state.",
+                "value": "Inconsistent"
+              }
+            ]
+          }
+        },
+        "keyVaultProperties": {
+          "$ref": "#/definitions/CmkKeyVaultProperties"
+        },
+        "kekIdentity": {
+          "$ref": "#/definitions/CmkKekIdentity"
+        },
+        "infrastructureEncryption": {
+          "description": "Enabling/Disabling the Double Encryption state",
+          "type": "string",
+          "enum": [
+            "Enabled",
+            "Disabled"
+          ],
+          "x-ms-enum": {
+            "name": "InfrastructureEncryptionState",
+            "modelAsString": true
+          }
+        }
+      }
+    },
+    "Error": {
+      "description": "The resource management error response.",
+      "properties": {
+        "additionalInfo": {
+          "description": "The error additional info.",
+          "items": {
+            "$ref": "#/definitions/ErrorAdditionalInfo"
+          },
+          "x-ms-identifiers": [],
+          "readOnly": true,
+          "type": "array"
+        },
+        "code": {
+          "description": "The error code.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "details": {
+          "description": "The error details.",
+          "items": {
+            "$ref": "#/definitions/Error"
+          },
+          "x-ms-identifiers": [],
+          "readOnly": true,
+          "type": "array"
+        },
+        "message": {
+          "description": "The error message.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "target": {
+          "description": "The error target.",
+          "readOnly": true,
+          "type": "string"
+        }
+      }
+    },
+    "ErrorAdditionalInfo": {
+      "description": "The resource management error additional info.",
+      "properties": {
+        "info": {
+          "description": "The additional info.",
+          "readOnly": true,
+          "type": "object"
+        },
+        "type": {
+          "description": "The additional info type.",
+          "readOnly": true,
+          "type": "string"
+        }
+      }
+    },
+    "ExportJobsResult": {
+      "description": "The result for export jobs containing blob details.",
+      "properties": {
+        "blobUrl": {
+          "description": "URL of the blob into which the serialized string of list of jobs is exported.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "blobSasKey": {
+          "description": "SAS key to access the blob.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "excelFileBlobUrl": {
+          "description": "URL of the blob into which the ExcelFile is uploaded.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "excelFileBlobSasKey": {
+          "description": "SAS key to access the ExcelFile blob.",
+          "readOnly": true,
+          "type": "string"
+        }
+      },
+      "title": "ExportJobsResult",
+      "type": "object"
+    },
+    "FeatureSettings": {
+      "description": "Class containing feature settings of vault",
+      "type": "object",
+      "properties": {
+        "crossSubscriptionRestoreSettings": {
+          "$ref": "#/definitions/CrossSubscriptionRestoreSettings"
+        },
+        "crossRegionRestoreSettings": {
+          "$ref": "#/definitions/CrossRegionRestoreSettings"
+        }
+      }
+    },
+    "FeatureValidationRequest": {
+      "description": "Base class for feature object",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/FeatureValidationRequestBase"
+        }
+      ],
+      "properties": {
+        "featureType": {
+          "description": "backup support feature type.",
+          "enum": [
+            "Invalid",
+            "DataSourceType"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "FeatureType",
+            "modelAsString": true
+          }
+        },
+        "featureName": {
+          "description": "backup support feature name.",
+          "type": "string"
+        }
+      },
+      "x-ms-discriminator-value": "FeatureValidationRequest"
+    },
+    "FeatureValidationRequestBase": {
+      "description": "Base class for Backup Feature support",
+      "required": [
+        "objectType"
+      ],
+      "type": "object",
+      "properties": {
+        "objectType": {
+          "description": "Type of the specific object - used for deserializing",
+          "type": "string",
+          "readOnly": false
+        }
+      },
+      "discriminator": "objectType"
+    },
+    "FeatureValidationResponse": {
+      "description": "Feature Validation Response",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/FeatureValidationResponseBase"
+        }
+      ],
+      "properties": {
+        "featureType": {
+          "description": "backup support feature type.",
+          "enum": [
+            "Invalid",
+            "DataSourceType"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "FeatureType",
+            "modelAsString": true
+          }
+        },
+        "features": {
+          "description": "Response features",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SupportedFeature"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "x-ms-discriminator-value": "FeatureValidationResponse"
+    },
+    "FeatureValidationResponseBase": {
+      "description": "Base class for Backup Feature support",
+      "required": [
+        "objectType"
+      ],
+      "type": "object",
+      "properties": {
+        "objectType": {
+          "description": "Type of the specific object - used for deserializing",
+          "type": "string",
+          "readOnly": false
+        }
+      },
+      "discriminator": "objectType"
+    },
+    "ImmediateCopyOption": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/CopyOption"
+        }
+      ],
+      "description": "Immediate copy Option",
+      "required": [
+        "objectType"
+      ],
+      "title": "ImmediateCopyOption",
+      "type": "object",
+      "x-ms-discriminator-value": "ImmediateCopyOption"
+    },
+    "InnerError": {
+      "description": "Inner Error",
+      "properties": {
+        "additionalInfo": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Any Key value pairs that can be provided to the client for additional  verbose information.",
+          "type": "object"
+        },
+        "code": {
+          "description": "Unique code for this error",
+          "type": "string"
+        },
+        "embeddedInnerError": {
+          "$ref": "#/definitions/InnerError",
+          "description": "Child Inner Error, to allow Nesting."
+        }
+      },
+      "title": "InnerError",
+      "type": "object"
+    },
+    "ItemLevelRestoreCriteria": {
+      "description": "Class to contain criteria for item level restore",
+      "required": [
+        "objectType"
+      ],
+      "type": "object",
+      "properties": {
+        "objectType": {
+          "description": "Type of the specific object - used for deserializing",
+          "type": "string"
+        }
+      },
+      "discriminator": "objectType"
+    },
+    "ItemLevelRestoreTargetInfo": {
+      "description": "Restore target info for Item level restore operation",
+      "required": [
+        "restoreCriteria",
+        "datasourceInfo",
+        "recoveryOption"
+      ],
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/RestoreTargetInfoBase"
+        }
+      ],
+      "properties": {
+        "restoreCriteria": {
+          "description": "Restore Criteria",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ItemLevelRestoreCriteria"
+          },
+          "x-ms-identifiers": []
+        },
+        "datasourceInfo": {
+          "$ref": "#/definitions/Datasource",
+          "description": "Information of target DS"
+        },
+        "datasourceSetInfo": {
+          "$ref": "#/definitions/DatasourceSet",
+          "description": "Information of target DS Set"
+        },
+        "datasourceAuthCredentials": {
+          "$ref": "#/definitions/AuthCredentials",
+          "description": "Credentials to use to authenticate with data source provider."
+        }
+      },
+      "x-ms-discriminator-value": "ItemLevelRestoreTargetInfo"
+    },
+    "ItemPathBasedRestoreCriteria": {
+      "description": "Prefix criteria to be used to during restore",
+      "required": [
+        "itemPath",
+        "isPathRelativeToBackupItem",
+        "objectType"
+      ],
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ItemLevelRestoreCriteria"
+        }
+      ],
+      "properties": {
+        "itemPath": {
+          "description": "The path of the item to be restored. It could be the full path of the item or the path relative to the backup item",
+          "type": "string"
+        },
+        "isPathRelativeToBackupItem": {
+          "description": "Flag to specify if the path is relative to backup item or full path",
+          "type": "boolean"
+        },
+        "subItemPathPrefix": {
+          "description": "The list of prefix strings to be used as filter criteria during restore. These are relative to the item path specified.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "x-ms-discriminator-value": "ItemPathBasedRestoreCriteria"
+    },
+    "JobExtendedInfo": {
+      "description": "Extended Information about the job",
+      "properties": {
+        "additionalDetails": {
+          "additionalProperties": {
+            "readOnly": true,
+            "type": "string"
+          },
+          "description": "Job's Additional Details"
+        },
+        "backupInstanceState": {
+          "description": "State of the Backup Instance",
+          "readOnly": true,
+          "type": "string"
+        },
+        "dataTransferredInBytes": {
+          "description": "Number of bytes transferred",
+          "format": "double",
+          "readOnly": true,
+          "type": "number"
+        },
+        "recoveryDestination": {
+          "description": "Destination where restore is done",
+          "readOnly": true,
+          "type": "string"
+        },
+        "sourceRecoverPoint": {
+          "$ref": "#/definitions/RestoreJobRecoveryPointDetails",
+          "description": "Details of the Source Recovery Point",
+          "readOnly": true
+        },
+        "subTasks": {
+          "description": "List of Sub Tasks of the job",
+          "items": {
+            "$ref": "#/definitions/JobSubTask"
+          },
+          "x-ms-identifiers": [],
+          "readOnly": true,
+          "type": "array"
+        },
+        "targetRecoverPoint": {
+          "$ref": "#/definitions/RestoreJobRecoveryPointDetails",
+          "description": "Details of the Target Recovery Point",
+          "readOnly": true
+        },
+        "warningDetails": {
+          "description": "A List, detailing the warnings related to the job",
+          "items": {
+            "$ref": "#/definitions/UserFacingWarningDetail"
+          },
+          "x-ms-identifiers": [],
+          "readOnly": true,
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "JobSubTask": {
+      "description": "Details of Job's Sub Task",
+      "properties": {
+        "additionalDetails": {
+          "additionalProperties": {
+            "readOnly": true,
+            "type": "string"
+          },
+          "description": "Additional details of Sub Tasks"
+        },
+        "taskId": {
+          "description": "Task Id of the Sub Task",
+          "format": "int32",
+          "type": "integer"
+        },
+        "taskName": {
+          "description": "Name of the Sub Task",
+          "type": "string"
+        },
+        "taskProgress": {
+          "description": "Progress of the Sub Task",
+          "readOnly": true,
+          "type": "string"
+        },
+        "taskStatus": {
+          "description": "Status of the Sub Task",
+          "type": "string"
+        }
+      },
+      "required": [
+        "taskId",
+        "taskName",
+        "taskStatus"
+      ],
+      "type": "object"
+    },
+    "MonitoringSettings": {
+      "type": "object",
+      "description": "Monitoring Settings",
+      "properties": {
+        "azureMonitorAlertSettings": {
+          "$ref": "#/definitions/AzureMonitorAlertSettings"
+        }
+      }
+    },
+    "OperationExtendedInfo": {
+      "description": "Operation Extended Info",
+      "properties": {
+        "objectType": {
+          "description": "This property will be used as the discriminator for deciding the specific types in the polymorphic chain of types.",
+          "type": "string"
+        }
+      },
+      "title": "OperationExtendedInfo",
+      "discriminator": "objectType",
+      "type": "object",
+      "required": [
+        "objectType"
+      ]
+    },
+    "CrossRegionRestoreDetails": {
+      "description": "Cross Region Restore details",
+      "required": [
+        "sourceRegion",
+        "sourceBackupInstanceId"
+      ],
+      "type": "object",
+      "properties": {
+        "sourceRegion": {
+          "type": "string"
+        },
+        "sourceBackupInstanceId": {
+          "type": "string"
+        }
+      }
+    },
+    "ValidateCrossRegionRestoreRequestObject": {
+      "description": "Cross Region Restore Request Object",
+      "required": [
+        "restoreRequestObject",
+        "crossRegionRestoreDetails"
+      ],
+      "type": "object",
+      "properties": {
+        "restoreRequestObject": {
+          "$ref": "#/definitions/AzureBackupRestoreRequest",
+          "description": "Gets or sets the restore request object."
+        },
+        "crossRegionRestoreDetails": {
+          "$ref": "#/definitions/CrossRegionRestoreDetails",
+          "description": "Cross region restore details."
+        }
+      }
+    },
+    "CrossRegionRestoreRequestObject": {
+      "description": "Cross Region Restore Request Object",
+      "required": [
+        "restoreRequestObject",
+        "crossRegionRestoreDetails"
+      ],
+      "type": "object",
+      "properties": {
+        "restoreRequestObject": {
+          "$ref": "#/definitions/AzureBackupRestoreRequest",
+          "description": "Gets or sets the restore request object."
+        },
+        "crossRegionRestoreDetails": {
+          "$ref": "#/definitions/CrossRegionRestoreDetails",
+          "description": "Cross region restore details."
+        }
+      }
+    },
+    "OperationJobExtendedInfo": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/OperationExtendedInfo"
+        }
+      ],
+      "description": "Operation Job Extended Info",
+      "properties": {
+        "jobId": {
+          "description": "Name or Arm Id of the job created for this operation.",
+          "type": "string"
+        }
+      },
+      "title": "OperationJobExtendedInfo",
+      "type": "object",
+      "x-ms-discriminator-value": "OperationJobExtendedInfo"
+    },
+    "OperationResource": {
+      "description": "Operation Resource",
+      "properties": {
+        "endTime": {
+          "description": "End time of the operation",
+          "format": "date-time",
+          "type": "string"
+        },
+        "error": {
+          "$ref": "#/definitions/Error",
+          "description": "Required if status == failed or status == canceled. This is the OData v4 error format, used by the RPC and will go into the v2.2 Azure REST API guidelines.\r\nThe full set of optional properties (e.g. inner errors / details) can be found in the \"Error Response\" section."
+        },
+        "id": {
+          "description": "It should match what is used to GET the operation result",
+          "type": "string"
+        },
+        "name": {
+          "description": "It must match the last segment of the \"id\" field, and will typically be a GUID / system generated value",
+          "type": "string"
+        },
+        "properties": {
+          "$ref": "#/definitions/OperationExtendedInfo",
+          "description": "End time of the operation"
+        },
+        "startTime": {
+          "description": "Start time of the operation",
+          "format": "date-time",
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        }
+      },
+      "title": "OperationResource",
+      "type": "object"
+    },
+    "PatchBackupVaultInput": {
+      "description": "Backup Vault Contract for Patch Backup Vault API.",
+      "type": "object",
+      "properties": {
+        "monitoringSettings": {
+          "$ref": "#/definitions/MonitoringSettings",
+          "description": "Monitoring Settings"
+        },
+        "securitySettings": {
+          "$ref": "#/definitions/SecuritySettings",
+          "description": "Security Settings"
+        },
+        "featureSettings": {
+          "$ref": "#/definitions/FeatureSettings",
+          "description": "Feature Settings"
+        },
+        "resourceGuardOperationRequests": {
+          "description": "ResourceGuardOperationRequests on which LAC check will be performed",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PatchResourceRequestInput": {
+      "description": "Patch Request content for Microsoft.DataProtection resources",
+      "properties": {
+        "identity": {
+          "$ref": "#/definitions/DppIdentityDetails",
+          "description": "Input Managed Identity Details"
+        },
+        "properties": {
+          "$ref": "#/definitions/PatchBackupVaultInput",
+          "description": "Resource properties."
+        },
+        "tags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Resource tags.",
+          "type": "object"
+        }
+      },
+      "title": "PatchResourceRequestInput",
+      "type": "object"
+    },
+    "PatchResourceGuardInput": {
+      "description": "Patch Request content for Microsoft.DataProtection Resource Guard resources",
+      "properties": {
+        "tags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Resource Guard tags.",
+          "type": "object"
+        }
+      },
+      "title": "PatchResourceGuardInput",
+      "type": "object"
+    },
+    "PolicyInfo": {
+      "description": "Policy Info in backupInstance",
+      "properties": {
+        "policyId": {
+          "type": "string"
+        },
+        "policyVersion": {
+          "readOnly": true,
+          "type": "string"
+        },
+        "policyParameters": {
+          "$ref": "#/definitions/PolicyParameters",
+          "description": "Policy parameters for the backup instance"
+        }
+      },
+      "required": [
+        "policyId"
+      ],
+      "title": "PolicyInfo",
+      "type": "object"
+    },
+    "PolicyParameters": {
+      "description": "Parameters in Policy",
+      "type": "object",
+      "x-ms-mutability": [
+        "create",
+        "read"
+      ],
+      "properties": {
+        "dataStoreParametersList": {
+          "description": "Gets or sets the DataStore Parameters",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DataStoreParameters"
+          },
+          "x-ms-identifiers": []
+        },
+        "backupDatasourceParametersList": {
+          "description": "Gets or sets the Backup Data Source Parameters",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BackupDatasourceParameters"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "ProtectionStatusDetails": {
+      "description": "Protection status details",
+      "properties": {
+        "errorDetails": {
+          "$ref": "#/definitions/UserFacingError",
+          "description": "Specifies the protection status error of the resource"
+        },
+        "status": {
+          "description": "Specifies the protection status of the resource",
+          "enum": [
+            "ConfiguringProtection",
+            "ConfiguringProtectionFailed",
+            "ProtectionConfigured",
+            "ProtectionStopped",
+            "SoftDeleted",
+            "SoftDeleting"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "modelAsString": true,
+            "name": "Status"
+          }
+        }
+      },
+      "title": "ProtectionStatusDetails",
+      "type": "object"
+    },
+    "RangeBasedItemLevelRestoreCriteria": {
+      "description": "Item Level target info for restore operation",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ItemLevelRestoreCriteria"
+        }
+      ],
+      "properties": {
+        "minMatchingValue": {
+          "description": "minimum value for range prefix match",
+          "type": "string"
+        },
+        "maxMatchingValue": {
+          "description": "maximum value for range prefix match",
+          "type": "string"
+        }
+      },
+      "x-ms-discriminator-value": "RangeBasedItemLevelRestoreCriteria"
+    },
+    "KubernetesStorageClassRestoreCriteria": {
+      "description": "Item Level kubernetes storage class target info for restore operation",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ItemLevelRestoreCriteria"
+        }
+      ],
+      "properties": {
+        "selectedStorageClassName": {
+          "description": "Selected storage class name",
+          "type": "string"
+        },
+        "provisioner": {
+          "description": "Provisioner of the storage class",
+          "type": "string"
+        }
+      },
+      "x-ms-discriminator-value": "KubernetesStorageClassRestoreCriteria"
+    },
+    "NamespacedNameResource": {
+      "description": "Class to refer resources which contains namespace and name",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the resource",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace in which the resource exists",
+          "type": "string"
+        }
+      },
+      "title": "NamespacedNameResource"
+    },
+    "KubernetesPVRestoreCriteria": {
+      "description": "Item Level kubernetes persistent volume target info for restore operation",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ItemLevelRestoreCriteria"
+        }
+      ],
+      "properties": {
+        "name": {
+          "description": "Selected persistent volume claim name",
+          "type": "string"
+        },
+        "storageClassName": {
+          "description": "Selected storage class name for restore operation",
+          "type": "string"
+        }
+      },
+      "x-ms-discriminator-value": "KubernetesPVRestoreCriteria"
+    },
+    "KubernetesClusterRestoreCriteria": {
+      "description": "kubernetes Cluster Backup target info for restore operation",
+      "required": [
+        "includeClusterScopeResources"
+      ],
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ItemLevelRestoreCriteria"
+        }
+      ],
+      "properties": {
+        "includeClusterScopeResources": {
+          "description": "Gets or sets the include cluster resources property. This property if enabled will include cluster scope resources during restore.",
+          "type": "boolean"
+        },
+        "includedNamespaces": {
+          "description": "Gets or sets the include namespaces property. This property sets the namespaces to be included during restore.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "excludedNamespaces": {
+          "description": "Gets or sets the exclude namespaces property. This property sets the namespaces to be excluded during restore.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "includedResourceTypes": {
+          "description": "Gets or sets the include resource types property. This property sets the resource types to be included during restore.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "excludedResourceTypes": {
+          "description": "Gets or sets the exclude resource types property. This property sets the resource types to be excluded during restore.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "labelSelectors": {
+          "description": "Gets or sets the LabelSelectors property. This property sets the resource with such label selectors to be included during restore.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "persistentVolumeRestoreMode": {
+          "description": "Gets or sets the PV (Persistent Volume) Restore Mode property. This property sets whether volumes needs to be restored.",
+          "enum": [
+            "RestoreWithVolumeData",
+            "RestoreWithoutVolumeData"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "PersistentVolumeRestoreMode",
+            "modelAsString": true
+          }
+        },
+        "conflictPolicy": {
+          "description": "Gets or sets the Conflict Policy property. This property sets policy during conflict of resources during restore.",
+          "enum": [
+            "Skip",
+            "Patch"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "ExistingResourcePolicy",
+            "modelAsString": true
+          }
+        },
+        "namespaceMappings": {
+          "description": "Gets or sets the Namespace Mappings property. This property sets if namespace needs to be change during restore.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "restoreHookReferences": {
+          "description": "Gets or sets the restore hook references. This property sets the hook reference to be executed during restore.",
+          "items": {
+            "$ref": "#/definitions/NamespacedNameResource"
+          },
+          "x-ms-identifiers": [],
+          "type": "array"
+        },
+        "resourceModifierReference": {
+          "description": "Gets or sets the resource modifier reference. This property sets the reference for resource modifier during restore.",
+          "$ref": "#/definitions/NamespacedNameResource"
+        }
+      },
+      "x-ms-discriminator-value": "KubernetesClusterRestoreCriteria"
+    },
+    "KubernetesClusterVaultTierRestoreCriteria": {
+      "description": "kubernetes Cluster Backup target info for restore operation from vault",
+      "required": [
+        "includeClusterScopeResources"
+      ],
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ItemLevelRestoreCriteria"
+        }
+      ],
+      "properties": {
+        "includeClusterScopeResources": {
+          "description": "Gets or sets the include cluster resources property. This property if enabled will include cluster scope resources during restore from vault.",
+          "type": "boolean"
+        },
+        "includedNamespaces": {
+          "description": "Gets or sets the include namespaces property. This property sets the namespaces to be included during restore from vault.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "excludedNamespaces": {
+          "description": "Gets or sets the exclude namespaces property. This property sets the namespaces to be excluded during restore from vault.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "includedResourceTypes": {
+          "description": "Gets or sets the include resource types property. This property sets the resource types to be included during restore from vault.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "excludedResourceTypes": {
+          "description": "Gets or sets the exclude resource types property. This property sets the resource types to be excluded during restore from vault.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "labelSelectors": {
+          "description": "Gets or sets the LabelSelectors property. This property sets the resource with such label selectors to be included during restore from vault.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "persistentVolumeRestoreMode": {
+          "description": "Gets or sets the PV (Persistent Volume) Restore Mode property. This property sets whether volumes needs to be restored from vault.",
+          "enum": [
+            "RestoreWithVolumeData",
+            "RestoreWithoutVolumeData"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "PersistentVolumeRestoreMode",
+            "modelAsString": true
+          }
+        },
+        "conflictPolicy": {
+          "description": "Gets or sets the Conflict Policy property. This property sets policy during conflict of resources during restore from vault.",
+          "enum": [
+            "Skip",
+            "Patch"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "ExistingResourcePolicy",
+            "modelAsString": true
+          }
+        },
+        "namespaceMappings": {
+          "description": "Gets or sets the Namespace Mappings property. This property sets if namespace needs to be change during restore from vault.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "restoreHookReferences": {
+          "description": "Gets or sets the restore hook references. This property sets the hook reference to be executed during restore from vault.",
+          "items": {
+            "$ref": "#/definitions/NamespacedNameResource"
+          },
+          "x-ms-identifiers": [],
+          "type": "array"
+        },
+        "stagingResourceGroupId": {
+          "description": "Gets or sets the staging RG Id for creating staging disks and snapshots during restore from vault.",
+          "type": "string",
+          "format": "arm-id"
+        },
+        "stagingStorageAccountId": {
+          "description": "Gets or sets the staging Storage Account Id for creating backup extension object store data during restore from vault.",
+          "type": "string",
+          "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Storage/storageAccounts"
+              }
+            ]
+          }
+        },
+        "resourceModifierReference": {
+          "description": "Gets or sets the resource modifier reference. This property sets the reference for resource modifier during restore.",
+          "$ref": "#/definitions/NamespacedNameResource"
+        }
+      },
+      "x-ms-discriminator-value": "KubernetesClusterVaultTierRestoreCriteria"
+    },
+    "RecoveryPointDataStoreDetails": {
+      "description": "RecoveryPoint datastore details",
+      "properties": {
+        "creationTime": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "expiryTime": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "metaData": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "visible": {
+          "type": "boolean"
+        },
+        "rehydrationExpiryTime": {
+          "format": "date-time",
+          "type": "string",
+          "readOnly": true
+        },
+        "rehydrationStatus": {
+          "readOnly": true,
+          "enum": [
+            "CREATE_IN_PROGRESS",
+            "COMPLETED",
+            "DELETE_IN_PROGRESS",
+            "DELETED",
+            "FAILED"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "modelAsString": true,
+            "name": "RehydrationStatus"
+          }
+        }
+      },
+      "title": "RecoveryPointDataStoreDetails",
+      "type": "object"
+    },
+    "RehydrationPriority": {
+      "description": "Priority to be used for rehydration. Values High or Standard",
+      "enum": [
+        "Invalid",
+        "High",
+        "Standard"
+      ],
+      "type": "string",
+      "x-ms-enum": {
+        "modelAsString": true,
+        "name": "RehydrationPriority"
+      }
+    },
+    "RestoreFilesTargetInfo": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/RestoreTargetInfoBase"
+        }
+      ],
+      "description": "Class encapsulating restore as files target parameters",
+      "properties": {
+        "targetDetails": {
+          "$ref": "#/definitions/TargetDetails",
+          "description": "Destination of RestoreAsFiles operation, when destination is not a datasource"
+        }
+      },
+      "required": [
+        "recoveryOption",
+        "targetDetails"
+      ],
+      "type": "object",
+      "x-ms-discriminator-value": "RestoreFilesTargetInfo"
+    },
+    "RestoreJobRecoveryPointDetails": {
+      "properties": {
+        "recoveryPointID": {
+          "type": "string"
+        },
+        "recoveryPointTime": {
+          "format": "date-time",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "RestoreTargetInfo": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/RestoreTargetInfoBase"
+        }
+      ],
+      "description": "Class encapsulating restore target parameters",
+      "properties": {
+        "datasourceInfo": {
+          "$ref": "#/definitions/Datasource",
+          "description": "Information of target DS"
+        },
+        "datasourceSetInfo": {
+          "$ref": "#/definitions/DatasourceSet",
+          "description": "Information of target DS Set"
+        },
+        "datasourceAuthCredentials": {
+          "$ref": "#/definitions/AuthCredentials",
+          "description": "Credentials to use to authenticate with data source provider."
+        }
+      },
+      "required": [
+        "datasourceInfo",
+        "recoveryOption"
+      ],
+      "type": "object",
+      "x-ms-discriminator-value": "RestoreTargetInfo"
+    },
+    "RestoreTargetInfoBase": {
+      "description": "Base class common to RestoreTargetInfo and RestoreFilesTargetInfo",
+      "discriminator": "objectType",
+      "properties": {
+        "objectType": {
+          "description": "Type of Datasource object, used to initialize the right inherited type",
+          "type": "string"
+        },
+        "recoveryOption": {
+          "description": "Recovery Option",
+          "enum": [
+            "FailIfExists"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "modelAsString": true,
+            "name": "RecoveryOption"
+          }
+        },
+        "restoreLocation": {
+          "description": "Target Restore region",
+          "type": "string"
+        }
+      },
+      "required": [
+        "objectType",
+        "recoveryOption"
+      ],
+      "type": "object"
+    },
+    "ResourceMoveDetails": {
+      "description": "ResourceMoveDetails will be returned in response to GetResource call from ARM",
+      "type": "object",
+      "properties": {
+        "operationId": {
+          "description": "CorrelationId of latest ResourceMove operation attempted",
+          "type": "string"
+        },
+        "startTimeUtc": {
+          "description": "Start time in UTC of latest ResourceMove operation attempted. ISO 8601 format.",
+          "type": "string"
+        },
+        "completionTimeUtc": {
+          "description": "Completion time in UTC of latest ResourceMove operation attempted. ISO 8601 format.",
+          "type": "string"
+        },
+        "sourceResourcePath": {
+          "description": "ARM resource path of source resource",
+          "type": "string"
+        },
+        "targetResourcePath": {
+          "description": "ARM resource path of target resource used in latest ResourceMove operation",
+          "type": "string"
+        }
+      }
+    },
+    "RestorableTimeRange": {
+      "required": [
+        "startTime",
+        "endTime"
+      ],
+      "type": "object",
+      "properties": {
+        "startTime": {
+          "description": "Start time for the available restore range",
+          "type": "string"
+        },
+        "endTime": {
+          "description": "End time for the available restore range",
+          "type": "string"
+        },
+        "objectType": {
+          "type": "string"
+        }
+      }
+    },
+    "RetentionTag": {
+      "description": "Retention tag",
+      "properties": {
+        "eTag": {
+          "description": "Retention Tag version.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "id": {
+          "description": "Retention Tag version.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "tagName": {
+          "description": "Retention Tag Name to relate it to retention rule.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "tagName"
+      ],
+      "title": "RetentionTag",
+      "type": "object"
+    },
+    "ScheduleBasedBackupCriteria": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/BackupCriteria"
+        }
+      ],
+      "description": "Schedule based backup criteria",
+      "properties": {
+        "absoluteCriteria": {
+          "description": "it contains absolute values like \"AllBackup\" / \"FirstOfDay\" / \"FirstOfWeek\" / \"FirstOfMonth\"\r\nand should be part of AbsoluteMarker enum",
+          "items": {
+            "enum": [
+              "AllBackup",
+              "FirstOfDay",
+              "FirstOfMonth",
+              "FirstOfWeek",
+              "FirstOfYear"
+            ],
+            "type": "string",
+            "x-ms-enum": {
+              "modelAsString": true,
+              "name": "AbsoluteMarker"
+            }
+          },
+          "type": "array"
+        },
+        "daysOfMonth": {
+          "description": "This is day of the month from 1 to 28 other wise last of month",
+          "items": {
+            "$ref": "#/definitions/Day"
+          },
+          "x-ms-identifiers": [],
+          "type": "array"
+        },
+        "daysOfTheWeek": {
+          "description": "It should be Sunday/Monday/T..../Saturday",
+          "items": {
+            "enum": [
+              "Friday",
+              "Monday",
+              "Saturday",
+              "Sunday",
+              "Thursday",
+              "Tuesday",
+              "Wednesday"
+            ],
+            "type": "string",
+            "x-ms-enum": {
+              "modelAsString": true,
+              "name": "DayOfWeek"
+            }
+          },
+          "type": "array"
+        },
+        "monthsOfYear": {
+          "description": "It should be January/February/....../December",
+          "items": {
+            "enum": [
+              "April",
+              "August",
+              "December",
+              "February",
+              "January",
+              "July",
+              "June",
+              "March",
+              "May",
+              "November",
+              "October",
+              "September"
+            ],
+            "type": "string",
+            "x-ms-enum": {
+              "modelAsString": true,
+              "name": "Month"
+            }
+          },
+          "type": "array"
+        },
+        "scheduleTimes": {
+          "description": "List of schedule times for backup",
+          "items": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "weeksOfTheMonth": {
+          "description": "It should be First/Second/Third/Fourth/Last",
+          "items": {
+            "enum": [
+              "First",
+              "Fourth",
+              "Last",
+              "Second",
+              "Third"
+            ],
+            "type": "string",
+            "x-ms-enum": {
+              "modelAsString": true,
+              "name": "WeekNumber"
+            }
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "objectType"
+      ],
+      "title": "ScheduleBasedBackupCriteria",
+      "type": "object",
+      "x-ms-discriminator-value": "ScheduleBasedBackupCriteria"
+    },
+    "ScheduleBasedTriggerContext": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/TriggerContext"
+        }
+      ],
+      "description": "Schedule based trigger context",
+      "properties": {
+        "schedule": {
+          "$ref": "#/definitions/BackupSchedule",
+          "description": "Schedule for this backup"
+        },
+        "taggingCriteria": {
+          "description": "List of tags that can be applicable for given schedule.",
+          "items": {
+            "$ref": "#/definitions/TaggingCriteria"
+          },
+          "x-ms-identifiers": [],
+          "type": "array"
+        }
+      },
+      "required": [
+        "objectType",
+        "schedule",
+        "taggingCriteria"
+      ],
+      "title": "ScheduleBasedTriggerContext",
+      "type": "object",
+      "x-ms-discriminator-value": "ScheduleBasedTriggerContext"
+    },
+    "SecretStoreBasedAuthCredentials": {
+      "description": "Secret store based authentication credentials.",
+      "required": [
+        "objectType"
+      ],
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AuthCredentials"
+        }
+      ],
+      "properties": {
+        "secretStoreResource": {
+          "$ref": "#/definitions/SecretStoreResource",
+          "description": "Secret store resource"
+        }
+      },
+      "x-ms-discriminator-value": "SecretStoreBasedAuthCredentials"
+    },
+    "SecretStoreResource": {
+      "description": "Class representing a secret store resource.",
+      "required": [
+        "secretStoreType"
+      ],
+      "type": "object",
+      "properties": {
+        "uri": {
+          "description": "Uri to get to the resource",
+          "type": "string"
+        },
+        "secretStoreType": {
+          "description": "Gets or sets the type of secret store",
+          "enum": [
+            "Invalid",
+            "AzureKeyVault"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "SecretStoreType",
+            "modelAsString": true
+          }
+        },
+        "value": {
+          "description": "Gets or sets value stored in secret store resource",
+          "type": "string"
+        }
+      }
+    },
+    "SecuritySettings": {
+      "description": "Class containing security settings of vault",
+      "type": "object",
+      "properties": {
+        "softDeleteSettings": {
+          "$ref": "#/definitions/SoftDeleteSettings"
+        },
+        "immutabilitySettings": {
+          "$ref": "#/definitions/ImmutabilitySettings"
+        },
+        "encryptionSettings": {
+          "$ref": "#/definitions/encryptionSettings"
+        }
+      }
+    },
+    "SoftDeleteSettings": {
+      "description": "Soft delete related settings",
+      "type": "object",
+      "properties": {
+        "state": {
+          "description": "State of soft delete",
+          "enum": [
+            "Off",
+            "On",
+            "AlwaysOn"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "SoftDeleteState",
+            "modelAsString": true,
+            "values": [
+              {
+                "description": "Soft Delete is turned off for the BackupVault",
+                "value": "Off"
+              },
+              {
+                "description": "Soft Delete is enabled for the BackupVault but can be turned off",
+                "value": "On"
+              },
+              {
+                "description": "Soft Delete is permanently enabled for the BackupVault and the setting cannot be changed",
+                "value": "AlwaysOn"
+              }
+            ]
+          }
+        },
+        "retentionDurationInDays": {
+          "description": "Soft delete retention duration",
+          "format": "double",
+          "type": "number"
+        }
+      }
+    },
+    "SourceLifeCycle": {
+      "description": "Source LifeCycle",
+      "properties": {
+        "deleteAfter": {
+          "$ref": "#/definitions/DeleteOption"
+        },
+        "sourceDataStore": {
+          "$ref": "#/definitions/DataStoreInfoBase"
+        },
+        "targetDataStoreCopySettings": {
+          "items": {
+            "$ref": "#/definitions/TargetCopySetting"
+          },
+          "x-ms-identifiers": [],
+          "type": "array"
+        }
+      },
+      "required": [
+        "deleteAfter",
+        "sourceDataStore"
+      ],
+      "title": "SourceLifeCycle",
+      "type": "object"
+    },
+    "StorageSetting": {
+      "description": "Storage setting",
+      "properties": {
+        "datastoreType": {
+          "description": "Gets or sets the type of the datastore.",
+          "enum": [
+            "ArchiveStore",
+            "OperationalStore",
+            "VaultStore"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "modelAsString": true,
+            "name": "StorageSettingStoreTypes"
+          }
+        },
+        "type": {
+          "description": "Gets or sets the type.",
+          "enum": [
+            "GeoRedundant",
+            "LocallyRedundant",
+            "ZoneRedundant"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "modelAsString": true,
+            "name": "StorageSettingTypes"
+          }
+        }
+      },
+      "title": "StorageSetting",
+      "type": "object"
+    },
+    "SupportedFeature": {
+      "description": "Elements class for feature request",
+      "type": "object",
+      "properties": {
+        "featureName": {
+          "description": "support feature type.",
+          "type": "string"
+        },
+        "supportStatus": {
+          "description": "feature support status",
+          "enum": [
+            "Invalid",
+            "NotSupported",
+            "AlphaPreview",
+            "PrivatePreview",
+            "PublicPreview",
+            "GenerallyAvailable"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "FeatureSupportStatus",
+            "modelAsString": true
+          }
+        },
+        "exposureControlledFeatures": {
+          "description": "support feature type.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "SyncBackupInstanceRequest": {
+      "description": "Sync BackupInstance Request",
+      "type": "object",
+      "properties": {
+        "syncType": {
+          "description": "Field indicating sync type e.g. to sync only in case of failure or in all cases",
+          "enum": [
+            "Default",
+            "ForceResync"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "SyncType",
+            "modelAsString": true
+          }
+        }
+      }
+    },
+    "StopProtectionRequest": {
+      "description": "Request body of Stop protection when MUA is Enabled",
+      "type": "object",
+      "properties": {
+        "resourceGuardOperationRequests": {
+          "description": "ResourceGuardOperationRequests on which LAC check will be performed",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "SuspendBackupRequest": {
+      "description": "Request body of Suspend backup when MUA is Enabled",
+      "type": "object",
+      "properties": {
+        "resourceGuardOperationRequests": {
+          "description": "ResourceGuardOperationRequests on which LAC check will be performed",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "TaggingCriteria": {
+      "description": "Tagging criteria",
+      "properties": {
+        "criteria": {
+          "description": "Criteria which decides whether the tag can be applied to a triggered backup.",
+          "items": {
+            "$ref": "#/definitions/BackupCriteria"
+          },
+          "x-ms-identifiers": [],
+          "type": "array"
+        },
+        "isDefault": {
+          "description": "Specifies if tag is default.",
+          "type": "boolean"
+        },
+        "taggingPriority": {
+          "description": "Retention Tag priority.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "tagInfo": {
+          "$ref": "#/definitions/RetentionTag",
+          "description": "Retention tag information"
+        }
+      },
+      "required": [
+        "isDefault",
+        "tagInfo",
+        "taggingPriority"
+      ],
+      "title": "TaggingCriteria",
+      "type": "object"
+    },
+    "TargetCopySetting": {
+      "description": "Target copy settings",
+      "properties": {
+        "copyAfter": {
+          "$ref": "#/definitions/CopyOption",
+          "description": "It can be CustomCopyOption or ImmediateCopyOption."
+        },
+        "dataStore": {
+          "$ref": "#/definitions/DataStoreInfoBase",
+          "description": "Info of target datastore"
+        }
+      },
+      "required": [
+        "copyAfter",
+        "dataStore"
+      ],
+      "title": "TargetCopySetting",
+      "type": "object"
+    },
+    "TargetDetails": {
+      "description": "Class encapsulating target details, used where the destination is not a datasource",
+      "properties": {
+        "filePrefix": {
+          "description": "Restore operation may create multiple files inside location pointed by Url\r\nBelow will be the common prefix for all of them",
+          "type": "string"
+        },
+        "restoreTargetLocationType": {
+          "description": "Denotes the target location where the data will be restored,\r\nstring value for the enum {Microsoft.Internal.AzureBackup.DataProtection.Common.Interface.RestoreTargetLocationType}",
+          "enum": [
+            "Invalid",
+            "AzureBlobs",
+            "AzureFiles"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "RestoreTargetLocationType",
+            "modelAsString": true
+          }
+        },
+        "url": {
+          "description": "Url denoting the restore destination. It can point to container / file share etc",
+          "type": "string"
+        },
+        "targetResourceArmId": {
+          "description": "Full ARM Id denoting the restore destination. It is the ARM Id pointing to container / file share\r\nThis is optional if the target subscription can be identified with the URL field. If not\r\nthen this is needed if CrossSubscriptionRestore field of BackupVault is in any of the disabled states",
+          "type": "string"
+        }
+      },
+      "required": [
+        "filePrefix",
+        "restoreTargetLocationType",
+        "url"
+      ],
+      "type": "object"
+    },
+    "TriggerBackupRequest": {
+      "description": "Trigger backup request",
+      "properties": {
+        "backupRuleOptions": {
+          "$ref": "#/definitions/AdHocBackupRuleOptions",
+          "description": "Name for the Rule of the Policy which needs to be applied for this backup"
+        }
+      },
+      "required": [
+        "backupRuleOptions"
+      ],
+      "title": "TriggerBackupRequest",
+      "type": "object"
+    },
+    "TriggerContext": {
+      "description": "Trigger context",
+      "discriminator": "objectType",
+      "properties": {
+        "objectType": {
+          "description": "Type of the specific object - used for deserializing",
+          "type": "string"
+        }
+      },
+      "required": [
+        "objectType"
+      ],
+      "title": "TriggerContext",
+      "type": "object"
+    },
+    "UserFacingError": {
+      "description": "Error object used by layers that have access to localized content, and propagate that to user",
+      "properties": {
+        "code": {
+          "description": "Unique code for this error",
+          "type": "string"
+        },
+        "details": {
+          "description": "Additional related Errors",
+          "items": {
+            "$ref": "#/definitions/UserFacingError"
+          },
+          "x-ms-identifiers": [],
+          "type": "array"
+        },
+        "innerError": {
+          "$ref": "#/definitions/InnerError",
+          "description": "Inner Error"
+        },
+        "isRetryable": {
+          "description": "Whether the operation will be retryable or not",
+          "type": "boolean"
+        },
+        "isUserError": {
+          "description": "Whether the operation is due to a user error or service error",
+          "type": "boolean"
+        },
+        "properties": {
+          "description": "Any key value pairs that can be injected inside error object",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "message": {
+          "type": "string"
+        },
+        "recommendedAction": {
+          "description": "RecommendedAction � localized.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "target": {
+          "description": "Target of the error.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "UserFacingWarningDetail": {
+      "description": "Warning object used by layers that have access to localized content, and propagate that to user",
+      "properties": {
+        "resourceName": {
+          "description": "Name of resource for which warning is raised.",
+          "type": "string"
+        },
+        "warning": {
+          "$ref": "#/definitions/UserFacingError",
+          "description": "Error details for the warning."
+        }
+      },
+      "required": [
+        "warning"
+      ],
+      "type": "object"
+    },
+    "ValidateForBackupRequest": {
+      "description": "Validate for backup request",
+      "properties": {
+        "backupInstance": {
+          "$ref": "#/definitions/BackupInstance"
+        }
+      },
+      "required": [
+        "backupInstance"
+      ],
+      "title": "ValidateForBackupRequest",
+      "type": "object"
+    },
+    "ValidateForModifyBackupRequest": {
+      "description": "Validate for modify backup request",
+      "properties": {
+        "backupInstance": {
+          "$ref": "#/definitions/BackupInstance"
+        }
+      },
+      "required": [
+        "backupInstance"
+      ],
+      "title": "ValidateForModifyBackupRequest",
+      "type": "object"
+    },
+    "ValidateRestoreRequestObject": {
+      "description": "Validate restore request object",
+      "properties": {
+        "restoreRequestObject": {
+          "$ref": "#/definitions/AzureBackupRestoreRequest",
+          "description": "Gets or sets the restore request object."
+        }
+      },
+      "required": [
+        "restoreRequestObject"
+      ],
+      "title": "ValidateRestoreRequestObject",
+      "type": "object"
+    },
+    "ResourceGuard": {
+      "type": "object",
+      "properties": {
+        "provisioningState": {
+          "description": "Provisioning state of the BackupVault resource",
+          "enum": [
+            "Failed",
+            "Provisioning",
+            "Succeeded",
+            "Unknown",
+            "Updating"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "ProvisioningState",
+            "modelAsString": true
+          }
+        },
+        "allowAutoApprovals": {
+          "description": "This flag indicates whether auto approval is allowed or not.",
+          "type": "boolean",
+          "readOnly": true
+        },
+        "resourceGuardOperations": {
+          "description": "{readonly} List of operation details those are protected by the ResourceGuard resource",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ResourceGuardOperation"
+          },
+          "x-ms-identifiers": [],
+          "readOnly": true
+        },
+        "vaultCriticalOperationExclusionList": {
+          "description": "List of critical operations which are not protected by this resourceGuard",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "description": {
+          "description": "Description about the pre-req steps to perform all the critical operations.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "ResourceGuardOperation": {
+      "description": "This class contains all the details about a critical operation.",
+      "type": "object",
+      "properties": {
+        "vaultCriticalOperation": {
+          "description": "Name of the critical operation.",
+          "type": "string",
+          "readOnly": true
+        },
+        "requestResourceType": {
+          "description": "Type of resource request.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "ResourceGuardResource": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/DppBaseTrackedResource"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ResourceGuard",
+          "description": "ResourceGuardResource properties"
+        }
+      }
+    },
+    "ResourceGuardResourceList": {
+      "description": "List of ResourceGuard resources",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/DppTrackedResourceList"
+        }
+      ],
+      "properties": {
+        "value": {
+          "description": "List of resources.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ResourceGuardResource"
+          }
+        }
+      }
+    },
+    "ResourceGuardOperationDetail": {
+      "description": "VaultCritical Operation protected by a resource guard",
+      "type": "object",
+      "properties": {
+        "vaultCriticalOperation": {
+          "type": "string"
+        },
+        "defaultResourceRequest": {
+          "type": "string"
+        }
+      }
+    },
+    "ResourceGuardProxyBase": {
+      "description": "ResourceGuardProxyBase object, used in ResourceGuardProxyBaseResource",
+      "type": "object",
+      "properties": {
+        "resourceGuardResourceId": {
+          "type": "string"
+        },
+        "resourceGuardOperationDetails": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ResourceGuardOperationDetail"
+          },
+          "x-ms-identifiers": []
+        },
+        "lastUpdatedTime": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "ResourceGuardProxyBaseResource": {
+      "description": "ResourceGuardProxyBaseResource object, used for response and request bodies for ResourceGuardProxy APIs",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/DppResource"
+        }
+      ],
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ResourceGuardProxyBase",
+          "description": "ResourceGuardProxyBaseResource properties"
+        }
+      }
+    },
+    "ResourceGuardProxyBaseResourceList": {
+      "description": "List of ResourceGuardProxyBase resources",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/DppResourceList"
+        }
+      ],
+      "properties": {
+        "value": {
+          "description": "List of resources.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ResourceGuardProxyBaseResource"
+          }
+        }
+      }
+    },
+    "UnlockDeleteRequest": {
+      "description": "Request body of unlock delete API.",
+      "type": "object",
+      "properties": {
+        "resourceGuardOperationRequests": {
+          "description": "ResourceGuardOperationRequests on which LAC check will be performed",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "resourceToBeDeleted": {
+          "type": "string"
+        }
+      }
+    },
+    "UnlockDeleteResponse": {
+      "description": "Response of Unlock Delete API.",
+      "type": "object",
+      "properties": {
+        "unlockDeleteExpiryTime": {
+          "description": "This is the time when unlock delete privileges will get expired.",
+          "type": "string"
+        }
+      }
+    }
+  },
+  "parameters": {
+    "VaultName": {
+      "name": "vaultName",
+      "in": "path",
+      "description": "The name of the backup vault.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "BackupInstanceName": {
+      "name": "backupInstanceName",
+      "in": "path",
+      "description": "The name of the backup instance.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "ResourceId": {
+      "name": "resourceId",
+      "in": "path",
+      "description": "ARM path of the resource to be protected using Microsoft.DataProtection",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method",
+      "x-ms-skip-url-encoding": true
+    },
+    "RestrictedVaultName": {
+      "name": "vaultName",
+      "in": "path",
+      "description": "The name of the backup vault.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method",
+      "pattern": "^[A-Za-z][-A-Za-z0-9]*[A-Za-z0-9]$",
+      "minLength": 2,
+      "maxLength": 50
+    }
+  },
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account."
+      }
+    }
+  },
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ]
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/dataprotection.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/dataprotection.json
@@ -6841,6 +6841,10 @@
           "items": {
             "type": "string"
           }
+        },
+        "renameTo": {
+          "description": "Rename the item to be restored. Restore will rename the itemPath to this new name if the value is specified otherwise the itemPath will be restored as same name.",
+          "type": "string"
         }
       },
       "x-ms-discriminator-value": "ItemPathBasedRestoreCriteria"

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/dataprotection.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/dataprotection.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "version": "2025-02-01",
+    "version": "2025-07-01",
     "title": "DataProtectionBackupClient",
     "x-ms-code-generation-settings": {
       "internalConstructors": false

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/DeleteBackupInstance.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/DeleteBackupInstance.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "resourceGroupName": "000pikumar",
+    "vaultName": "PratikPrivatePreviewVault1",
+    "backupInstanceName": "testInstance1",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupInstances/harshitbi1/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Retry-After": "60"
+      }
+    },
+    "204": {},
+    "200": {}
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/DeleteBackupInstance.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/DeleteBackupInstance.json
@@ -4,13 +4,13 @@
     "resourceGroupName": "000pikumar",
     "vaultName": "PratikPrivatePreviewVault1",
     "backupInstanceName": "testInstance1",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "202": {
       "headers": {
-        "Location": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupInstances/harshitbi1/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Location": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupInstances/harshitbi1/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
         "Retry-After": "60"
       }
     },

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/FindRestorableTimeRanges.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/FindRestorableTimeRanges.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "resourceGroupName": "Blob-Backup",
+    "vaultName": "ZBlobBackupVaultBVTD3",
+    "backupInstanceName": "zblobbackuptestsa58",
+    "api-version": "2025-02-01",
+    "parameters": {
+      "sourceDataStoreType": "OperationalStore",
+      "startTime": "2020-10-17T23:28:17.6829685Z",
+      "endTime": "2021-02-24T00:35:17.6829685Z"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "zblobbackuptestsa58",
+        "type": "Microsoft.DataProtection/backupVaults/backupInstances/findRestorableTimeRanges",
+        "properties": {
+          "restorableTimeRanges": [
+            {
+              "startTime": "2021-02-23T18:33:51.6349708Z",
+              "endTime": "2021-02-24T00:35:17.0000000Z",
+              "objectType": "RestorableTimeRange"
+            }
+          ],
+          "objectType": "AzureBackupFindRestorableTimeRangesResponse"
+        }
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/FindRestorableTimeRanges.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/FindRestorableTimeRanges.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "Blob-Backup",
     "vaultName": "ZBlobBackupVaultBVTD3",
     "backupInstanceName": "zblobbackuptestsa58",
-    "api-version": "2025-02-01",
+    "api-version": "2025-07-01",
     "parameters": {
       "sourceDataStoreType": "OperationalStore",
       "startTime": "2020-10-17T23:28:17.6829685Z",

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/GetBackupInstance.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/GetBackupInstance.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "resourceGroupName": "000pikumar",
+    "vaultName": "PratikPrivatePreviewVault1",
+    "api-version": "2025-02-01",
+    "backupInstanceName": "testInstance1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/backupInstances/harshitbi2",
+        "name": "harshitbi2",
+        "type": "Microsoft.DataProtection/backupVaults/backupInstances",
+        "tags": {
+          "key1": "val1"
+        },
+        "properties": {
+          "friendlyName": "harshitbi2",
+          "dataSourceInfo": {
+            "resourceID": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest/databases/testdb",
+            "resourceUri": "",
+            "datasourceType": "OssDB",
+            "resourceName": "testdb",
+            "resourceType": "OssDB",
+            "resourceLocation": "",
+            "objectType": "Datasource"
+          },
+          "dataSourceSetInfo": {
+            "resourceID": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest",
+            "resourceUri": "",
+            "datasourceType": "OssDB",
+            "resourceName": "viveksipgtest",
+            "resourceType": "OssDB",
+            "resourceLocation": "",
+            "objectType": "DatasourceSet"
+          },
+          "policyInfo": {
+            "policyId": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/backupPolicies/PratikPolicy1",
+            "policyVersion": "3.2"
+          },
+          "identityDetails": {
+            "useSystemAssignedIdentity": false,
+            "userAssignedIdentityArmUrl": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourcegroups/rg-name/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testUami"
+          },
+          "protectionStatus": {
+            "status": "NotProtected"
+          },
+          "provisioningState": "Provisioning",
+          "objectType": "BackupInstance"
+        }
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/GetBackupInstance.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/GetBackupInstance.json
@@ -3,7 +3,7 @@
     "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
     "resourceGroupName": "000pikumar",
     "vaultName": "PratikPrivatePreviewVault1",
-    "api-version": "2025-02-01",
+    "api-version": "2025-07-01",
     "backupInstanceName": "testInstance1"
   },
   "responses": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/GetBackupInstanceOperationResult.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/GetBackupInstanceOperationResult.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "resourceGroupName": "SampleResourceGroup",
+    "vaultName": "swaggerExample",
+    "backupInstanceName": "testInstance1",
+    "operationId": "YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/backupVaults/swaggerExample/backupInstances/testInstance1",
+        "name": "testInstance1",
+        "type": "Microsoft.DataProtection/backupVaults/backupInstances",
+        "properties": {
+          "friendlyName": "testInstance1",
+          "dataSourceInfo": {
+            "resourceID": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest/databases/testdb",
+            "resourceUri": "",
+            "datasourceType": "OssDB",
+            "resourceName": "testdb",
+            "resourceType": "OssDB",
+            "resourceLocation": "",
+            "objectType": "Datasource"
+          },
+          "dataSourceSetInfo": {
+            "resourceID": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest",
+            "resourceUri": "",
+            "datasourceType": "OssDB",
+            "resourceName": "viveksipgtest",
+            "resourceType": "OssDB",
+            "resourceLocation": "",
+            "objectType": "DatasourceSet"
+          },
+          "policyInfo": {
+            "policyId": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/backupVaults/swaggerExample/backupPolicies/PratikPolicy1",
+            "policyVersion": "3.2"
+          },
+          "protectionStatus": {
+            "status": "ConfiguringProtection"
+          },
+          "provisioningState": "Provisioned",
+          "objectType": "BackupInstance"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Retry-After": "10",
+        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/backupVaults/swaggerExample/operationStatus/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-02-01",
+        "Location": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/backupvaults/swaggerExample/backupInstances/testInstance1/operationResults/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-02-01"
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/GetBackupInstanceOperationResult.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/GetBackupInstanceOperationResult.json
@@ -5,7 +5,7 @@
     "vaultName": "swaggerExample",
     "backupInstanceName": "testInstance1",
     "operationId": "YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {
@@ -48,8 +48,8 @@
     "202": {
       "headers": {
         "Retry-After": "10",
-        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/backupVaults/swaggerExample/operationStatus/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-02-01",
-        "Location": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/backupvaults/swaggerExample/backupInstances/testInstance1/operationResults/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-02-01"
+        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/backupVaults/swaggerExample/operationStatus/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-07-01",
+        "Location": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/backupvaults/swaggerExample/backupInstances/testInstance1/operationResults/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-07-01"
       }
     }
   }

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/GetBackupInstance_ADLSBlobBackupDatasourceParameters.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/GetBackupInstance_ADLSBlobBackupDatasourceParameters.json
@@ -1,0 +1,62 @@
+{
+  "parameters": {
+    "subscriptionId": "54707983-993e-43de-8d94-074451394eda",
+    "resourceGroupName": "adlsrg",
+    "vaultName": "adlsvault",
+    "api-version": "2025-02-01",
+    "backupInstanceName": "adlsbackupinstance"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.DataProtection/backupVaults/adlsvault/backupInstances/adlsbackupinstance",
+        "name": "adlsbackupinstance",
+        "type": "Microsoft.DataProtection/backupVaults/backupInstances",
+        "tags": {
+          "key1": "val1"
+        },
+        "properties": {
+          "friendlyName": "adlsbackupinstance",
+          "dataSourceInfo": {
+            "resourceID": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.Storage/storageAccounts/adlsstorageaccount",
+            "resourceUri": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.Storage/storageAccounts/adlsstorageaccount",
+            "datasourceType": "Microsoft.Storage/storageAccounts/adlsBlobServices",
+            "resourceName": "adls5blbcentraluseuap2",
+            "resourceType": "Microsoft.Storage/storageAccounts",
+            "resourceLocation": "centraluseuap",
+            "objectType": "Datasource"
+          },
+          "dataSourceSetInfo": {
+            "resourceID": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.Storage/storageAccounts/adlsstorageaccount",
+            "resourceUri": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.Storage/storageAccounts/adlsstorageaccount",
+            "datasourceType": "Microsoft.Storage/storageAccounts/adlsBlobServices",
+            "resourceName": "adls5blbcentraluseuap2",
+            "resourceType": "Microsoft.Storage/storageAccounts",
+            "resourceLocation": "centraluseuap",
+            "objectType": "DatasourceSet"
+          },
+          "policyInfo": {
+            "policyId": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.DataProtection/backupVaults/adlsvault/backupPolicies/adlspolicy",
+            "policyParameters": {
+              "backupDatasourceParametersList": [
+                {
+                  "containersList": [
+                    "container1",
+                    "container2"
+                  ],
+                  "objectType": "AdlsBlobBackupDatasourceParameters"
+                }
+              ]
+            }
+          },
+          "protectionStatus": {
+            "status": "ProtectionConfigured"
+          },
+          "currentProtectionState": "ProtectionConfigured",
+          "provisioningState": "Succeeded",
+          "objectType": "BackupInstance"
+        }
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/GetBackupInstance_ADLSBlobBackupDatasourceParameters.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/GetBackupInstance_ADLSBlobBackupDatasourceParameters.json
@@ -3,7 +3,7 @@
     "subscriptionId": "54707983-993e-43de-8d94-074451394eda",
     "resourceGroupName": "adlsrg",
     "vaultName": "adlsvault",
-    "api-version": "2025-02-01",
+    "api-version": "2025-07-01",
     "backupInstanceName": "adlsbackupinstance"
   },
   "responses": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/GetRecoveryPoint.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/GetRecoveryPoint.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "resourceGroupName": "000pikumar",
+    "vaultName": "PratikPrivatePreviewVault1",
+    "api-version": "2025-02-01",
+    "backupInstanceName": "testInstance1",
+    "recoveryPointId": "7fb2cddd-c5b3-44f6-a0d9-db3c4f9d5f25"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/HelloTest/providers/Microsoft.DataProtection/backupVaults/HelloTestVault/backupInstances/653213d-c5b3-44f6-a0d9-db3c4f9d8e34/recoveryPoints/7fb2cddd-c5b3-44f6-a0d9-db3c4f9d5f25",
+        "name": "7fb2cddd-c5b3-44f6-a0d9-db3c4f9d5f25",
+        "type": "microsoft.dataprotection/backupvaults/backupInstances/recoveryPoints",
+        "properties": {
+          "objectType": "AzureBackupDiscreteRecoveryPoint",
+          "recoveryPointTime": "2019-03-01T13:00:00Z",
+          "recoveryPointType": "Full",
+          "friendlyName": "panbha4",
+          "recoveryPointDataStoresDetails": [
+            {
+              "id": "0ff03512-b333-4509-a6c7-12164c8b1dce",
+              "type": "Snapshot",
+              "creationTime": "2019-03-01T13:00:00Z",
+              "metaData": "123456"
+            },
+            {
+              "id": "5d8cfd30-722e-4bab-85f6-4a9d01ffc6f1",
+              "type": "BackupStorage",
+              "creationTime": "2019-03-01T13:00:00Z",
+              "metaData": "123456"
+            }
+          ],
+          "recoveryPointState": "Completed"
+        }
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/GetRecoveryPoint.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/GetRecoveryPoint.json
@@ -3,7 +3,7 @@
     "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
     "resourceGroupName": "000pikumar",
     "vaultName": "PratikPrivatePreviewVault1",
-    "api-version": "2025-02-01",
+    "api-version": "2025-07-01",
     "backupInstanceName": "testInstance1",
     "recoveryPointId": "7fb2cddd-c5b3-44f6-a0d9-db3c4f9d5f25"
   },

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/ListBackupInstances.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/ListBackupInstances.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "resourceGroupName": "000pikumar",
+    "vaultName": "PratikPrivatePreviewVault1",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/backupInstances/harshitbi2",
+            "name": "harshitbi2",
+            "type": "Microsoft.DataProtection/backupVaults/backupInstances",
+            "tags": {
+              "key1": "val1"
+            },
+            "properties": {
+              "friendlyName": "harshitbi2",
+              "dataSourceInfo": {
+                "resourceID": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest/databases/testdb",
+                "resourceUri": "",
+                "datasourceType": "OssDB",
+                "resourceName": "testdb",
+                "resourceType": "OssDB",
+                "resourceLocation": "",
+                "objectType": "Datasource"
+              },
+              "dataSourceSetInfo": {
+                "resourceID": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest",
+                "resourceUri": "",
+                "datasourceType": "OssDB",
+                "resourceName": "viveksipgtest",
+                "resourceType": "OssDB",
+                "resourceLocation": "",
+                "objectType": "DatasourceSet"
+              },
+              "policyInfo": {
+                "policyId": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/backupPolicies/PratikPolicy1",
+                "policyVersion": "3.2"
+              },
+              "protectionStatus": {
+                "status": "NotProtected"
+              },
+              "provisioningState": "Provisioning",
+              "objectType": "BackupInstance"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/ListBackupInstances.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/ListBackupInstances.json
@@ -3,7 +3,7 @@
     "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
     "resourceGroupName": "000pikumar",
     "vaultName": "PratikPrivatePreviewVault1",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/ListBackupInstancesExtensionRouting.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/ListBackupInstancesExtensionRouting.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "resourceId": "subscriptions/36d32b25-3dc7-41b0-bde1-397500644591/resourceGroups/testRG/providers/Microsoft.Compute/disks/testDisk",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "friendlyName": "testDisk",
+              "dataSourceInfo": {
+                "resourceID": "/subscriptions/36d32b25-3dc7-41b0-bde1-397500644591/resourceGroups/testRG/providers/Microsoft.Compute/disks/testDisk",
+                "resourceUri": "/subscriptions/36d32b25-3dc7-41b0-bde1-397500644591/resourceGroups/testRG/providers/Microsoft.Compute/disks/testDisk",
+                "datasourceType": "Microsoft.Compute/disks",
+                "resourceName": "testDisk",
+                "resourceType": "Microsoft.Compute/disks",
+                "resourceLocation": "eastus2euap",
+                "objectType": "Datasource"
+              },
+              "dataSourceSetInfo": {
+                "resourceID": "/subscriptions/36d32b25-3dc7-41b0-bde1-397500644591/resourceGroups/testRG/providers/Microsoft.Compute/disks/testDisk",
+                "resourceUri": "/subscriptions/36d32b25-3dc7-41b0-bde1-397500644591/resourceGroups/testRG/providers/Microsoft.Compute/disks/testDisk",
+                "datasourceType": "Microsoft.Compute/disks",
+                "resourceName": "testDisk",
+                "resourceType": "Microsoft.Compute/disks",
+                "resourceLocation": "eastus2euap",
+                "objectType": "DatasourceSet"
+              },
+              "policyInfo": {
+                "policyId": "/subscriptions/36d32b25-3dc7-41b0-bde1-397500644591/resourceGroups/policyRG/providers/Microsoft.DataProtection/backupVaults/jeczrsecy/backupPolicies/disk",
+                "policyVersion": "",
+                "policyParameters": {
+                  "dataStoreParametersList": [
+                    {
+                      "objectType": "AzureOperationalStoreParameters",
+                      "dataStoreType": "OperationalStore",
+                      "resourceGroupId": "/subscriptions/36d32b25-3dc7-41b0-bde1-397500644591/resourceGroups/policyRG"
+                    }
+                  ]
+                }
+              },
+              "protectionStatus": {
+                "status": "ProtectionConfigured"
+              },
+              "currentProtectionState": "ProtectionConfigured",
+              "provisioningState": "Succeeded",
+              "objectType": "BackupInstance"
+            },
+            "id": "/subscriptions/36d32b25-3dc7-41b0-bde1-397500644591/resourceGroups/testRG/providers/Microsoft.Compute/disks/testDisk/providers/Microsoft.DataProtection/backupInstances/testDiskBI1-testDiskBI1-7664c12f-4d0a-440f-a0dc-b64f708b10e3",
+            "name": "testDiskBI1-testDiskBI1-7664c12f-4d0a-440f-a0dc-b64f708b10e3",
+            "type": "Microsoft.DataProtection/backupVaults/backupInstances"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/ListBackupInstancesExtensionRouting.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/ListBackupInstancesExtensionRouting.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "resourceId": "subscriptions/36d32b25-3dc7-41b0-bde1-397500644591/resourceGroups/testRG/providers/Microsoft.Compute/disks/testDisk",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/ListRecoveryPoints.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/ListRecoveryPoints.json
@@ -1,0 +1,70 @@
+{
+  "parameters": {
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "resourceGroupName": "000pikumar",
+    "vaultName": "PratikPrivatePreviewVault1",
+    "api-version": "2025-02-01",
+    "backupInstanceName": "testInstance1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/HelloTest/providers/Microsoft.DataProtection/backupVaults/HelloTestVault/backupInstances/653213d-c5b3-44f6-a0d9-db3c4f9d8e34/recoveryPoints/7fb2cddd-c5b3-44f6-a0d9-db3c4f9d5f25",
+            "name": "7fb2cddd-c5b3-44f6-a0d9-db3c4f9d5e35",
+            "type": "microsoft.dataprotection/backupvaults/backupInstances/recoveryPoints",
+            "properties": {
+              "objectType": "AzureBackupDiscreteRecoveryPoint",
+              "recoveryPointTime": "2019-03-01T13:00:00Z",
+              "recoveryPointType": "Full",
+              "friendlyName": "panbha4",
+              "expiryTime": "2023-03-01T13:00:00Z",
+              "recoveryPointDataStoresDetails": [
+                {
+                  "id": "0ff03512-b333-4509-a6c7-12164c8b1dce",
+                  "type": "Snapshot",
+                  "creationTime": "2019-03-01T13:00:00Z",
+                  "metaData": "123456"
+                },
+                {
+                  "id": "5d8cfd30-722e-4bab-85f6-4a9d01ffc6f1",
+                  "type": "BackupStorage",
+                  "creationTime": "2019-03-01T13:00:00Z",
+                  "metaData": "123456"
+                }
+              ],
+              "recoveryPointState": "Completed"
+            }
+          },
+          {
+            "id": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/HelloTest/providers/Microsoft.DataProtection/backupVaults/HelloTestVault/backupInstances/653213d-c5b3-44f6-a0d9-db3c4f9d8e34/recoveryPoints/7fb2cddd-c5b3-44f6-a0d9-db3c4f9d5f25",
+            "name": "7fb2cddd-c5b3-44f6-a0d9-db3c4f9d5f25",
+            "type": "microsoft.dataprotection/backupvaults/backupInstances/recoveryPoints",
+            "properties": {
+              "objectType": "AzureBackupDiscreteRecoveryPoint",
+              "recoveryPointTime": "2019-03-01T13:00:00Z",
+              "recoveryPointType": "Full",
+              "friendlyName": "panbha4",
+              "recoveryPointDataStoresDetails": [
+                {
+                  "id": "808cfd30-722e-4bab-85f6-4a9d01ffc6f2",
+                  "type": "Snapshot",
+                  "creationTime": "2019-03-01T13:00:00Z",
+                  "metaData": "123456"
+                },
+                {
+                  "id": "798cfd30-722e-4bab-85f6-4a9d01ffc6f3",
+                  "type": "BackupStorage",
+                  "creationTime": "2019-03-01T13:00:00Z",
+                  "metaData": "123456"
+                }
+              ],
+              "recoveryPointState": "Completed"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/ListRecoveryPoints.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/ListRecoveryPoints.json
@@ -3,7 +3,7 @@
     "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
     "resourceGroupName": "000pikumar",
     "vaultName": "PratikPrivatePreviewVault1",
-    "api-version": "2025-02-01",
+    "api-version": "2025-07-01",
     "backupInstanceName": "testInstance1"
   },
   "responses": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/PutBackupInstance.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/PutBackupInstance.json
@@ -1,0 +1,171 @@
+{
+  "parameters": {
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "resourceGroupName": "000pikumar",
+    "vaultName": "PratikPrivatePreviewVault1",
+    "api-version": "2025-02-01",
+    "backupInstanceName": "testInstance1",
+    "parameters": {
+      "tags": {
+        "key1": "val1"
+      },
+      "properties": {
+        "objectType": "BackupInstance",
+        "friendlyName": "harshitbi2",
+        "dataSourceSetInfo": {
+          "objectType": "DatasourceSet",
+          "resourceID": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest",
+          "resourceName": "viveksipgtest",
+          "resourceType": "Microsoft.DBforPostgreSQL/servers",
+          "resourceUri": "",
+          "resourceLocation": "",
+          "datasourceType": "Microsoft.DBforPostgreSQL/servers/databases"
+        },
+        "dataSourceInfo": {
+          "objectType": "Datasource",
+          "resourceID": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest/databases/testdb",
+          "resourceName": "testdb",
+          "resourceType": "Microsoft.DBforPostgreSQL/servers/databases",
+          "resourceUri": "",
+          "resourceLocation": "",
+          "datasourceType": "Microsoft.DBforPostgreSQL/servers/databases"
+        },
+        "datasourceAuthCredentials": {
+          "secretStoreResource": {
+            "uri": "https://samplevault.vault.azure.net/secrets/credentials",
+            "secretStoreType": "AzureKeyVault"
+          },
+          "objectType": "SecretStoreBasedAuthCredentials"
+        },
+        "policyInfo": {
+          "policyId": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/Backupvaults/PratikPrivatePreviewVault1/backupPolicies/PratikPolicy1",
+          "policyParameters": {
+            "dataStoreParametersList": [
+              {
+                "objectType": "AzureOperationalStoreParameters",
+                "dataStoreType": "OperationalStore",
+                "resourceGroupId": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest"
+              }
+            ]
+          }
+        },
+        "identityDetails": {
+          "useSystemAssignedIdentity": false,
+          "userAssignedIdentityArmUrl": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourcegroups/rg-name/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testUami"
+        },
+        "validationType": "ShallowValidation"
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Retry-After": "60"
+      },
+      "body": {
+        "id": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/backupInstances/harshitbi2",
+        "name": "harshitbi2",
+        "type": "Microsoft.DataProtection/backupVaults/backupInstances",
+        "tags": {
+          "key1": "val1"
+        },
+        "properties": {
+          "friendlyName": "harshitbi2",
+          "dataSourceInfo": {
+            "resourceID": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest/databases/testdb",
+            "resourceUri": "",
+            "datasourceType": "OssDB",
+            "resourceName": "testdb",
+            "resourceType": "OssDB",
+            "resourceLocation": "",
+            "objectType": "Datasource"
+          },
+          "dataSourceSetInfo": {
+            "resourceID": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest",
+            "resourceUri": "",
+            "datasourceType": "OssDB",
+            "resourceName": "viveksipgtest",
+            "resourceType": "OssDB",
+            "resourceLocation": "",
+            "objectType": "DatasourceSet"
+          },
+          "policyInfo": {
+            "policyId": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/backupPolicies/PratikPolicy1",
+            "policyVersion": "3.2",
+            "policyParameters": {
+              "dataStoreParametersList": [
+                {
+                  "objectType": "AzureOperationalStoreParameters",
+                  "dataStoreType": "OperationalStore",
+                  "resourceGroupId": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest"
+                }
+              ]
+            }
+          },
+          "protectionStatus": {
+            "status": "NotProtected"
+          },
+          "provisioningState": "Provisioning",
+          "objectType": "BackupInstance"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-02-01",
+        "Location": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/backupInstances/testInstance1/operationResults/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-02-01",
+        "Retry-After": "60"
+      }
+    },
+    "200": {
+      "body": {
+        "id": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/backupInstances/harshitbi2",
+        "name": "harshitbi2",
+        "type": "Microsoft.DataProtection/backupVaults/backupInstances",
+        "tags": {
+          "key1": "val1"
+        },
+        "properties": {
+          "friendlyName": "harshitbi2",
+          "dataSourceInfo": {
+            "resourceID": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest/databases/testdb",
+            "resourceUri": "",
+            "datasourceType": "OssDB",
+            "resourceName": "testdb",
+            "resourceType": "OssDB",
+            "resourceLocation": "",
+            "objectType": "Datasource"
+          },
+          "dataSourceSetInfo": {
+            "resourceID": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest",
+            "resourceUri": "",
+            "datasourceType": "OssDB",
+            "resourceName": "viveksipgtest",
+            "resourceType": "OssDB",
+            "resourceLocation": "",
+            "objectType": "DatasourceSet"
+          },
+          "policyInfo": {
+            "policyId": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/backupPolicies/PratikPolicy1",
+            "policyVersion": "3.2",
+            "policyParameters": {
+              "dataStoreParametersList": [
+                {
+                  "objectType": "AzureOperationalStoreParameters",
+                  "dataStoreType": "OperationalStore",
+                  "resourceGroupId": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest"
+                }
+              ]
+            }
+          },
+          "protectionStatus": {
+            "status": "NotProtected"
+          },
+          "provisioningState": "Provisioned",
+          "objectType": "BackupInstance"
+        }
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/PutBackupInstance.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/PutBackupInstance.json
@@ -3,7 +3,7 @@
     "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
     "resourceGroupName": "000pikumar",
     "vaultName": "PratikPrivatePreviewVault1",
-    "api-version": "2025-02-01",
+    "api-version": "2025-07-01",
     "backupInstanceName": "testInstance1",
     "parameters": {
       "tags": {
@@ -60,7 +60,7 @@
   "responses": {
     "201": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
         "Retry-After": "60"
       },
       "body": {
@@ -113,8 +113,8 @@
     },
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-02-01",
-        "Location": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/backupInstances/testInstance1/operationResults/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-02-01",
+        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-07-01",
+        "Location": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/backupInstances/testInstance1/operationResults/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-07-01",
         "Retry-After": "60"
       }
     },

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/PutBackupInstance_ADLSBlobBackupDatasourceParameters.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/PutBackupInstance_ADLSBlobBackupDatasourceParameters.json
@@ -1,0 +1,158 @@
+{
+  "parameters": {
+    "subscriptionId": "54707983-993e-43de-8d94-074451394eda",
+    "resourceGroupName": "adlsrg",
+    "vaultName": "adlsvault",
+    "api-version": "2025-02-01",
+    "backupInstanceName": "adlsstorageaccount-adlsstorageaccount-19a76f8a-c176-4f7d-819e-95157e2b0071",
+    "parameters": {
+      "tags": {
+        "key1": "val1"
+      },
+      "properties": {
+        "friendlyName": "adlsstorageaccount\\adlsbackupinstance",
+        "dataSourceInfo": {
+          "resourceID": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.Storage/storageAccounts/adlsstorageaccount",
+          "resourceUri": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.Storage/storageAccounts/adlsstorageaccount",
+          "datasourceType": "Microsoft.Storage/storageAccounts/adlsBlobServices",
+          "resourceName": "adlsstorageaccount",
+          "resourceType": "microsoft.storage/storageAccounts",
+          "resourceLocation": "centraluseuap",
+          "objectType": "Datasource"
+        },
+        "dataSourceSetInfo": {
+          "resourceID": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.Storage/storageAccounts/adlsstorageaccount",
+          "resourceUri": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.Storage/storageAccounts/adlsstorageaccount",
+          "datasourceType": "Microsoft.Storage/storageAccounts/adlsBlobServices",
+          "resourceName": "adlsstorageaccount",
+          "resourceType": "microsoft.storage/storageAccounts",
+          "resourceLocation": "centraluseuap",
+          "objectType": "DatasourceSet"
+        },
+        "policyInfo": {
+          "policyId": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.DataProtection/backupVaults/adlsvault/backupPolicies/adlspolicy",
+          "policyParameters": {
+            "backupDatasourceParametersList": [
+              {
+                "objectType": "AdlsBlobBackupDatasourceParameters",
+                "containersList": [
+                  "container1"
+                ]
+              }
+            ]
+          }
+        },
+        "objectType": "BackupInstance"
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/54707983-993e-43de-8d94-074451394eda/resourcegroups/adlsrg/providers/Microsoft.Resources/deployments/ConfigureProtection-2097/operationStatuses/08584622124860116406?api-version=2022-12-01&t=638749912006014742&c=MIIHhzCCBm-gAwIBAgITfAaTiaklTwdb3CiPmAAABpOJqTANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDUw",
+        "Retry-After": "60"
+      },
+      "body": {
+        "id": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.DataProtection/backupVaults/adlsvault/backupInstances/19a76f8a-c176-4f7d-819e-95157e2b0077",
+        "name": "19a76f8a-c176-4f7d-819e-95157e2b0077",
+        "type": "Microsoft.DataProtection/backupVaults/backupInstances",
+        "tags": {
+          "key1": "val1"
+        },
+        "properties": {
+          "friendlyName": "adlsstorageaccount\\adlsbackupinstance",
+          "dataSourceInfo": {
+            "resourceID": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.Storage/storageAccounts/adlsstorageaccount",
+            "resourceUri": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.Storage/storageAccounts/adlsstorageaccount",
+            "datasourceType": "Microsoft.Storage/storageAccounts/adlsBlobServices",
+            "resourceName": "adlsstorageaccount",
+            "resourceType": "microsoft.storage/storageAccounts",
+            "resourceLocation": "centraluseuap",
+            "objectType": "Datasource"
+          },
+          "dataSourceSetInfo": {
+            "resourceID": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.Storage/storageAccounts/adlsstorageaccount",
+            "resourceUri": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.Storage/storageAccounts/adlsstorageaccount",
+            "datasourceType": "Microsoft.Storage/storageAccounts/adlsBlobServices",
+            "resourceName": "adlsstorageaccount",
+            "resourceType": "microsoft.storage/storageAccounts",
+            "resourceLocation": "centraluseuap",
+            "objectType": "DatasourceSet"
+          },
+          "policyInfo": {
+            "policyId": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.DataProtection/backupVaults/adlsvault/backupPolicies/adlspolicy",
+            "policyParameters": {
+              "backupDatasourceParametersList": [
+                {
+                  "objectType": "AdlsBlobBackupDatasourceParameters",
+                  "containersList": []
+                }
+              ]
+            }
+          },
+          "protectionStatus": {
+            "status": "NotProtected"
+          },
+          "provisioningState": "Provisioning",
+          "objectType": "BackupInstance"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/54707983-993e-43de-8d94-074451394eda/resourcegroups/adlsrg/providers/Microsoft.Resources/deployments/ConfigureProtection-2097/operationStatuses/08584622124860116406?api-version=2022-12-01&t=638749912006014742&c=MIIHhzCCBm-gAwIBAgITfAaTiaklTwdb3CiPmAAABpOJqTANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDUw",
+        "Location": "https://management.azure.com/subscriptions/54707983-993e-43de-8d94-074451394eda/resourcegroups/adlsrg/providers/Microsoft.DataProtection/backupVaults/adlsvault/backupInstances/adlsstorageaccount-adlsstorageaccount-19a76f8a-c176-4f7d-819e-95157e2b0071/operationStatuses/08584622124860116406?api-version=2022-12-01&t=638749912006014742&c=MIIHhzCCBm-gAwIBAgITfAaTiaklTwdb3CiPmAAABpOJqTANBgkqhkiG9w0BAQsFADBEMRMwEQYKCZImiZPyLGQBGRYDR0JMMRMwEQYKCZImiZPyLGQBGRYDQU1FMRgwFgYDVQQDEw9BTUUgSW5mcmEgQ0EgMDUw",
+        "Retry-After": "60"
+      }
+    },
+    "200": {
+      "body": {
+        "id": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.DataProtection/backupVaults/adlsvault/backupInstances/19a76f8a-c176-4f7d-819e-95157e2b0077",
+        "name": "19a76f8a-c176-4f7d-819e-95157e2b0077",
+        "type": "Microsoft.DataProtection/backupVaults/backupInstances",
+        "tags": {
+          "key1": "val1"
+        },
+        "properties": {
+          "friendlyName": "adlsstorageaccount\\adlsbackupinstance",
+          "dataSourceInfo": {
+            "resourceID": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.Storage/storageAccounts/adlsstorageaccount",
+            "resourceUri": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.Storage/storageAccounts/adlsstorageaccount",
+            "datasourceType": "Microsoft.Storage/storageAccounts/adlsBlobServices",
+            "resourceName": "adlsstorageaccount",
+            "resourceType": "microsoft.storage/storageAccounts",
+            "resourceLocation": "centraluseuap",
+            "objectType": "Datasource"
+          },
+          "dataSourceSetInfo": {
+            "resourceID": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.Storage/storageAccounts/adlsstorageaccount",
+            "resourceUri": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.Storage/storageAccounts/adlsstorageaccount",
+            "datasourceType": "Microsoft.Storage/storageAccounts/adlsBlobServices",
+            "resourceName": "adlsstorageaccount",
+            "resourceType": "microsoft.storage/storageAccounts",
+            "resourceLocation": "centraluseuap",
+            "objectType": "DatasourceSet"
+          },
+          "policyInfo": {
+            "policyId": "/subscriptions/54707983-993e-43de-8d94-074451394eda/resourceGroups/adlsrg/providers/Microsoft.DataProtection/backupVaults/adlsvault/backupPolicies/adlspolicy",
+            "policyParameters": {
+              "backupDatasourceParametersList": [
+                {
+                  "objectType": "AdlsBlobBackupDatasourceParameters",
+                  "containersList": [
+                    "container1"
+                  ]
+                }
+              ]
+            }
+          },
+          "protectionStatus": {
+            "status": "NotProtected"
+          },
+          "provisioningState": "Provisioned",
+          "objectType": "BackupInstance"
+        }
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/PutBackupInstance_ADLSBlobBackupDatasourceParameters.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/PutBackupInstance_ADLSBlobBackupDatasourceParameters.json
@@ -3,7 +3,7 @@
     "subscriptionId": "54707983-993e-43de-8d94-074451394eda",
     "resourceGroupName": "adlsrg",
     "vaultName": "adlsvault",
-    "api-version": "2025-02-01",
+    "api-version": "2025-07-01",
     "backupInstanceName": "adlsstorageaccount-adlsstorageaccount-19a76f8a-c176-4f7d-819e-95157e2b0071",
     "parameters": {
       "tags": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/PutBackupInstance_KubernetesClusterBackupDatasourceParameters.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/PutBackupInstance_KubernetesClusterBackupDatasourceParameters.json
@@ -1,0 +1,219 @@
+{
+  "parameters": {
+    "subscriptionId": "62b829ee-7936-40c9-a1c9-47a93f9f3965",
+    "resourceGroupName": "aksrg",
+    "vaultName": "aksvault",
+    "api-version": "2025-02-01",
+    "backupInstanceName": "aksbi",
+    "parameters": {
+      "tags": {
+        "key1": "val1"
+      },
+      "properties": {
+        "friendlyName": "aksbi",
+        "dataSourceInfo": {
+          "resourceID": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/aksrg/providers/Microsoft.ContainerService/managedClusters/akscluster",
+          "resourceUri": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/aksrg/providers/Microsoft.ContainerService/managedClusters/akscluster",
+          "datasourceType": "Microsoft.ContainerService/managedclusters",
+          "resourceName": "akscluster",
+          "resourceType": "Microsoft.ContainerService/managedclusters",
+          "resourceLocation": "eastus2euap",
+          "objectType": "Datasource"
+        },
+        "dataSourceSetInfo": {
+          "resourceID": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/aksrg/providers/Microsoft.ContainerService/managedClusters/akscluster",
+          "resourceUri": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/aksrg/providers/Microsoft.ContainerService/managedClusters/akscluster",
+          "datasourceType": "Microsoft.ContainerService/managedclusters",
+          "resourceName": "akscluster",
+          "resourceType": "Microsoft.ContainerService/managedclusters",
+          "resourceLocation": "eastus2euap",
+          "objectType": "DatasourceSet"
+        },
+        "policyInfo": {
+          "policyId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourcegroups/aksrg/providers/Microsoft.DataProtection/BackupVaults/aksvault/backupPolicies/akspolicy",
+          "policyParameters": {
+            "dataStoreParametersList": [
+              {
+                "resourceGroupId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/aksrg",
+                "objectType": "AzureOperationalStoreParameters",
+                "dataStoreType": "OperationalStore"
+              }
+            ],
+            "backupDatasourceParametersList": [
+              {
+                "objectType": "KubernetesClusterBackupDatasourceParameters",
+                "includedNamespaces": [
+                  "test"
+                ],
+                "excludedNamespaces": [
+                  "kube-system"
+                ],
+                "includedResourceTypes": [],
+                "excludedResourceTypes": [
+                  "v1/Secret"
+                ],
+                "includedVolumeTypes": [
+                  "AzureDisk",
+                  "AzureFileShareSMB"
+                ],
+                "labelSelectors": [],
+                "snapshotVolumes": true,
+                "includeClusterScopeResources": true
+              }
+            ]
+          }
+        },
+        "objectType": "BackupInstance"
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/aksrg/providers/Microsoft.DataProtection/backupVaults/aksvault/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Retry-After": "60"
+      },
+      "body": {
+        "id": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/aksrg/providers/Microsoft.DataProtection/backupVaults/aksvault/backupInstances/aksbi",
+        "name": "aksbi",
+        "type": "Microsoft.DataProtection/backupVaults/backupInstances",
+        "tags": {
+          "key1": "val1"
+        },
+        "properties": {
+          "friendlyName": "aksbi",
+          "dataSourceInfo": {
+            "resourceID": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/aksrg/providers/Microsoft.ContainerService/managedClusters/akscluster",
+            "resourceUri": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/aksrg/providers/Microsoft.ContainerService/managedClusters/akscluster",
+            "datasourceType": "Microsoft.ContainerService/managedclusters",
+            "resourceName": "akscluster",
+            "resourceType": "Microsoft.ContainerService/managedclusters",
+            "resourceLocation": "eastus2euap",
+            "objectType": "Datasource"
+          },
+          "dataSourceSetInfo": {
+            "resourceID": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/aksrg/providers/Microsoft.ContainerService/managedClusters/akscluster",
+            "datasourceType": "Microsoft.ContainerService/managedclusters",
+            "resourceType": "Microsoft.ContainerService/managedclusters",
+            "resourceLocation": "eastus2euap",
+            "objectType": "DatasourceSet"
+          },
+          "policyInfo": {
+            "policyId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/aksrg/providers/Microsoft.DataProtection/backupVaults/aksvault/backupPolicies/akspolicy",
+            "policyParameters": {
+              "dataStoreParametersList": [
+                {
+                  "resourceGroupId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/aksrg",
+                  "objectType": "AzureOperationalStoreParameters",
+                  "dataStoreType": "OperationalStore"
+                }
+              ],
+              "backupDatasourceParametersList": [
+                {
+                  "objectType": "KubernetesClusterBackupDatasourceParameters",
+                  "includedNamespaces": [
+                    "test"
+                  ],
+                  "excludedNamespaces": [
+                    "kube-system"
+                  ],
+                  "includedResourceTypes": [],
+                  "excludedResourceTypes": [
+                    "v1/Secret"
+                  ],
+                  "includedVolumeTypes": [
+                    "AzureDisk",
+                    "AzureFileShareSMB"
+                  ],
+                  "labelSelectors": [],
+                  "snapshotVolumes": true,
+                  "includeClusterScopeResources": true
+                }
+              ]
+            }
+          },
+          "protectionStatus": {
+            "status": "NotProtected"
+          },
+          "provisioningState": "Provisioning",
+          "objectType": "BackupInstance"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/aksrg/providers/Microsoft.DataProtection/backupVaults/aksvault/operationStatus/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-02-01",
+        "Location": "https://management.windowsazure.com/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/aksrg/providers/Microsoft.DataProtection/backupVaults/aksvault/backupInstances/aksbi/operationResults/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-02-01",
+        "Retry-After": "60"
+      }
+    },
+    "200": {
+      "body": {
+        "id": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/aksrg/providers/Microsoft.DataProtection/backupVaults/aksvault/backupInstances/aksbi",
+        "name": "aksbi",
+        "type": "Microsoft.DataProtection/backupVaults/backupInstances",
+        "tags": {
+          "key1": "val1"
+        },
+        "properties": {
+          "friendlyName": "aksbi",
+          "dataSourceInfo": {
+            "resourceID": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/aksrg/providers/Microsoft.ContainerService/managedClusters/akscluster",
+            "resourceUri": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/aksrg/providers/Microsoft.ContainerService/managedClusters/akscluster",
+            "datasourceType": "Microsoft.ContainerService/managedclusters",
+            "resourceName": "akscluster",
+            "resourceType": "Microsoft.ContainerService/managedclusters",
+            "resourceLocation": "eastus2euap",
+            "objectType": "Datasource"
+          },
+          "dataSourceSetInfo": {
+            "resourceID": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/aksrg/providers/Microsoft.ContainerService/managedClusters/akscluster",
+            "datasourceType": "Microsoft.ContainerService/managedclusters",
+            "resourceType": "Microsoft.ContainerService/managedclusters",
+            "resourceLocation": "eastus2euap",
+            "objectType": "DatasourceSet"
+          },
+          "policyInfo": {
+            "policyId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/aksrg/providers/Microsoft.DataProtection/backupVaults/aksvault/backupPolicies/akspolicy",
+            "policyParameters": {
+              "dataStoreParametersList": [
+                {
+                  "resourceGroupId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/aksrg",
+                  "objectType": "AzureOperationalStoreParameters",
+                  "dataStoreType": "OperationalStore"
+                }
+              ],
+              "backupDatasourceParametersList": [
+                {
+                  "objectType": "KubernetesClusterBackupDatasourceParameters",
+                  "includedNamespaces": [
+                    "test"
+                  ],
+                  "excludedNamespaces": [
+                    "kube-system"
+                  ],
+                  "includedResourceTypes": [],
+                  "excludedResourceTypes": [
+                    "v1/Secret"
+                  ],
+                  "includedVolumeTypes": [
+                    "AzureDisk",
+                    "AzureFileShareSMB"
+                  ],
+                  "labelSelectors": [],
+                  "snapshotVolumes": true,
+                  "includeClusterScopeResources": true
+                }
+              ]
+            }
+          },
+          "protectionStatus": {
+            "status": "NotProtected"
+          },
+          "provisioningState": "Provisioned",
+          "objectType": "BackupInstance"
+        }
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/PutBackupInstance_KubernetesClusterBackupDatasourceParameters.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/PutBackupInstance_KubernetesClusterBackupDatasourceParameters.json
@@ -3,7 +3,7 @@
     "subscriptionId": "62b829ee-7936-40c9-a1c9-47a93f9f3965",
     "resourceGroupName": "aksrg",
     "vaultName": "aksvault",
-    "api-version": "2025-02-01",
+    "api-version": "2025-07-01",
     "backupInstanceName": "aksbi",
     "parameters": {
       "tags": {
@@ -70,7 +70,7 @@
   "responses": {
     "201": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/aksrg/providers/Microsoft.DataProtection/backupVaults/aksvault/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/aksrg/providers/Microsoft.DataProtection/backupVaults/aksvault/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
         "Retry-After": "60"
       },
       "body": {
@@ -142,8 +142,8 @@
     },
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/aksrg/providers/Microsoft.DataProtection/backupVaults/aksvault/operationStatus/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-02-01",
-        "Location": "https://management.windowsazure.com/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/aksrg/providers/Microsoft.DataProtection/backupVaults/aksvault/backupInstances/aksbi/operationResults/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-02-01",
+        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/aksrg/providers/Microsoft.DataProtection/backupVaults/aksvault/operationStatus/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-07-01",
+        "Location": "https://management.windowsazure.com/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/aksrg/providers/Microsoft.DataProtection/backupVaults/aksvault/backupInstances/aksbi/operationResults/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-07-01",
         "Retry-After": "60"
       }
     },

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/PutBackupInstance_ResourceGuardEnabled.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/PutBackupInstance_ResourceGuardEnabled.json
@@ -1,0 +1,170 @@
+{
+  "parameters": {
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "resourceGroupName": "000pikumar",
+    "vaultName": "PratikPrivatePreviewVault1",
+    "api-version": "2025-02-01",
+    "backupInstanceName": "testInstance1",
+    "parameters": {
+      "tags": {
+        "key1": "val1"
+      },
+      "properties": {
+        "objectType": "BackupInstance",
+        "friendlyName": "harshitbi2",
+        "dataSourceSetInfo": {
+          "objectType": "DatasourceSet",
+          "resourceID": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest",
+          "resourceName": "viveksipgtest",
+          "resourceType": "Microsoft.DBforPostgreSQL/servers",
+          "resourceUri": "",
+          "resourceLocation": "",
+          "datasourceType": "Microsoft.DBforPostgreSQL/servers/databases"
+        },
+        "dataSourceInfo": {
+          "objectType": "Datasource",
+          "resourceID": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest/databases/testdb",
+          "resourceName": "testdb",
+          "resourceType": "Microsoft.DBforPostgreSQL/servers/databases",
+          "resourceUri": "",
+          "resourceLocation": "",
+          "datasourceType": "Microsoft.DBforPostgreSQL/servers/databases"
+        },
+        "datasourceAuthCredentials": {
+          "secretStoreResource": {
+            "uri": "https://samplevault.vault.azure.net/secrets/credentials",
+            "secretStoreType": "AzureKeyVault"
+          },
+          "objectType": "SecretStoreBasedAuthCredentials"
+        },
+        "policyInfo": {
+          "policyId": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/Backupvaults/PratikPrivatePreviewVault1/backupPolicies/PratikPolicy1",
+          "policyParameters": {
+            "dataStoreParametersList": [
+              {
+                "objectType": "AzureOperationalStoreParameters",
+                "dataStoreType": "OperationalStore",
+                "resourceGroupId": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest"
+              }
+            ]
+          }
+        },
+        "resourceGuardOperationRequests": [
+          "/subscriptions/38304e13-357e-405e-9e9a-220351dcce8c/resourcegroups/ankurResourceGuard1/providers/Microsoft.DataProtection/resourceGuards/ResourceGuard38-1/dppModifyPolicy/default"
+        ],
+        "validationType": "ShallowValidation"
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Retry-After": "60"
+      },
+      "body": {
+        "id": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/backupInstances/harshitbi2",
+        "name": "harshitbi2",
+        "type": "Microsoft.DataProtection/backupVaults/backupInstances",
+        "tags": {
+          "key1": "val1"
+        },
+        "properties": {
+          "friendlyName": "harshitbi2",
+          "dataSourceInfo": {
+            "resourceID": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest/databases/testdb",
+            "resourceUri": "",
+            "datasourceType": "OssDB",
+            "resourceName": "testdb",
+            "resourceType": "OssDB",
+            "resourceLocation": "",
+            "objectType": "Datasource"
+          },
+          "dataSourceSetInfo": {
+            "resourceID": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest",
+            "resourceUri": "",
+            "datasourceType": "OssDB",
+            "resourceName": "viveksipgtest",
+            "resourceType": "OssDB",
+            "resourceLocation": "",
+            "objectType": "DatasourceSet"
+          },
+          "policyInfo": {
+            "policyId": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/backupPolicies/PratikPolicy1",
+            "policyVersion": "3.2",
+            "policyParameters": {
+              "dataStoreParametersList": [
+                {
+                  "objectType": "AzureOperationalStoreParameters",
+                  "dataStoreType": "OperationalStore",
+                  "resourceGroupId": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest"
+                }
+              ]
+            }
+          },
+          "protectionStatus": {
+            "status": "NotProtected"
+          },
+          "provisioningState": "Provisioning",
+          "objectType": "BackupInstance"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-02-01",
+        "Location": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/backupInstances/testInstance1/operationResults/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-02-01",
+        "Retry-After": "60"
+      }
+    },
+    "200": {
+      "body": {
+        "id": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/backupInstances/harshitbi2",
+        "name": "harshitbi2",
+        "type": "Microsoft.DataProtection/backupVaults/backupInstances",
+        "tags": {
+          "key1": "val1"
+        },
+        "properties": {
+          "friendlyName": "harshitbi2",
+          "dataSourceInfo": {
+            "resourceID": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest/databases/testdb",
+            "resourceUri": "",
+            "datasourceType": "OssDB",
+            "resourceName": "testdb",
+            "resourceType": "OssDB",
+            "resourceLocation": "",
+            "objectType": "Datasource"
+          },
+          "dataSourceSetInfo": {
+            "resourceID": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest",
+            "resourceUri": "",
+            "datasourceType": "OssDB",
+            "resourceName": "viveksipgtest",
+            "resourceType": "OssDB",
+            "resourceLocation": "",
+            "objectType": "DatasourceSet"
+          },
+          "policyInfo": {
+            "policyId": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/backupPolicies/PratikPolicy1",
+            "policyVersion": "3.2",
+            "policyParameters": {
+              "dataStoreParametersList": [
+                {
+                  "objectType": "AzureOperationalStoreParameters",
+                  "dataStoreType": "OperationalStore",
+                  "resourceGroupId": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest"
+                }
+              ]
+            }
+          },
+          "protectionStatus": {
+            "status": "NotProtected"
+          },
+          "provisioningState": "Provisioned",
+          "objectType": "BackupInstance"
+        }
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/PutBackupInstance_ResourceGuardEnabled.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/PutBackupInstance_ResourceGuardEnabled.json
@@ -3,7 +3,7 @@
     "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
     "resourceGroupName": "000pikumar",
     "vaultName": "PratikPrivatePreviewVault1",
-    "api-version": "2025-02-01",
+    "api-version": "2025-07-01",
     "backupInstanceName": "testInstance1",
     "parameters": {
       "tags": {
@@ -59,7 +59,7 @@
   "responses": {
     "201": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
         "Retry-After": "60"
       },
       "body": {
@@ -112,8 +112,8 @@
     },
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-02-01",
-        "Location": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/backupInstances/testInstance1/operationResults/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-02-01",
+        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-07-01",
+        "Location": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/backupInstances/testInstance1/operationResults/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-07-01",
         "Retry-After": "60"
       }
     },

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/ResumeBackups.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/ResumeBackups.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "resourceGroupName": "testrg",
+    "vaultName": "testvault",
+    "backupInstanceName": "testbi",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupInstances/testbi/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Azure-AsyncOperation": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupVaults/testvault/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Retry-After": "60"
+      }
+    },
+    "200": {}
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/ResumeBackups.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/ResumeBackups.json
@@ -4,13 +4,13 @@
     "resourceGroupName": "testrg",
     "vaultName": "testvault",
     "backupInstanceName": "testbi",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "202": {
       "headers": {
-        "Location": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupInstances/testbi/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
-        "Azure-AsyncOperation": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupVaults/testvault/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Location": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupInstances/testbi/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
+        "Azure-AsyncOperation": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupVaults/testvault/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
         "Retry-After": "60"
       }
     },

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/ResumeProtection.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/ResumeProtection.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "resourceGroupName": "testrg",
+    "vaultName": "testvault",
+    "backupInstanceName": "testbi",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupInstances/testbi/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Azure-AsyncOperation": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupVaults/testvault/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Retry-After": "60"
+      }
+    },
+    "200": {}
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/ResumeProtection.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/ResumeProtection.json
@@ -4,13 +4,13 @@
     "resourceGroupName": "testrg",
     "vaultName": "testvault",
     "backupInstanceName": "testbi",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "202": {
       "headers": {
-        "Location": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupInstances/testbi/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
-        "Azure-AsyncOperation": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupVaults/testvault/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Location": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupInstances/testbi/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
+        "Azure-AsyncOperation": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupVaults/testvault/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
         "Retry-After": "60"
       }
     },

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/StopProtection.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/StopProtection.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "resourceGroupName": "testrg",
+    "vaultName": "testvault",
+    "backupInstanceName": "testbi",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupInstances/testbi/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Azure-AsyncOperation": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupVaults/testvault/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Retry-After": "60"
+      }
+    },
+    "200": {}
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/StopProtection.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/StopProtection.json
@@ -4,13 +4,13 @@
     "resourceGroupName": "testrg",
     "vaultName": "testvault",
     "backupInstanceName": "testbi",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "202": {
       "headers": {
-        "Location": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupInstances/testbi/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
-        "Azure-AsyncOperation": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupVaults/testvault/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Location": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupInstances/testbi/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
+        "Azure-AsyncOperation": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupVaults/testvault/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
         "Retry-After": "60"
       }
     },

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/StopProtection_ResourceGuardEnabled.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/StopProtection_ResourceGuardEnabled.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "resourceGroupName": "testrg",
+    "vaultName": "testvault",
+    "backupInstanceName": "testbi",
+    "api-version": "2025-02-01",
+    "parameters": {
+      "resourceGuardOperationRequests": [
+        "/subscriptions/754ec39f-8d2a-44cf-bfbf-13107ac85c36/resourcegroups/mua-testing/providers/Microsoft.DataProtection/resourceGuards/gvjreddy-test-ecy-rg-reader/dppDisableStopProtectionRequests/default"
+      ]
+    }
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupInstances/testbi/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Azure-AsyncOperation": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupVaults/testvault/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Retry-After": "60"
+      }
+    },
+    "200": {}
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/StopProtection_ResourceGuardEnabled.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/StopProtection_ResourceGuardEnabled.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "testrg",
     "vaultName": "testvault",
     "backupInstanceName": "testbi",
-    "api-version": "2025-02-01",
+    "api-version": "2025-07-01",
     "parameters": {
       "resourceGuardOperationRequests": [
         "/subscriptions/754ec39f-8d2a-44cf-bfbf-13107ac85c36/resourcegroups/mua-testing/providers/Microsoft.DataProtection/resourceGuards/gvjreddy-test-ecy-rg-reader/dppDisableStopProtectionRequests/default"
@@ -14,8 +14,8 @@
   "responses": {
     "202": {
       "headers": {
-        "Location": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupInstances/testbi/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
-        "Azure-AsyncOperation": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupVaults/testvault/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Location": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupInstances/testbi/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
+        "Azure-AsyncOperation": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupVaults/testvault/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
         "Retry-After": "60"
       }
     },

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/SuspendBackup_ResourceGuardEnabled.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/SuspendBackup_ResourceGuardEnabled.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "resourceGroupName": "testrg",
+    "vaultName": "testvault",
+    "backupInstanceName": "testbi",
+    "api-version": "2025-02-01",
+    "parameters": {
+      "resourceGuardOperationRequests": [
+        "/subscriptions/754ec39f-8d2a-44cf-bfbf-13107ac85c36/resourcegroups/mua-testing/providers/Microsoft.DataProtection/resourceGuards/gvjreddy-test-ecy-rg-reader/dppDisableSuspendBackupsRequests/default"
+      ]
+    }
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupInstances/testbi/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Azure-AsyncOperation": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupVaults/testvault/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Retry-After": "60"
+      }
+    },
+    "200": {}
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/SuspendBackup_ResourceGuardEnabled.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/SuspendBackup_ResourceGuardEnabled.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "testrg",
     "vaultName": "testvault",
     "backupInstanceName": "testbi",
-    "api-version": "2025-02-01",
+    "api-version": "2025-07-01",
     "parameters": {
       "resourceGuardOperationRequests": [
         "/subscriptions/754ec39f-8d2a-44cf-bfbf-13107ac85c36/resourcegroups/mua-testing/providers/Microsoft.DataProtection/resourceGuards/gvjreddy-test-ecy-rg-reader/dppDisableSuspendBackupsRequests/default"
@@ -14,8 +14,8 @@
   "responses": {
     "202": {
       "headers": {
-        "Location": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupInstances/testbi/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
-        "Azure-AsyncOperation": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupVaults/testvault/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Location": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupInstances/testbi/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
+        "Azure-AsyncOperation": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupVaults/testvault/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
         "Retry-After": "60"
       }
     },

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/SuspendBackups.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/SuspendBackups.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "resourceGroupName": "testrg",
+    "vaultName": "testvault",
+    "backupInstanceName": "testbi",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupInstances/testbi/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Azure-AsyncOperation": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupVaults/testvault/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Retry-After": "60"
+      }
+    },
+    "200": {}
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/SuspendBackups.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/SuspendBackups.json
@@ -4,13 +4,13 @@
     "resourceGroupName": "testrg",
     "vaultName": "testvault",
     "backupInstanceName": "testbi",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "202": {
       "headers": {
-        "Location": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupInstances/testbi/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
-        "Azure-AsyncOperation": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupVaults/testvault/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Location": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupInstances/testbi/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
+        "Azure-AsyncOperation": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupVaults/testvault/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
         "Retry-After": "60"
       }
     },

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/SyncBackupInstance.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/SyncBackupInstance.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "resourceGroupName": "testrg",
+    "vaultName": "testvault",
+    "backupInstanceName": "testbi",
+    "api-version": "2025-02-01",
+    "parameters": {
+      "syncType": "Default"
+    }
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupInstances/testbi/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Azure-AsyncOperation": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupVaults/testvault/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Retry-After": "60"
+      }
+    },
+    "200": {}
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/SyncBackupInstance.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/SyncBackupInstance.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "testrg",
     "vaultName": "testvault",
     "backupInstanceName": "testbi",
-    "api-version": "2025-02-01",
+    "api-version": "2025-07-01",
     "parameters": {
       "syncType": "Default"
     }
@@ -12,8 +12,8 @@
   "responses": {
     "202": {
       "headers": {
-        "Location": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupInstances/testbi/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
-        "Azure-AsyncOperation": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupVaults/testvault/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Location": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupInstances/testbi/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
+        "Azure-AsyncOperation": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupVaults/testvault/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
         "Retry-After": "60"
       }
     },

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/TriggerBackup.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/TriggerBackup.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "resourceGroupName": "000pikumar",
+    "vaultName": "PratikPrivatePreviewVault1",
+    "api-version": "2025-02-01",
+    "backupInstanceName": "testInstance1",
+    "parameters": {
+      "backupRuleOptions": {
+        "ruleName": "BackupWeekly",
+        "triggerOption": {
+          "retentionTagOverride": "yearly"
+        }
+      }
+    }
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupInstances/harshitbi1/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Retry-After": "60"
+      }
+    },
+    "200": {
+      "body": {
+        "jobId": "c60cb49-63e8-4b21-b9bd-26277b3fdfae",
+        "objectType": "OperationJobExtendedInfo"
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/TriggerBackup.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/TriggerBackup.json
@@ -3,7 +3,7 @@
     "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
     "resourceGroupName": "000pikumar",
     "vaultName": "PratikPrivatePreviewVault1",
-    "api-version": "2025-02-01",
+    "api-version": "2025-07-01",
     "backupInstanceName": "testInstance1",
     "parameters": {
       "backupRuleOptions": {
@@ -17,8 +17,8 @@
   "responses": {
     "202": {
       "headers": {
-        "Location": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupInstances/harshitbi1/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Location": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupInstances/harshitbi1/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
         "Retry-After": "60"
       }
     },

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/TriggerRehydrate.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/TriggerRehydrate.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "resourceGroupName": "000pikumar",
+    "vaultName": "PratikPrivatePreviewVault1",
+    "api-version": "2025-02-01",
+    "backupInstanceName": "testInstance1",
+    "parameters": {
+      "recoveryPointId": "hardcodedRP",
+      "rehydrationRetentionDuration": "7D",
+      "rehydrationPriority": "High"
+    }
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupInstances/harshitbi1/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Retry-After": "60"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/TriggerRehydrate.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/TriggerRehydrate.json
@@ -3,7 +3,7 @@
     "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
     "resourceGroupName": "000pikumar",
     "vaultName": "PratikPrivatePreviewVault1",
-    "api-version": "2025-02-01",
+    "api-version": "2025-07-01",
     "backupInstanceName": "testInstance1",
     "parameters": {
       "recoveryPointId": "hardcodedRP",
@@ -14,8 +14,8 @@
   "responses": {
     "202": {
       "headers": {
-        "Location": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupInstances/harshitbi1/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Location": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupInstances/harshitbi1/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
         "Retry-After": "60"
       }
     },

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/TriggerRestore.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/TriggerRestore.json
@@ -1,0 +1,64 @@
+{
+  "parameters": {
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "resourceGroupName": "000pikumar",
+    "vaultName": "PratikPrivatePreviewVault1",
+    "api-version": "2025-02-01",
+    "backupInstanceName": "testInstance1",
+    "parameters": {
+      "objectType": "AzureBackupRecoveryPointBasedRestoreRequest",
+      "recoveryPointId": "hardcodedRP",
+      "sourceDataStoreType": "VaultStore",
+      "sourceResourceId": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest/databases/testdb",
+      "restoreTargetInfo": {
+        "objectType": "RestoreTargetInfo",
+        "recoveryOption": "FailIfExists",
+        "datasourceSetInfo": {
+          "objectType": "DatasourceSet",
+          "resourceID": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest",
+          "resourceName": "viveksipgtest",
+          "resourceType": "Microsoft.DBforPostgreSQL/servers",
+          "resourceUri": "",
+          "resourceLocation": "",
+          "datasourceType": "Microsoft.DBforPostgreSQL/servers/databases"
+        },
+        "datasourceInfo": {
+          "objectType": "Datasource",
+          "resourceID": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest/databases/targetdb",
+          "resourceName": "targetdb",
+          "resourceType": "Microsoft.DBforPostgreSQL/servers/databases",
+          "resourceUri": "",
+          "resourceLocation": "",
+          "datasourceType": "Microsoft.DBforPostgreSQL/servers/databases"
+        },
+        "datasourceAuthCredentials": {
+          "secretStoreResource": {
+            "uri": "https://samplevault.vault.azure.net/secrets/credentials",
+            "secretStoreType": "AzureKeyVault"
+          },
+          "objectType": "SecretStoreBasedAuthCredentials"
+        },
+        "restoreLocation": "southeastasia"
+      },
+      "identityDetails": {
+        "useSystemAssignedIdentity": false,
+        "userAssignedIdentityArmUrl": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourcegroups/rg-name/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testUami"
+      }
+    }
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupInstances/harshitbi1/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Retry-After": "60"
+      }
+    },
+    "200": {
+      "body": {
+        "jobId": "c60cb49-63e8-4b21-b9bd-26277b3fdfae",
+        "objectType": "OperationJobExtendedInfo"
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/TriggerRestore.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/TriggerRestore.json
@@ -3,7 +3,7 @@
     "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
     "resourceGroupName": "000pikumar",
     "vaultName": "PratikPrivatePreviewVault1",
-    "api-version": "2025-02-01",
+    "api-version": "2025-07-01",
     "backupInstanceName": "testInstance1",
     "parameters": {
       "objectType": "AzureBackupRecoveryPointBasedRestoreRequest",
@@ -49,8 +49,8 @@
   "responses": {
     "202": {
       "headers": {
-        "Location": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupInstances/harshitbi1/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Location": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupInstances/harshitbi1/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
         "Retry-After": "60"
       }
     },

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/TriggerRestoreAsFiles.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/TriggerRestoreAsFiles.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "resourceGroupName": "000pikumar",
+    "vaultName": "PrivatePreviewVault1",
+    "api-version": "2025-02-01",
+    "backupInstanceName": "testInstance1",
+    "parameters": {
+      "objectType": "AzureBackupRecoveryPointBasedRestoreRequest",
+      "recoveryPointId": "hardcodedRP",
+      "sourceDataStoreType": "VaultStore",
+      "sourceResourceId": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest/databases/testdb",
+      "restoreTargetInfo": {
+        "targetDetails": {
+          "url": "https://teststorage.blob.core.windows.net/restoretest",
+          "filePrefix": "restoredblob",
+          "restoreTargetLocationType": "AzureBlobs"
+        },
+        "restoreLocation": "southeastasia",
+        "recoveryOption": "FailIfExists",
+        "objectType": "RestoreFilesTargetInfo"
+      }
+    }
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupInstances/testInstance1/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Retry-After": "60"
+      }
+    },
+    "200": {
+      "body": {
+        "jobId": "c60cb49-63e8-4b21-b9bd-26277b3fdfae",
+        "objectType": "OperationJobExtendedInfo"
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/TriggerRestoreAsFiles.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/TriggerRestoreAsFiles.json
@@ -3,7 +3,7 @@
     "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
     "resourceGroupName": "000pikumar",
     "vaultName": "PrivatePreviewVault1",
-    "api-version": "2025-02-01",
+    "api-version": "2025-07-01",
     "backupInstanceName": "testInstance1",
     "parameters": {
       "objectType": "AzureBackupRecoveryPointBasedRestoreRequest",
@@ -25,8 +25,8 @@
   "responses": {
     "202": {
       "headers": {
-        "Location": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupInstances/testInstance1/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Location": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupInstances/testInstance1/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
         "Retry-After": "60"
       }
     },

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/TriggerRestoreWithRehydration.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/TriggerRestoreWithRehydration.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "resourceGroupName": "000pikumar",
+    "vaultName": "PratikPrivatePreviewVault1",
+    "api-version": "2025-02-01",
+    "backupInstanceName": "testInstance1",
+    "parameters": {
+      "objectType": "AzureBackupRestoreWithRehydrationRequest",
+      "recoveryPointId": "hardcodedRP",
+      "rehydrationRetentionDuration": "7D",
+      "rehydrationPriority": "High",
+      "sourceDataStoreType": "VaultStore",
+      "sourceResourceId": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest/databases/testdb",
+      "restoreTargetInfo": {
+        "objectType": "RestoreTargetInfo",
+        "recoveryOption": "FailIfExists",
+        "datasourceSetInfo": {
+          "objectType": "DatasourceSet",
+          "resourceID": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest",
+          "resourceName": "viveksipgtest",
+          "resourceType": "Microsoft.DBforPostgreSQL/servers",
+          "resourceUri": "",
+          "resourceLocation": "",
+          "datasourceType": "OssDB"
+        },
+        "datasourceInfo": {
+          "objectType": "Datasource",
+          "resourceID": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest/databases/testdb",
+          "resourceName": "testdb",
+          "resourceType": "Microsoft.DBforPostgreSQL/servers/databases",
+          "resourceUri": "",
+          "resourceLocation": "",
+          "datasourceType": "OssDB"
+        },
+        "restoreLocation": "southeastasia"
+      }
+    }
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupInstances/harshitbi1/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Retry-After": "60"
+      }
+    },
+    "200": {
+      "body": {
+        "jobId": "c60cb49-63e8-4b21-b9bd-26277b3fdfae",
+        "objectType": "OperationJobExtendedInfo"
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/TriggerRestoreWithRehydration.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/TriggerRestoreWithRehydration.json
@@ -3,7 +3,7 @@
     "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
     "resourceGroupName": "000pikumar",
     "vaultName": "PratikPrivatePreviewVault1",
-    "api-version": "2025-02-01",
+    "api-version": "2025-07-01",
     "backupInstanceName": "testInstance1",
     "parameters": {
       "objectType": "AzureBackupRestoreWithRehydrationRequest",
@@ -40,8 +40,8 @@
   "responses": {
     "202": {
       "headers": {
-        "Location": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupInstances/harshitbi1/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Location": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupInstances/harshitbi1/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
         "Retry-After": "60"
       }
     },

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/TriggerRestore_ItemLevel.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/TriggerRestore_ItemLevel.json
@@ -1,0 +1,77 @@
+{
+  "parameters": {
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "resourceGroupName": "000pikumar",
+    "vaultName": "PratikPrivatePreviewVault1",
+    "api-version": "2025-07-01",
+    "backupInstanceName": "testInstance1",
+    "parameters": {
+      "objectType": "AzureBackupRecoveryPointBasedRestoreRequest",
+      "recoveryPointId": "33fdef0e0e2e4594b63092ae9a56f58d",
+      "sourceDataStoreType": "VaultStore",
+      "sourceResourceId": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.Storage/storageAccounts/azclitestrestore2",
+      "restoreTargetInfo": {
+        "objectType": "RestoreTargetInfo",
+        "recoveryOption": "FailIfExists",
+        "datasourceSetInfo": {
+          "objectType": "DatasourceSet",
+          "resourceID": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.Storage/storageAccounts/azclitestrestore2",
+          "resourceName": "azclitestrestore2",
+          "resourceType": "Microsoft.Storage/storageAccounts",
+          "resourceUri": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.Storage/storageAccounts/azclitestrestore2",
+          "resourceLocation": "southeastasia",
+          "datasourceType": "Microsoft.Storage/storageAccounts/blobServices"
+        },
+        "datasourceInfo": {
+          "objectType": "Datasource",
+          "resourceID": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.Storage/storageAccounts/azclitestrestore2",
+          "resourceName": "azclitestrestore2",
+          "resourceType": "Microsoft.Storage/storageAccounts",
+          "resourceUri": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.Storage/storageAccounts/azclitestrestore2",
+          "resourceLocation": "southeastasia",
+          "datasourceType": "Microsoft.Storage/storageAccounts/blobServices"
+        },
+        "datasourceAuthCredentials": {
+          "secretStoreResource": {
+            "uri": "https://samplevault.vault.azure.net/secrets/credentials",
+            "secretStoreType": "AzureKeyVault"
+          },
+          "objectType": "SecretStoreBasedAuthCredentials"
+        },
+        "restoreCriteria": [
+          {
+            "objectType": "ItemPathBasedRestoreCriteria",
+            "itemPath": "container1",
+            "isPathRelativeToBackupItem": true,
+            "subItemPathPrefix": [
+              "abc",
+              "def",
+              "ghi"
+            ],
+            "renameTo": "container1new"
+          }
+        ],
+        "restoreLocation": "southeastasia"
+      },
+      "identityDetails": {
+        "useSystemAssignedIdentity": false,
+        "userAssignedIdentityArmUrl": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourcegroups/000pikumar/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testUami"
+      }
+    }
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupInstances/testInstance1/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
+        "Retry-After": "60"
+      }
+    },
+    "200": {
+      "body": {
+        "jobId": "c60cb49-63e8-4b21-b9bd-26277b3fdfae",
+        "objectType": "OperationJobExtendedInfo"
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/ValidateForBackup.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/ValidateForBackup.json
@@ -1,0 +1,62 @@
+{
+  "parameters": {
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "resourceGroupName": "000pikumar",
+    "vaultName": "PratikPrivatePreviewVault1",
+    "api-version": "2025-02-01",
+    "backupInstanceName": "testInstance1",
+    "parameters": {
+      "backupInstance": {
+        "objectType": "BackupInstance",
+        "friendlyName": "harshitbi2",
+        "dataSourceSetInfo": {
+          "objectType": "DatasourceSet",
+          "resourceID": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest",
+          "resourceName": "viveksipgtest",
+          "resourceType": "Microsoft.DBforPostgreSQL/servers",
+          "resourceUri": "",
+          "resourceLocation": "",
+          "datasourceType": "OssDB"
+        },
+        "dataSourceInfo": {
+          "objectType": "Datasource",
+          "resourceID": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest/databases/testdb",
+          "resourceName": "testdb",
+          "resourceType": "Microsoft.DBforPostgreSQL/servers/databases",
+          "resourceUri": "",
+          "resourceLocation": "",
+          "datasourceType": "OssDB"
+        },
+        "datasourceAuthCredentials": {
+          "secretStoreResource": {
+            "uri": "https://samplevault.vault.azure.net/secrets/credentials",
+            "secretStoreType": "AzureKeyVault"
+          },
+          "objectType": "SecretStoreBasedAuthCredentials"
+        },
+        "policyInfo": {
+          "policyId": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/Backupvaults/PratikPrivatePreviewVault1/backupPolicies/PratikPolicy1"
+        },
+        "identityDetails": {
+          "useSystemAssignedIdentity": false,
+          "userAssignedIdentityArmUrl": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourcegroups/rg-name/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testUami"
+        }
+      }
+    }
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Retry-After": "60"
+      }
+    },
+    "200": {
+      "body": {
+        "jobId": "c60cb49-63e8-4b21-b9bd-26277b3fdfae",
+        "objectType": "OperationJobExtendedInfo"
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/ValidateForBackup.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/ValidateForBackup.json
@@ -3,7 +3,7 @@
     "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
     "resourceGroupName": "000pikumar",
     "vaultName": "PratikPrivatePreviewVault1",
-    "api-version": "2025-02-01",
+    "api-version": "2025-07-01",
     "backupInstanceName": "testInstance1",
     "parameters": {
       "backupInstance": {
@@ -47,8 +47,8 @@
   "responses": {
     "202": {
       "headers": {
-        "Location": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Location": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
         "Retry-After": "60"
       }
     },

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/ValidateForModifyBackup.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/ValidateForModifyBackup.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "resourceGroupName": "000pikumar",
+    "vaultName": "PratikPrivatePreviewVault1",
+    "api-version": "2025-02-01",
+    "backupInstanceName": "testInstance1",
+    "parameters": {
+      "backupInstance": {
+        "objectType": "BackupInstance",
+        "friendlyName": "harshitbi2",
+        "dataSourceSetInfo": {
+          "objectType": "DatasourceSet",
+          "resourceID": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest",
+          "resourceName": "viveksipgtest",
+          "resourceType": "Microsoft.DBforPostgreSQL/servers",
+          "resourceUri": "",
+          "resourceLocation": "",
+          "datasourceType": "OssDB"
+        },
+        "dataSourceInfo": {
+          "objectType": "Datasource",
+          "resourceID": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest/databases/testdb",
+          "resourceName": "testdb",
+          "resourceType": "Microsoft.DBforPostgreSQL/servers/databases",
+          "resourceUri": "",
+          "resourceLocation": "",
+          "datasourceType": "OssDB"
+        },
+        "datasourceAuthCredentials": {
+          "secretStoreResource": {
+            "uri": "https://samplevault.vault.azure.net/secrets/credentials",
+            "secretStoreType": "AzureKeyVault"
+          },
+          "objectType": "SecretStoreBasedAuthCredentials"
+        },
+        "policyInfo": {
+          "policyId": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/Backupvaults/PratikPrivatePreviewVault1/backupPolicies/PratikPolicy1"
+        },
+        "identityDetails": {
+          "useSystemAssignedIdentity": false,
+          "userAssignedIdentityArmUrl": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourcegroups/rg-name/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testUami"
+        }
+      }
+    }
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2023-08-01-preview",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2023-08-01-preview",
+        "Retry-After": "60"
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/ValidateForModifyBackup.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/ValidateForModifyBackup.json
@@ -3,7 +3,7 @@
     "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
     "resourceGroupName": "000pikumar",
     "vaultName": "PratikPrivatePreviewVault1",
-    "api-version": "2025-02-01",
+    "api-version": "2025-07-01",
     "backupInstanceName": "testInstance1",
     "parameters": {
       "backupInstance": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/ValidateRestore.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/ValidateRestore.json
@@ -1,0 +1,66 @@
+{
+  "parameters": {
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "resourceGroupName": "000pikumar",
+    "vaultName": "PratikPrivatePreviewVault1",
+    "api-version": "2025-02-01",
+    "backupInstanceName": "testInstance1",
+    "parameters": {
+      "restoreRequestObject": {
+        "objectType": "AzureBackupRecoveryPointBasedRestoreRequest",
+        "recoveryPointId": "hardcodedRP",
+        "sourceDataStoreType": "VaultStore",
+        "sourceResourceId": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest/databases/testdb",
+        "restoreTargetInfo": {
+          "objectType": "RestoreTargetInfo",
+          "recoveryOption": "FailIfExists",
+          "datasourceSetInfo": {
+            "objectType": "DatasourceSet",
+            "resourceID": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest",
+            "resourceName": "viveksipgtest",
+            "resourceType": "Microsoft.DBforPostgreSQL/servers",
+            "resourceUri": "",
+            "resourceLocation": "",
+            "datasourceType": "Microsoft.DBforPostgreSQL/servers/databases"
+          },
+          "datasourceInfo": {
+            "objectType": "Datasource",
+            "resourceID": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest/databases/targetdb",
+            "resourceName": "targetdb",
+            "resourceType": "Microsoft.DBforPostgreSQL/servers/databases",
+            "resourceUri": "",
+            "resourceLocation": "",
+            "datasourceType": "Microsoft.DBforPostgreSQL/servers/databases"
+          },
+          "datasourceAuthCredentials": {
+            "secretStoreResource": {
+              "uri": "https://samplevault.vault.azure.net/secrets/credentials",
+              "secretStoreType": "AzureKeyVault"
+            },
+            "objectType": "SecretStoreBasedAuthCredentials"
+          },
+          "restoreLocation": "southeastasia"
+        },
+        "identityDetails": {
+          "useSystemAssignedIdentity": false,
+          "userAssignedIdentityArmUrl": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourcegroups/rg-name/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testUami"
+        }
+      }
+    }
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Retry-After": "60"
+      }
+    },
+    "200": {
+      "body": {
+        "jobId": "c60cb49-63e8-4b21-b9bd-26277b3fdfae",
+        "objectType": "OperationJobExtendedInfo"
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/ValidateRestore.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/BackupInstanceOperations/ValidateRestore.json
@@ -3,7 +3,7 @@
     "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
     "resourceGroupName": "000pikumar",
     "vaultName": "PratikPrivatePreviewVault1",
-    "api-version": "2025-02-01",
+    "api-version": "2025-07-01",
     "backupInstanceName": "testInstance1",
     "parameters": {
       "restoreRequestObject": {
@@ -51,8 +51,8 @@
   "responses": {
     "202": {
       "headers": {
-        "Location": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Location": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
         "Retry-After": "60"
       }
     },

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/CheckfeatureSupport.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/CheckfeatureSupport.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "location": "WestUS",
+    "api-version": "2025-02-01",
+    "parameters": {
+      "featureType": "DataSourceType",
+      "objectType": "FeatureValidationRequest"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "featureType": "DataSourceType",
+        "features": [
+          {
+            "featureName": "Microsoft.Storage/storageAccounts/blobServices",
+            "supportStatus": "PrivatePreview",
+            "exposureControlledFeatures": []
+          },
+          {
+            "featureName": "Microsoft.DBforPostgreSQL/servers/databases",
+            "supportStatus": "PublicPreview",
+            "exposureControlledFeatures": []
+          }
+        ],
+        "objectType": "FeatureValidationResponse"
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/CheckfeatureSupport.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/CheckfeatureSupport.json
@@ -2,7 +2,7 @@
   "parameters": {
     "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
     "location": "WestUS",
-    "api-version": "2025-02-01",
+    "api-version": "2025-07-01",
     "parameters": {
       "featureType": "DataSourceType",
       "objectType": "FeatureValidationRequest"

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/CrossRegionRestore/FetchCrossRegionRestoreJob.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/CrossRegionRestore/FetchCrossRegionRestoreJob.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "subscriptionId": "62b829ee-7936-40c9-a1c9-47a93f9f3965",
+    "resourceGroupName": "BugBash1",
+    "location": "west us",
+    "parameters": {
+      "sourceRegion": "east us",
+      "sourceBackupVaultId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/BugBash1/providers/Microsoft.DataProtection/backupVaults/BugBashVaultForCCYv11",
+      "jobId": "3c60cb49-63e8-4b21-b9bd-26277b3fdfae"
+    },
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "activityID": "c4344fb4-7c11-43a4-8307-7ae7c7fb09b9",
+          "subscriptionId": "62b829ee-7936-40c9-a1c9-47a93f9f3965",
+          "backupInstanceId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/BugBash1/providers/Microsoft.DataProtection/backupVaults/BugBashVaultForCCYv11/backupInstances/28460a9d-707a-45f3-ace6-b16284c2900e",
+          "policyId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/BugBash1/providers/Microsoft.DataProtection/backupVaults/BugBashVaultForCCYv11/backupPolicies/jakavetdailypolicy",
+          "dataSourceId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/DppPostgresTestingCcy/providers/Microsoft.DBforPostgreSQL/servers/mabtestingccybasicv11/databases/bugbashdb2",
+          "vaultName": "BugBashVaultForCCYv11",
+          "backupInstanceFriendlyName": "mabtestingccybasicv11\\bugbashdb2",
+          "policyName": "jakavetdailypolicy",
+          "sourceResourceGroup": "DppPostgresTestingCcy",
+          "dataSourceSetName": "mabtestingccybasicv11",
+          "dataSourceName": "bugbashdb2",
+          "progressEnabled": false,
+          "sourceSubscriptionID": "62b829ee-7936-40c9-a1c9-47a93f9f3965",
+          "startTime": "2021-03-17T03:00:03.7604146Z",
+          "dataSourceType": "Microsoft.DBforPostgreSQL/servers/databases",
+          "operationCategory": "Backup",
+          "operation": "Backup",
+          "status": "Started",
+          "isUserTriggered": false,
+          "supportedActions": [],
+          "duration": "00:00:00",
+          "dataSourceLocation": "east us",
+          "extendedInfo": {
+            "subTasks": [
+              {
+                "taskId": 1,
+                "taskName": "Trigger Backup",
+                "taskStatus": "Started"
+              }
+            ],
+            "additionalDetails": {
+              "RetentionTag": "Default",
+              "PolicyRuleName": "BackupWeekly",
+              "TaskId": "c4344fb4-7c11-43a4-8307-7ae7c7fb09b9"
+            }
+          }
+        },
+        "id": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/BugBash1/providers/Microsoft.DataProtection/Backupvaults/BugBashVaultForCCYv11/backupJobs/3c60cb49-63e8-4b21-b9bd-26277b3fdfae",
+        "name": "3c60cb49-63e8-4b21-b9bd-26277b3fdfae",
+        "type": "Microsoft.DataProtection/Backupvaults/backupJobs"
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/CrossRegionRestore/FetchCrossRegionRestoreJob.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/CrossRegionRestore/FetchCrossRegionRestoreJob.json
@@ -8,7 +8,7 @@
       "sourceBackupVaultId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/BugBash1/providers/Microsoft.DataProtection/backupVaults/BugBashVaultForCCYv11",
       "jobId": "3c60cb49-63e8-4b21-b9bd-26277b3fdfae"
     },
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/CrossRegionRestore/FetchCrossRegionRestoreJobs.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/CrossRegionRestore/FetchCrossRegionRestoreJobs.json
@@ -1,0 +1,139 @@
+{
+  "parameters": {
+    "subscriptionId": "62b829ee-7936-40c9-a1c9-47a93f9f3965",
+    "resourceGroupName": "BugBash1",
+    "location": "east us",
+    "api-version": "2025-02-01",
+    "parameters": {
+      "sourceRegion": "east us",
+      "sourceBackupVaultId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/BugBash1/providers/Microsoft.DataProtection/backupVaults/BugBashVaultForCCYv11"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "activityID": "932925c4-3d81-4550-8105-c7f7b0a934c5",
+              "subscriptionId": "62b829ee-7936-40c9-a1c9-47a93f9f3965",
+              "backupInstanceId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/BugBash1/providers/Microsoft.DataProtection/backupVaults/BugBashVaultForCCYv11/backupInstances/3048870f-b1b7-44c4-b078-368da3fd000e",
+              "policyId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/BugBash1/providers/Microsoft.DataProtection/backupVaults/BugBashVaultForCCYv11/backupPolicies/jakavetPolicy2",
+              "dataSourceId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/DppPostgresTestingCcy/providers/Microsoft.DBforPostgreSQL/servers/mabtestingccybasicv11/databases/bugbashdb4",
+              "vaultName": "BugBashVaultForCCYv11",
+              "backupInstanceFriendlyName": "mabtestingccybasicv11\\bugbashdb4",
+              "policyName": "jakavetPolicy2",
+              "sourceResourceGroup": "DppPostgresTestingCcy",
+              "dataSourceSetName": "mabtestingccybasicv11",
+              "dataSourceName": "bugbashdb4",
+              "progressEnabled": false,
+              "sourceSubscriptionID": "62b829ee-7936-40c9-a1c9-47a93f9f3965",
+              "startTime": "2021-03-16T05:00:08.1746833Z",
+              "dataSourceType": "Microsoft.DBforPostgreSQL/servers/databases",
+              "operationCategory": "Backup",
+              "operation": "Backup",
+              "status": "Started",
+              "isUserTriggered": false,
+              "supportedActions": [],
+              "duration": "00:00:00",
+              "dataSourceLocation": "centraluseuap"
+            },
+            "id": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/BugBash1/providers/Microsoft.DataProtection/Backupvaults/BugBashVaultForCCYv11/backupJobs/8989416e-7573-4836-8cf1-0e90954f1002",
+            "name": "8989416e-7573-4836-8cf1-0e90954f1002",
+            "type": "Microsoft.DataProtection/Backupvaults/backupJobs"
+          },
+          {
+            "properties": {
+              "activityID": "b4f32e03-ded0-46fc-9afc-91853878efcd",
+              "subscriptionId": "62b829ee-7936-40c9-a1c9-47a93f9f3965",
+              "backupInstanceId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/BugBash1/providers/Microsoft.DataProtection/backupVaults/BugBashVaultForCCYv11/backupInstances/943c60db-c033-4d93-bb00-66048474e00e",
+              "policyId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/BugBash1/providers/Microsoft.DataProtection/backupVaults/BugBashVaultForCCYv11/backupPolicies/jakavetPolicy3",
+              "dataSourceId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/DppPostgresTestingCcy/providers/Microsoft.DBforPostgreSQL/servers/mabtestingccybasicv11/databases/bugbashdb5",
+              "vaultName": "BugBashVaultForCCYv11",
+              "backupInstanceFriendlyName": "mabtestingccybasicv11\\bugbashdb5",
+              "policyName": "jakavetPolicy3",
+              "sourceResourceGroup": "DppPostgresTestingCcy",
+              "dataSourceSetName": "mabtestingccybasicv11",
+              "dataSourceName": "bugbashdb5",
+              "progressEnabled": false,
+              "sourceSubscriptionID": "62b829ee-7936-40c9-a1c9-47a93f9f3965",
+              "startTime": "2021-03-16T18:00:03.6660733Z",
+              "dataSourceType": "Microsoft.DBforPostgreSQL/servers/databases",
+              "operationCategory": "Backup",
+              "operation": "Backup",
+              "status": "Started",
+              "isUserTriggered": false,
+              "supportedActions": [],
+              "duration": "00:00:00",
+              "dataSourceLocation": "centraluseuap"
+            },
+            "id": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/BugBash1/providers/Microsoft.DataProtection/Backupvaults/BugBashVaultForCCYv11/backupJobs/ad218c05-242a-47c2-b7b7-c16bd0f8870c",
+            "name": "ad218c05-242a-47c2-b7b7-c16bd0f8870c",
+            "type": "Microsoft.DataProtection/Backupvaults/backupJobs"
+          },
+          {
+            "properties": {
+              "activityID": "c4344fb4-7c11-43a4-8307-7ae7c7fb09b9",
+              "subscriptionId": "62b829ee-7936-40c9-a1c9-47a93f9f3965",
+              "backupInstanceId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/BugBash1/providers/Microsoft.DataProtection/backupVaults/BugBashVaultForCCYv11/backupInstances/28460a9d-707a-45f3-ace6-b16284c2900e",
+              "policyId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/BugBash1/providers/Microsoft.DataProtection/backupVaults/BugBashVaultForCCYv11/backupPolicies/jakavetdailypolicy",
+              "dataSourceId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/DppPostgresTestingCcy/providers/Microsoft.DBforPostgreSQL/servers/mabtestingccybasicv11/databases/bugbashdb2",
+              "vaultName": "BugBashVaultForCCYv11",
+              "backupInstanceFriendlyName": "mabtestingccybasicv11\\bugbashdb2",
+              "policyName": "jakavetdailypolicy",
+              "sourceResourceGroup": "DppPostgresTestingCcy",
+              "dataSourceSetName": "mabtestingccybasicv11",
+              "dataSourceName": "bugbashdb2",
+              "progressEnabled": false,
+              "sourceSubscriptionID": "62b829ee-7936-40c9-a1c9-47a93f9f3965",
+              "startTime": "2021-03-17T03:00:03.7604146Z",
+              "dataSourceType": "Microsoft.DBforPostgreSQL/servers/databases",
+              "operationCategory": "Backup",
+              "operation": "Backup",
+              "status": "Started",
+              "isUserTriggered": false,
+              "supportedActions": [],
+              "duration": "00:00:00",
+              "dataSourceLocation": "centraluseuap"
+            },
+            "id": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/BugBash1/providers/Microsoft.DataProtection/Backupvaults/BugBashVaultForCCYv11/backupJobs/3c60cb49-63e8-4b21-b9bd-26277b3fdfae",
+            "name": "3c60cb49-63e8-4b21-b9bd-26277b3fdfae",
+            "type": "Microsoft.DataProtection/Backupvaults/backupJobs"
+          },
+          {
+            "properties": {
+              "activityID": "94052cf1-a47f-4c1b-93e7-79e07b2bd008-Tue Mar 17 2021 11:11:48 GMT+0530 (India Standard Time)-Ibz",
+              "subscriptionId": "62b829ee-7936-40c9-a1c9-47a93f9f3965",
+              "backupInstanceId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/BugBash1/providers/Microsoft.DataProtection/backupVaults/BugBashVaultForCCYv11/backupInstances/0b247869-b8be-4885-b832-8ac4cdf5b00e",
+              "policyId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/BugBash1/providers/Microsoft.DataProtection/backupVaults/BugBashVaultForCCYv11/backupPolicies/jakavetPolicy1",
+              "dataSourceId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/DppPostgresTestingCcy/providers/Microsoft.DBforPostgreSQL/servers/mabtestingccybasicv11/databases/bugbashdb3",
+              "vaultName": "BugBashVaultForCCYv11",
+              "backupInstanceFriendlyName": "mabtestingccybasicv11\\bugbashdb3",
+              "policyName": "jakavetPolicy1",
+              "sourceResourceGroup": "DppPostgresTestingCcy",
+              "dataSourceSetName": "mabtestingccybasicv11",
+              "dataSourceName": "bugbashdb3",
+              "progressEnabled": false,
+              "sourceSubscriptionID": "62b829ee-7936-40c9-a1c9-47a93f9f3965",
+              "startTime": "2021-03-17T11:11:50.5595259Z",
+              "endTime": "2021-03-17T11:14:02.5319646Z",
+              "dataSourceType": "Microsoft.DBforPostgreSQL/servers/databases",
+              "operationCategory": "Backup",
+              "operation": "Backup",
+              "status": "Succeeded",
+              "isUserTriggered": true,
+              "supportedActions": [
+                ""
+              ],
+              "duration": "00:02:11.9724387",
+              "dataSourceLocation": "centraluseuap"
+            },
+            "id": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/BugBash1/providers/Microsoft.DataProtection/Backupvaults/BugBashVaultForCCYv11/backupJobs/43252662-1b43-44fd-a856-0055665cb097",
+            "name": "43252662-1b43-44fd-a856-0055665cb097",
+            "type": "Microsoft.DataProtection/Backupvaults/backupJobs"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/CrossRegionRestore/FetchCrossRegionRestoreJobs.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/CrossRegionRestore/FetchCrossRegionRestoreJobs.json
@@ -3,7 +3,7 @@
     "subscriptionId": "62b829ee-7936-40c9-a1c9-47a93f9f3965",
     "resourceGroupName": "BugBash1",
     "location": "east us",
-    "api-version": "2025-02-01",
+    "api-version": "2025-07-01",
     "parameters": {
       "sourceRegion": "east us",
       "sourceBackupVaultId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/BugBash1/providers/Microsoft.DataProtection/backupVaults/BugBashVaultForCCYv11"

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/CrossRegionRestore/FetchSecondaryRPs.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/CrossRegionRestore/FetchSecondaryRPs.json
@@ -1,0 +1,71 @@
+{
+  "parameters": {
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "resourceGroupName": "000pikumar",
+    "api-version": "2025-02-01",
+    "location": "WestUS",
+    "parameters": {
+      "sourceBackupInstanceId": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/HelloTest/providers/Microsoft.DataProtection/backupVaults/HelloTestVault/backupInstances/653213d-c5b3-44f6-a0d9-db3c4f9d8e34",
+      "sourceRegion": "EastUS"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/HelloTest/providers/Microsoft.DataProtection/backupVaults/HelloTestVault/backupInstances/653213d-c5b3-44f6-a0d9-db3c4f9d8e34/recoveryPoints/7fb2cddd-c5b3-44f6-a0d9-db3c4f9d5f25",
+            "name": "7fb2cddd-c5b3-44f6-a0d9-db3c4f9d5e35",
+            "type": "microsoft.dataprotection/backupvaults/backupInstances/recoveryPoints",
+            "properties": {
+              "objectType": "AzureBackupDiscreteRecoveryPoint",
+              "recoveryPointTime": "2019-03-01T13:00:00Z",
+              "recoveryPointType": "Full",
+              "friendlyName": "panbha4",
+              "expiryTime": "2023-03-01T13:00:00Z",
+              "recoveryPointDataStoresDetails": [
+                {
+                  "id": "0ff03512-b333-4509-a6c7-12164c8b1dce",
+                  "type": "Snapshot",
+                  "creationTime": "2019-03-01T13:00:00Z",
+                  "metaData": "123456"
+                },
+                {
+                  "id": "5d8cfd30-722e-4bab-85f6-4a9d01ffc6f1",
+                  "type": "BackupStorage",
+                  "creationTime": "2019-03-01T13:00:00Z",
+                  "metaData": "123456"
+                }
+              ]
+            }
+          },
+          {
+            "id": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/HelloTest/providers/Microsoft.DataProtection/backupVaults/HelloTestVault/backupInstances/653213d-c5b3-44f6-a0d9-db3c4f9d8e34/recoveryPoints/7fb2cddd-c5b3-44f6-a0d9-db3c4f9d5f25",
+            "name": "7fb2cddd-c5b3-44f6-a0d9-db3c4f9d5f25",
+            "type": "microsoft.dataprotection/backupvaults/backupInstances/recoveryPoints",
+            "properties": {
+              "objectType": "AzureBackupDiscreteRecoveryPoint",
+              "recoveryPointTime": "2019-03-01T13:00:00Z",
+              "recoveryPointType": "Full",
+              "friendlyName": "panbha4",
+              "recoveryPointDataStoresDetails": [
+                {
+                  "id": "808cfd30-722e-4bab-85f6-4a9d01ffc6f2",
+                  "type": "Snapshot",
+                  "creationTime": "2019-03-01T13:00:00Z",
+                  "metaData": "123456"
+                },
+                {
+                  "id": "798cfd30-722e-4bab-85f6-4a9d01ffc6f3",
+                  "type": "BackupStorage",
+                  "creationTime": "2019-03-01T13:00:00Z",
+                  "metaData": "123456"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/CrossRegionRestore/FetchSecondaryRPs.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/CrossRegionRestore/FetchSecondaryRPs.json
@@ -2,7 +2,7 @@
   "parameters": {
     "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
     "resourceGroupName": "000pikumar",
-    "api-version": "2025-02-01",
+    "api-version": "2025-07-01",
     "location": "WestUS",
     "parameters": {
       "sourceBackupInstanceId": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/HelloTest/providers/Microsoft.DataProtection/backupVaults/HelloTestVault/backupInstances/653213d-c5b3-44f6-a0d9-db3c4f9d8e34",

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/CrossRegionRestore/TriggerCrossRegionRestore.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/CrossRegionRestore/TriggerCrossRegionRestore.json
@@ -1,0 +1,67 @@
+{
+  "parameters": {
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "resourceGroupName": "000pikumar",
+    "location": "EastAsia",
+    "vaultName": "PratikPrivatePreviewVault1",
+    "api-version": "2025-02-01",
+    "backupInstanceName": "testInstance1",
+    "parameters": {
+      "restoreRequestObject": {
+        "objectType": "AzureBackupRecoveryPointBasedRestoreRequest",
+        "recoveryPointId": "hardcodedRP",
+        "sourceDataStoreType": "VaultStore",
+        "sourceResourceId": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest/databases/testdb",
+        "restoreTargetInfo": {
+          "objectType": "RestoreTargetInfo",
+          "recoveryOption": "FailIfExists",
+          "datasourceSetInfo": {
+            "objectType": "DatasourceSet",
+            "resourceID": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest",
+            "resourceName": "viveksipgtest",
+            "resourceType": "Microsoft.DBforPostgreSQL/servers",
+            "resourceUri": "",
+            "resourceLocation": "",
+            "datasourceType": "Microsoft.DBforPostgreSQL/servers/databases"
+          },
+          "datasourceInfo": {
+            "objectType": "Datasource",
+            "resourceID": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest/databases/targetdb",
+            "resourceName": "targetdb",
+            "resourceType": "Microsoft.DBforPostgreSQL/servers/databases",
+            "resourceUri": "",
+            "resourceLocation": "",
+            "datasourceType": "Microsoft.DBforPostgreSQL/servers/databases"
+          },
+          "datasourceAuthCredentials": {
+            "secretStoreResource": {
+              "uri": "https://samplevault.vault.azure.net/secrets/credentials",
+              "secretStoreType": "AzureKeyVault"
+            },
+            "objectType": "SecretStoreBasedAuthCredentials"
+          },
+          "restoreLocation": "southeastasia"
+        }
+      },
+      "crossRegionRestoreDetails": {
+        "sourceRegion": "east asia",
+        "sourceBackupInstanceId": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/BackupInstances/harshitbi1"
+      }
+    }
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupInstances/harshitbi1/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Retry-After": "60"
+      }
+    },
+    "200": {
+      "body": {
+        "jobId": "c60cb49-63e8-4b21-b9bd-26277b3fdfae",
+        "objectType": "OperationJobExtendedInfo"
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/CrossRegionRestore/TriggerCrossRegionRestore.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/CrossRegionRestore/TriggerCrossRegionRestore.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "000pikumar",
     "location": "EastAsia",
     "vaultName": "PratikPrivatePreviewVault1",
-    "api-version": "2025-02-01",
+    "api-version": "2025-07-01",
     "backupInstanceName": "testInstance1",
     "parameters": {
       "restoreRequestObject": {
@@ -52,8 +52,8 @@
   "responses": {
     "202": {
       "headers": {
-        "Location": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupInstances/harshitbi1/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Location": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupInstances/harshitbi1/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
         "Retry-After": "60"
       }
     },

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/CrossRegionRestore/ValidateCrossRegionRestore.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/CrossRegionRestore/ValidateCrossRegionRestore.json
@@ -1,0 +1,67 @@
+{
+  "parameters": {
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "resourceGroupName": "000pikumar",
+    "location": "EastAsia",
+    "vaultName": "PratikPrivatePreviewVault1",
+    "api-version": "2025-02-01",
+    "backupInstanceName": "testInstance1",
+    "parameters": {
+      "restoreRequestObject": {
+        "objectType": "AzureBackupRecoveryPointBasedRestoreRequest",
+        "recoveryPointId": "hardcodedRP",
+        "sourceDataStoreType": "VaultStore",
+        "sourceResourceId": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest/databases/testdb",
+        "restoreTargetInfo": {
+          "objectType": "RestoreTargetInfo",
+          "recoveryOption": "FailIfExists",
+          "datasourceSetInfo": {
+            "objectType": "DatasourceSet",
+            "resourceID": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest",
+            "resourceName": "viveksipgtest",
+            "resourceType": "Microsoft.DBforPostgreSQL/servers",
+            "resourceUri": "",
+            "resourceLocation": "",
+            "datasourceType": "Microsoft.DBforPostgreSQL/servers/databases"
+          },
+          "datasourceInfo": {
+            "objectType": "Datasource",
+            "resourceID": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest/databases/targetdb",
+            "resourceName": "targetdb",
+            "resourceType": "Microsoft.DBforPostgreSQL/servers/databases",
+            "resourceUri": "",
+            "resourceLocation": "",
+            "datasourceType": "Microsoft.DBforPostgreSQL/servers/databases"
+          },
+          "datasourceAuthCredentials": {
+            "secretStoreResource": {
+              "uri": "https://samplevault.vault.azure.net/secrets/credentials",
+              "secretStoreType": "AzureKeyVault"
+            },
+            "objectType": "SecretStoreBasedAuthCredentials"
+          },
+          "restoreLocation": "southeastasia"
+        }
+      },
+      "crossRegionRestoreDetails": {
+        "sourceRegion": "east asia",
+        "sourceBackupInstanceId": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/BackupInstances/harshitbi1"
+      }
+    }
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupInstances/harshitbi1/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Retry-After": "60"
+      }
+    },
+    "200": {
+      "body": {
+        "jobId": "c60cb49-63e8-4b21-b9bd-26277b3fdfae",
+        "objectType": "OperationJobExtendedInfo"
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/CrossRegionRestore/ValidateCrossRegionRestore.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/CrossRegionRestore/ValidateCrossRegionRestore.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "000pikumar",
     "location": "EastAsia",
     "vaultName": "PratikPrivatePreviewVault1",
-    "api-version": "2025-02-01",
+    "api-version": "2025-07-01",
     "backupInstanceName": "testInstance1",
     "parameters": {
       "restoreRequestObject": {
@@ -52,8 +52,8 @@
   "responses": {
     "202": {
       "headers": {
-        "Location": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupInstances/harshitbi1/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Location": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupInstances/harshitbi1/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
         "Retry-After": "60"
       }
     },

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/DeletedBackupInstanceOperations/GetDeletedBackupInstance.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/DeletedBackupInstanceOperations/GetDeletedBackupInstance.json
@@ -1,0 +1,53 @@
+{
+  "parameters": {
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "resourceGroupName": "000pikumar",
+    "vaultName": "PratikPrivatePreviewVault1",
+    "api-version": "2025-02-01",
+    "backupInstanceName": "testInstance1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/deletedBackupInstances/testInstance1",
+        "name": "testInstance1",
+        "type": "Microsoft.DataProtection/backupVaults/deletedBackupInstances",
+        "properties": {
+          "friendlyName": "testInstance1",
+          "dataSourceInfo": {
+            "resourceID": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest/databases/testdb",
+            "resourceUri": "",
+            "datasourceType": "Microsoft.DBforPostgreSQL/servers/databases",
+            "resourceName": "testdb",
+            "resourceType": "Microsoft.DBforPostgreSQL/servers/databases",
+            "resourceLocation": "",
+            "objectType": "Datasource"
+          },
+          "dataSourceSetInfo": {
+            "resourceID": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest",
+            "resourceUri": "",
+            "datasourceType": "Microsoft.DBforPostgreSQL/servers/databases",
+            "resourceName": "viveksipgtest",
+            "resourceType": "Microsoft.DBforPostgreSQL/servers",
+            "resourceLocation": "",
+            "objectType": "DatasourceSet"
+          },
+          "deletionInfo": {
+            "deletionTime": "2022-05-04T00:00:36.6660445Z",
+            "scheduledPurgeTime": "2022-05-20T00:00:36.6660445Z",
+            "billingEndDate": "2022-05-06T00:00:36.6660445Z",
+            "deleteActivityID": "1e9ec790-d198-4efb-bbd7-e4669d5351a4"
+          },
+          "policyInfo": {
+            "policyId": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/backupPolicies/PratikPolicy1"
+          },
+          "protectionStatus": {
+            "status": "SoftDeleted"
+          },
+          "provisioningState": "Succeeded",
+          "objectType": "DeletedBackupInstance"
+        }
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/DeletedBackupInstanceOperations/GetDeletedBackupInstance.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/DeletedBackupInstanceOperations/GetDeletedBackupInstance.json
@@ -3,7 +3,7 @@
     "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
     "resourceGroupName": "000pikumar",
     "vaultName": "PratikPrivatePreviewVault1",
-    "api-version": "2025-02-01",
+    "api-version": "2025-07-01",
     "backupInstanceName": "testInstance1"
   },
   "responses": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/DeletedBackupInstanceOperations/ListDeletedBackupInstances.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/DeletedBackupInstanceOperations/ListDeletedBackupInstances.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "resourceGroupName": "000pikumar",
+    "vaultName": "PratikPrivatePreviewVault1",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/deletedBackupInstances/testInstance1",
+            "name": "testInstance1",
+            "type": "Microsoft.DataProtection/backupVaults/deletedBackupInstances",
+            "properties": {
+              "friendlyName": "testInstance1",
+              "dataSourceInfo": {
+                "resourceID": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest/databases/testdb",
+                "resourceUri": "",
+                "datasourceType": "Microsoft.DBforPostgreSQL/servers/databases",
+                "resourceName": "testdb",
+                "resourceType": "Microsoft.DBforPostgreSQL/servers/databases",
+                "resourceLocation": "",
+                "objectType": "Datasource"
+              },
+              "dataSourceSetInfo": {
+                "resourceID": "/subscriptions/f75d8d8b-6735-4697-82e1-1a7a3ff0d5d4/resourceGroups/viveksipgtest/providers/Microsoft.DBforPostgreSQL/servers/viveksipgtest",
+                "resourceUri": "",
+                "datasourceType": "Microsoft.DBforPostgreSQL/servers/databases",
+                "resourceName": "viveksipgtest",
+                "resourceType": "Microsoft.DBforPostgreSQL/servers",
+                "resourceLocation": "",
+                "objectType": "DatasourceSet"
+              },
+              "deletionInfo": {
+                "deletionTime": "2022-05-04T00:00:36.6660445Z",
+                "scheduledPurgeTime": "2022-05-20T00:00:36.6660445Z",
+                "billingEndDate": "2022-05-06T00:00:36.6660445Z",
+                "deleteActivityID": "1e9ec790-d198-4efb-bbd7-e4669d5351a4"
+              },
+              "policyInfo": {
+                "policyId": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PratikPrivatePreviewVault1/backupPolicies/PratikPolicy1"
+              },
+              "protectionStatus": {
+                "status": "SoftDeleted"
+              },
+              "provisioningState": "Succeeded",
+              "objectType": "DeletedBackupInstance"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/DeletedBackupInstanceOperations/ListDeletedBackupInstances.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/DeletedBackupInstanceOperations/ListDeletedBackupInstances.json
@@ -3,7 +3,7 @@
     "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
     "resourceGroupName": "000pikumar",
     "vaultName": "PratikPrivatePreviewVault1",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/DeletedBackupInstanceOperations/UndeleteDeletedBackupInstance.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/DeletedBackupInstanceOperations/UndeleteDeletedBackupInstance.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "resourceGroupName": "testrg",
+    "vaultName": "testvault",
+    "backupInstanceName": "testbi",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupInstances/testbi/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Azure-AsyncOperation": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupVaults/testvault/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Retry-After": "60"
+      }
+    },
+    "200": {}
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/DeletedBackupInstanceOperations/UndeleteDeletedBackupInstance.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/DeletedBackupInstanceOperations/UndeleteDeletedBackupInstance.json
@@ -4,13 +4,13 @@
     "resourceGroupName": "testrg",
     "vaultName": "testvault",
     "backupInstanceName": "testbi",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "202": {
       "headers": {
-        "Location": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupInstances/testbi/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
-        "Azure-AsyncOperation": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupVaults/testvault/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-02-01",
+        "Location": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupInstances/testbi/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
+        "Azure-AsyncOperation": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/testrg/providers/Microsoft.DataProtection/backupVaults/testvault/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2025-07-01",
         "Retry-After": "60"
       }
     },

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/GetOperationResult.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/GetOperationResult.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "location": "WestUS",
+    "operationId": "MjkxOTMyODMtYTE3My00YzJjLTg5NjctN2E4MDIxNDA3NjA2OzdjNGE2ZWRjLWJjMmItNDRkYi1hYzMzLWY1YzEwNzk5Y2EyOA==",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/operationResults/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2021-01-01",
+        "Azure-AsyncOperation": "https://api-dogfood.resources.windows-int.net/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/providers/Microsoft.DataProtection/locations/westus/operationStatus/ZTA4YjQ0ZGYtYmNkNS00YTk1LWFjZTMtOTc1MjNmZWIxYWZlO2Y1ODg1MzA3LWJkNjItNDQ2OC05ZjZlLTJkMGM2NjNiNmJmNg==?api-version=2021-01-01",
+        "Retry-After": "60"
+      }
+    },
+    "200": {
+      "body": {
+        "jobId": "c60cb49-63e8-4b21-b9bd-26277b3fdfae",
+        "objectType": "OperationJobExtendedInfo"
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/GetOperationResult.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/GetOperationResult.json
@@ -3,7 +3,7 @@
     "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
     "location": "WestUS",
     "operationId": "MjkxOTMyODMtYTE3My00YzJjLTg5NjctN2E4MDIxNDA3NjA2OzdjNGE2ZWRjLWJjMmItNDRkYi1hYzMzLWY1YzEwNzk5Y2EyOA==",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "202": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/GetOperationStatus.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/GetOperationStatus.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "location": "WestUS",
+    "operationId": "MjkxOTMyODMtYTE3My00YzJjLTg5NjctN2E4MDIxNDA3NjA2OzdjNGE2ZWRjLWJjMmItNDRkYi1hYzMzLWY1YzEwNzk5Y2EyOA==",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/0b352192-dcac-4cc7-992e-a96190ccc68c/providers/Microsoft.DataProtection/locations/WestUS/operationStatus/MjkxOTMyODMtYTE3My00YzJjLTg5NjctN2E4MDIxNDA3NjA2OzdjNGE2ZWRjLWJjMmItNDRkYi1hYzMzLWY1YzEwNzk5Y2EyOA==",
+        "name": "MjkxOTMyODMtYTE3My00YzJjLTg5NjctN2E4MDIxNDA3NjA2OzdjNGE2ZWRjLWJjMmItNDRkYi1hYzMzLWY1YzEwNzk5Y2EyOA==",
+        "status": "Succeeded",
+        "startTime": "2019-11-20T09:49:44.0478496Z",
+        "endTime": "2019-11-20T09:49:46Z"
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/GetOperationStatus.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/GetOperationStatus.json
@@ -3,7 +3,7 @@
     "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
     "location": "WestUS",
     "operationId": "MjkxOTMyODMtYTE3My00YzJjLTg5NjctN2E4MDIxNDA3NjA2OzdjNGE2ZWRjLWJjMmItNDRkYi1hYzMzLWY1YzEwNzk5Y2EyOA==",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/GetOperationStatusRGContext.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/GetOperationStatusRGContext.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "resourceGroupName": "SampleResourceGroup",
+    "operationId": "MjkxOTMyODMtYTE3My00YzJjLTg5NjctN2E4MDIxNDA3NjA2OzdjNGE2ZWRjLWJjMmItNDRkYi1hYzMzLWY1YzEwNzk5Y2EyOA==",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/0b352192-dcac-4cc7-992e-a96190ccc68c/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/operationStatus/MjkxOTMyODMtYTE3My00YzJjLTg5NjctN2E4MDIxNDA3NjA2OzdjNGE2ZWRjLWJjMmItNDRkYi1hYzMzLWY1YzEwNzk5Y2EyOA==",
+        "name": "MjkxOTMyODMtYTE3My00YzJjLTg5NjctN2E4MDIxNDA3NjA2OzdjNGE2ZWRjLWJjMmItNDRkYi1hYzMzLWY1YzEwNzk5Y2EyOA==",
+        "status": "Succeeded",
+        "startTime": "2019-11-20T09:49:44.0478496Z",
+        "endTime": "2019-11-20T09:49:46Z"
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/GetOperationStatusRGContext.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/GetOperationStatusRGContext.json
@@ -3,7 +3,7 @@
     "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
     "resourceGroupName": "SampleResourceGroup",
     "operationId": "MjkxOTMyODMtYTE3My00YzJjLTg5NjctN2E4MDIxNDA3NjA2OzdjNGE2ZWRjLWJjMmItNDRkYi1hYzMzLWY1YzEwNzk5Y2EyOA==",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/GetOperationStatusVaultContext.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/GetOperationStatusVaultContext.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "resourceGroupName": "SampleResourceGroup",
+    "vaultName": "swaggerExample",
+    "operationId": "MjkxOTMyODMtYTE3My00YzJjLTg5NjctN2E4MDIxNDA3NjA2OzdjNGE2ZWRjLWJjMmItNDRkYi1hYzMzLWY1YzEwNzk5Y2EyOA==",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/0b352192-dcac-4cc7-992e-a96190ccc68c/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/backupVaults/swaggerExample/operationStatus/MjkxOTMyODMtYTE3My00YzJjLTg5NjctN2E4MDIxNDA3NjA2OzdjNGE2ZWRjLWJjMmItNDRkYi1hYzMzLWY1YzEwNzk5Y2EyOA==",
+        "name": "MjkxOTMyODMtYTE3My00YzJjLTg5NjctN2E4MDIxNDA3NjA2OzdjNGE2ZWRjLWJjMmItNDRkYi1hYzMzLWY1YzEwNzk5Y2EyOA==",
+        "status": "Succeeded",
+        "startTime": "2019-11-20T09:49:44.0478496Z",
+        "endTime": "2019-11-20T09:49:46Z"
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/GetOperationStatusVaultContext.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/GetOperationStatusVaultContext.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "SampleResourceGroup",
     "vaultName": "swaggerExample",
     "operationId": "MjkxOTMyODMtYTE3My00YzJjLTg5NjctN2E4MDIxNDA3NjA2OzdjNGE2ZWRjLWJjMmItNDRkYi1hYzMzLWY1YzEwNzk5Y2EyOA==",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/JobCRUD/GetExportJobsOperationResult.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/JobCRUD/GetExportJobsOperationResult.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "SwaggerTestRg",
+    "vaultName": "NetSDKTestRsVault",
+    "operationId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "blobUrl": "https://azureblob.blob.core.windows.net/reportcontainer/exportjobsreport00000000-0000-0000-0000-000000000000",
+        "blobSasKey": "someKey",
+        "excelFileBlobUrl": "https://azureblob.blob.core.windows.net/reportcontainer/exportjobsreport00000000-0000-0000-0000-000000000000_ExcelFile.xlsx",
+        "excelFileBlobSasKey": "someKey"
+      }
+    },
+    "202": {
+      "headers": {
+        "Retry-After": 60,
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.DataProtection/backupVaults/NetSDKTestRsVault/backupJobs/operations/00000000-0000-0000-0000-000000000000?api-version=2025-02-01"
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/JobCRUD/GetExportJobsOperationResult.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/JobCRUD/GetExportJobsOperationResult.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "SwaggerTestRg",
     "vaultName": "NetSDKTestRsVault",
     "operationId": "00000000-0000-0000-0000-000000000000",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {
@@ -19,7 +19,7 @@
     "202": {
       "headers": {
         "Retry-After": 60,
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.DataProtection/backupVaults/NetSDKTestRsVault/backupJobs/operations/00000000-0000-0000-0000-000000000000?api-version=2025-02-01"
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.DataProtection/backupVaults/NetSDKTestRsVault/backupJobs/operations/00000000-0000-0000-0000-000000000000?api-version=2025-07-01"
       }
     }
   }

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/JobCRUD/GetJob.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/JobCRUD/GetJob.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "subscriptionId": "62b829ee-7936-40c9-a1c9-47a93f9f3965",
+    "resourceGroupName": "BugBash1",
+    "vaultName": "BugBashVaultForCCYv11",
+    "jobId": "3c60cb49-63e8-4b21-b9bd-26277b3fdfae",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "activityID": "c4344fb4-7c11-43a4-8307-7ae7c7fb09b9",
+          "subscriptionId": "62b829ee-7936-40c9-a1c9-47a93f9f3965",
+          "backupInstanceId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/BugBash1/providers/Microsoft.DataProtection/backupVaults/BugBashVaultForCCYv11/backupInstances/28460a9d-707a-45f3-ace6-b16284c2900e",
+          "policyId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/BugBash1/providers/Microsoft.DataProtection/backupVaults/BugBashVaultForCCYv11/backupPolicies/jakavetdailypolicy",
+          "dataSourceId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/DppPostgresTestingCcy/providers/Microsoft.DBforPostgreSQL/servers/mabtestingccybasicv11/databases/bugbashdb2",
+          "vaultName": "BugBashVaultForCCYv11",
+          "backupInstanceFriendlyName": "mabtestingccybasicv11\\bugbashdb2",
+          "policyName": "jakavetdailypolicy",
+          "sourceResourceGroup": "DppPostgresTestingCcy",
+          "dataSourceSetName": "mabtestingccybasicv11",
+          "dataSourceName": "bugbashdb2",
+          "progressEnabled": false,
+          "sourceSubscriptionID": "62b829ee-7936-40c9-a1c9-47a93f9f3965",
+          "startTime": "2021-03-17T03:00:03.7604146Z",
+          "dataSourceType": "Microsoft.DBforPostgreSQL/servers/databases",
+          "operationCategory": "Backup",
+          "operation": "Backup",
+          "status": "Started",
+          "isUserTriggered": false,
+          "supportedActions": [],
+          "duration": "00:00:00",
+          "dataSourceLocation": "centraluseuap",
+          "extendedInfo": {
+            "subTasks": [
+              {
+                "taskId": 1,
+                "taskName": "Trigger Backup",
+                "taskStatus": "Started"
+              }
+            ],
+            "additionalDetails": {
+              "RetentionTag": "Default",
+              "PolicyRuleName": "BackupWeekly",
+              "TaskId": "c4344fb4-7c11-43a4-8307-7ae7c7fb09b9"
+            }
+          }
+        },
+        "id": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/BugBash1/providers/Microsoft.DataProtection/Backupvaults/BugBashVaultForCCYv11/backupJobs/3c60cb49-63e8-4b21-b9bd-26277b3fdfae",
+        "name": "3c60cb49-63e8-4b21-b9bd-26277b3fdfae",
+        "type": "Microsoft.DataProtection/Backupvaults/backupJobs"
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/JobCRUD/GetJob.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/JobCRUD/GetJob.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "BugBash1",
     "vaultName": "BugBashVaultForCCYv11",
     "jobId": "3c60cb49-63e8-4b21-b9bd-26277b3fdfae",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/JobCRUD/ListJobs.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/JobCRUD/ListJobs.json
@@ -1,0 +1,135 @@
+{
+  "parameters": {
+    "subscriptionId": "62b829ee-7936-40c9-a1c9-47a93f9f3965",
+    "resourceGroupName": "BugBash1",
+    "vaultName": "BugBashVaultForCCYv11",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "activityID": "932925c4-3d81-4550-8105-c7f7b0a934c5",
+              "subscriptionId": "62b829ee-7936-40c9-a1c9-47a93f9f3965",
+              "backupInstanceId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/BugBash1/providers/Microsoft.DataProtection/backupVaults/BugBashVaultForCCYv11/backupInstances/3048870f-b1b7-44c4-b078-368da3fd000e",
+              "policyId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/BugBash1/providers/Microsoft.DataProtection/backupVaults/BugBashVaultForCCYv11/backupPolicies/jakavetPolicy2",
+              "dataSourceId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/DppPostgresTestingCcy/providers/Microsoft.DBforPostgreSQL/servers/mabtestingccybasicv11/databases/bugbashdb4",
+              "vaultName": "BugBashVaultForCCYv11",
+              "backupInstanceFriendlyName": "mabtestingccybasicv11\\bugbashdb4",
+              "policyName": "jakavetPolicy2",
+              "sourceResourceGroup": "DppPostgresTestingCcy",
+              "dataSourceSetName": "mabtestingccybasicv11",
+              "dataSourceName": "bugbashdb4",
+              "progressEnabled": false,
+              "sourceSubscriptionID": "62b829ee-7936-40c9-a1c9-47a93f9f3965",
+              "startTime": "2021-03-16T05:00:08.1746833Z",
+              "dataSourceType": "Microsoft.DBforPostgreSQL/servers/databases",
+              "operationCategory": "Backup",
+              "operation": "Backup",
+              "status": "Started",
+              "isUserTriggered": false,
+              "supportedActions": [],
+              "duration": "00:00:00",
+              "dataSourceLocation": "centraluseuap"
+            },
+            "id": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/BugBash1/providers/Microsoft.DataProtection/Backupvaults/BugBashVaultForCCYv11/backupJobs/8989416e-7573-4836-8cf1-0e90954f1002",
+            "name": "8989416e-7573-4836-8cf1-0e90954f1002",
+            "type": "Microsoft.DataProtection/Backupvaults/backupJobs"
+          },
+          {
+            "properties": {
+              "activityID": "b4f32e03-ded0-46fc-9afc-91853878efcd",
+              "subscriptionId": "62b829ee-7936-40c9-a1c9-47a93f9f3965",
+              "backupInstanceId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/BugBash1/providers/Microsoft.DataProtection/backupVaults/BugBashVaultForCCYv11/backupInstances/943c60db-c033-4d93-bb00-66048474e00e",
+              "policyId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/BugBash1/providers/Microsoft.DataProtection/backupVaults/BugBashVaultForCCYv11/backupPolicies/jakavetPolicy3",
+              "dataSourceId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/DppPostgresTestingCcy/providers/Microsoft.DBforPostgreSQL/servers/mabtestingccybasicv11/databases/bugbashdb5",
+              "vaultName": "BugBashVaultForCCYv11",
+              "backupInstanceFriendlyName": "mabtestingccybasicv11\\bugbashdb5",
+              "policyName": "jakavetPolicy3",
+              "sourceResourceGroup": "DppPostgresTestingCcy",
+              "dataSourceSetName": "mabtestingccybasicv11",
+              "dataSourceName": "bugbashdb5",
+              "progressEnabled": false,
+              "sourceSubscriptionID": "62b829ee-7936-40c9-a1c9-47a93f9f3965",
+              "startTime": "2021-03-16T18:00:03.6660733Z",
+              "dataSourceType": "Microsoft.DBforPostgreSQL/servers/databases",
+              "operationCategory": "Backup",
+              "operation": "Backup",
+              "status": "Started",
+              "isUserTriggered": false,
+              "supportedActions": [],
+              "duration": "00:00:00",
+              "dataSourceLocation": "centraluseuap"
+            },
+            "id": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/BugBash1/providers/Microsoft.DataProtection/Backupvaults/BugBashVaultForCCYv11/backupJobs/ad218c05-242a-47c2-b7b7-c16bd0f8870c",
+            "name": "ad218c05-242a-47c2-b7b7-c16bd0f8870c",
+            "type": "Microsoft.DataProtection/Backupvaults/backupJobs"
+          },
+          {
+            "properties": {
+              "activityID": "c4344fb4-7c11-43a4-8307-7ae7c7fb09b9",
+              "subscriptionId": "62b829ee-7936-40c9-a1c9-47a93f9f3965",
+              "backupInstanceId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/BugBash1/providers/Microsoft.DataProtection/backupVaults/BugBashVaultForCCYv11/backupInstances/28460a9d-707a-45f3-ace6-b16284c2900e",
+              "policyId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/BugBash1/providers/Microsoft.DataProtection/backupVaults/BugBashVaultForCCYv11/backupPolicies/jakavetdailypolicy",
+              "dataSourceId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/DppPostgresTestingCcy/providers/Microsoft.DBforPostgreSQL/servers/mabtestingccybasicv11/databases/bugbashdb2",
+              "vaultName": "BugBashVaultForCCYv11",
+              "backupInstanceFriendlyName": "mabtestingccybasicv11\\bugbashdb2",
+              "policyName": "jakavetdailypolicy",
+              "sourceResourceGroup": "DppPostgresTestingCcy",
+              "dataSourceSetName": "mabtestingccybasicv11",
+              "dataSourceName": "bugbashdb2",
+              "progressEnabled": false,
+              "sourceSubscriptionID": "62b829ee-7936-40c9-a1c9-47a93f9f3965",
+              "startTime": "2021-03-17T03:00:03.7604146Z",
+              "dataSourceType": "Microsoft.DBforPostgreSQL/servers/databases",
+              "operationCategory": "Backup",
+              "operation": "Backup",
+              "status": "Started",
+              "isUserTriggered": false,
+              "supportedActions": [],
+              "duration": "00:00:00",
+              "dataSourceLocation": "centraluseuap"
+            },
+            "id": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/BugBash1/providers/Microsoft.DataProtection/Backupvaults/BugBashVaultForCCYv11/backupJobs/3c60cb49-63e8-4b21-b9bd-26277b3fdfae",
+            "name": "3c60cb49-63e8-4b21-b9bd-26277b3fdfae",
+            "type": "Microsoft.DataProtection/Backupvaults/backupJobs"
+          },
+          {
+            "properties": {
+              "activityID": "94052cf1-a47f-4c1b-93e7-79e07b2bd008-Tue Mar 17 2021 11:11:48 GMT+0530 (India Standard Time)-Ibz",
+              "subscriptionId": "62b829ee-7936-40c9-a1c9-47a93f9f3965",
+              "backupInstanceId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/BugBash1/providers/Microsoft.DataProtection/backupVaults/BugBashVaultForCCYv11/backupInstances/0b247869-b8be-4885-b832-8ac4cdf5b00e",
+              "policyId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/BugBash1/providers/Microsoft.DataProtection/backupVaults/BugBashVaultForCCYv11/backupPolicies/jakavetPolicy1",
+              "dataSourceId": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/DppPostgresTestingCcy/providers/Microsoft.DBforPostgreSQL/servers/mabtestingccybasicv11/databases/bugbashdb3",
+              "vaultName": "BugBashVaultForCCYv11",
+              "backupInstanceFriendlyName": "mabtestingccybasicv11\\bugbashdb3",
+              "policyName": "jakavetPolicy1",
+              "sourceResourceGroup": "DppPostgresTestingCcy",
+              "dataSourceSetName": "mabtestingccybasicv11",
+              "dataSourceName": "bugbashdb3",
+              "progressEnabled": false,
+              "sourceSubscriptionID": "62b829ee-7936-40c9-a1c9-47a93f9f3965",
+              "startTime": "2021-03-17T11:11:50.5595259Z",
+              "endTime": "2021-03-17T11:14:02.5319646Z",
+              "dataSourceType": "Microsoft.DBforPostgreSQL/servers/databases",
+              "operationCategory": "Backup",
+              "operation": "Backup",
+              "status": "Succeeded",
+              "isUserTriggered": true,
+              "supportedActions": [
+                ""
+              ],
+              "duration": "00:02:11.9724387",
+              "dataSourceLocation": "centraluseuap"
+            },
+            "id": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/BugBash1/providers/Microsoft.DataProtection/Backupvaults/BugBashVaultForCCYv11/backupJobs/43252662-1b43-44fd-a856-0055665cb097",
+            "name": "43252662-1b43-44fd-a856-0055665cb097",
+            "type": "Microsoft.DataProtection/Backupvaults/backupJobs"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/JobCRUD/ListJobs.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/JobCRUD/ListJobs.json
@@ -3,7 +3,7 @@
     "subscriptionId": "62b829ee-7936-40c9-a1c9-47a93f9f3965",
     "resourceGroupName": "BugBash1",
     "vaultName": "BugBashVaultForCCYv11",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/JobCRUD/TriggerExportJobs.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/JobCRUD/TriggerExportJobs.json
@@ -1,0 +1,17 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "SwaggerTestRg",
+    "vaultName": "NetSDKTestRsVault",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.DataProtection/backupVaults/NetSDKTestRsVault/backupJobs/operations/00000000-0000-0000-0000-000000000000?api-version=2025-02-01",
+        "Retry-After": 60
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/JobCRUD/TriggerExportJobs.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/JobCRUD/TriggerExportJobs.json
@@ -3,12 +3,12 @@
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "SwaggerTestRg",
     "vaultName": "NetSDKTestRsVault",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "202": {
       "headers": {
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.DataProtection/backupVaults/NetSDKTestRsVault/backupJobs/operations/00000000-0000-0000-0000-000000000000?api-version=2025-02-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.DataProtection/backupVaults/NetSDKTestRsVault/backupJobs/operations/00000000-0000-0000-0000-000000000000?api-version=2025-07-01",
         "Retry-After": 60
       }
     },

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/Operations/List.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/Operations/List.json
@@ -1,0 +1,533 @@
+{
+  "parameters": {
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.DataProtection/locations/getBackupStatus/action",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Backup Status",
+              "operation": "Check Backup Status for Vault",
+              "description": "Check Backup Status for Recovery Services Vaults"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/backupVaults/backupInstances/write",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Backup Instance",
+              "operation": "Create a Backup Instance",
+              "description": "Creates a Backup Instance"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/backupVaults/backupInstances/delete",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Backup Instance",
+              "operation": "Delete Backup Instance",
+              "description": "Deletes the Backup Instance"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/backupVaults/backupInstances/read",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Backup Instance",
+              "operation": "Get Backup Instance Details",
+              "description": "Returns details of the Backup Instance"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/backupVaults/backupInstances/read",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Backup Instance",
+              "operation": "Get Backup Instances",
+              "description": "Returns all Backup Instances"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/backupVaults/backupInstances/backup/action",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Backup Instance",
+              "operation": "Backup Backup Instance",
+              "description": "Performs Backup on the Backup Instance"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/backupVaults/backupInstances/sync/action",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Backup Instance",
+              "operation": "Sync Backup Instance",
+              "description": "Sync operation retries last failed operation on backup instance to bring it to a valid state."
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/backupVaults/backupInstances/operationResults/read",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Backup Instance",
+              "operation": "Get Backup Operation Result",
+              "description": "Returns Backup Operation Result for Backup Vault."
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/backupVaults/backupInstances/stopProtection/action",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Backup Instance",
+              "operation": "Stop Protection of Backup Instance",
+              "description": "Stop Protection operation stops both backup and retention schedules of backup instance. Existing data will be retained forever."
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/backupVaults/backupInstances/suspendBackups/action",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Backup Instance",
+              "operation": "Suspend Backups of Backup Instance",
+              "description": "Suspend Backups operation stops only backups of backup instance. Retention activities will continue and hence data will be ratained as per policy."
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/backupVaults/backupInstances/resumeProtection/action",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Backup Instance",
+              "operation": "Resume Protection of Backup Instance",
+              "description": "Resume protection of a ProtectionStopped BI."
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/backupVaults/backupInstances/resumeBackups/action",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Backup Instance",
+              "operation": "Resume Backups of Backup Instance",
+              "description": "Resume Backups for a BackupsSuspended BI."
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/backupVaults/backupInstances/validateRestore/action",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Backup Instance",
+              "operation": "Validate for Restore of Backup Instance",
+              "description": "Validates for Restore of the Backup Instance"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/backupVaults/backupInstances/restore/action",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Backup Instance",
+              "operation": "Restore Backup Instance",
+              "description": "Triggers restore on the Backup Instance"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/backupVaults/backupPolicies/write",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Backup Policies",
+              "operation": "Create Backup Policy",
+              "description": "Creates Backup Policy"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/backupVaults/backupPolicies/delete",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Backup Policies",
+              "operation": "Delete Backup Policy",
+              "description": "Deletes the Backup Policy"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/backupVaults/backupPolicies/read",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Backup Policies",
+              "operation": "Get Backup Policy details",
+              "description": "Returns details of the Backup Policy"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/backupVaults/backupPolicies/read",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Backup Policies",
+              "operation": "Get Backup Policies",
+              "description": "Returns all Backup Policies"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/backupVaults/backupResourceGuardProxies/read",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Resource Guard Proxy",
+              "operation": "Get the list of ResourceGuard proxies for a resource",
+              "description": "Get the list of ResourceGuard proxies for a resource"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/backupVaults/backupResourceGuardProxies/read",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Resource Guard Proxy",
+              "operation": "Get ResourceGuard proxy",
+              "description": "Get ResourceGuard proxy operation gets an object representing the Azure resource of type 'ResourceGuard proxy'"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/backupVaults/backupResourceGuardProxies/write",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Resource Guard Proxy",
+              "operation": "Create ResourceGuard proxy",
+              "description": "Create ResourceGuard proxy operation creates an Azure resource of type 'ResourceGuard Proxy'"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/backupVaults/backupResourceGuardProxies/delete",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Resource Guard Proxy",
+              "operation": "Delete ResourceGuard proxy",
+              "description": "The Delete ResourceGuard proxy operation deletes the specified Azure resource of type 'ResourceGuard proxy'"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/backupVaults/backupResourceGuardProxies/unlockDelete/action",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Resource Guard Proxy",
+              "operation": "Unlock delete ResourceGuard proxy operation unlocks the next delete critical operation",
+              "description": "Unlock delete ResourceGuard proxy operation unlocks the next delete critical operation"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/backupVaults/backupInstances/recoveryPoints/read",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Recovery Points",
+              "operation": "Get Recovery Point Details",
+              "description": "Returns details of the Recovery Point"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/backupVaults/backupInstances/recoveryPoints/read",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Recovery Points",
+              "operation": "Get Recovery Points",
+              "description": "Returns all Recovery Points"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/backupVaults/backupInstances/findRestorableTimeRanges/action",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Restorable Time Ranges",
+              "operation": "Find Restorable Time Ranges",
+              "description": "Finds Restorable Time Ranges"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/backupVaults/write",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Backup Vaults",
+              "operation": "Create Backup Vault",
+              "description": "Create BackupVault operation creates an Azure resource of type 'Backup Vault'"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/backupVaults/read",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Backup Vaults",
+              "operation": "Create Backup Vault",
+              "description": "Create BackupVault operation creates an Azure resource of type 'Backup Vault'"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/backupVaults/delete",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Backup Vaults",
+              "operation": "Create Backup Vault",
+              "description": "Create BackupVault operation creates an Azure resource of type 'Backup Vault'"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/backupVaults/operationResults/read",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Backup Vaults",
+              "operation": "Get Operation Result of a Patch Operation for a Backup Vault",
+              "description": "Gets Operation Result of a Patch Operation for a Backup Vault"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/locations/checkNameAvailability/action",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Backup Vaults",
+              "operation": "Check if the requested BackupVault Name is Available",
+              "description": "Checks if the requested BackupVault Name is Available"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/backupVaults/read",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Backup Vaults",
+              "operation": "Get Backup Vaults in a Resource Group",
+              "description": "Gets list of Backup Vaults in a Resource Group"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/backupVaults/read",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Backup Vaults",
+              "operation": "Get Backup Vaults in a Subscription",
+              "description": "Gets list of Backup Vaults in a Subscription"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/subscriptions/resourceGroups/providers/resourceGuards/write",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Resource Guards",
+              "operation": "Create ResourceGuard",
+              "description": "Create ResourceGuard operation creates an Azure resource of type 'ResourceGuard'"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/subscriptions/resourceGroups/providers/resourceGuards/read",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Resource Guards",
+              "operation": "Get ResourceGuard",
+              "description": "The Get ResourceGuard operation gets an object representing the Azure resource of type 'ResourceGuard'"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/subscriptions/resourceGroups/providers/resourceGuards/delete",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Resource Guards",
+              "operation": "Delete ResourceGuard",
+              "description": "The Delete ResourceGuard operation deletes the specified Azure resource of type 'ResourceGuard'"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/subscriptions/resourceGroups/providers/resourceGuards/read",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Resource Guards",
+              "operation": "Get ResourceGuards in a Resource Group",
+              "description": "Gets list of ResourceGuards in a Resource Group"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/subscriptions/providers/resourceGuards/read",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Resource Guards",
+              "operation": "Get ResourceGuards in a Subscription",
+              "description": "Gets list of ResourceGuards in a Subscription"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/subscriptions/resourceGroups/providers/resourceGuards/write",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Resource Guards",
+              "operation": "Update ResourceGuard",
+              "description": "Update ResouceGuard operation updates an Azure resource of type 'ResourceGuard'"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/subscriptions/resourceGroups/providers/resourceGuards/{operationName}/read",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Resource Guards",
+              "operation": "Get ResourceGuard operation request info",
+              "description": "Gets ResourceGuard operation request info"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/subscriptions/resourceGroups/providers/resourceGuards/{operationName}/read",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Resource Guards",
+              "operation": "Get ResourceGuard default operation request info",
+              "description": "Gets ResourceGuard default operation request info"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/subscriptions/providers/locations/checkFeatureSupport/action",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Resource Provider Operation",
+              "operation": "Validate if a feature is supported",
+              "description": "Validates if a feature is supported"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/locations/operationStatus/read",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Backup Operation Status",
+              "operation": "Get Backup Operation Status",
+              "description": "Returns Backup Operation Status for Backup Vault."
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/backupVaults/operationStatus/read",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Backup Operation Status",
+              "operation": "Get Backup Operation Status",
+              "description": "Returns Backup Operation Status for Backup Vault."
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/subscriptions/resourceGroups/providers/operationStatus/read",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Backup Operation Status",
+              "operation": "Get Backup Operation Status",
+              "description": "Returns Backup Operation Status for Backup Vault."
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/locations/operationResults/read",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Backup Operation Results",
+              "operation": "Get Backup Operation Result",
+              "description": "Returns Backup Operation Result for Backup Vault."
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/backupVaults/validateForBackup/action",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Validate Backup",
+              "operation": "Validate for backup of Backup Instance",
+              "description": "Validates for backup of Backup Instance"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/backupVaults/backupJobs/read",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Backup Jobs",
+              "operation": "Backup Jobs",
+              "description": "Get Jobs list"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.RecoveryServices/Vaults/backupJobs/read",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Backup Jobs",
+              "operation": "Backup Job Object",
+              "description": "Get Job details"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/register/action",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Resource Provider Operation",
+              "operation": "Register Resource Provider",
+              "description": "Registers subscription for given Resource Provider"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/unregister/action",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Resource Provider Operation",
+              "operation": "Unregister Resource Provider",
+              "description": "Unregisters subscription for given Resource Provider"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "Microsoft.DataProtection/operations/read",
+            "display": {
+              "provider": "Microsoft.DataProtection",
+              "resource": "Resource Provider Operation",
+              "operation": "List of Operations",
+              "description": "Operation returns the list of Operations for a Resource Provider"
+            },
+            "origin": "user"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/Operations/List.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/Operations/List.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/PolicyCRUD/CreateOrUpdateBackupPolicy.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/PolicyCRUD/CreateOrUpdateBackupPolicy.json
@@ -1,0 +1,200 @@
+{
+  "parameters": {
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "resourceGroupName": "000pikumar",
+    "vaultName": "PrivatePreviewVault",
+    "backupPolicyName": "OSSDBPolicy",
+    "api-version": "2025-02-01",
+    "parameters": {
+      "properties": {
+        "policyRules": [
+          {
+            "backupParameters": {
+              "backupType": "Full",
+              "objectType": "AzureBackupParams"
+            },
+            "trigger": {
+              "schedule": {
+                "repeatingTimeIntervals": [
+                  "R/2019-11-20T08:00:00-08:00/P1W"
+                ]
+              },
+              "taggingCriteria": [
+                {
+                  "tagInfo": {
+                    "tagName": "Default"
+                  },
+                  "taggingPriority": 99,
+                  "isDefault": true
+                },
+                {
+                  "tagInfo": {
+                    "tagName": "Weekly"
+                  },
+                  "taggingPriority": 20,
+                  "isDefault": false,
+                  "criteria": [
+                    {
+                      "scheduleTimes": [
+                        "2019-03-01T13:00:00Z"
+                      ],
+                      "daysOfTheWeek": [
+                        "Sunday"
+                      ],
+                      "objectType": "ScheduleBasedBackupCriteria"
+                    }
+                  ]
+                }
+              ],
+              "objectType": "ScheduleBasedTriggerContext"
+            },
+            "dataStore": {
+              "dataStoreType": "VaultStore",
+              "objectType": "DataStoreInfoBase"
+            },
+            "name": "BackupWeekly",
+            "objectType": "AzureBackupRule"
+          },
+          {
+            "lifecycles": [
+              {
+                "sourceDataStore": {
+                  "dataStoreType": "VaultStore",
+                  "objectType": "DataStoreInfoBase"
+                },
+                "deleteAfter": {
+                  "objectType": "AbsoluteDeleteOption",
+                  "duration": "P1W"
+                }
+              }
+            ],
+            "isDefault": true,
+            "name": "Default",
+            "objectType": "AzureRetentionRule"
+          },
+          {
+            "lifecycles": [
+              {
+                "sourceDataStore": {
+                  "dataStoreType": "VaultStore",
+                  "objectType": "DataStoreInfoBase"
+                },
+                "deleteAfter": {
+                  "objectType": "AbsoluteDeleteOption",
+                  "duration": "P12W"
+                }
+              }
+            ],
+            "isDefault": false,
+            "name": "Weekly",
+            "objectType": "AzureRetentionRule"
+          }
+        ],
+        "datasourceTypes": [
+          "OssDB"
+        ],
+        "objectType": "BackupPolicy"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PrivatePreviewVault/backupPolicies/OSSDBPolicy",
+        "name": "OSSDBPolicy",
+        "type": "Microsoft.DataProtection/backupVaults/backupPolicies",
+        "properties": {
+          "policyRules": [
+            {
+              "backupParameters": {
+                "backupType": "Full",
+                "objectType": "AzureBackupParams"
+              },
+              "trigger": {
+                "schedule": {
+                  "repeatingTimeIntervals": [
+                    "R/2019-11-20T08:00:00-08:00/P1W"
+                  ]
+                },
+                "taggingCriteria": [
+                  {
+                    "tagInfo": {
+                      "tagName": "Default",
+                      "id": "Default_"
+                    },
+                    "taggingPriority": 99,
+                    "isDefault": true
+                  },
+                  {
+                    "tagInfo": {
+                      "tagName": "Weekly",
+                      "id": "Weekly_"
+                    },
+                    "taggingPriority": 20,
+                    "isDefault": false,
+                    "criteria": [
+                      {
+                        "scheduleTimes": [
+                          "2019-03-01T13:00:00Z"
+                        ],
+                        "daysOfTheWeek": [
+                          "Sunday"
+                        ],
+                        "objectType": "ScheduleBasedBackupCriteria"
+                      }
+                    ]
+                  }
+                ],
+                "objectType": "ScheduleBasedTriggerContext"
+              },
+              "dataStore": {
+                "dataStoreType": "VaultStore",
+                "objectType": "DataStoreInfoBase"
+              },
+              "name": "BackupWeekly",
+              "objectType": "AzureBackupRule"
+            },
+            {
+              "lifecycles": [
+                {
+                  "sourceDataStore": {
+                    "dataStoreType": "VaultStore",
+                    "objectType": "DataStoreInfoBase"
+                  },
+                  "deleteAfter": {
+                    "objectType": "AbsoluteDeleteOption",
+                    "duration": "P1W"
+                  }
+                }
+              ],
+              "isDefault": true,
+              "name": "Default",
+              "objectType": "AzureRetentionRule"
+            },
+            {
+              "lifecycles": [
+                {
+                  "sourceDataStore": {
+                    "dataStoreType": "VaultStore",
+                    "objectType": "DataStoreInfoBase"
+                  },
+                  "deleteAfter": {
+                    "objectType": "AbsoluteDeleteOption",
+                    "duration": "P12W"
+                  }
+                }
+              ],
+              "isDefault": false,
+              "name": "Weekly",
+              "objectType": "AzureRetentionRule"
+            }
+          ],
+          "datasourceTypes": [
+            "OssDB"
+          ],
+          "objectType": "BackupPolicy"
+        }
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/PolicyCRUD/CreateOrUpdateBackupPolicy.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/PolicyCRUD/CreateOrUpdateBackupPolicy.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "000pikumar",
     "vaultName": "PrivatePreviewVault",
     "backupPolicyName": "OSSDBPolicy",
-    "api-version": "2025-02-01",
+    "api-version": "2025-07-01",
     "parameters": {
       "properties": {
         "policyRules": [

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/PolicyCRUD/DeleteBackupPolicy.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/PolicyCRUD/DeleteBackupPolicy.json
@@ -1,0 +1,13 @@
+{
+  "parameters": {
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "resourceGroupName": "000pikumar",
+    "vaultName": "PrivatePreviewVault",
+    "backupPolicyName": "OSSDBPolicy",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/PolicyCRUD/DeleteBackupPolicy.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/PolicyCRUD/DeleteBackupPolicy.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "000pikumar",
     "vaultName": "PrivatePreviewVault",
     "backupPolicyName": "OSSDBPolicy",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {},

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/PolicyCRUD/GetBackupPolicy.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/PolicyCRUD/GetBackupPolicy.json
@@ -1,0 +1,109 @@
+{
+  "parameters": {
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "resourceGroupName": "000pikumar",
+    "vaultName": "PrivatePreviewVault",
+    "backupPolicyName": "OSSDBPolicy",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PrivatePreviewVault/backupPolicies/OSSDBPolicy",
+        "name": "OSSDBPolicy",
+        "type": "Microsoft.DataProtection/backupVaults/backupPolicies",
+        "properties": {
+          "policyRules": [
+            {
+              "backupParameters": {
+                "backupType": "Full",
+                "objectType": "AzureBackupParams"
+              },
+              "trigger": {
+                "schedule": {
+                  "repeatingTimeIntervals": [
+                    "R/2019-11-20T08:00:00-08:00/P1W"
+                  ]
+                },
+                "taggingCriteria": [
+                  {
+                    "tagInfo": {
+                      "tagName": "Default",
+                      "id": "Default_"
+                    },
+                    "taggingPriority": 99,
+                    "isDefault": true
+                  },
+                  {
+                    "tagInfo": {
+                      "tagName": "Weekly",
+                      "id": "Weekly_"
+                    },
+                    "taggingPriority": 20,
+                    "isDefault": false,
+                    "criteria": [
+                      {
+                        "scheduleTimes": [
+                          "2019-03-01T13:00:00Z"
+                        ],
+                        "daysOfTheWeek": [
+                          "Sunday"
+                        ],
+                        "objectType": "ScheduleBasedBackupCriteria"
+                      }
+                    ]
+                  }
+                ],
+                "objectType": "ScheduleBasedTriggerContext"
+              },
+              "dataStore": {
+                "dataStoreType": "VaultStore",
+                "objectType": "DataStoreInfoBase"
+              },
+              "name": "BackupWeekly",
+              "objectType": "AzureBackupRule"
+            },
+            {
+              "lifecycles": [
+                {
+                  "sourceDataStore": {
+                    "dataStoreType": "VaultStore",
+                    "objectType": "DataStoreInfoBase"
+                  },
+                  "deleteAfter": {
+                    "objectType": "AbsoluteDeleteOption",
+                    "duration": "P1W"
+                  }
+                }
+              ],
+              "isDefault": true,
+              "name": "Default",
+              "objectType": "AzureRetentionRule"
+            },
+            {
+              "lifecycles": [
+                {
+                  "sourceDataStore": {
+                    "dataStoreType": "VaultStore",
+                    "objectType": "DataStoreInfoBase"
+                  },
+                  "deleteAfter": {
+                    "objectType": "AbsoluteDeleteOption",
+                    "duration": "P12W"
+                  }
+                }
+              ],
+              "isDefault": false,
+              "name": "Weekly",
+              "objectType": "AzureRetentionRule"
+            }
+          ],
+          "datasourceTypes": [
+            "OssDB"
+          ],
+          "objectType": "BackupPolicy"
+        }
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/PolicyCRUD/GetBackupPolicy.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/PolicyCRUD/GetBackupPolicy.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "000pikumar",
     "vaultName": "PrivatePreviewVault",
     "backupPolicyName": "OSSDBPolicy",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/PolicyCRUD/ListBackupPolicy.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/PolicyCRUD/ListBackupPolicy.json
@@ -1,0 +1,112 @@
+{
+  "parameters": {
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "resourceGroupName": "000pikumar",
+    "vaultName": "PrivatePreviewVault",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/000pikumar/providers/Microsoft.DataProtection/backupVaults/PrivatePreviewVault/backupPolicies/OSSDBPolicy",
+            "name": "OSSDBPolicy",
+            "type": "Microsoft.DataProtection/backupVaults/backupPolicies",
+            "properties": {
+              "policyRules": [
+                {
+                  "backupParameters": {
+                    "backupType": "Full",
+                    "objectType": "AzureBackupParams"
+                  },
+                  "trigger": {
+                    "schedule": {
+                      "repeatingTimeIntervals": [
+                        "R/2019-11-20T08:00:00-08:00/P1W"
+                      ]
+                    },
+                    "taggingCriteria": [
+                      {
+                        "tagInfo": {
+                          "tagName": "Default",
+                          "id": "Default_"
+                        },
+                        "taggingPriority": 99,
+                        "isDefault": true
+                      },
+                      {
+                        "tagInfo": {
+                          "tagName": "Weekly",
+                          "id": "Weekly_"
+                        },
+                        "taggingPriority": 20,
+                        "isDefault": false,
+                        "criteria": [
+                          {
+                            "scheduleTimes": [
+                              "2019-03-01T13:00:00Z"
+                            ],
+                            "daysOfTheWeek": [
+                              "Sunday"
+                            ],
+                            "objectType": "ScheduleBasedBackupCriteria"
+                          }
+                        ]
+                      }
+                    ],
+                    "objectType": "ScheduleBasedTriggerContext"
+                  },
+                  "dataStore": {
+                    "dataStoreType": "VaultStore",
+                    "objectType": "DataStoreInfoBase"
+                  },
+                  "name": "BackupWeekly",
+                  "objectType": "AzureBackupRule"
+                },
+                {
+                  "lifecycles": [
+                    {
+                      "sourceDataStore": {
+                        "dataStoreType": "VaultStore",
+                        "objectType": "DataStoreInfoBase"
+                      },
+                      "deleteAfter": {
+                        "objectType": "AbsoluteDeleteOption",
+                        "duration": "P1W"
+                      }
+                    }
+                  ],
+                  "isDefault": true,
+                  "name": "Default",
+                  "objectType": "AzureRetentionRule"
+                },
+                {
+                  "lifecycles": [
+                    {
+                      "sourceDataStore": {
+                        "dataStoreType": "VaultStore",
+                        "objectType": "DataStoreInfoBase"
+                      },
+                      "deleteAfter": {
+                        "objectType": "AbsoluteDeleteOption",
+                        "duration": "P12W"
+                      }
+                    }
+                  ],
+                  "isDefault": false,
+                  "name": "Weekly",
+                  "objectType": "AzureRetentionRule"
+                }
+              ],
+              "datasourceTypes": [
+                "OssDB"
+              ],
+              "objectType": "BackupPolicy"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/PolicyCRUD/ListBackupPolicy.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/PolicyCRUD/ListBackupPolicy.json
@@ -3,7 +3,7 @@
     "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
     "resourceGroupName": "000pikumar",
     "vaultName": "PrivatePreviewVault",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/DeleteResourceGuard.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/DeleteResourceGuard.json
@@ -1,0 +1,12 @@
+{
+  "parameters": {
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "resourceGroupName": "SampleResourceGroup",
+    "resourceGuardsName": "swaggerExample",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/DeleteResourceGuard.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/DeleteResourceGuard.json
@@ -3,7 +3,7 @@
     "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
     "resourceGroupName": "SampleResourceGroup",
     "resourceGuardsName": "swaggerExample",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {},

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/GetDefaultBackupSecurityPINRequests.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/GetDefaultBackupSecurityPINRequests.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "resourceGroupName": "SampleResourceGroup",
+    "resourceGuardsName": "swaggerExample",
+    "requestName": "default",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "subscriotions/0b352192-dcac-4cc7-992e-a96190ccc68c/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/resourceGuards/swaggerExample/getBackupSecurityPINRequests/default",
+        "name": "default",
+        "type": "Microsoft.DataProtection/resourceGuards/getBackupSecurityPINRequests"
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/GetDefaultBackupSecurityPINRequests.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/GetDefaultBackupSecurityPINRequests.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "SampleResourceGroup",
     "resourceGuardsName": "swaggerExample",
     "requestName": "default",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/GetDefaultDeleteProtectedItemRequests.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/GetDefaultDeleteProtectedItemRequests.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "resourceGroupName": "SampleResourceGroup",
+    "resourceGuardsName": "swaggerExample",
+    "requestName": "default",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "subscriotions/0b352192-dcac-4cc7-992e-a96190ccc68c/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/resourceGuards/swaggerExample/deleteProtectedItemRequests/default",
+        "name": "default",
+        "type": "Microsoft.DataProtection/resourceGuards/deleteProtectedItemRequests"
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/GetDefaultDeleteProtectedItemRequests.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/GetDefaultDeleteProtectedItemRequests.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "SampleResourceGroup",
     "resourceGuardsName": "swaggerExample",
     "requestName": "default",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/GetDefaultDeleteResourceGuardProxyRequests.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/GetDefaultDeleteResourceGuardProxyRequests.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "resourceGroupName": "SampleResourceGroup",
+    "resourceGuardsName": "swaggerExample",
+    "requestName": "default",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "subscriotions/0b352192-dcac-4cc7-992e-a96190ccc68c/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/resourceGuards/swaggerExample/deleteResourceGuardProxyRequests/default",
+        "name": "default",
+        "type": "Microsoft.DataProtection/resourceGuards/deleteResourceGuardProxyRequests"
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/GetDefaultDeleteResourceGuardProxyRequests.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/GetDefaultDeleteResourceGuardProxyRequests.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "SampleResourceGroup",
     "resourceGuardsName": "swaggerExample",
     "requestName": "default",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/GetDefaultDisableSoftDeleteRequests.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/GetDefaultDisableSoftDeleteRequests.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "resourceGroupName": "SampleResourceGroup",
+    "resourceGuardsName": "swaggerExample",
+    "requestName": "default",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "subscriotions/0b352192-dcac-4cc7-992e-a96190ccc68c/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/resourceGuards/swaggerExample/disableSoftDeleteRequests/default",
+        "name": "default",
+        "type": "Microsoft.DataProtection/resourceGuards/disableSoftDeleteRequests"
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/GetDefaultDisableSoftDeleteRequests.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/GetDefaultDisableSoftDeleteRequests.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "SampleResourceGroup",
     "resourceGuardsName": "swaggerExample",
     "requestName": "default",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/GetDefaultUpdateProtectedItemRequests.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/GetDefaultUpdateProtectedItemRequests.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "resourceGroupName": "SampleResourceGroup",
+    "resourceGuardsName": "swaggerExample",
+    "requestName": "default",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "subscriotions/0b352192-dcac-4cc7-992e-a96190ccc68c/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/resourceGuards/swaggerExample/updateProtectedItemRequests/default",
+        "name": "default",
+        "type": "Microsoft.DataProtection/resourceGuards/updateProtectedItemRequests"
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/GetDefaultUpdateProtectedItemRequests.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/GetDefaultUpdateProtectedItemRequests.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "SampleResourceGroup",
     "resourceGuardsName": "swaggerExample",
     "requestName": "default",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/GetDefaultUpdateProtectionPolicyRequests.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/GetDefaultUpdateProtectionPolicyRequests.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "resourceGroupName": "SampleResourceGroup",
+    "resourceGuardsName": "swaggerExample",
+    "requestName": "default",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "subscriotions/0b352192-dcac-4cc7-992e-a96190ccc68c/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/resourceGuards/swaggerExample/updateProtectionPolicyRequests/default",
+        "name": "default",
+        "type": "Microsoft.DataProtection/resourceGuards/updateProtectionPolicyRequests"
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/GetDefaultUpdateProtectionPolicyRequests.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/GetDefaultUpdateProtectionPolicyRequests.json
@@ -4,7 +4,7 @@
     "resourceGroupName": "SampleResourceGroup",
     "resourceGuardsName": "swaggerExample",
     "requestName": "default",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/GetResourceGuard.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/GetResourceGuard.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "resourceGroupName": "SampleResourceGroup",
+    "resourceGuardsName": "swaggerExample",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "location": "eastus",
+        "tags": {
+          "TestKey": "TestValue"
+        },
+        "id": "/subscriptions/c999d45b-944f-418c-a0d8-c3fcfd1802c8/resourceGroups/vaultguardRGNew/providers/Microsoft.DataProtection/resourceGuards/VaultGuardTestNew",
+        "name": "ResourceGuardTestNew",
+        "type": "Microsoft.DataProtection/resourceGuards",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "allowAutoApprovals": true,
+          "resourceGuardOperations": [
+            {
+              "vaultCriticalOperation": "Microsoft.RecoveryServices/vaults/backupResourceGuardProxies/delete",
+              "requestResourceType": "Microsoft.DataProtection/resourceGuards/deleteResourceGuardProxyRequests"
+            },
+            {
+              "vaultCriticalOperation": "Microsoft.RecoveryServices/vaults/backupconfig/write",
+              "requestResourceType": "Microsoft.DataProtection/resourceGuards/disableSoftDeleteRequests"
+            }
+          ],
+          "description": "Please take JIT access before performing any of the critical operation",
+          "vaultCriticalOperationExclusionList": []
+        }
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/GetResourceGuard.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/GetResourceGuard.json
@@ -3,7 +3,7 @@
     "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
     "resourceGroupName": "SampleResourceGroup",
     "resourceGuardsName": "swaggerExample",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/GetResourceGuardsInResourceGroup.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/GetResourceGuardsInResourceGroup.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "resourceGroupName": "SampleResourceGroup",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "location": "eastus",
+            "tags": {
+              "TestKey": "TestValue"
+            },
+            "id": "/subscriptions/c999d45b-944f-418c-a0d8-c3fcfd1802c8/resourceGroups/vaultguardRGNew/providers/Microsoft.DataProtection/resourceGuards/VaultGuardTestNew",
+            "name": "VaultGuardTestNew",
+            "type": "Microsoft.DataProtection/resourceGuards",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "allowAutoApprovals": true,
+              "resourceGuardOperations": [
+                {
+                  "vaultCriticalOperation": "Microsoft.RecoveryServices/vaults/backupResourceGuardProxies/delete",
+                  "requestResourceType": "Microsoft.DataProtection/resourceGuards/deleteResourceGuardProxyRequests"
+                },
+                {
+                  "vaultCriticalOperation": "Microsoft.RecoveryServices/vaults/backupconfig/write",
+                  "requestResourceType": "Microsoft.DataProtection/resourceGuards/disableSoftDeleteRequests"
+                }
+              ],
+              "description": "Please take JIT access before performing any of the critical operation",
+              "vaultCriticalOperationExclusionList": []
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/GetResourceGuardsInResourceGroup.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/GetResourceGuardsInResourceGroup.json
@@ -2,7 +2,7 @@
   "parameters": {
     "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
     "resourceGroupName": "SampleResourceGroup",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/GetResourceGuardsInSubscription.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/GetResourceGuardsInSubscription.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "location": "eastus",
+            "tags": {
+              "TestKey": "TestValue"
+            },
+            "id": "/subscriptions/c999d45b-944f-418c-a0d8-c3fcfd1802c8/resourceGroups/vaultguardRGNew/providers/Microsoft.DataProtection/resourceGuards/VaultGuardTestNew",
+            "name": "VaultGuardTestNew",
+            "type": "Microsoft.DataProtection/resourceGuards",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "allowAutoApprovals": true,
+              "resourceGuardOperations": [
+                {
+                  "vaultCriticalOperation": "Microsoft.RecoveryServices/vaults/backupResourceGuardProxies/delete",
+                  "requestResourceType": "Microsoft.DataProtection/resourceGuards/deleteResourceGuardProxyRequests"
+                },
+                {
+                  "vaultCriticalOperation": "Microsoft.RecoveryServices/vaults/backupconfig/write",
+                  "requestResourceType": "Microsoft.DataProtection/resourceGuards/disableSoftDeleteRequests"
+                }
+              ],
+              "description": "Please take JIT access before performing any of the critical operation",
+              "vaultCriticalOperationExclusionList": []
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/GetResourceGuardsInSubscription.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/GetResourceGuardsInSubscription.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/ListBackupSecurityPINRequests.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/ListBackupSecurityPINRequests.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "resourceGroupName": "SampleResourceGroup",
+    "resourceGuardsName": "swaggerExample",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "subscriotions/0b352192-dcac-4cc7-992e-a96190ccc68c/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/resourceGuards/swaggerExample/getBackupSecurityPINRequests/default",
+            "name": "default",
+            "type": "Microsoft.DataProtection/resourceGuards/getBackupSecurityPINRequests"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/ListBackupSecurityPINRequests.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/ListBackupSecurityPINRequests.json
@@ -3,7 +3,7 @@
     "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
     "resourceGroupName": "SampleResourceGroup",
     "resourceGuardsName": "swaggerExample",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/ListDeleteProtectedItemRequests.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/ListDeleteProtectedItemRequests.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "resourceGroupName": "SampleResourceGroup",
+    "resourceGuardsName": "swaggerExample",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "subscriotions/0b352192-dcac-4cc7-992e-a96190ccc68c/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/resourceGuards/swaggerExample/deleteProtectedItemRequests/default",
+            "name": "default",
+            "type": "Microsoft.DataProtection/resourceGuards/deleteProtectedItemRequests"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/ListDeleteProtectedItemRequests.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/ListDeleteProtectedItemRequests.json
@@ -3,7 +3,7 @@
     "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
     "resourceGroupName": "SampleResourceGroup",
     "resourceGuardsName": "swaggerExample",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/ListDeleteResourceGuardProxyRequests.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/ListDeleteResourceGuardProxyRequests.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "resourceGroupName": "SampleResourceGroup",
+    "resourceGuardsName": "swaggerExample",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "subscriotions/0b352192-dcac-4cc7-992e-a96190ccc68c/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/resourceGuards/swaggerExample/deleteResourceGuardProxyRequests/default",
+            "name": "default",
+            "type": "Microsoft.DataProtection/resourceGuards/deleteResourceGuardProxyRequests"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/ListDeleteResourceGuardProxyRequests.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/ListDeleteResourceGuardProxyRequests.json
@@ -3,7 +3,7 @@
     "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
     "resourceGroupName": "SampleResourceGroup",
     "resourceGuardsName": "swaggerExample",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/ListDisableSoftDeleteRequests.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/ListDisableSoftDeleteRequests.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "resourceGroupName": "SampleResourceGroup",
+    "resourceGuardsName": "swaggerExample",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "subscriotions/0b352192-dcac-4cc7-992e-a96190ccc68c/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/resourceGuards/swaggerExample/disableSoftDeleteRequests/default",
+            "name": "default",
+            "type": "Microsoft.DataProtection/resourceGuards/disableSoftDeleteRequests"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/ListDisableSoftDeleteRequests.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/ListDisableSoftDeleteRequests.json
@@ -3,7 +3,7 @@
     "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
     "resourceGroupName": "SampleResourceGroup",
     "resourceGuardsName": "swaggerExample",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/ListUpdateProtectedItemRequests.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/ListUpdateProtectedItemRequests.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "resourceGroupName": "SampleResourceGroup",
+    "resourceGuardsName": "swaggerExample",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "subscriotions/0b352192-dcac-4cc7-992e-a96190ccc68c/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/resourceGuards/swaggerExample/updateProtectedItemRequests/default",
+            "name": "default",
+            "type": "Microsoft.DataProtection/resourceGuards/updateProtectedItemRequests"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/ListUpdateProtectedItemRequests.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/ListUpdateProtectedItemRequests.json
@@ -3,7 +3,7 @@
     "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
     "resourceGroupName": "SampleResourceGroup",
     "resourceGuardsName": "swaggerExample",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/ListUpdateProtectionPolicyRequests.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/ListUpdateProtectionPolicyRequests.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "resourceGroupName": "SampleResourceGroup",
+    "resourceGuardsName": "swaggerExample",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "subscriotions/0b352192-dcac-4cc7-992e-a96190ccc68c/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/resourceGuards/swaggerExample/updateProtectionPolicyRequests/default",
+            "name": "default",
+            "type": "Microsoft.DataProtection/resourceGuards/updateProtectionPolicyRequests"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/ListUpdateProtectionPolicyRequests.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/ListUpdateProtectionPolicyRequests.json
@@ -3,7 +3,7 @@
     "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
     "resourceGroupName": "SampleResourceGroup",
     "resourceGuardsName": "swaggerExample",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/PatchResourceGuard.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/PatchResourceGuard.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "resourceGroupName": "SampleResourceGroup",
+    "resourceGuardsName": "swaggerExample",
+    "api-version": "2025-02-01",
+    "parameters": {
+      "tags": {
+        "newKey": "newVal"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "location": "eastus",
+        "tags": {
+          "TestKey": "TestValue"
+        },
+        "id": "/subscriptions/c999d45b-944f-418c-a0d8-c3fcfd1802c8/resourceGroups/vaultguardRGNew/providers/Microsoft.DataProtection/resourceGuards/VaultGuardTestNew",
+        "name": "VaultGuardTestNew",
+        "type": "Microsoft.DataProtection/resourceGuards",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "allowAutoApprovals": true,
+          "resourceGuardOperations": [
+            {
+              "vaultCriticalOperation": "Microsoft.RecoveryServices/vaults/backupResourceGuardProxies/delete",
+              "requestResourceType": "Microsoft.DataProtection/resourceGuards/deleteResourceGuardProxyRequests"
+            },
+            {
+              "vaultCriticalOperation": "Microsoft.RecoveryServices/vaults/backupconfig/write",
+              "requestResourceType": "Microsoft.DataProtection/resourceGuards/disableSoftDeleteRequests"
+            }
+          ],
+          "description": "Please take JIT access before performing any of the critical operation"
+        }
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/PatchResourceGuard.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/PatchResourceGuard.json
@@ -3,7 +3,7 @@
     "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
     "resourceGroupName": "SampleResourceGroup",
     "resourceGuardsName": "swaggerExample",
-    "api-version": "2025-02-01",
+    "api-version": "2025-07-01",
     "parameters": {
       "tags": {
         "newKey": "newVal"

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/PutResourceGuard.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/PutResourceGuard.json
@@ -1,0 +1,70 @@
+{
+  "parameters": {
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "resourceGroupName": "SampleResourceGroup",
+    "resourceGuardsName": "swaggerExample",
+    "api-version": "2025-02-01",
+    "parameters": {
+      "location": "WestUS",
+      "tags": {
+        "key1": "val1"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "location": "eastus",
+        "tags": {
+          "TestKey": "TestValue"
+        },
+        "id": "/subscriptions/c999d45b-944f-418c-a0d8-c3fcfd1802c8/resourceGroups/vaultguardRGNew/providers/Microsoft.DataProtection/resourceGuards/VaultGuardTestNew",
+        "name": "VaultGuardTestNew",
+        "type": "Microsoft.DataProtection/resourceGuards",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "allowAutoApprovals": true,
+          "resourceGuardOperations": [
+            {
+              "vaultCriticalOperation": "Microsoft.RecoveryServices/vaults/backupResourceGuardProxies/delete",
+              "requestResourceType": "Microsoft.DataProtection/resourceGuards/deleteResourceGuardProxyRequests"
+            },
+            {
+              "vaultCriticalOperation": "Microsoft.RecoveryServices/vaults/backupconfig/write",
+              "requestResourceType": "Microsoft.DataProtection/resourceGuards/disableSoftDeleteRequests"
+            }
+          ],
+          "description": "Please take JIT access before performing any of the critical operation",
+          "vaultCriticalOperationExclusionList": []
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "location": "eastus",
+        "tags": {
+          "TestKey": "TestValue"
+        },
+        "id": "/subscriptions/c999d45b-944f-418c-a0d8-c3fcfd1802c8/resourceGroups/vaultguardRGNew/providers/Microsoft.DataProtection/resourceGuards/VaultGuardTestNew",
+        "name": "VaultGuardTestNew",
+        "type": "Microsoft.DataProtection/resourceGuards",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "allowAutoApprovals": true,
+          "resourceGuardOperations": [
+            {
+              "vaultCriticalOperation": "Microsoft.RecoveryServices/vaults/backupResourceGuardProxies/delete",
+              "requestResourceType": "Microsoft.DataProtection/resourceGuards/deleteResourceGuardProxyRequests"
+            },
+            {
+              "vaultCriticalOperation": "Microsoft.RecoveryServices/vaults/backupconfig/write",
+              "requestResourceType": "Microsoft.DataProtection/resourceGuards/disableSoftDeleteRequests"
+            }
+          ],
+          "description": "Please take JIT access before performing any of the critical operation",
+          "vaultCriticalOperationExclusionList": []
+        }
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/PutResourceGuard.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardCRUD/PutResourceGuard.json
@@ -3,7 +3,7 @@
     "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
     "resourceGroupName": "SampleResourceGroup",
     "resourceGuardsName": "swaggerExample",
-    "api-version": "2025-02-01",
+    "api-version": "2025-07-01",
     "parameters": {
       "location": "WestUS",
       "tags": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardProxyCRUD/DeleteResourceGuardProxy.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardProxyCRUD/DeleteResourceGuardProxy.json
@@ -1,0 +1,13 @@
+{
+  "parameters": {
+    "subscriptionId": "5e13b949-1218-4d18-8b99-7e12155ec4f7",
+    "vaultName": "sampleVault",
+    "resourceGroupName": "SampleResourceGroup",
+    "resourceGuardProxyName": "swaggerExample",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardProxyCRUD/DeleteResourceGuardProxy.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardProxyCRUD/DeleteResourceGuardProxy.json
@@ -4,7 +4,7 @@
     "vaultName": "sampleVault",
     "resourceGroupName": "SampleResourceGroup",
     "resourceGuardProxyName": "swaggerExample",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {},

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardProxyCRUD/GetResourceGuardProxy.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardProxyCRUD/GetResourceGuardProxy.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "subscriptionId": "5e13b949-1218-4d18-8b99-7e12155ec4f7",
+    "vaultName": "sampleVault",
+    "resourceGroupName": "SampleResourceGroup",
+    "resourceGuardProxyName": "swaggerExample",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/5e13b949-1218-4d18-8b99-7e12155ec4f7/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/backupVaults/sampleVault/backupResourceGuardProxies/swaggerExample",
+        "name": "swaggerExample",
+        "type": "Microsoft.DataProtection/vaults/backupResourceGuardProxies",
+        "properties": {
+          "resourceGuardResourceId": "/subscriptions/f9e67185-f313-4e79-aa71-6458d429369d/resourceGroups/ResourceGuardSecurityAdminRG/providers/Microsoft.DataProtection/resourceGuards/ResourceGuardTestResource",
+          "resourceGuardOperationDetails": [
+            {
+              "vaultCriticalOperation": "Microsoft.DataProtection/backupVaults/backupInstances/delete",
+              "defaultResourceRequest": "/subscriptions/f9e67185-f313-4e79-aa71-6458d429369d/resourceGroups/ResourceGuardSecurityAdminRG/providers/Microsoft.DataProtection/resourceGuards/ResourceGuardTestResource/deleteBackupInstanceRequests/default"
+            },
+            {
+              "vaultCriticalOperation": "Microsoft.DataProtection/backupVaults/backupResourceGuardProxies/delete",
+              "defaultResourceRequest": "/subscriptions/f9e67185-f313-4e79-aa71-6458d429369d/resourceGroups/ResourceGuardSecurityAdminRG/providers/Microsoft.DataProtection/resourceGuards/ResourceGuardTestResource/deleteResourceGuardProxyRequests/default"
+            }
+          ],
+          "lastUpdatedTime": "2022-09-16T11:44:37.6130487Z",
+          "description": "Please take JIT access before performing any of the critical operation"
+        }
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardProxyCRUD/GetResourceGuardProxy.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardProxyCRUD/GetResourceGuardProxy.json
@@ -4,7 +4,7 @@
     "vaultName": "sampleVault",
     "resourceGroupName": "SampleResourceGroup",
     "resourceGuardProxyName": "swaggerExample",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardProxyCRUD/ListResourceGuardProxy.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardProxyCRUD/ListResourceGuardProxy.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "subscriptionId": "5e13b949-1218-4d18-8b99-7e12155ec4f7",
+    "vaultName": "sampleVault",
+    "resourceGroupName": "SampleResourceGroup",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/5e13b949-1218-4d18-8b99-7e12155ec4f7/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/backupVaults/sampleVault/backupResourceGuardProxies/swaggerExample",
+            "name": "swaggerExample",
+            "type": "Microsoft.DataProtection/vaults/backupResourceGuardProxies",
+            "properties": {
+              "resourceGuardResourceId": "/subscriptions/f9e67185-f313-4e79-aa71-6458d429369d/resourceGroups/ResourceGuardSecurityAdminRG/providers/Microsoft.DataProtection/resourceGuards/ResourceGuardTestResource",
+              "resourceGuardOperationDetails": [
+                {
+                  "vaultCriticalOperation": "Microsoft.DataProtection/backupVaults/backupInstances/delete",
+                  "defaultResourceRequest": "/subscriptions/f9e67185-f313-4e79-aa71-6458d429369d/resourceGroups/ResourceGuardSecurityAdminRG/providers/Microsoft.DataProtection/resourceGuards/ResourceGuardTestResource/deleteBackupInstanceRequests/default"
+                },
+                {
+                  "vaultCriticalOperation": "Microsoft.DataProtection/backupVaults/backupResourceGuardProxies/delete",
+                  "defaultResourceRequest": "/subscriptions/f9e67185-f313-4e79-aa71-6458d429369d/resourceGroups/ResourceGuardSecurityAdminRG/providers/Microsoft.DataProtection/resourceGuards/ResourceGuardTestResource/deleteResourceGuardProxyRequests/default"
+                }
+              ],
+              "lastUpdatedTime": "2022-09-16T11:44:37.6130487Z",
+              "description": "Please take JIT access before performing any of the critical operation"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardProxyCRUD/ListResourceGuardProxy.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardProxyCRUD/ListResourceGuardProxy.json
@@ -3,7 +3,7 @@
     "subscriptionId": "5e13b949-1218-4d18-8b99-7e12155ec4f7",
     "vaultName": "sampleVault",
     "resourceGroupName": "SampleResourceGroup",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardProxyCRUD/PutResourceGuardProxy.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardProxyCRUD/PutResourceGuardProxy.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "subscriptionId": "5e13b949-1218-4d18-8b99-7e12155ec4f7",
+    "vaultName": "sampleVault",
+    "resourceGroupName": "SampleResourceGroup",
+    "resourceGuardProxyName": "swaggerExample",
+    "api-version": "2025-02-01",
+    "parameters": {
+      "properties": {
+        "resourceGuardResourceId": "/subscriptions/f9e67185-f313-4e79-aa71-6458d429369d/resourceGroups/ResourceGuardSecurityAdminRG/providers/Microsoft.DataProtection/resourceGuards/ResourceGuardTestResource"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/5e13b949-1218-4d18-8b99-7e12155ec4f7/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/backupVaults/sampleVault/backupResourceGuardProxies/swaggerExample",
+        "name": "swaggerExample",
+        "type": "Microsoft.DataProtection/vaults/backupResourceGuardProxies",
+        "properties": {
+          "resourceGuardResourceId": "/subscriptions/f9e67185-f313-4e79-aa71-6458d429369d/resourceGroups/ResourceGuardSecurityAdminRG/providers/Microsoft.DataProtection/resourceGuards/ResourceGuardTestResource",
+          "resourceGuardOperationDetails": [
+            {
+              "vaultCriticalOperation": "Microsoft.DataProtection/backupVaults/backupInstances/delete",
+              "defaultResourceRequest": "/subscriptions/f9e67185-f313-4e79-aa71-6458d429369d/resourceGroups/ResourceGuardSecurityAdminRG/providers/Microsoft.DataProtection/resourceGuards/ResourceGuardTestResource/deleteBackupInstanceRequests/default"
+            },
+            {
+              "vaultCriticalOperation": "Microsoft.DataProtection/backupVaults/backupResourceGuardProxies/delete",
+              "defaultResourceRequest": "/subscriptions/f9e67185-f313-4e79-aa71-6458d429369d/resourceGroups/ResourceGuardSecurityAdminRG/providers/Microsoft.DataProtection/resourceGuards/ResourceGuardTestResource/deleteResourceGuardProxyRequests/default"
+            }
+          ],
+          "lastUpdatedTime": "2022-09-16T11:44:37.6130487Z",
+          "description": "Please take JIT access before performing any of the critical operation"
+        }
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardProxyCRUD/PutResourceGuardProxy.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardProxyCRUD/PutResourceGuardProxy.json
@@ -4,7 +4,7 @@
     "vaultName": "sampleVault",
     "resourceGroupName": "SampleResourceGroup",
     "resourceGuardProxyName": "swaggerExample",
-    "api-version": "2025-02-01",
+    "api-version": "2025-07-01",
     "parameters": {
       "properties": {
         "resourceGuardResourceId": "/subscriptions/f9e67185-f313-4e79-aa71-6458d429369d/resourceGroups/ResourceGuardSecurityAdminRG/providers/Microsoft.DataProtection/resourceGuards/ResourceGuardTestResource"

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardProxyCRUD/UnlockDeleteResourceGuardProxy.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardProxyCRUD/UnlockDeleteResourceGuardProxy.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "subscriptionId": "5e13b949-1218-4d18-8b99-7e12155ec4f7",
+    "vaultName": "sampleVault",
+    "resourceGroupName": "SampleResourceGroup",
+    "resourceGuardProxyName": "swaggerExample",
+    "api-version": "2025-02-01",
+    "parameters": {
+      "resourceGuardOperationRequests": [
+        "/subscriptions/f9e67185-f313-4e79-aa71-6458d429369d/resourceGroups/ResourceGuardSecurityAdminRG/providers/Microsoft.DataProtection/resourceGuards/ResourceGuardTestResource/deleteBackupInstanceRequests/default"
+      ],
+      "resourceToBeDeleted": "/subscriptions/5e13b949-1218-4d18-8b99-7e12155ec4f7/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/backupVaults/sampleVault/backupInstances/TestBI9779f4de"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "unlockDeleteExpiryTime": "2022-09-16T12:50:10.7039695Z"
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardProxyCRUD/UnlockDeleteResourceGuardProxy.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/ResourceGuardProxyCRUD/UnlockDeleteResourceGuardProxy.json
@@ -4,7 +4,7 @@
     "vaultName": "sampleVault",
     "resourceGroupName": "SampleResourceGroup",
     "resourceGuardProxyName": "swaggerExample",
-    "api-version": "2025-02-01",
+    "api-version": "2025-07-01",
     "parameters": {
       "resourceGuardOperationRequests": [
         "/subscriptions/f9e67185-f313-4e79-aa71-6458d429369d/resourceGroups/ResourceGuardSecurityAdminRG/providers/Microsoft.DataProtection/resourceGuards/ResourceGuardTestResource/deleteBackupInstanceRequests/default"

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/CheckBackupVaultsNameAvailability.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/CheckBackupVaultsNameAvailability.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "resourceGroupName": "SampleResourceGroup",
+    "location": "westus",
+    "api-version": "2025-02-01",
+    "parameters": {
+      "type": "Microsoft.DataProtection/BackupVaults",
+      "name": "swaggerExample"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nameAvailable": true
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/CheckBackupVaultsNameAvailability.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/CheckBackupVaultsNameAvailability.json
@@ -3,7 +3,7 @@
     "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
     "resourceGroupName": "SampleResourceGroup",
     "location": "westus",
-    "api-version": "2025-02-01",
+    "api-version": "2025-07-01",
     "parameters": {
       "type": "Microsoft.DataProtection/BackupVaults",
       "name": "swaggerExample"

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/DeleteBackupVault.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/DeleteBackupVault.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "resourceGroupName": "SampleResourceGroup",
+    "vaultName": "swaggerExample",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {},
+    "204": {},
+    "202": {
+      "headers": {
+        "Retry-After": "10",
+        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/operationStatus/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-02-01",
+        "Location": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample/operationResults/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-02-01"
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/DeleteBackupVault.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/DeleteBackupVault.json
@@ -3,7 +3,7 @@
     "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
     "resourceGroupName": "SampleResourceGroup",
     "vaultName": "swaggerExample",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {},
@@ -11,8 +11,8 @@
     "202": {
       "headers": {
         "Retry-After": "10",
-        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/operationStatus/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-02-01",
-        "Location": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample/operationResults/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-02-01"
+        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/operationStatus/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-07-01",
+        "Location": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample/operationResults/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-07-01"
       }
     }
   }

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/GetBackupVault.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/GetBackupVault.json
@@ -1,0 +1,51 @@
+{
+  "parameters": {
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "resourceGroupName": "SampleResourceGroup",
+    "vaultName": "swaggerExample",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "identity": {
+          "type": "None"
+        },
+        "id": "/subscriptions/0b352192-dcac-4cc7-992e-a96190ccc68c/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample",
+        "name": "swaggerExample",
+        "type": "Microsoft.DataProtection/Backupvaults",
+        "location": "WestUS",
+        "tags": {
+          "key1": "val1"
+        },
+        "properties": {
+          "monitoringSettings": {
+            "azureMonitorAlertSettings": {
+              "alertsForAllJobFailures": "Enabled"
+            }
+          },
+          "provisioningState": "Succeeded",
+          "storageSettings": [
+            {
+              "datastoreType": "VaultStore",
+              "type": "LocallyRedundant"
+            }
+          ],
+          "featureSettings": {
+            "crossRegionRestoreSettings": {
+              "state": "Enabled"
+            }
+          },
+          "securitySettings": {
+            "softDeleteSettings": {
+              "state": "Enabled",
+              "retentionDurationInDays": 14
+            }
+          },
+          "secureScore": "Adequate",
+          "bcdrSecurityLevel": "Good"
+        }
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/GetBackupVault.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/GetBackupVault.json
@@ -3,7 +3,7 @@
     "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
     "resourceGroupName": "SampleResourceGroup",
     "vaultName": "swaggerExample",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/GetBackupVaultWithCMK.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/GetBackupVaultWithCMK.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "resourceGroupName": "SampleResourceGroup",
+    "vaultName": "swaggerExample",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "identity": {
+          "principalId": "c009b9a0-0024-417c-83cd-025d3776045d",
+          "tenantId": "83abe5cd-bcc3-441a-bd86-e6a75360cecc",
+          "type": "SystemAssigned"
+        },
+        "id": "/subscriptions/0b352192-dcac-4cc7-992e-a96190ccc68c/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample",
+        "name": "swaggerExample",
+        "type": "Microsoft.DataProtection/Backupvaults",
+        "location": "WestUS",
+        "tags": {
+          "key1": "val1"
+        },
+        "properties": {
+          "provisioningState": "Succeeded",
+          "securitySettings": {
+            "softDeleteSettings": {
+              "state": "Off",
+              "retentionDurationInDays": 0
+            },
+            "immutabilitySettings": {
+              "state": "Disabled"
+            },
+            "encryptionSettings": {
+              "state": "Enabled",
+              "keyVaultProperties": {
+                "keyUri": "https://cmk2xkv.vault.azure.net/keys/Key1/0767b348bb1a4c07baa6c4ec0055d2b3"
+              },
+              "kekIdentity": {
+                "identityType": "UserAssigned",
+                "identityId": "/subscriptions/85bf5e8c-3084-4f42-add2-746ebb7e97b2/resourcegroups/defaultrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/examplemsi"
+              },
+              "infrastructureEncryption": "Disabled"
+            }
+          },
+          "storageSettings": [
+            {
+              "datastoreType": "VaultStore",
+              "type": "LocallyRedundant"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/GetBackupVaultWithCMK.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/GetBackupVaultWithCMK.json
@@ -3,7 +3,7 @@
     "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
     "resourceGroupName": "SampleResourceGroup",
     "vaultName": "swaggerExample",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/GetBackupVaultWithMSI.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/GetBackupVaultWithMSI.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "resourceGroupName": "SampleResourceGroup",
+    "vaultName": "swaggerExample",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "identity": {
+          "principalId": "c009b9a0-0024-417c-83cd-025d3776045d",
+          "tenantId": "83abe5cd-bcc3-441a-bd86-e6a75360cecc",
+          "type": "SystemAssigned"
+        },
+        "id": "/subscriptions/0b352192-dcac-4cc7-992e-a96190ccc68c/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample",
+        "name": "swaggerExample",
+        "type": "Microsoft.DataProtection/Backupvaults",
+        "location": "WestUS",
+        "tags": {
+          "key1": "val1"
+        },
+        "properties": {
+          "provisioningState": "Succeeded",
+          "storageSettings": [
+            {
+              "datastoreType": "VaultStore",
+              "type": "LocallyRedundant"
+            }
+          ],
+          "featureSettings": {
+            "crossRegionRestoreSettings": {
+              "state": "Enabled"
+            }
+          },
+          "securitySettings": {
+            "softDeleteSettings": {
+              "state": "Enabled",
+              "retentionDurationInDays": 14
+            }
+          },
+          "secureScore": "Adequate",
+          "bcdrSecurityLevel": "Good"
+        }
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/GetBackupVaultWithMSI.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/GetBackupVaultWithMSI.json
@@ -3,7 +3,7 @@
     "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
     "resourceGroupName": "SampleResourceGroup",
     "vaultName": "swaggerExample",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/GetBackupVaultsInResourceGroup.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/GetBackupVaultsInResourceGroup.json
@@ -1,0 +1,90 @@
+{
+  "parameters": {
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "resourceGroupName": "SampleResourceGroup",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "identity": {
+              "type": "None"
+            },
+            "id": "/subscriptions/0b352192-dcac-4cc7-992e-a96190ccc68c/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/BackupVaults/ExampleVault1",
+            "name": "ExampleVault1",
+            "type": "Microsoft.DataProtection/BackupVaults",
+            "location": "WestUS",
+            "tags": {
+              "key1": "val1"
+            },
+            "properties": {
+              "provisioningState": "Succeeded",
+              "storageSettings": [
+                {
+                  "datastoreType": "VaultStore",
+                  "type": "LocallyRedundant"
+                }
+              ],
+              "featureSettings": {
+                "crossRegionRestoreSettings": {
+                  "state": "Enabled"
+                }
+              },
+              "securitySettings": {
+                "softDeleteSettings": {
+                  "state": "Enabled",
+                  "retentionDurationInDays": 14
+                }
+              },
+              "secureScore": "Adequate",
+              "bcdrSecurityLevel": "Good"
+            }
+          },
+          {
+            "identity": {
+              "principalId": "c009b9a0-0024-417c-83cd-025d3776045d",
+              "tenantId": "83abe5cd-bcc3-441a-bd86-e6a75360cecc",
+              "type": "SystemAssigned"
+            },
+            "id": "/subscriptions/0b352192-dcac-4cc7-992e-a96190ccc68c/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/BackupVaults/ExampleVault2",
+            "name": "ExampleVault2",
+            "type": "Microsoft.DataProtection/BackupVaults",
+            "location": "WestUS",
+            "tags": {
+              "key1": "val1"
+            },
+            "properties": {
+              "monitoringSettings": {
+                "azureMonitorAlertSettings": {
+                  "alertsForAllJobFailures": "Enabled"
+                }
+              },
+              "provisioningState": "Succeeded",
+              "storageSettings": [
+                {
+                  "datastoreType": "VaultStore",
+                  "type": "LocallyRedundant"
+                }
+              ],
+              "featureSettings": {
+                "crossRegionRestoreSettings": {
+                  "state": "Enabled"
+                }
+              },
+              "securitySettings": {
+                "softDeleteSettings": {
+                  "state": "Enabled",
+                  "retentionDurationInDays": 14
+                }
+              },
+              "secureScore": "Adequate",
+              "bcdrSecurityLevel": "Good"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/GetBackupVaultsInResourceGroup.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/GetBackupVaultsInResourceGroup.json
@@ -2,7 +2,7 @@
   "parameters": {
     "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
     "resourceGroupName": "SampleResourceGroup",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/GetBackupVaultsInSubscription.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/GetBackupVaultsInSubscription.json
@@ -1,0 +1,82 @@
+{
+  "parameters": {
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "identity": {
+              "type": "None"
+            },
+            "id": "/subscriptions/0b352192-dcac-4cc7-992e-a96190ccc68c/resourceGroups/SampleResourceGroup2/providers/Microsoft.DataProtection/BackupVaults/ExampleVault1",
+            "name": "ExampleVault1",
+            "type": "Microsoft.DataProtection/BackupVaults",
+            "location": "WestUS",
+            "tags": {
+              "key1": "val1"
+            },
+            "properties": {
+              "provisioningState": "Succeeded",
+              "storageSettings": [
+                {
+                  "datastoreType": "VaultStore",
+                  "type": "LocallyRedundant"
+                }
+              ],
+              "featureSettings": {
+                "crossRegionRestoreSettings": {
+                  "state": "Enabled"
+                }
+              },
+              "securitySettings": {
+                "softDeleteSettings": {
+                  "state": "Enabled",
+                  "retentionDurationInDays": 14
+                }
+              },
+              "secureScore": "Adequate",
+              "bcdrSecurityLevel": "Good"
+            }
+          },
+          {
+            "identity": {
+              "type": "None"
+            },
+            "id": "/subscriptions/0b352192-dcac-4cc7-992e-a96190ccc68c/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/BackupVaults/ExampleVault2",
+            "name": "ExampleVault2",
+            "type": "Microsoft.DataProtection/BackupVaults",
+            "location": "WestUS",
+            "tags": {
+              "key1": "val1"
+            },
+            "properties": {
+              "provisioningState": "Succeeded",
+              "storageSettings": [
+                {
+                  "datastoreType": "VaultStore",
+                  "type": "LocallyRedundant"
+                }
+              ],
+              "featureSettings": {
+                "crossRegionRestoreSettings": {
+                  "state": "Enabled"
+                }
+              },
+              "securitySettings": {
+                "softDeleteSettings": {
+                  "state": "Enabled",
+                  "retentionDurationInDays": 14
+                }
+              },
+              "secureScore": "Adequate",
+              "bcdrSecurityLevel": "Good"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/GetBackupVaultsInSubscription.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/GetBackupVaultsInSubscription.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/GetOperationResultPatch.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/GetOperationResultPatch.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "resourceGroupName": "SampleResourceGroup",
+    "vaultName": "swaggerExample",
+    "operationId": "YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==",
+    "api-version": "2025-02-01"
+  },
+  "responses": {
+    "200": {
+      "headers": {
+        "Retry-After": "10",
+        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/backupVaults/swaggerExample/operationStatus/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-02-01",
+        "Location": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample/operationResults/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-02-01"
+      },
+      "body": {
+        "identity": {
+          "type": "None"
+        },
+        "id": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample",
+        "name": "swaggerExample",
+        "type": "Microsoft.DataProtection/Backupvaults",
+        "location": "WestUS",
+        "tags": {
+          "key1": "val1"
+        },
+        "properties": {
+          "provisioningState": "Succeeded",
+          "storageSettings": [
+            {
+              "datastoreType": "VaultStore",
+              "type": "LocallyRedundant"
+            }
+          ]
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/backupVaults/swaggerExample/operationStatus/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-02-01",
+        "Location": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample/operationResults/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-02-01",
+        "Retry-After": "60"
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/GetOperationResultPatch.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/GetOperationResultPatch.json
@@ -4,14 +4,14 @@
     "resourceGroupName": "SampleResourceGroup",
     "vaultName": "swaggerExample",
     "operationId": "YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==",
-    "api-version": "2025-02-01"
+    "api-version": "2025-07-01"
   },
   "responses": {
     "200": {
       "headers": {
         "Retry-After": "10",
-        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/backupVaults/swaggerExample/operationStatus/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-02-01",
-        "Location": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample/operationResults/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-02-01"
+        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/backupVaults/swaggerExample/operationStatus/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-07-01",
+        "Location": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample/operationResults/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-07-01"
       },
       "body": {
         "identity": {
@@ -37,8 +37,8 @@
     },
     "202": {
       "headers": {
-        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/backupVaults/swaggerExample/operationStatus/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-02-01",
-        "Location": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample/operationResults/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-02-01",
+        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/backupVaults/swaggerExample/operationStatus/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-07-01",
+        "Location": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample/operationResults/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-07-01",
         "Retry-After": "60"
       }
     }

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/PatchBackupVault.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/PatchBackupVault.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "resourceGroupName": "SampleResourceGroup",
+    "vaultName": "swaggerExample",
+    "api-version": "2025-02-01",
+    "operationId": "YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==",
+    "parameters": {
+      "tags": {
+        "newKey": "newVal"
+      },
+      "properties": {
+        "monitoringSettings": {
+          "azureMonitorAlertSettings": {
+            "alertsForAllJobFailures": "Enabled"
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Retry-After": "10",
+        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample/operationStatus/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-02-01",
+        "Location": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample/operationResults/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-02-01"
+      }
+    },
+    "200": {
+      "body": {
+        "id": "/subscriptions/0b352192-dcac-4cc7-992e-a96190ccc68c/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample",
+        "name": "swaggerExample",
+        "type": "Microsoft.DataProtection/Backupvaults",
+        "location": "WestUS",
+        "tags": {
+          "newKey": "newVal"
+        },
+        "properties": {
+          "monitoringSettings": {
+            "azureMonitorAlertSettings": {
+              "alertsForAllJobFailures": "Enabled"
+            }
+          },
+          "provisioningState": "Succeeded",
+          "storageSettings": [
+            {
+              "datastoreType": "VaultStore",
+              "type": "LocallyRedundant"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/PatchBackupVault.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/PatchBackupVault.json
@@ -3,7 +3,7 @@
     "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
     "resourceGroupName": "SampleResourceGroup",
     "vaultName": "swaggerExample",
-    "api-version": "2025-02-01",
+    "api-version": "2025-07-01",
     "operationId": "YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==",
     "parameters": {
       "tags": {
@@ -22,8 +22,8 @@
     "202": {
       "headers": {
         "Retry-After": "10",
-        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample/operationStatus/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-02-01",
-        "Location": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample/operationResults/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-02-01"
+        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample/operationStatus/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-07-01",
+        "Location": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample/operationResults/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-07-01"
       }
     },
     "200": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/PatchBackupVaultWithCMK.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/PatchBackupVaultWithCMK.json
@@ -1,0 +1,92 @@
+{
+  "parameters": {
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "resourceGroupName": "SampleResourceGroup",
+    "vaultName": "swaggerExample",
+    "api-version": "2025-02-01",
+    "operationId": "YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==",
+    "parameters": {
+      "tags": {
+        "newKey": "newVal"
+      },
+      "properties": {
+        "monitoringSettings": {
+          "azureMonitorAlertSettings": {
+            "alertsForAllJobFailures": "Enabled"
+          }
+        },
+        "securitySettings": {
+          "softDeleteSettings": {
+            "state": "On",
+            "retentionDurationInDays": 90
+          },
+          "immutabilitySettings": {
+            "state": "Disabled"
+          },
+          "encryptionSettings": {
+            "state": "Enabled",
+            "keyVaultProperties": {
+              "keyUri": "https://cmk2xkv.vault.azure.net/keys/Key1/0767b348bb1a4c07baa6c4ec0055d2b3"
+            },
+            "kekIdentity": {
+              "identityType": "SystemAssigned"
+            },
+            "infrastructureEncryption": "Enabled"
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Retry-After": "10",
+        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample/operationStatus/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2023-04-01-privatepreview",
+        "Location": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample/operationResults/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2023-04-01-privatepreview"
+      }
+    },
+    "200": {
+      "body": {
+        "id": "/subscriptions/0b352192-dcac-4cc7-992e-a96190ccc68c/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample",
+        "name": "swaggerExample",
+        "type": "Microsoft.DataProtection/Backupvaults",
+        "location": "WestUS",
+        "tags": {
+          "newKey": "newVal"
+        },
+        "properties": {
+          "monitoringSettings": {
+            "azureMonitorAlertSettings": {
+              "alertsForAllJobFailures": "Enabled"
+            }
+          },
+          "securitySettings": {
+            "softDeleteSettings": {
+              "state": "On",
+              "retentionDurationInDays": 90
+            },
+            "immutabilitySettings": {
+              "state": "Disabled"
+            },
+            "encryptionSettings": {
+              "keyVaultProperties": {
+                "keyUri": "https://cmk2xkv.vault.azure.net/keys/Key1/0767b348bb1a4c07baa6c4ec0055d2b3"
+              },
+              "kekIdentity": {
+                "identityType": "SystemAssigned"
+              },
+              "infrastructureEncryption": "Enabled"
+            }
+          },
+          "provisioningState": "Succeeded",
+          "storageSettings": [
+            {
+              "datastoreType": "VaultStore",
+              "type": "LocallyRedundant"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/PatchBackupVaultWithCMK.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/PatchBackupVaultWithCMK.json
@@ -3,7 +3,7 @@
     "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
     "resourceGroupName": "SampleResourceGroup",
     "vaultName": "swaggerExample",
-    "api-version": "2025-02-01",
+    "api-version": "2025-07-01",
     "operationId": "YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==",
     "parameters": {
       "tags": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/PutBackupVault.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/PutBackupVault.json
@@ -1,0 +1,124 @@
+{
+  "parameters": {
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "resourceGroupName": "SampleResourceGroup",
+    "vaultName": "swaggerExample",
+    "api-version": "2025-02-01",
+    "parameters": {
+      "location": "WestUS",
+      "tags": {
+        "key1": "val1"
+      },
+      "identity": {
+        "type": "None"
+      },
+      "properties": {
+        "monitoringSettings": {
+          "azureMonitorAlertSettings": {
+            "alertsForAllJobFailures": "Enabled"
+          }
+        },
+        "storageSettings": [
+          {
+            "datastoreType": "VaultStore",
+            "type": "LocallyRedundant"
+          }
+        ],
+        "featureSettings": {
+          "crossRegionRestoreSettings": {
+            "state": "Enabled"
+          }
+        },
+        "securitySettings": {
+          "softDeleteSettings": {
+            "state": "Enabled",
+            "retentionDurationInDays": 14
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "id": "/subscriptions/0b352192-dcac-4cc7-992e-a96190ccc68c/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample",
+        "name": "swaggerExample",
+        "type": "Microsoft.DataProtection/Backupvaults",
+        "location": "WestUS",
+        "tags": {
+          "key1": "val1"
+        },
+        "properties": {
+          "monitoringSettings": {
+            "azureMonitorAlertSettings": {
+              "alertsForAllJobFailures": "Enabled"
+            }
+          },
+          "provisioningState": "Provisioning",
+          "storageSettings": [
+            {
+              "datastoreType": "VaultStore",
+              "type": "LocallyRedundant"
+            }
+          ],
+          "featureSettings": {
+            "crossRegionRestoreSettings": {
+              "state": "Enabled"
+            }
+          },
+          "securitySettings": {
+            "softDeleteSettings": {
+              "state": "Enabled",
+              "retentionDurationInDays": 14
+            }
+          },
+          "secureScore": "Adequate"
+        }
+      },
+      "headers": {
+        "Retry-After": "10",
+        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample/operationStatus/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-02-01"
+      }
+    },
+    "200": {
+      "body": {
+        "identity": {
+          "type": "None"
+        },
+        "id": "/subscriptions/0b352192-dcac-4cc7-992e-a96190ccc68c/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample",
+        "name": "swaggerExample",
+        "type": "Microsoft.DataProtection/Backupvaults",
+        "location": "WestUS",
+        "tags": {
+          "key1": "val1"
+        },
+        "properties": {
+          "monitoringSettings": {
+            "azureMonitorAlertSettings": {
+              "alertsForAllJobFailures": "Enabled"
+            }
+          },
+          "provisioningState": "Succeeded",
+          "storageSettings": [
+            {
+              "datastoreType": "VaultStore",
+              "type": "LocallyRedundant"
+            }
+          ],
+          "featureSettings": {
+            "crossRegionRestoreSettings": {
+              "state": "Enabled"
+            }
+          },
+          "securitySettings": {
+            "softDeleteSettings": {
+              "state": "Enabled",
+              "retentionDurationInDays": 14
+            }
+          },
+          "secureScore": "Adequate"
+        }
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/PutBackupVault.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/PutBackupVault.json
@@ -3,7 +3,7 @@
     "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
     "resourceGroupName": "SampleResourceGroup",
     "vaultName": "swaggerExample",
-    "api-version": "2025-02-01",
+    "api-version": "2025-07-01",
     "parameters": {
       "location": "WestUS",
       "tags": {
@@ -77,7 +77,7 @@
       },
       "headers": {
         "Retry-After": "10",
-        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample/operationStatus/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-02-01"
+        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample/operationStatus/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-07-01"
       }
     },
     "200": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/PutBackupVaultCMKSettings_ResourceGuardEnabled
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/PutBackupVaultCMKSettings_ResourceGuardEnabled
@@ -1,0 +1,133 @@
+{
+  "parameters": {
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "resourceGroupName": "SampleResourceGroup",
+    "vaultName": "swaggerExample",
+    "api-version": "2025-02-01",
+    "parameters": {
+      "location": "WestUS",
+      "tags": {
+        "key1": "val1"
+      },
+      "identity": {
+        "type": "None"
+      },
+      "properties": {
+        "monitoringSettings": {
+          "azureMonitorAlertSettings": {
+            "alertsForAllJobFailures": "Enabled"
+          }
+        },
+        "securitySettings": {
+          "softDeleteSettings": {
+            "state": "Off",
+            "retentionDurationInDays": 0
+          },
+          "immutabilitySettings": {
+            "state": "Disabled"
+          },
+          "encryptionSettings": {
+            "state": "Enabled",
+            "keyVaultProperties": {
+              "keyUri": "https://cmk2xkv.vault.azure.net/keys/Key1/0767b348bb1a4c07baa6c4ec0055d2b3"
+            },
+            "kekIdentity": {
+              "identityType": "UserAssigned",
+              "identityId": "/subscriptions/85bf5e8c-3084-4f42-add2-746ebb7e97b2/resourcegroups/defaultrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/examplemsi"
+            },
+            "infrastructureEncryption": "Enabled"
+          }
+        },
+        "storageSettings": [
+          {
+            "datastoreType": "VaultStore",
+            "type": "LocallyRedundant"
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "id": "/subscriptions/0b352192-dcac-4cc7-992e-a96190ccc68c/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample",
+        "name": "swaggerExample",
+        "type": "Microsoft.DataProtection/Backupvaults",
+        "location": "WestUS",
+        "tags": {
+          "key1": "val1"
+        },
+        "properties": {
+          "monitoringSettings": {
+            "azureMonitorAlertSettings": {
+              "alertsForAllJobFailures": "Enabled"
+            }
+          },
+          "securitySettings": {
+            "softDeleteSettings": {
+              "state": "Off",
+              "retentionDurationInDays": 0
+            },
+            "immutabilitySettings": {
+              "state": "Disabled"
+            },
+            "encryptionSettings": {
+              "state": "Enabled",
+              "keyVaultProperties": {
+                "keyUri": "https://cmk2xkv.vault.azure.net/keys/Key1/0767b348bb1a4c07baa6c4ec0055d2b3"
+              },
+              "kekIdentity": {
+                "identityType": "UserAssigned",
+                "identityId": "/subscriptions/85bf5e8c-3084-4f42-add2-746ebb7e97b2/resourcegroups/defaultrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/examplemsi"
+              },
+              "infrastructureEncryption": "Enabled"
+            },
+            "resourceGuardOperationRequests": [
+                "/subscriptions/754ec39f-8d2a-44cf-bfbf-13107ac85c36/resourcegroups/mua-testing/providers/Microsoft.DataProtection/resourceGuards/gvjreddy-test-ecy-rg-reader/dppModifyEncryptionSettingsRequests/default"
+              ]
+          },
+          "provisioningState": "Provisioning",
+          "storageSettings": [
+            {
+              "datastoreType": "VaultStore",
+              "type": "LocallyRedundant"
+            }
+          ]
+        }
+      },
+      "headers": {
+        "Retry-After": "10",
+        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample/operationStatus/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2023-04-01-privatepreview"
+      }
+    },
+    "200": {
+      "body": {
+        "identity": {
+          "type": "None"
+        },
+        "id": "/subscriptions/0b352192-dcac-4cc7-992e-a96190ccc68c/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample",
+        "name": "swaggerExample",
+        "type": "Microsoft.DataProtection/Backupvaults",
+        "location": "WestUS",
+        "tags": {
+          "key1": "val1"
+        },
+        "properties": {
+          "monitoringSettings": {
+            "azureMonitorAlertSettings": {
+              "alertsForAllJobFailures": "Enabled"
+            }
+          },
+          "provisioningState": "Succeeded",
+          "storageSettings": [
+            {
+              "datastoreType": "VaultStore",
+              "type": "LocallyRedundant"
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/PutBackupVaultCMKSettings_ResourceGuardEnabled
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/PutBackupVaultCMKSettings_ResourceGuardEnabled
@@ -3,7 +3,7 @@
     "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
     "resourceGroupName": "SampleResourceGroup",
     "vaultName": "swaggerExample",
-    "api-version": "2025-02-01",
+    "api-version": "2025-07-01",
     "parameters": {
       "location": "WestUS",
       "tags": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/PutBackupVaultWithCMK.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/PutBackupVaultWithCMK.json
@@ -1,0 +1,129 @@
+{
+  "parameters": {
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "resourceGroupName": "SampleResourceGroup",
+    "vaultName": "swaggerExample",
+    "api-version": "2025-02-01",
+    "parameters": {
+      "location": "WestUS",
+      "tags": {
+        "key1": "val1"
+      },
+      "identity": {
+        "type": "None"
+      },
+      "properties": {
+        "monitoringSettings": {
+          "azureMonitorAlertSettings": {
+            "alertsForAllJobFailures": "Enabled"
+          }
+        },
+        "securitySettings": {
+          "softDeleteSettings": {
+            "state": "Off",
+            "retentionDurationInDays": 0
+          },
+          "immutabilitySettings": {
+            "state": "Disabled"
+          },
+          "encryptionSettings": {
+            "state": "Enabled",
+            "keyVaultProperties": {
+              "keyUri": "https://cmk2xkv.vault.azure.net/keys/Key1/0767b348bb1a4c07baa6c4ec0055d2b3"
+            },
+            "kekIdentity": {
+              "identityType": "UserAssigned",
+              "identityId": "/subscriptions/85bf5e8c-3084-4f42-add2-746ebb7e97b2/resourcegroups/defaultrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/examplemsi"
+            },
+            "infrastructureEncryption": "Enabled"
+          }
+        },
+        "storageSettings": [
+          {
+            "datastoreType": "VaultStore",
+            "type": "LocallyRedundant"
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "id": "/subscriptions/0b352192-dcac-4cc7-992e-a96190ccc68c/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample",
+        "name": "swaggerExample",
+        "type": "Microsoft.DataProtection/Backupvaults",
+        "location": "WestUS",
+        "tags": {
+          "key1": "val1"
+        },
+        "properties": {
+          "monitoringSettings": {
+            "azureMonitorAlertSettings": {
+              "alertsForAllJobFailures": "Enabled"
+            }
+          },
+          "securitySettings": {
+            "softDeleteSettings": {
+              "state": "Off",
+              "retentionDurationInDays": 0
+            },
+            "immutabilitySettings": {
+              "state": "Disabled"
+            },
+            "encryptionSettings": {
+              "state": "Enabled",
+              "keyVaultProperties": {
+                "keyUri": "https://cmk2xkv.vault.azure.net/keys/Key1/0767b348bb1a4c07baa6c4ec0055d2b3"
+              },
+              "kekIdentity": {
+                "identityType": "UserAssigned",
+                "identityId": "/subscriptions/85bf5e8c-3084-4f42-add2-746ebb7e97b2/resourcegroups/defaultrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/examplemsi"
+              },
+              "infrastructureEncryption": "Enabled"
+            }
+          },
+          "provisioningState": "Provisioning",
+          "storageSettings": [
+            {
+              "datastoreType": "VaultStore",
+              "type": "LocallyRedundant"
+            }
+          ]
+        }
+      },
+      "headers": {
+        "Retry-After": "10",
+        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample/operationStatus/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2023-04-01-privatepreview"
+      }
+    },
+    "200": {
+      "body": {
+        "identity": {
+          "type": "None"
+        },
+        "id": "/subscriptions/0b352192-dcac-4cc7-992e-a96190ccc68c/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample",
+        "name": "swaggerExample",
+        "type": "Microsoft.DataProtection/Backupvaults",
+        "location": "WestUS",
+        "tags": {
+          "key1": "val1"
+        },
+        "properties": {
+          "monitoringSettings": {
+            "azureMonitorAlertSettings": {
+              "alertsForAllJobFailures": "Enabled"
+            }
+          },
+          "provisioningState": "Succeeded",
+          "storageSettings": [
+            {
+              "datastoreType": "VaultStore",
+              "type": "LocallyRedundant"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/PutBackupVaultWithCMK.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/PutBackupVaultWithCMK.json
@@ -3,7 +3,7 @@
     "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
     "resourceGroupName": "SampleResourceGroup",
     "vaultName": "swaggerExample",
-    "api-version": "2025-02-01",
+    "api-version": "2025-07-01",
     "parameters": {
       "location": "WestUS",
       "tags": {

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/PutBackupVaultWithMSI.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/PutBackupVaultWithMSI.json
@@ -1,0 +1,126 @@
+{
+  "parameters": {
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "resourceGroupName": "SampleResourceGroup",
+    "vaultName": "swaggerExample",
+    "api-version": "2025-02-01",
+    "parameters": {
+      "location": "WestUS",
+      "tags": {
+        "key1": "val1"
+      },
+      "identity": {
+        "type": "systemAssigned"
+      },
+      "properties": {
+        "monitoringSettings": {
+          "azureMonitorAlertSettings": {
+            "alertsForAllJobFailures": "Enabled"
+          }
+        },
+        "storageSettings": [
+          {
+            "datastoreType": "VaultStore",
+            "type": "LocallyRedundant"
+          }
+        ],
+        "featureSettings": {
+          "crossRegionRestoreSettings": {
+            "state": "Enabled"
+          }
+        },
+        "securitySettings": {
+          "softDeleteSettings": {
+            "state": "Enabled",
+            "retentionDurationInDays": 14
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "id": "/subscriptions/0b352192-dcac-4cc7-992e-a96190ccc68c/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample",
+        "name": "swaggerExample",
+        "type": "Microsoft.DataProtection/Backupvaults",
+        "location": "WestUS",
+        "tags": {
+          "key1": "val1"
+        },
+        "properties": {
+          "monitoringSettings": {
+            "azureMonitorAlertSettings": {
+              "alertsForAllJobFailures": "Enabled"
+            }
+          },
+          "provisioningState": "Provisioning",
+          "storageSettings": [
+            {
+              "datastoreType": "VaultStore",
+              "type": "LocallyRedundant"
+            }
+          ],
+          "featureSettings": {
+            "crossRegionRestoreSettings": {
+              "state": "Enabled"
+            }
+          },
+          "securitySettings": {
+            "softDeleteSettings": {
+              "state": "Enabled",
+              "retentionDurationInDays": 14
+            }
+          },
+          "secureScore": "Adequate"
+        }
+      },
+      "headers": {
+        "Retry-After": "10",
+        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample/operationStatus/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-02-01"
+      }
+    },
+    "200": {
+      "body": {
+        "identity": {
+          "principalId": "c009b9a0-0024-417c-83cd-025d3776045d",
+          "tenantId": "83abe5cd-bcc3-441a-bd86-e6a75360cecc",
+          "type": "SystemAssigned"
+        },
+        "id": "/subscriptions/0b352192-dcac-4cc7-992e-a96190ccc68c/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample",
+        "name": "swaggerExample",
+        "type": "Microsoft.DataProtection/Backupvaults",
+        "location": "WestUS",
+        "tags": {
+          "key1": "val1"
+        },
+        "properties": {
+          "monitoringSettings": {
+            "azureMonitorAlertSettings": {
+              "alertsForAllJobFailures": "Enabled"
+            }
+          },
+          "provisioningState": "Succeeded",
+          "storageSettings": [
+            {
+              "datastoreType": "VaultStore",
+              "type": "LocallyRedundant"
+            }
+          ],
+          "featureSettings": {
+            "crossRegionRestoreSettings": {
+              "state": "Enabled"
+            }
+          },
+          "securitySettings": {
+            "softDeleteSettings": {
+              "state": "Enabled",
+              "retentionDurationInDays": 14
+            }
+          },
+          "secureScore": "Adequate"
+        }
+      }
+    }
+  }
+}

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/PutBackupVaultWithMSI.json
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/stable/2025-07-01/examples/VaultCRUD/PutBackupVaultWithMSI.json
@@ -3,7 +3,7 @@
     "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
     "resourceGroupName": "SampleResourceGroup",
     "vaultName": "swaggerExample",
-    "api-version": "2025-02-01",
+    "api-version": "2025-07-01",
     "parameters": {
       "location": "WestUS",
       "tags": {
@@ -77,7 +77,7 @@
       },
       "headers": {
         "Retry-After": "10",
-        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample/operationStatus/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-02-01"
+        "Azure-AsyncOperation": "https://management.windowsazure.com/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/SampleResourceGroup/providers/Microsoft.DataProtection/Backupvaults/swaggerExample/operationStatus/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2025-07-01"
       }
     },
     "200": {

--- a/specification/dataprotection/resource-manager/readme.md
+++ b/specification/dataprotection/resource-manager/readme.md
@@ -28,7 +28,7 @@ These are the global settings for the DataProtection API.
 title: Data Protection Client
 description: Open API 2.0 Specs for Azure Data Protection service
 openapi-type: arm
-tag: package-2025-02-01
+tag: package-2025-07-01
 csharp-sdks-folder: ./Generated/CSharp
 python-sdks-folder: ./Generated/Python
 go-sdk-folder: ./Generated/Golang
@@ -47,6 +47,15 @@ azure-validator: true
 model-validator: true
 semantic-validator: true
 message-format: json
+```
+
+### Tag: package-2025-07-01
+
+These settings apply only when `--tag=package-2025-07-01` is specified on the command line.
+
+```yaml $(tag) == 'package-2025-07-01'
+input-file:
+  - Microsoft.DataProtection/stable/2025-07-01/dataprotection.json
 ```
 
 ### Tag: package-2025-02-01


### PR DESCRIPTION
@IannGeorges - Create new API version 2025-07-01 to enable new optional parameter which will allow blob workloads to rename containers during restore.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
