### PR TITLE
[EngSys] Verbose lint logging in .github

### DIFF
--- a/.github/package-lock.json
+++ b/.github/package-lock.json
@@ -20,6 +20,7 @@
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^20.0.0",
         "@vitest/coverage-v8": "^3.0.7",
+        "cross-env": "^7.0.3",
         "eslint": "^9.22.0",
         "globals": "^16.0.0",
         "prettier": "~3.5.3",
@@ -1904,6 +1905,25 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/.github/package.json
+++ b/.github/package.json
@@ -21,6 +21,7 @@
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.0.0",
     "@vitest/coverage-v8": "^3.0.7",
+    "cross-env": "^7.0.3",
     "eslint": "^9.22.0",
     "globals": "^16.0.0",
     "prettier": "~3.5.3",
@@ -30,8 +31,8 @@
   },
   "scripts": {
     "lint": "npm run lint:eslint && npm run lint:tsc",
-    "lint:eslint": "eslint",
-    "lint:tsc": "tsc && echo 'Type checking completed successfully'",
+    "lint:eslint": "cross-env DEBUG=eslint:eslint eslint",
+    "lint:tsc": "tsc --build --verbose",
     "format": "prettier . --write",
     "format:check": "prettier . --check",
     "format:check:ci": "prettier . --check --log-level debug",

--- a/.github/shared/package-lock.json
+++ b/.github/shared/package-lock.json
@@ -22,6 +22,7 @@
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^20.0.0",
         "@vitest/coverage-v8": "^3.0.7",
+        "cross-env": "^7.0.3",
         "eslint": "^9.22.0",
         "globals": "^16.0.0",
         "prettier": "~3.5.3",
@@ -1585,6 +1586,25 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/.github/shared/package.json
+++ b/.github/shared/package.json
@@ -42,6 +42,7 @@
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.0.0",
     "@vitest/coverage-v8": "^3.0.7",
+    "cross-env": "^7.0.3",
     "eslint": "^9.22.0",
     "globals": "^16.0.0",
     "prettier": "~3.5.3",
@@ -51,8 +52,8 @@
   },
   "scripts": {
     "lint": "npm run lint:eslint && npm run lint:tsc",
-    "lint:eslint": "eslint",
-    "lint:tsc": "tsc && echo 'Type checking completed successfully'",
+    "lint:eslint": "cross-env DEBUG=eslint:eslint eslint",
+    "lint:tsc": "tsc --build --verbose",
     "format": "prettier . --ignore-path ../.prettierignore --write",
     "format:check": "prettier . --ignore-path ../.prettierignore --check",
     "format:check:ci": "prettier . --ignore-path ../.prettierignore --check --log-level debug",

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^20.0.0",
         "@vitest/coverage-v8": "^3.0.7",
+        "cross-env": "^7.0.3",
         "eslint": "^9.22.0",
         "globals": "^16.0.0",
         "prettier": "~3.5.3",
@@ -6407,6 +6408,25 @@
       "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",


### PR DESCRIPTION
- Makes lint logging more verbose to ensure it's working

# Before
```
~/specs-mh/.github$ npm run lint

> lint
> npm run lint:eslint && npm run lint:tsc

> lint:eslint
> eslint

> lint:tsc
> tsc && echo 'Type checking completed successfully'

Type checking completed successfully
```

# After
```
~/specs-mh/.github$ npm run lint

> lint
> npm run lint:eslint && npm run lint:tsc


> lint:eslint
> cross-env DEBUG=eslint:eslint eslint

  eslint:eslint Using config loader LegacyConfigLoader +0ms
  eslint:eslint Using file patterns: . +1ms
  eslint:eslint Deleting cache file at /home/mharder/specs-mh/.github/.eslintcache +0ms
  eslint:eslint 65 files found in: 131ms +131ms
  eslint:eslint Lint /home/mharder/specs-mh/.github/eslint.config.js +26ms
  ...
  eslint:eslint Lint /home/mharder/specs-mh/.github/workflows/src/github.js +3ms

> lint:tsc
> tsc --build --verbose

[9:59:18 PM] Projects in this build:
    * tsconfig.json
[9:59:18 PM] Project 'tsconfig.json' is out of date because output file 'tsconfig.tsbuildinfo' does not exist
[9:59:18 PM] Building project '/home/mharder/specs-mh/.github/tsconfig.json'...
```