### PR TITLE
[TypeSpecValidation] Only "main" and "RPSaaSMaster" should validate all specs on core changes

### DIFF
--- a/.github/workflows/typespec-validation.yaml
+++ b/.github/workflows/typespec-validation.yaml
@@ -27,5 +27,5 @@ jobs:
           # Only "main" and "RPSaaSMaster" should validate all specs if core files change
           $isProduction = @('main', 'RPSaaSMaster') -contains $Env:GITHUB_BASE_REF
 
-          ./eng/scripts/TypeSpec-Validation.ps1 -GitClean -Verbose -IgnoreCoreFiles:!$isProduction
+          ./eng/scripts/TypeSpec-Validation.ps1 -GitClean -Verbose -IgnoreCoreFiles:!($isProduction)
         shell: pwsh

--- a/.github/workflows/typespec-validation.yaml
+++ b/.github/workflows/typespec-validation.yaml
@@ -24,5 +24,8 @@ jobs:
           # step as failed. 
           $ErrorActionPreference = 'Continue'
 
-          ./eng/scripts/TypeSpec-Validation.ps1 -GitClean -Verbose
+          # Branches named "release-*" should ignore core files to allow PRs merging from main
+          $ignoreCoreFiles = $Env:GITHUB_BASE_REF -like 'release-*'
+
+          ./eng/scripts/TypeSpec-Validation.ps1 -GitClean -Verbose -IgnoreCoreFiles:$ignoreCoreFiles
         shell: pwsh

--- a/.github/workflows/typespec-validation.yaml
+++ b/.github/workflows/typespec-validation.yaml
@@ -25,7 +25,7 @@ jobs:
           $ErrorActionPreference = 'Continue'
 
           # Only "main" and "RPSaaSMaster" should validate all specs if core files change
-          $isProduction = @('main', 'RPSaaSMaster') -contains $Env:GITHUB_BASE_REF
+          $ignoreCoreFiles = -not (@('main', 'RPSaaSMaster') -contains $Env:GITHUB_BASE_REF)
 
-          ./eng/scripts/TypeSpec-Validation.ps1 -GitClean -Verbose -IgnoreCoreFiles:!($isProduction)
+          ./eng/scripts/TypeSpec-Validation.ps1 -GitClean -Verbose -IgnoreCoreFiles:$ignoreCoreFiles
         shell: pwsh

--- a/.github/workflows/typespec-validation.yaml
+++ b/.github/workflows/typespec-validation.yaml
@@ -24,8 +24,8 @@ jobs:
           # step as failed. 
           $ErrorActionPreference = 'Continue'
 
-          # Branches named "release-*" should ignore core files to allow PRs merging from main
-          $ignoreCoreFiles = $Env:GITHUB_BASE_REF -like 'release-*'
+          # Only "main" and "RPSaaSMaster" should validate all specs if core files change
+          $isProduction = @('main', 'RPSaaSMaster') -contains $Env:GITHUB_BASE_REF
 
-          ./eng/scripts/TypeSpec-Validation.ps1 -GitClean -Verbose -IgnoreCoreFiles:$ignoreCoreFiles
+          ./eng/scripts/TypeSpec-Validation.ps1 -GitClean -Verbose -IgnoreCoreFiles:!$isProduction
         shell: pwsh

--- a/eng/scripts/TypeSpec-Validation.ps1
+++ b/eng/scripts/TypeSpec-Validation.ps1
@@ -1,5 +1,6 @@
 [CmdletBinding()]
 param (
+  [switch]$IgnoreCoreFiles = $false,
   [switch]$CheckAll = $false,
   [int]$Shard = 0,
   [int]$TotalShards = 1,
@@ -20,7 +21,8 @@ if ($TotalShards -gt 0 -and $Shard -ge $TotalShards) {
 $typespecFolders, $checkedAll = &"$PSScriptRoot/Get-TypeSpec-Folders.ps1" `
   -BaseCommitish:$BaseCommitish `
   -HeadCommitish:$HeadCommitish `
-  -CheckAll:$CheckAll
+  -CheckAll:$CheckAll `
+  -IgnoreCoreFiles:$IgnoreCoreFiles
 
 if ($TotalShards -gt 1 -and $TotalShards -le $typespecFolders.Count) { 
   $typespecFolders = shardArray $typespecFolders $Shard $TotalShards


### PR DESCRIPTION
Unblocks PRs merging from main, like https://github.com/Azure/azure-rest-api-specs-pr/pull/23405