### PR TITLE
[EngSys] Check formatting in PR checks for eng/tools

### DIFF
--- a/.github/workflows/_reusable-eng-tools-test.yaml
+++ b/.github/workflows/_reusable-eng-tools-test.yaml
@@ -14,10 +14,12 @@ on:
       lint:
         description: Run 'npm run lint' if true
         required: false
+        default: false
         type: boolean
       check-formatting:
         description: Run 'npm run format:check' if true
         required: false
+        default: true
         type: boolean
 
 permissions:

--- a/.github/workflows/_reusable-eng-tools-test.yaml
+++ b/.github/workflows/_reusable-eng-tools-test.yaml
@@ -16,11 +16,6 @@ on:
         required: false
         default: false
         type: boolean
-      check-formatting:
-        description: Run 'npm run format:check' if true
-        required: false
-        default: true
-        type: boolean
 
 permissions:
   contents: read
@@ -69,7 +64,6 @@ jobs:
 
       - name: Check Formatting
         run: npm run format:check
-        if: inputs.check-formatting == true
         shell: pwsh
         working-directory: ./eng/tools/${{ inputs.package }}
 

--- a/.github/workflows/_reusable-eng-tools-test.yaml
+++ b/.github/workflows/_reusable-eng-tools-test.yaml
@@ -15,8 +15,8 @@ on:
         description: Run 'npm run lint' if true
         required: false
         type: boolean
-      prettier:
-        description: Run 'npm run prettier' if true
+      format:
+        description: Run 'npm run format:check' if true
         required: false
         type: boolean
 
@@ -63,8 +63,8 @@ jobs:
         shell: pwsh
         working-directory: ./eng/tools/${{ inputs.package }}
 
-      - run: npm run prettier
-        if: inputs.prettier == true
+      - run: npm run format:check
+        if: inputs.format == true
         shell: pwsh
         working-directory: ./eng/tools/${{ inputs.package }}
 

--- a/.github/workflows/_reusable-eng-tools-test.yaml
+++ b/.github/workflows/_reusable-eng-tools-test.yaml
@@ -54,21 +54,25 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}.x
 
-      - run: npm run build
+      - name: Build
+        run: npm run build
         shell: pwsh
         working-directory: ./eng/tools/${{ inputs.package }}
 
-      - run: npm run lint
+      - name: Lint
+        run: npm run lint
         if: inputs.lint == true
         shell: pwsh
         working-directory: ./eng/tools/${{ inputs.package }}
 
-      - run: npm run format:check
+      - name: Check Formatting
+        run: npm run format:check
         if: inputs.format == true
         shell: pwsh
         working-directory: ./eng/tools/${{ inputs.package }}
 
-      - run: npm run test:ci
+      - name: Test
+        run: npm run test:ci
         shell: pwsh
         working-directory: ./eng/tools/${{ inputs.package }}
 

--- a/.github/workflows/_reusable-eng-tools-test.yaml
+++ b/.github/workflows/_reusable-eng-tools-test.yaml
@@ -14,7 +14,6 @@ on:
       lint:
         description: Run 'npm run lint' if true
         required: false
-        default: false
         type: boolean
 
 permissions:

--- a/.github/workflows/_reusable-eng-tools-test.yaml
+++ b/.github/workflows/_reusable-eng-tools-test.yaml
@@ -15,7 +15,7 @@ on:
         description: Run 'npm run lint' if true
         required: false
         type: boolean
-      format:
+      check-formatting:
         description: Run 'npm run format:check' if true
         required: false
         type: boolean
@@ -67,7 +67,7 @@ jobs:
 
       - name: Check Formatting
         run: npm run format:check
-        if: inputs.format == true
+        if: inputs.check-formatting == true
         shell: pwsh
         working-directory: ./eng/tools/${{ inputs.package }}
 

--- a/.github/workflows/lintdiff-test.yaml
+++ b/.github/workflows/lintdiff-test.yaml
@@ -31,5 +31,5 @@ jobs:
     uses: ./.github/workflows/_reusable-eng-tools-test.yaml
     with:
       package: lint-diff
+      format: true
       lint: false
-      prettier: false

