### PR TITLE
[Communication.Messages] Update definition in client.tsp 

### DIFF
--- a/specification/communication/Communication.Messages/client.tsp
+++ b/specification/communication/Communication.Messages/client.tsp
@@ -15,15 +15,12 @@ namespace ClientForAcsMessages;
   service: Azure.Communication.MessagesService,
 })
 interface NotificationMessagesClient
-  extends Azure.Communication.MessagesService.NotificationMessagesOperations {}
-
-@@clientName(Azure.Communication.MessagesService.StreamOperations.getMedia,
-  "downloadMedia",
-  "csharp"
-);
-#suppress "@azure-tools/typespec-azure-core/use-standard-names" ""
-@@access(Azure.Communication.MessagesService.StreamOperations.getMedia, Access.internal, "csharp");
-
+  extends Azure.Communication.MessagesService.NotificationMessagesOperations {
+  #suppress "@azure-tools/typespec-azure-core/use-standard-names" ""
+  @access(Access.internal, "csharp")
+  @clientName("downloadMediaInternal", "csharp")
+  downloadMedia is Azure.Communication.MessagesService.StreamOperations.getMedia;
+}
 
 @client({
   name: "MessageTemplateClient",

--- a/specification/communication/Communication.Messages/client.tsp
+++ b/specification/communication/Communication.Messages/client.tsp
@@ -15,12 +15,15 @@ namespace ClientForAcsMessages;
   service: Azure.Communication.MessagesService,
 })
 interface NotificationMessagesClient
-  extends Azure.Communication.MessagesService.NotificationMessagesOperations {
-  #suppress "@azure-tools/typespec-azure-core/use-standard-names" ""
-  @access(Access.internal, "csharp")
-  @clientName("downloadMediaInternal", "csharp")
-  downloadMedia is Azure.Communication.MessagesService.StreamOperations.getMedia;
-}
+  extends Azure.Communication.MessagesService.NotificationMessagesOperations {}
+
+@@clientName(Azure.Communication.MessagesService.StreamOperations.getMedia,
+  "downloadMedia",
+  "csharp"
+);
+#suppress "@azure-tools/typespec-azure-core/use-standard-names" ""
+@@access(Azure.Communication.MessagesService.StreamOperations.getMedia, Access.internal, "csharp");
+
 
 @client({
   name: "MessageTemplateClient",
@@ -36,13 +39,7 @@ interface MessageTemplateClient
   service: Azure.Communication.MessagesService,
 })
 interface ConversationAdministrationClient
-  extends Azure.Communication.MessagesService.ConversationAdministrationOperations {
-  listConversations is Azure.Communication.MessagesService.ConversationThreadOperations.listConversations;
-  listMessages is Azure.Communication.MessagesService.ConversationThreadOperations.listMessages;
-  addParticipants is Azure.Communication.MessagesService.ConversationThreadOperations.addParticipants;
-  removeParticipants is Azure.Communication.MessagesService.ConversationThreadOperations.removeParticipants;
-  analyzeConversation is Azure.Communication.MessagesService.ConversationThreadOperations.analyzeConversation;
-}
+  extends Azure.Communication.MessagesService.ConversationAdministrationOperations {}
 
 @added(Azure.Communication.MessagesService.Versions.c2025_04_01_Preview)
 @client({


### PR DESCRIPTION
CI failure: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4968394&view=logs&j=83516c17-6666-5250-abde-63983ce72a49&t=00be4b52-4a63-5865-8e02-c61723ad0692&l=22902

Cause is below `interface extends` in `client.tsp`:
```
#suppress "@azure-tools/typespec-azure-core/use-standard-operations" ""
@added(Azure.Communication.MessagesService.Versions.c2025_04_01_Preview)
@client({
  name: "ConversationAdministrationClient",
  service: Azure.Communication.MessagesService,
})
interface ConversationAdministrationClient
  extends Azure.Communication.MessagesService.ConversationAdministrationOperations {
  listConversations is Azure.Communication.MessagesService.ConversationThreadOperations.listConversations;
  listMessages is Azure.Communication.MessagesService.ConversationThreadOperations.listMessages;
  addParticipants is Azure.Communication.MessagesService.ConversationThreadOperations.addParticipants;
  removeParticipants is Azure.Communication.MessagesService.ConversationThreadOperations.removeParticipants;
  analyzeConversation is Azure.Communication.MessagesService.ConversationThreadOperations.analyzeConversation;
}
```

By using `extends`, there will be duplicate methods (eg.`listConversations`) created in different clients, is this service's intension to duplicate the methods in two clients (`ConversationAdministrationClient` and `ConversationThreadClient`)?
If there is no need to duplicate, this pr would fix it.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
