### PR TITLE
[Do not merge] Test PR. Update PureStorage TypeSpec configuration for beta SDK release

### DIFF
--- a/specification/purestorage/PureStorage.Block.Management/tspconfig.yaml
+++ b/specification/purestorage/PureStorage.Block.Management/tspconfig.yaml
@@ -16,30 +16,30 @@ options:
     arm-resource-flattening: true
     emit-common-types-schema: "never"
   "@azure-tools/typespec-csharp":
-    package-dir: "Azure.ResourceManager.PureStorageBlock"
+    package-dir: "Azure.ResourceManager.PureStorage"
     flavor: azure
     clear-output-folder: true
     namespace: "{package-dir}"
   "@azure-tools/typespec-python":
-    package-dir: "azure-mgmt-purestorageblock"
-    namespace: "azure.mgmt.purestorageblock"
+    package-dir: "azure-mgmt-purestorage"
+    namespace: "azure.mgmt.purestorage"
     flavor: "azure"
     generate-test: true
     generate-sample: true
   "@azure-tools/typespec-java":
-    package-dir: "azure-resourcemanager-purestorageblock"
-    namespace: "com.azure.resourcemanager.purestorageblock"
+    package-dir: "azure-resourcemanager-purestorage"
+    namespace: "com.azure.resourcemanager.purestorage"
     flavor: "azure"
-    service-name: "Pure Storage Block"
+    service-name: "Pure Storage"
   "@azure-tools/typespec-ts":
     experimental-extensible-enums: true
-    package-dir: "arm-purestorageblock"
+    package-dir: "arm-purestorage"
     flavor: "azure"
     package-details:
-      name: "@azure/arm-purestorageblock"
+      name: "@azure/arm-purestorage"
   "@azure-tools/typespec-go":
-    service-dir: "sdk/resourcemanager/purestorageblock"
-    package-dir: "armpurestorageblock"
+    service-dir: "sdk/resourcemanager/purestorage"
+    package-dir: "armpurestorage"
     module: "github.com/Azure/azure-sdk-for-go/{service-dir}/{package-dir}"
     fix-const-stuttering: true
     flavor: "azure"


### PR DESCRIPTION
This PR updates the PureStorage TypeSpec configuration with package naming changes for SDK generation test release.

**Changes:**
- Updated package directory names to use "purestorage" instead of "purestorageblock"
- Updated namespaces and service names accordingly
- Prepared for beta SDK generation for .NET, Java, and Python

**SDK Generation Details:**
- Target Languages: .NET (C#), Java, Python
- Release Type: Beta
- Purpose: Test release for demo

**API Versions Available:**
- 2024-10-01-preview
- 2024-11-01-preview  
- 2024-11-01 (stable)