--- a/.github/workflows/lintdiff-test.yaml
+++ b/.github/workflows/lintdiff-test.yaml
@@ -32,4 +32,3 @@ jobs:
     with:
       package: lint-diff
       lint: false
-      check-formatting: true

--- a/.github/workflows/lintdiff-test.yaml
+++ b/.github/workflows/lintdiff-test.yaml
@@ -31,5 +31,5 @@ jobs:
     uses: ./.github/workflows/_reusable-eng-tools-test.yaml
     with:
       package: lint-diff
-      format: true
       lint: false
+      check-formatting: true

--- a/.github/workflows/oav-runner-tests.yaml
+++ b/.github/workflows/oav-runner-tests.yaml
@@ -27,4 +27,3 @@ jobs:
     with:
       package: oav-runner
       lint: false
-      check-formatting: true

--- a/.github/workflows/oav-runner-tests.yaml
+++ b/.github/workflows/oav-runner-tests.yaml
@@ -27,4 +27,4 @@ jobs:
     with:
       package: oav-runner
       lint: false
-      prettier: false
+      check-formatting: true

--- a/.github/workflows/openapi-diff-runner-test.yaml
+++ b/.github/workflows/openapi-diff-runner-test.yaml
@@ -26,4 +26,3 @@ jobs:
     with:
       package: openapi-diff-runner
       lint: false
-      prettier: true

