### PR TITLE
Updating the union so the two fields we need to rename are explicitly named

### DIFF
--- a/specification/eventgrid/Azure.Messaging.EventGrid.SystemEvents/Microsoft.Communication/AzureCommunicationServices.tsp
+++ b/specification/eventgrid/Azure.Messaging.EventGrid.SystemEvents/Microsoft.Communication/AzureCommunicationServices.tsp
@@ -940,10 +940,10 @@ union recordingFormatType {
   "Wav",
 
   /** MP3 format */
-  "Mp3",
+  Mp3: "Mp3",
 
   /** MP4 format */
-  "Mp4",
+  Mp4: "Mp4",
 
   string,
 }

--- a/specification/eventgrid/Azure.Messaging.EventGrid.SystemEvents/propertyNameOverrideGo.tsp
+++ b/specification/eventgrid/Azure.Messaging.EventGrid.SystemEvents/propertyNameOverrideGo.tsp
@@ -620,5 +620,7 @@ using Microsoft.EventGrid.SystemEvents;
   "go"
 );
 @@clientName(AcsCallParticipantKind, "ACSCallParticipantRoleKind", "go");
+@@clientName(recordingFormatType.Mp3, "MP3", "go");
+@@clientName(recordingFormatType.Mp4, "MP4", "go");
 
 // [END] ACS renames (and acronym casing)


### PR DESCRIPTION
The clientName decorator can't be applied to unnamed fields within a union. This change gives them a name (the same as they would have, normally), which allows them to be renamed like any other type.