### PR TITLE
[Storage] Lease operations and `AppendBlobClient` feature parity TypeSpec Changes

### DIFF
--- a/specification/storage/Microsoft.BlobStorage/models.tsp
+++ b/specification/storage/Microsoft.BlobStorage/models.tsp
@@ -2172,7 +2172,7 @@ alias LeaseDurationResponseHeader = {
 alias LeaseDurationHeaderParameter = {
   /** Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires. A non-infinite lease can be between 15 and 60 seconds. A lease duration cannot be changed using renew or change. */
   @header("x-ms-lease-duration")
-  duration?: int32;
+  duration: int32;
 };
 
 /** The container name path parameter */

--- a/specification/storage/Microsoft.BlobStorage/routes.tsp
+++ b/specification/storage/Microsoft.BlobStorage/routes.tsp
@@ -484,7 +484,6 @@ namespace Storage.Blob {
         ...LeaseIdResponseHeader;
         ...EtagResponseHeader;
         ...LastModifiedResponseHeader;
-        ...DateResponseHeader;
       }
     >;
 
@@ -506,7 +505,6 @@ namespace Storage.Blob {
       {
         ...EtagResponseHeader;
         ...LastModifiedResponseHeader;
-        ...DateResponseHeader;
       }
     >;
 
@@ -529,7 +527,6 @@ namespace Storage.Blob {
         ...LeaseIdResponseHeader;
         ...EtagResponseHeader;
         ...LastModifiedResponseHeader;
-        ...DateResponseHeader;
       }
     >;
 
@@ -552,8 +549,6 @@ namespace Storage.Blob {
         ...LeaseTimeResponseHeader;
         ...EtagResponseHeader;
         ...LastModifiedResponseHeader;
-        ...LeaseIdResponseHeader;
-        ...DateResponseHeader;
       }
     >;
 
@@ -577,7 +572,6 @@ namespace Storage.Blob {
         ...LeaseIdResponseHeader;
         ...EtagResponseHeader;
         ...LastModifiedResponseHeader;
-        ...DateResponseHeader;
       }
     >;
 
@@ -1108,7 +1102,6 @@ namespace Storage.Blob {
           @statusCode statusCode: 201;
           ...EtagResponseHeader;
           ...LastModifiedResponseHeader;
-          ...DateResponseHeader;
           ...LeaseIdResponseHeader;
         }
       >;
@@ -1135,7 +1128,6 @@ namespace Storage.Blob {
         {
           ...EtagResponseHeader;
           ...LastModifiedResponseHeader;
-          ...DateResponseHeader;
         }
       >;
 
@@ -1161,7 +1153,6 @@ namespace Storage.Blob {
         {
           ...EtagResponseHeader;
           ...LastModifiedResponseHeader;
-          ...DateResponseHeader;
           ...LeaseIdResponseHeader;
         }
       >;
@@ -1189,7 +1180,6 @@ namespace Storage.Blob {
         {
           ...EtagResponseHeader;
           ...LastModifiedResponseHeader;
-          ...DateResponseHeader;
           ...LeaseIdResponseHeader;
         }
       >;
@@ -1217,7 +1207,6 @@ namespace Storage.Blob {
           @statusCode statusCode: 202;
           ...EtagResponseHeader;
           ...LastModifiedResponseHeader;
-          ...DateResponseHeader;
           ...LeaseTimeResponseHeader;
         }
       >;
@@ -1977,7 +1966,6 @@ namespace Storage.Blob {
             ...LastModifiedResponseHeader;
             ...ContentMd5ResponseHeader;
             ...ContentCrc64ResponseHeader;
-            ...DateResponseHeader;
             ...BlobAppendOffsetResponseHeader;
             ...BlobCommittedBlockCountResponseHeader;
             ...RequestServerEncryptedResponseHeader;
@@ -2031,7 +2019,6 @@ namespace Storage.Blob {
             ...LastModifiedResponseHeader;
             ...ContentMd5ResponseHeader;
             ...ContentCrc64ResponseHeader;
-            ...DateResponseHeader;
             ...BlobAppendOffsetResponseHeader;
             ...BlobCommittedBlockCountResponseHeader;
             ...RequestServerEncryptedResponseHeader;
@@ -2062,7 +2049,6 @@ namespace Storage.Blob {
           {
             ...EtagResponseHeader;
             ...LastModifiedResponseHeader;
-            ...DateResponseHeader;
             ...IsSealedResponseHeader;
           }
         >;

--- a/specification/storage/Microsoft.BlobStorage/routes.tsp
+++ b/specification/storage/Microsoft.BlobStorage/routes.tsp
@@ -484,6 +484,7 @@ namespace Storage.Blob {
         ...LeaseIdResponseHeader;
         ...EtagResponseHeader;
         ...LastModifiedResponseHeader;
+        ...DateResponseHeaderPrivate;
       }
     >;
 
@@ -505,6 +506,7 @@ namespace Storage.Blob {
       {
         ...EtagResponseHeader;
         ...LastModifiedResponseHeader;
+        ...DateResponseHeaderPrivate;
       }
     >;
 
@@ -527,6 +529,7 @@ namespace Storage.Blob {
         ...LeaseIdResponseHeader;
         ...EtagResponseHeader;
         ...LastModifiedResponseHeader;
+        ...DateResponseHeaderPrivate;
       }
     >;
 
@@ -549,6 +552,7 @@ namespace Storage.Blob {
         ...LeaseTimeResponseHeader;
         ...EtagResponseHeader;
         ...LastModifiedResponseHeader;
+        ...DateResponseHeaderPrivate;
       }
     >;
 
@@ -572,6 +576,7 @@ namespace Storage.Blob {
         ...LeaseIdResponseHeader;
         ...EtagResponseHeader;
         ...LastModifiedResponseHeader;
+        ...DateResponseHeaderPrivate;
       }
     >;
 
@@ -1103,6 +1108,7 @@ namespace Storage.Blob {
           ...EtagResponseHeader;
           ...LastModifiedResponseHeader;
           ...LeaseIdResponseHeader;
+          ...DateResponseHeaderPrivate;
         }
       >;
 
@@ -1128,6 +1134,7 @@ namespace Storage.Blob {
         {
           ...EtagResponseHeader;
           ...LastModifiedResponseHeader;
+          ...DateResponseHeaderPrivate;
         }
       >;
 
@@ -1154,6 +1161,7 @@ namespace Storage.Blob {
           ...EtagResponseHeader;
           ...LastModifiedResponseHeader;
           ...LeaseIdResponseHeader;
+          ...DateResponseHeaderPrivate;
         }
       >;
 
@@ -1181,6 +1189,7 @@ namespace Storage.Blob {
           ...EtagResponseHeader;
           ...LastModifiedResponseHeader;
           ...LeaseIdResponseHeader;
+          ...DateResponseHeaderPrivate;
         }
       >;
 
@@ -1208,6 +1217,7 @@ namespace Storage.Blob {
           ...EtagResponseHeader;
           ...LastModifiedResponseHeader;
           ...LeaseTimeResponseHeader;
+          ...DateResponseHeaderPrivate;
         }
       >;
 
@@ -1966,6 +1976,7 @@ namespace Storage.Blob {
             ...LastModifiedResponseHeader;
             ...ContentMd5ResponseHeader;
             ...ContentCrc64ResponseHeader;
+            ...DateResponseHeaderPrivate;
             ...BlobAppendOffsetResponseHeader;
             ...BlobCommittedBlockCountResponseHeader;
             ...RequestServerEncryptedResponseHeader;
@@ -2019,6 +2030,7 @@ namespace Storage.Blob {
             ...LastModifiedResponseHeader;
             ...ContentMd5ResponseHeader;
             ...ContentCrc64ResponseHeader;
+            ...DateResponseHeaderPrivate;
             ...BlobAppendOffsetResponseHeader;
             ...BlobCommittedBlockCountResponseHeader;
             ...RequestServerEncryptedResponseHeader;
@@ -2049,6 +2061,7 @@ namespace Storage.Blob {
           {
             ...EtagResponseHeader;
             ...LastModifiedResponseHeader;
+            ...DateResponseHeaderPrivate;
             ...IsSealedResponseHeader;
           }
         >;


### PR DESCRIPTION
This PR introduces the following:

- Makes `x-ms-lease-duration` a required parameter in all instances that the alias `LeaseDurationHeaderParameter` is used (`acquire_lease` API)

**Leasing Operations**

**`BlobClient` Lease Operations:**
`acquire_lease`
-  ̶d̶a̶t̶e̶
- last_modified
- etag
- lease_id

`break_lease`
- d̶a̶t̶e̶
- last_modified
- etag
- lease_time

`change_lease`
- d̶a̶t̶e̶
- last_modified
- etag
- lease_id

`release_lease`
- d̶a̶t̶e̶
- last_modified
- etag

`renew_lease`
-  ̶d̶a̶t̶e̶
- last_modified
- etag
- lease_id

**`BlobContainerClient` Lease Operations:**
`acquire_lease`
-  ̶d̶a̶t̶e̶
- last_modified
- etag
- lease_id

`break_lease`
- d̶a̶t̶e̶
- last_modified
- etag
-  ̶l̶e̶a̶s̶e̶_̶i̶d̶
- lease_time

`change_lease`
- d̶a̶t̶e̶
- last_modified
- etag
- lease_id

`release_lease`
- d̶a̶t̶e̶
- last_modified
- etag

`renew_lease`
-  ̶d̶a̶t̶e̶
- last_modified
- etag
- lease_id

**AppendBlobClient APIs**

`append_block`
- content_md5
- d̶a̶t̶e̶
- last_modified
- etag
- blob_append_offset
- blob_commited_block_count
- content_crc64
- encryption_key_sha256
- encryption_scope
- is_server_encrypted

`append_block_from_url`
- content_md5
- d̶a̶t̶e̶
- last_modified
- etag
- blob_append_offset
- blob_commited_block_count
- content_crc64
- encryption_key_sha256
- encryption_scope
- is_server_encrypted

`seal`
- d̶a̶t̶e̶
- last_modified
- etag
- is_sealed