--- a/eng/tools/lint-diff/package.json
+++ b/eng/tools/lint-diff/package.json
@@ -8,12 +8,12 @@
   },
   "scripts": {
     "build": "tsc --build",
-    "test": "vitest",
-    "test:ci": "vitest run --coverage --reporter=verbose",
     "clean": "rm -rf dist && rm -rf node_modules",
     "format": "prettier . --ignore-path ../.prettierignore --write",
     "format:check": "prettier . --ignore-path ../.prettierignore --check",
-    "format:debug": "prettier . --ignore-path ../.prettierignore --check --log-level debug"
+    "format:debug": "prettier . --ignore-path ../.prettierignore --check --log-level debug",
+    "test": "vitest",
+    "test:ci": "vitest run --coverage --reporter=verbose"
   },
   "engines": {
     "node": ">= 20.0.0"

--- a/eng/tools/lint-diff/package.json
+++ b/eng/tools/lint-diff/package.json
@@ -11,9 +11,9 @@
     "test": "vitest",
     "test:ci": "vitest run --coverage --reporter=verbose",
     "clean": "rm -rf dist && rm -rf node_modules",
-    "prettier": "prettier \"**/*.js\" --check",
-    "prettier:debug": "prettier \"**/*.js\" --check ---log-level debug",
-    "prettier:write": "prettier \"**/*.js\" --write"
+    "format": "prettier . --ignore-path ../.prettierignore --write",
+    "format:check": "prettier . --ignore-path ../.prettierignore --check",
+    "format:debug": "prettier . --ignore-path ../.prettierignore --check --log-level debug"
   },
   "engines": {
     "node": ">= 20.0.0"

--- a/eng/tools/oav-runner/package.json
+++ b/eng/tools/oav-runner/package.json
@@ -10,8 +10,8 @@
     "build": "tsc --build",
     "test": "vitest",
     "test:ci": "vitest run --coverage --reporter=verbose",
-    "prettier": "prettier \"**/*.js\" --check",
-    "prettier:write": "prettier \"**/*.js\" --write"
+    "format": "prettier . --ignore-path ../.prettierignore --write",
+    "format:check": "prettier . --ignore-path ../.prettierignore --check"
   },
   "dependencies": {
     "@azure-tools/specs-shared": "file:../../../.github/shared",

--- a/eng/tools/oav-runner/package.json
+++ b/eng/tools/oav-runner/package.json
@@ -8,10 +8,10 @@
   },
   "scripts": {
     "build": "tsc --build",
-    "test": "vitest",
-    "test:ci": "vitest run --coverage --reporter=verbose",
     "format": "prettier . --ignore-path ../.prettierignore --write",
-    "format:check": "prettier . --ignore-path ../.prettierignore --check"
+    "format:check": "prettier . --ignore-path ../.prettierignore --check",
+    "test": "vitest",
+    "test:ci": "vitest run --coverage --reporter=verbose"
   },
   "dependencies": {
     "@azure-tools/specs-shared": "file:../../../.github/shared",

--- a/eng/tools/openapi-diff-runner/package.json
+++ b/eng/tools/openapi-diff-runner/package.json
@@ -8,10 +8,10 @@
   },
   "scripts": {
     "build": "tsc --build",
-    "test": "vitest",
-    "test:ci": "vitest --coverage --reporter=verbose",
     "format": "prettier . --ignore-path ../.prettierignore --write",
-    "format:check": "prettier . --ignore-path ../.prettierignore --check"
+    "format:check": "prettier . --ignore-path ../.prettierignore --check",
+    "test": "vitest",
+    "test:ci": "vitest --coverage --reporter=verbose"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/eng/tools/openapi-diff-runner/package.json
+++ b/eng/tools/openapi-diff-runner/package.json
@@ -10,8 +10,8 @@
     "build": "tsc --build",
     "test": "vitest",
     "test:ci": "vitest --coverage --reporter=verbose",
-    "prettier": "prettier \"**/*.ts\" \"!dist/**\" --check",
-    "prettier:write": "prettier \"**/*.ts\" \"!dist/**\" --write"
+    "format": "prettier . --ignore-path ../.prettierignore --write",
+    "format:check": "prettier . --ignore-path ../.prettierignore --check"
   },
   "engines": {
     "node": ">=20.0.0"
@@ -23,6 +23,7 @@
   "devDependencies": {
     "@types/node": "^20.0.0",
     "@vitest/coverage-v8": "^3.0.7",
+    "prettier": "~3.5.3",
     "typescript": "~5.8.2",
     "vitest": "^3.0.7"
   }

--- a/eng/tools/sdk-suppressions/package.json
+++ b/eng/tools/sdk-suppressions/package.json
@@ -10,7 +10,9 @@
   "scripts": {
     "build": "tsc --build",
     "test": "vitest",
-    "test:ci": "vitest run --coverage --reporter=verbose"
+    "test:ci": "vitest run --coverage --reporter=verbose",
+    "format": "prettier . --ignore-path ../.prettierignore --write",
+    "format:check": "prettier . --ignore-path ../.prettierignore --check"
   },
   "engines": {
     "node": ">=20.0.0"
@@ -28,6 +30,7 @@
     "@types/lodash": "^4.14.161",
     "@types/node": "^20.0.0",
     "@vitest/coverage-v8": "^3.0.7",
+    "prettier": "~3.5.3",
     "typescript": "~5.8.2",
     "vitest": "^3.0.7"
   }

--- a/eng/tools/sdk-suppressions/package.json
+++ b/eng/tools/sdk-suppressions/package.json
@@ -9,10 +9,10 @@
   },
   "scripts": {
     "build": "tsc --build",
-    "test": "vitest",
-    "test:ci": "vitest run --coverage --reporter=verbose",
     "format": "prettier . --ignore-path ../.prettierignore --write",
-    "format:check": "prettier . --ignore-path ../.prettierignore --check"
+    "format:check": "prettier . --ignore-path ../.prettierignore --check",
+    "test": "vitest",
+    "test:ci": "vitest run --coverage --reporter=verbose"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/eng/tools/spec-gen-sdk-runner/package.json
+++ b/eng/tools/spec-gen-sdk-runner/package.json
@@ -9,6 +9,8 @@
   },
   "scripts": {
     "build": "tsc --build",
+    "format": "prettier . --ignore-path ../.prettierignore --write",
+    "format:check": "prettier . --ignore-path ../.prettierignore --check",
     "lint": "eslint . -c eslint.config.js --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "eslint . -c eslint.config.js --fix",
     "test": "vitest run",
@@ -24,6 +26,7 @@
     "@vitest/coverage-v8": "^3.0.7",
     "eslint": "^9.21.0",
     "eslint-plugin-unicorn": "^59.0.0",
+    "prettier": "~3.5.3",
     "typescript": "~5.8.2",
     "typescript-eslint": "^8.26.0",
     "vitest": "^3.0.7"

--- a/eng/tools/suppressions/package.json
+++ b/eng/tools/suppressions/package.json
@@ -8,6 +8,8 @@
   },
   "scripts": {
     "build": "tsc --build",
+    "format": "prettier . --ignore-path ../.prettierignore --write",
+    "format:check": "prettier . --ignore-path ../.prettierignore --check",
     "test": "vitest",
     "test:ci": "vitest run --coverage --reporter=verbose"
   },
