### PR TITLE
Fix LocalDNSProfile to model vnet/kubeDNSOverrides as maps

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2025-03-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2025-03-02-preview/managedClusters.json
@@ -7934,18 +7934,22 @@
           "description": "System-generated state of localDNS."
         },
         "vnetDNSOverrides": {
-          "type": "object",
           "description": "VnetDNS overrides apply to DNS traffic from pods with dnsPolicy:default or kubelet (referred to as VnetDNS traffic).",
-          "$ref": "#/definitions/LocalDNSOverrides"
+          "$ref": "#/definitions/LocalDNSOverrideMap"
         },
         "kubeDNSOverrides": {
-          "type": "object",
           "description": "KubeDNS overrides apply to DNS traffic from pods with dnsPolicy:ClusterFirst (referred to as KubeDNS traffic).",
-          "$ref": "#/definitions/LocalDNSOverrides"
+          "$ref": "#/definitions/LocalDNSOverrideMap"
         }
       }
     },
-    "LocalDNSOverrides": {
+    "LocalDNSOverrideMap": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/LocalDNSOverride"
+      }
+    },
+    "LocalDNSOverride": {
       "type": "object",
       "description": "Overrides for localDNS profile.",
       "properties": {
@@ -8090,7 +8094,7 @@
             ]
           },
           "description": "Policy for serving stale data. See [cache plugin](https://coredns.io/plugins/cache) for more information.",
-          "default": "Verify"
+          "default": "Immediate"
         }
       }
     },


### PR DESCRIPTION
Fix LocalDNSProfile to model kubeDNSOverrides and vnetDNSOverrides as maps

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
