### PR TITLE
Add testIds filter for ListTestRuns

### DIFF
--- a/specification/loadtestservice/LoadTestService/models.tsp
+++ b/specification/loadtestservice/LoadTestService/models.tsp
@@ -1347,7 +1347,7 @@ model ListTestRunQueryParams {
   @added(APIVersions.v2024_07_01_preview)
   createdByTypes?: string[];
 
-  @doc("Comma separated set of test IDs.")
+  @doc("Comma-separated list of test IDs. If you are using testIds, do not send a value for testId.")
   @query(#{ explode: false })
   @added(APIVersions.v2025_03_01_preview)
   testIds?: string[];

--- a/specification/loadtestservice/LoadTestService/models.tsp
+++ b/specification/loadtestservice/LoadTestService/models.tsp
@@ -1346,6 +1346,11 @@ model ListTestRunQueryParams {
   @query(#{ explode: false })
   @added(APIVersions.v2024_07_01_preview)
   createdByTypes?: string[];
+
+  @doc("Comma separated set of test IDs.")
+  @query(#{ explode: false })
+  @added(APIVersions.v2025_03_01_preview)
+  testIds?: string[];
 }
 
 @doc("Parameters for list test operation")

--- a/specification/loadtestservice/data-plane/Microsoft.LoadTestService/preview/2025-03-01-preview/examples/ListTestRuns_TestIds.json
+++ b/specification/loadtestservice/data-plane/Microsoft.LoadTestService/preview/2025-03-01-preview/examples/ListTestRuns_TestIds.json
@@ -1,6 +1,6 @@
 {
-  "operationId": "LoadTestRun_ListTestRuns_TestIds",
-  "title": "List test runs.",
+  "operationId": "LoadTestRun_ListTestRuns",
+  "title": "List test runs filtered by multiple testIds.",
   "parameters": {
     "testIds": "12345678-1234-1234-1234-123456789012,23456789-2345-2345-2345-234567890123",
     "orderBy": "executedDateTime",

--- a/specification/loadtestservice/data-plane/Microsoft.LoadTestService/preview/2025-03-01-preview/examples/ListTestRuns_TestIds.json
+++ b/specification/loadtestservice/data-plane/Microsoft.LoadTestService/preview/2025-03-01-preview/examples/ListTestRuns_TestIds.json
@@ -1,5 +1,5 @@
 {
-  "operationId": "LoadTestRun_ListTestRuns",
+  "operationId": "LoadTestRun_ListTestRuns_TestIds",
   "title": "List test runs.",
   "parameters": {
     "testIds": "12345678-1234-1234-1234-123456789012,23456789-2345-2345-2345-234567890123",

--- a/specification/loadtestservice/data-plane/Microsoft.LoadTestService/preview/2025-03-01-preview/examples/ListTestRuns_TestIds.json
+++ b/specification/loadtestservice/data-plane/Microsoft.LoadTestService/preview/2025-03-01-preview/examples/ListTestRuns_TestIds.json
@@ -1,0 +1,306 @@
+{
+  "operationId": "LoadTestRun_ListTestRuns",
+  "title": "List test runs.",
+  "parameters": {
+    "testIds": "12345678-1234-1234-1234-123456789012,23456789-2345-2345-2345-234567890123",
+    "orderBy": "executedDateTime",
+    "continuationToken": "continuation token",
+    "search": "Performance_LoadTest_Run1",
+    "executionFrom": "2021-12-05T16:43:48.805Z",
+    "executionTo": "2021-12-05T16:43:48.805Z",
+    "status": "DONE,EXECUTING",
+    "maxPageSize": 30,
+    "api-version": "2025-03-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "testRunId": "12316678-1234-1234-1234-122451189012",
+            "displayName": "Performance_LoadTest_Run1",
+            "testId": "12345678-1234-1234-1234-123456789012",
+            "description": "sample description",
+            "status": "DONE",
+            "startDateTime": "2021-12-05T16:43:48.125Z",
+            "endDateTime": "2021-12-05T16:43:48.125Z",
+            "kind": "JMX",
+            "loadTestConfiguration": {
+              "engineInstances": 6,
+              "splitAllCSVs": true,
+              "regionalLoadTestConfig": [
+                {
+                  "engineInstances": 4,
+                  "region": "northeurope"
+                },
+                {
+                  "engineInstances": 2,
+                  "region": "westeurope"
+                }
+              ]
+            },
+            "testResult": "PASSED",
+            "passFailCriteria": {
+              "passFailMetrics": {
+                "fefd759d-7fe8-4f83-8b6d-aeebe0f491fe": {
+                  "clientMetric": "response_time_ms",
+                  "aggregate": "percentage",
+                  "condition": ">",
+                  "value": 10,
+                  "action": "continue",
+                  "actualValue": 10,
+                  "result": "passed"
+                }
+              },
+              "passFailServerMetrics": {
+                "fefd759d-7fe8-4f83-8b6d-aeebe0f491fe": {
+                  "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789abc/resourceGroups/MyResourceGroup/providers/Microsoft.Compute/virtualMachines/MyVM",
+                  "metricNamespace": "Microsoft.Compute/virtualMachines",
+                  "metricName": "Percentage CPU",
+                  "aggregation": "Average",
+                  "condition": ">",
+                  "value": 20,
+                  "action": "continue"
+                }
+              }
+            },
+            "autoStopCriteria": {
+              "autoStopDisabled": true,
+              "errorRate": 70,
+              "errorRateTimeWindowInSeconds": 60,
+              "maximumVirtualUsersPerEngine": 5000
+            },
+            "testArtifacts": {
+              "inputArtifacts": {
+                "configFileInfo": {
+                  "url": "https://somestorageaccount.blob.core.windows.net/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000.yaml?sv=2019-12-12&st=2021-01-26T18%3A30%3A20Z&se=2021-02-05T18%3A30%3A00Z&sr=c&sp=rl&sig=d7PZKyQsIeE6xb%2B1M4Yb56I%2FEEKoNIF65D%2Fs0IFsYcE%3D",
+                  "fileName": "config.yaml",
+                  "fileType": "ADDITIONAL_ARTIFACTS",
+                  "expireDateTime": "2021-12-05T16:43:46.072Z",
+                  "validationStatus": ""
+                },
+                "testScriptFileInfo": {
+                  "url": "https://somestorageaccount.blob.core.windows.net/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000.jmx?sv=2019-12-12&st=2021-01-26T18%3A30%3A20Z&se=2021-02-05T18%3A30%3A00Z&sr=c&sp=rl&sig=d7PZKyQsIeE6xb%2B1M4Yb56I%2FEEKoNIF65D%2Fs0IFsYcE%3D",
+                  "fileName": "sample.jmx",
+                  "fileType": "JMX_FILE",
+                  "expireDateTime": "2021-12-05T16:43:46.072Z",
+                  "validationStatus": "VALIDATION_SUCCESS"
+                },
+                "userPropFileInfo": {
+                  "url": "https://somestorageaccount.blob.core.windows.net/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000.properties?sv=2019-12-12&st=2021-01-26T18%3A30%3A20Z&se=2021-02-05T18%3A30%3A00Z&sr=c&sp=rl&sig=d7PZKyQsIeE6xb%2B1M4Yb56I%2FEEKoNIF65D%2Fs0IFsYcE%3D",
+                  "fileName": "user.properties",
+                  "fileType": "USER_PROPERTIES",
+                  "expireDateTime": "2021-12-05T16:43:46.072Z",
+                  "validationStatus": ""
+                },
+                "inputArtifactsZipFileInfo": {
+                  "url": "https://somestorageaccount.blob.core.windows.net/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000.zip?sv=2019-12-12&st=2021-01-26T18%3A30%3A20Z&se=2021-02-05T18%3A30%3A00Z&sr=c&sp=rl&sig=d7PZKyQsIeE6xb%2B1M4Yb56I%2FEEKoNIF65D%2Fs0IFsYcE%3D",
+                  "fileName": "inputartifacts.zip",
+                  "fileType": "ADDITIONAL_ARTIFACTS",
+                  "expireDateTime": "2021-12-05T16:43:46.072Z",
+                  "validationStatus": ""
+                },
+                "additionalFileInfo": []
+              },
+              "outputArtifacts": {
+                "resultFileInfo": {
+                  "url": "https://somestorageaccount.blob.core.windows.net/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000.zip?sv=2019-12-12&st=2021-01-26T18%3A30%3A20Z&se=2021-02-05T18%3A30%3A00Z&sr=c&sp=rl&sig=d7PZKyQsIeE6xb%2B1M4Yb56I%2FEEKoNIF65D%2Fs0IFsYcE%3D",
+                  "fileName": "sample.jmx",
+                  "fileType": "JMX_FILE",
+                  "expireDateTime": "2021-12-05T16:43:46.072Z",
+                  "validationStatus": "VALIDATION_SUCCESS"
+                },
+                "logsFileInfo": {
+                  "url": "https://somestorageaccount.blob.core.windows.net/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000.zip?sv=2019-12-12&st=2021-01-26T18%3A30%3A20Z&se=2021-02-05T18%3A30%3A00Z&sr=c&sp=rl&sig=d7PZKyQsIeE6xb%2B1M4Yb56I%2FEEKoNIF65D%2Fs0IFsYcE%3D",
+                  "fileName": "worker.log",
+                  "fileType": "ADDITIONAL_ARTIFACTS",
+                  "expireDateTime": "2022-05-16T09:14:46.0411793+00:00",
+                  "validationStatus": ""
+                }
+              }
+            },
+            "executedDateTime": "2021-12-05T16:43:48.125Z",
+            "virtualUsers": 4,
+            "virtualUserHours": 20.50,
+            "testRunStatistics": {
+              "Total": {
+                "transaction": "Total",
+                "sampleCount": 18,
+                "errorCount": 19,
+                "errorPct": 17,
+                "meanResTime": 13,
+                "medianResTime": 10,
+                "maxResTime": 16,
+                "minResTime": 18,
+                "pct1ResTime": 27,
+                "pct2ResTime": 20,
+                "pct3ResTime": 3,
+                "throughput": 5,
+                "receivedKBytesPerSec": 13,
+                "sentKBytesPerSec": 4
+              }
+            },
+            "createdDateTime": "2021-12-05T16:43:46.072Z",
+            "createdBy": "user@contoso.com",
+            "lastModifiedDateTime": "2021-12-05T16:43:46.072Z",
+            "lastModifiedBy": "user@contoso.com",
+            "portalUrl": "https://portal.azure.com/dummyresource",
+            "secrets": {
+              "secret1": {
+                "value": "https://samplevault.vault.azure.net/secrets/samplesecret/f113f91fd4c44a368049849c164db827",
+                "type": "AKV_SECRET_URI"
+              }
+            },
+            "environmentVariables": {
+              "envvar1": "sampletext"
+            },
+            "duration": 18,
+            "subnetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/samplerg/providers/Microsoft.Network/virtualNetworks/samplenetworkresource/subnets/AAAAA0A0A0"
+          },
+          {
+            "testRunId": "12316678-1234-1234-1234-122451189013",
+            "displayName": "Performance_LoadTest_Run2",
+            "testId": "12345678-1234-1234-1234-123456789013",
+            "description": "sample description 2",
+            "status": "DONE",
+            "startDateTime": "2021-12-05T16:43:48.125Z",
+            "endDateTime": "2021-12-05T16:43:48.125Z",
+            "kind": "Locust",
+            "loadTestConfiguration": {
+              "engineInstances": 6,
+              "splitAllCSVs": false,
+              "regionalLoadTestConfig": [
+                {
+                  "engineInstances": 4,
+                  "region": "northeurope"
+                },
+                {
+                  "engineInstances": 2,
+                  "region": "westeurope"
+                }
+              ]
+            },
+            "testResult": "PASSED",
+            "passFailCriteria": {
+              "passFailMetrics": {
+                "fefd759d-7fe8-4f83-8b6d-aeebe0f491fe": {
+                  "clientMetric": "response_time_ms",
+                  "aggregate": "percentage",
+                  "condition": ">",
+                  "value": 10,
+                  "action": "continue",
+                  "actualValue": 10,
+                  "result": "passed"
+                }
+              },
+              "passFailServerMetrics": {
+                "fefd759d-7fe8-4f83-8b6d-aeebe0f491fe": {
+                  "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789abc/resourceGroups/MyResourceGroup/providers/Microsoft.Compute/virtualMachines/MyVM",
+                  "metricNamespace": "Microsoft.Compute/virtualMachines",
+                  "metricName": "Percentage CPU",
+                  "aggregation": "Average",
+                  "condition": ">",
+                  "value": 20,
+                  "action": "continue"
+                }
+              }
+            },
+            "autoStopCriteria": {
+              "autoStopDisabled": true,
+              "errorRate": 70,
+              "errorRateTimeWindowInSeconds": 60,
+              "maximumVirtualUsersPerEngine": 5000
+            },
+            "testArtifacts": {
+              "inputArtifacts": {
+                "configFileInfo": {
+                  "url": "https://somestorageaccount.blob.core.windows.net/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000.yaml?sv=2019-12-12&st=2021-01-26T18%3A30%3A20Z&se=2021-02-05T18%3A30%3A00Z&sr=c&sp=rl&sig=d7PZKyQsIeE6xb%2B1M4Yb56I%2FEEKoNIF65D%2Fs0IFsYcE%3D",
+                  "fileName": "config.yaml",
+                  "fileType": "ADDITIONAL_ARTIFACTS",
+                  "expireDateTime": "2021-12-05T16:43:46.072Z",
+                  "validationStatus": ""
+                },
+                "testScriptFileInfo": {
+                  "url": "https://somestorageaccount.blob.core.windows.net/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000.jmx?sv=2019-12-12&st=2021-01-26T18%3A30%3A20Z&se=2021-02-05T18%3A30%3A00Z&sr=c&sp=rl&sig=d7PZKyQsIeE6xb%2B1M4Yb56I%2FEEKoNIF65D%2Fs0IFsYcE%3D",
+                  "fileName": "sample.jmx",
+                  "fileType": "JMX_FILE",
+                  "expireDateTime": "2021-12-05T16:43:46.072Z",
+                  "validationStatus": "VALIDATION_SUCCESS"
+                },
+                "userPropFileInfo": {
+                  "url": "https://somestorageaccount.blob.core.windows.net/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000.properties?sv=2019-12-12&st=2021-01-26T18%3A30%3A20Z&se=2021-02-05T18%3A30%3A00Z&sr=c&sp=rl&sig=d7PZKyQsIeE6xb%2B1M4Yb56I%2FEEKoNIF65D%2Fs0IFsYcE%3D",
+                  "fileName": "user.properties",
+                  "fileType": "USER_PROPERTIES",
+                  "expireDateTime": "2021-12-05T16:43:46.072Z",
+                  "validationStatus": ""
+                },
+                "inputArtifactsZipFileInfo": {
+                  "url": "https://somestorageaccount.blob.core.windows.net/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000.zip?sv=2019-12-12&st=2021-01-26T18%3A30%3A20Z&se=2021-02-05T18%3A30%3A00Z&sr=c&sp=rl&sig=d7PZKyQsIeE6xb%2B1M4Yb56I%2FEEKoNIF65D%2Fs0IFsYcE%3D",
+                  "fileName": "inputartifacts.zip",
+                  "fileType": "ADDITIONAL_ARTIFACTS",
+                  "expireDateTime": "2021-12-05T16:43:46.072Z",
+                  "validationStatus": ""
+                },
+                "additionalFileInfo": []
+              },
+              "outputArtifacts": {
+                "resultFileInfo": {
+                  "url": "https://somestorageaccount.blob.core.windows.net/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000.zip?sv=2019-12-12&st=2021-01-26T18%3A30%3A20Z&se=2021-02-05T18%3A30%3A00Z&sr=c&sp=rl&sig=d7PZKyQsIeE6xb%2B1M4Yb56I%2FEEKoNIF65D%2Fs0IFsYcE%3D",
+                  "fileName": "sample.jmx",
+                  "fileType": "JMX_FILE",
+                  "expireDateTime": "2021-12-05T16:43:46.072Z",
+                  "validationStatus": "VALIDATION_SUCCESS"
+                },
+                "logsFileInfo": {
+                  "url": "https://somestorageaccount.blob.core.windows.net/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000.zip?sv=2019-12-12&st=2021-01-26T18%3A30%3A20Z&se=2021-02-05T18%3A30%3A00Z&sr=c&sp=rl&sig=d7PZKyQsIeE6xb%2B1M4Yb56I%2FEEKoNIF65D%2Fs0IFsYcE%3D",
+                  "fileName": "worker.log",
+                  "fileType": "ADDITIONAL_ARTIFACTS",
+                  "expireDateTime": "2022-05-16T09:14:46.0411793+00:00",
+                  "validationStatus": ""
+                }
+              }
+            },
+            "executedDateTime": "2021-12-05T16:43:48.125Z",
+            "virtualUsers": 4,
+            "virtualUserHours": 20.50,
+            "testRunStatistics": {
+              "Total": {
+                "transaction": "Total",
+                "sampleCount": 18,
+                "errorCount": 19,
+                "errorPct": 17,
+                "meanResTime": 13,
+                "medianResTime": 10,
+                "maxResTime": 16,
+                "minResTime": 18,
+                "pct1ResTime": 27,
+                "pct2ResTime": 20,
+                "pct3ResTime": 3,
+                "throughput": 5,
+                "receivedKBytesPerSec": 13,
+                "sentKBytesPerSec": 4
+              }
+            },
+            "createdDateTime": "2021-12-05T16:43:46.072Z",
+            "createdBy": "user@contoso.com",
+            "lastModifiedDateTime": "2021-12-05T16:43:46.072Z",
+            "lastModifiedBy": "user@contoso.com",
+            "portalUrl": "https://portal.azure.com/dummyresource",
+            "secrets": {
+              "secret1": {
+                "value": "https://samplevault.vault.azure.net/secrets/samplesecret/f113f91fd4c44a368049849c164db827",
+                "type": "AKV_SECRET_URI"
+              }
+            },
+            "environmentVariables": {
+              "envvar1": "sampletext"
+            },
+            "duration": 18,
+            "subnetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/samplerg/providers/Microsoft.Network/virtualNetworks/samplenetworkresource/subnets/AAAAA0A0A0"
+          }
+        ],
+        "nextLink": "https://nextlink.com"
+      }
+    }
+  }
+}

--- a/specification/loadtestservice/data-plane/Microsoft.LoadTestService/preview/2025-03-01-preview/loadtestservice.json
+++ b/specification/loadtestservice/data-plane/Microsoft.LoadTestService/preview/2025-03-01-preview/loadtestservice.json
@@ -7401,6 +7401,18 @@
       "type": "string",
       "x-ms-parameter-location": "method"
     },
+    "ListTestRunQueryParams.testIds": {
+      "name": "testIds",
+      "in": "query",
+      "description": "Comma separated list of test IDs to filter for test runs.",
+      "required": false,
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "collectionFormat": "csv",
+      "x-ms-parameter-location": "method"
+    },
     "ListTriggerQueryParams.lastModifiedEndTime": {
       "name": "lastModifiedEndTime",
       "in": "query",


### PR DESCRIPTION
Add new query param `testIds` to `ListTestRunQueryParams` model in `LoadTestService` to filter test runs by multiple test IDs.
This is for the upcoming `2025-03-01-public-preview` release