@@ -23,6 +25,7 @@
   "devDependencies": {
     "@types/node": "^20.0.0",
     "@vitest/coverage-v8": "^3.0.7",
+    "prettier": "~3.5.3",
     "typescript": "~5.8.2",
     "vitest": "^3.0.7"
   }

--- a/eng/tools/tsp-client-tests/package.json
+++ b/eng/tools/tsp-client-tests/package.json
@@ -5,11 +5,14 @@
   "devDependencies": {
     "@azure-tools/specs-shared": "file:../../../.github/shared",
     "@types/node": "^20.0.0",
+    "prettier": "~3.5.3",
     "typescript": "~5.8.2",
     "vitest": "^3.0.7"
   },
   "scripts": {
     "build": "tsc --build",
+    "format": "prettier . --ignore-path ../.prettierignore --write",
+    "format:check": "prettier . --ignore-path ../.prettierignore --check",
     "test": "vitest",
     "test:ci": "vitest run --reporter=verbose"
   },

--- a/eng/tools/typespec-migration-validation/package.json
+++ b/eng/tools/typespec-migration-validation/package.json
@@ -23,11 +23,11 @@
   },
   "scripts": {
     "build": "tsc --build",
-    "watch": "tsc --build --watch",
     "format": "prettier . --ignore-path ../.prettierignore --write",
     "format:check": "prettier . --ignore-path ../.prettierignore --check",
     "test": "vitest",
-    "test:ci": "vitest run --coverage --reporter=verbose"
+    "test:ci": "vitest run --coverage --reporter=verbose",
+    "watch": "tsc --build --watch"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/eng/tools/typespec-migration-validation/package.json
+++ b/eng/tools/typespec-migration-validation/package.json
@@ -18,11 +18,14 @@
     "@typescript-eslint/eslint-plugin": "^8.32.1",
     "@typescript-eslint/parser": "^8.32.1",
     "eslint": "^9.26.0",
+    "prettier": "~3.5.3",
     "typescript": "^5.8.3"
   },
   "scripts": {
     "build": "tsc --build",
     "watch": "tsc --build --watch",
+    "format": "prettier . --ignore-path ../.prettierignore --write",
+    "format:check": "prettier . --ignore-path ../.prettierignore --check",
     "test": "vitest",
     "test:ci": "vitest run --coverage --reporter=verbose"
   },

--- a/eng/tools/typespec-requirement/package.json
+++ b/eng/tools/typespec-requirement/package.json
@@ -5,11 +5,14 @@
   "devDependencies": {
     "@types/node": "^20.0.0",
     "execa": "^9.3.0",
+    "prettier": "~3.5.3",
     "typescript": "~5.8.2",
     "vitest": "^3.0.7"
   },
   "scripts": {
     "build": "tsc --build",
+    "format": "prettier . --ignore-path ../.prettierignore --write",
+    "format:check": "prettier . --ignore-path ../.prettierignore --check",
     "test": "vitest",
     "test:ci": "vitest run --reporter=verbose"
   },

--- a/eng/tools/typespec-validation/package.json
+++ b/eng/tools/typespec-validation/package.json
@@ -20,11 +20,14 @@
     "@types/debug": "^4.1.12",
     "@types/node": "^20.0.0",
     "@vitest/coverage-v8": "^3.0.7",
+    "prettier": "~3.5.3",
     "typescript": "~5.8.2",
     "vitest": "^3.0.7"
   },
   "scripts": {
     "build": "tsc --build",
+    "format": "prettier . --ignore-path ../.prettierignore --write",
+    "format:check": "prettier . --ignore-path ../.prettierignore --check",
     "test": "vitest",
     "test:ci": "vitest run --coverage --reporter=verbose"
   },


### PR DESCRIPTION
- Fixes #35544
- Renames GitHub script from "prettier" to "format" (aligns with TypeSpec)
- Enables format PR check for all projects under eng/tools