### PR TITLE
[Storage] `PageBlobClient` and `AppendBlobClient` initial introduction TypeSpec Changes

### DIFF
--- a/specification/storage/Microsoft.BlobStorage/models.tsp
+++ b/specification/storage/Microsoft.BlobStorage/models.tsp
@@ -2035,7 +2035,7 @@ alias IfNoneMatchParameter = {
 /** The range parameter. */
 alias RangeParameter = {
   /** Return only the bytes of the blob in the specified range. */
-  @header("x-ms-range")
+  @header("Range")
   range?: string;
 };
 

--- a/specification/storage/Microsoft.BlobStorage/routes.tsp
+++ b/specification/storage/Microsoft.BlobStorage/routes.tsp
@@ -1549,7 +1549,7 @@ namespace Storage.Blob {
             ...LastModifiedResponseHeader;
             ...ContentMd5ResponseHeader;
             ...VersionIdResponseHeader;
-            ...DateResponseHeader;
+            ...DateResponseHeaderPrivate;
             ...RequestServerEncryptedResponseHeader;
             ...EncryptionKeySha256ResponseHeader;
             ...EncryptionScopeResponseHeader;
@@ -1605,7 +1605,7 @@ namespace Storage.Blob {
             ...ContentMd5ResponseHeader;
             ...ContentCrc64ResponseHeader;
             ...BlobSequenceNumberResponseHeader;
-            ...DateResponseHeader;
+            ...DateResponseHeaderPrivate;
             ...RequestServerEncryptedResponseHeader;
             ...EncryptionKeySha256ResponseHeader;
             ...EncryptionScopeResponseHeader;
@@ -1658,7 +1658,7 @@ namespace Storage.Blob {
             ...ContentMd5ResponseHeader;
             ...ContentCrc64ResponseHeader;
             ...BlobSequenceNumberResponseHeader;
-            ...DateResponseHeader;
+            ...DateResponseHeaderPrivate;
           }
         >;
 
@@ -1818,7 +1818,7 @@ namespace Storage.Blob {
             ...EtagResponseHeader;
             ...LastModifiedResponseHeader;
             ...BlobSequenceNumberResponseHeader;
-            ...DateResponseHeader;
+            ...DateResponseHeaderPrivate;
           }
         >;
 
@@ -1929,7 +1929,7 @@ namespace Storage.Blob {
             ...LastModifiedResponseHeader;
             ...ContentMd5ResponseHeader;
             ...VersionIdResponseHeader;
-            ...DateResponseHeader;
+            ...DateResponseHeaderPrivate;
             ...RequestServerEncryptedResponseHeader;
             ...EncryptionKeySha256ResponseHeader;
             ...EncryptionScopeResponseHeader;

--- a/specification/storage/Microsoft.BlobStorage/routes.tsp
+++ b/specification/storage/Microsoft.BlobStorage/routes.tsp
@@ -1576,7 +1576,11 @@ namespace Storage.Blob {
             ...ContentMd5Parameter;
             ...ContentCrc64Parameter;
             ...TimeoutParameter;
-            ...RangeParameter;
+
+            /** Bytes of data in the specified range. */
+            @header("Range")
+            range: string;
+
             ...LeaseIdOptionalParameter;
             ...EncryptionKeyParameter;
             ...EncryptionKeySha256Parameter;
@@ -1621,9 +1625,17 @@ namespace Storage.Blob {
           {
             ...ContainerNamePathParameter;
             ...BlobPathParameter;
-            ...ContentLengthParameter;
+
+            /** value must be 0 when x-ms-page-write is clear */
+            @header("Content-Length")
+            contentLength: 0;
+
             ...TimeoutParameter;
-            ...RangeParameter;
+
+            /** Bytes of data in the specified range. */
+            @header("Range")
+            range: string;
+
             ...LeaseIdOptionalParameter;
             ...EncryptionKeyParameter;
             ...EncryptionKeySha256Parameter;


### PR DESCRIPTION
This PR does the following:

- Makes `Range` a required parameter for `upload_page` and `clear_page`
- Make `contentLength` a fixed `0-size` which is required by the spec for `clear_page` API
- Move from `x-ms-range` to `Range` widely 