### PR TITLE
[EngSys] Improve set-status to dynamically detect job summaries

### DIFF
--- a/.github/workflows/_reusable-set-check-status.yml
+++ b/.github/workflows/_reusable-set-check-status.yml
@@ -16,11 +16,6 @@ on:
         description: Comma-separated list of labels that, when any is set, causes the check to always pass
         required: true
         type: string
-      failure_target:
-        description: On failure, should target_url point to the "job" or "run"?  Use "run" if you create a job summary, else "job" which points to the failing step.
-        required: false
-        default: job
-        type: string
 
 permissions:
   actions: read
@@ -69,6 +64,5 @@ jobs:
               { github, context, core }, 
               '${{ inputs.monitored_workflow_name }}',
               '${{ inputs.required_check_name }}',
-              '${{ inputs.overriding_label }}',
-              '${{ inputs.failure_target }}'
+              '${{ inputs.overriding_label }}'
             );

--- a/.github/workflows/lintdiff-code.yaml
+++ b/.github/workflows/lintdiff-code.yaml
@@ -51,7 +51,10 @@ jobs:
 
       # TODO: Could be github.sha for merge commit
       - name: Run LintDiff
+        id: run-lintdiff
         run: |
+          echo "summary=$GITHUB_STEP_SUMMARY" >> $GITHUB_OUTPUT
+
           npm exec --no -- lint-diff \
             --before before \
             --after after \
@@ -64,10 +67,12 @@ jobs:
           # default.
           NODE_OPTIONS: "--max-old-space-size=8192"
 
-      # Used by set-status.js to set failure targetUrl to job summary
+      # Used by other workflows like set-status
       - name: Set job-summary artifact
-        if: ${{ !cancelled() }}
-        uses: ./.github/actions/add-empty-artifact
+        if: ${{ steps.run-lintdiff.outputs.summary }}
+        uses: actions/upload-artifact@v4
         with:
-          name: "job-summary"
-          value: "true"
+          name: job-summary
+          path: ${{ steps.run-lintdiff.outputs.summary }}
+          # If the file doesn't exist, just don't add the label
+          if-no-files-found: ignore

--- a/.github/workflows/lintdiff-code.yaml
+++ b/.github/workflows/lintdiff-code.yaml
@@ -69,7 +69,7 @@ jobs:
 
       # Used by other workflows like set-status
       - name: Set job-summary artifact
-        if: ${{ steps.run-lintdiff.outputs.summary }}
+        if: ${{ always() && steps.run-lintdiff.outputs.summary }}
         uses: actions/upload-artifact@v4
         with:
           name: job-summary

--- a/.github/workflows/lintdiff-code.yaml
+++ b/.github/workflows/lintdiff-code.yaml
@@ -66,6 +66,7 @@ jobs:
 
       # Used by set-status.js to set failure targetUrl to job summary
       - name: Set job-summary=true
+        if: ${{ !cancelled() }}
         uses: ./.github/actions/add-empty-artifact
         with:
           name: "job-summary"

--- a/.github/workflows/lintdiff-code.yaml
+++ b/.github/workflows/lintdiff-code.yaml
@@ -63,3 +63,10 @@ jobs:
           # Some LintDiff runs are memory intensive and require more than the
           # default.
           NODE_OPTIONS: "--max-old-space-size=8192"
+
+      # Used by set-status.js to set failure targetUrl to job summary
+      - name: Set job-summary=true
+        uses: ./.github/actions/add-empty-artifact
+        with:
+          name: "job-summary"
+          value: "true"

--- a/.github/workflows/lintdiff-code.yaml
+++ b/.github/workflows/lintdiff-code.yaml
@@ -74,5 +74,5 @@ jobs:
         with:
           name: job-summary
           path: ${{ steps.run-lintdiff.outputs.summary }}
-          # If the file doesn't exist, just don't add the label
+          # If the file doesn't exist, just don't add the artifact
           if-no-files-found: ignore

--- a/.github/workflows/lintdiff-code.yaml
+++ b/.github/workflows/lintdiff-code.yaml
@@ -60,7 +60,6 @@ jobs:
             --base-branch ${{ github.event.pull_request.base.ref }} \
             --compare-sha ${{ github.event.pull_request.head.sha }} \
             --out-file $GITHUB_STEP_SUMMARY
-          echo "job-summary=true" >> $GITHUB_OUTPUT
         env:
           # Some LintDiff runs are memory intensive and require more than the
           # default.
@@ -68,7 +67,7 @@ jobs:
 
       # Used by set-status.js to set failure targetUrl to job summary
       - name: Set job-summary artifact
-        if: ${{ steps.run-lintdiff.outputs.job-summary == 'true' }}
+        if: ${{ !cancelled() }}
         uses: ./.github/actions/add-empty-artifact
         with:
           name: "job-summary"

--- a/.github/workflows/lintdiff-code.yaml
+++ b/.github/workflows/lintdiff-code.yaml
@@ -51,7 +51,6 @@ jobs:
 
       # TODO: Could be github.sha for merge commit
       - name: Run LintDiff
-        id: run-lintdiff
         run: |
           npm exec --no -- lint-diff \
             --before before \

--- a/.github/workflows/lintdiff-code.yaml
+++ b/.github/workflows/lintdiff-code.yaml
@@ -51,6 +51,7 @@ jobs:
 
       # TODO: Could be github.sha for merge commit
       - name: Run LintDiff
+        id: run-lintdiff
         run: |
           npm exec --no -- lint-diff \
             --before before \
@@ -59,14 +60,15 @@ jobs:
             --base-branch ${{ github.event.pull_request.base.ref }} \
             --compare-sha ${{ github.event.pull_request.head.sha }} \
             --out-file $GITHUB_STEP_SUMMARY
+          echo "job-summary=true" >> $GITHUB_OUTPUT
         env:
           # Some LintDiff runs are memory intensive and require more than the
           # default.
           NODE_OPTIONS: "--max-old-space-size=8192"
 
       # Used by set-status.js to set failure targetUrl to job summary
-      - name: Set job-summary=true
-        if: ${{ !cancelled() }}
+      - name: Set job-summary artifact
+        if: ${{ steps.run-lintdiff.outputs.job-summary == 'true' }}
         uses: ./.github/actions/add-empty-artifact
         with:
           name: "job-summary"

--- a/.github/workflows/lintdiff-status.yaml
+++ b/.github/workflows/lintdiff-status.yaml
@@ -33,4 +33,3 @@ jobs:
       monitored_workflow_name: "Swagger LintDiff - Analyze Code"
       required_check_name: "Swagger LintDiff"
       overriding_label: "Approved-LintDiff"
-      failure_target: "run"

--- a/.github/workflows/src/label.js
+++ b/.github/workflows/src/label.js
@@ -1,20 +1,14 @@
 // @ts-check
 
-// @ts-nocheck Prevent false positive for duplicate typedef and const names
-/**
- * @typedef {"none" | "add" | "remove"} LabelAction
- */
-
 /**
  * @readonly
- * @enum {LabelAction}
+ * @enum {"none" | "add" | "remove"}
  */
 export const LabelAction = Object.freeze({
   None: "none",
   Add: "add",
   Remove: "remove",
 });
-// @ts-check
 
 export const Label = {
   /**

--- a/.github/workflows/src/label.js
+++ b/.github/workflows/src/label.js
@@ -1,14 +1,20 @@
 // @ts-check
 
+// @ts-nocheck Prevent false positive for duplicate typedef and const names
+/**
+ * @typedef {"none" | "add" | "remove"} LabelAction
+ */
+
 /**
  * @readonly
- * @enum {"none" | "add" | "remove"}
+ * @enum {LabelAction}
  */
 export const LabelAction = Object.freeze({
   None: "none",
   Add: "add",
   Remove: "remove",
 });
+// @ts-check
 
 export const Label = {
   /**

--- a/.github/workflows/src/set-status.js
+++ b/.github/workflows/src/set-status.js
@@ -143,6 +143,9 @@ export async function setStatusImpl({
      */
     target_url = run.html_url;
 
+    // TODO: Only update target if run has marker artifact indicating it set status
+    core.info(`run: ${JSON.stringify(run, null, 2)}`);
+
     if (run.conclusion === CheckConclusion.FAILURE) {
       /**
        * Update target to point directly to the first failed job

--- a/.github/workflows/src/set-status.js
+++ b/.github/workflows/src/set-status.js
@@ -139,7 +139,7 @@ export async function setStatusImpl({
     /**
      * Update target to the "Analyze Code" run, which contains the meaningful output.
      *
-     * @example https://github.com/mikeharder/azure-rest-api-specs/actions/runs/14509047569
+     * @example https://github.com/Azure/azure-rest-api-specs/actions/runs/14509047569
      */
     target_url = run.html_url;
 
@@ -147,7 +147,7 @@ export async function setStatusImpl({
       /**
        * Update target to point directly to the first failed job
        *
-       * @example https://github.com/mikeharder/azure-rest-api-specs/actions/runs/14509047569/job/40703679014?pr=18
+       * @example https://github.com/Azure/azure-rest-api-specs/actions/runs/14509047569/job/40703679014?pr=18
        */
 
       const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {

--- a/.github/workflows/src/set-status.js
+++ b/.github/workflows/src/set-status.js
@@ -161,7 +161,7 @@ export async function setStatusImpl({
 
       if (!hasJobSummary) {
         /**
-         * Update target to point directly to the first failed job.
+         * Update target to point directly to the first failed job
          *
          * @example https://github.com/Azure/azure-rest-api-specs/actions/runs/14509047569/job/40703679014?pr=18
          */

--- a/.github/workflows/src/set-status.js
+++ b/.github/workflows/src/set-status.js
@@ -144,7 +144,7 @@ export async function setStatusImpl({
     target_url = run.html_url;
 
     if (run.conclusion === CheckConclusion.FAILURE) {
-      const jobSummaryLabel = "job-summary=true";
+      const jobSummaryLabel = "job-summary";
 
       // Check if run has a custom job summary
       core.info(`listWorkflowRunArtifacts(${owner}, ${repo}, ${run.id}, ${jobSummaryLabel})`);

--- a/.github/workflows/src/set-status.js
+++ b/.github/workflows/src/set-status.js
@@ -144,19 +144,24 @@ export async function setStatusImpl({
     target_url = run.html_url;
 
     if (run.conclusion === CheckConclusion.FAILURE) {
-      const jobSummaryLabel = "job-summary";
+      const jobSummaryArtifactName = "job-summary";
 
       // Check if run has a custom job summary
-      core.info(`listWorkflowRunArtifacts(${owner}, ${repo}, ${run.id}, ${jobSummaryLabel})`);
-      const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
-        owner: owner,
-        repo: repo,
-        run_id: run.id,
-        name: jobSummaryLabel,
-        per_page: PER_PAGE_MAX,
-      });
+      core.info(
+        `listWorkflowRunArtifacts(${owner}, ${repo}, ${run.id}, ${jobSummaryArtifactName})`,
+      );
+      const jobSummaryArtifacts = await github.paginate(
+        github.rest.actions.listWorkflowRunArtifacts,
+        {
+          owner: owner,
+          repo: repo,
+          run_id: run.id,
+          name: jobSummaryArtifactName,
+          per_page: PER_PAGE_MAX,
+        },
+      );
 
-      const hasJobSummary = artifacts.length > 0;
+      const hasJobSummary = jobSummaryArtifacts.length > 0;
       core.info(`hasJobSummary: ${hasJobSummary}`);
 
       if (!hasJobSummary) {

--- a/.github/workflows/test/set-status.test.js
+++ b/.github/workflows/test/set-status.test.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import { beforeEach, describe, expect, it } from "vitest";
 import { setStatusImpl } from "../src/set-status.js";
 

--- a/.github/workflows/test/set-status.test.js
+++ b/.github/workflows/test/set-status.test.js
@@ -214,6 +214,7 @@ describe("setStatusImpl", () => {
     });
   });
 
+  // TODO: Add tests for "job-summary" artifact
   it.each([
     [
       CheckStatus.COMPLETED,

--- a/.github/workflows/test/set-status.test.js
+++ b/.github/workflows/test/set-status.test.js
@@ -1,7 +1,5 @@
-// @ts-check
-
 import { beforeEach, describe, expect, it } from "vitest";
-import { FailureTarget, setStatusImpl } from "../src/set-status.js";
+import { setStatusImpl } from "../src/set-status.js";
 
 import { CheckConclusion, CheckStatus, CommitStatusState } from "../src/github.js";
 import { createMockCore, createMockGithub } from "./mocks.js";
@@ -219,86 +217,72 @@ describe("setStatusImpl", () => {
       CheckStatus.COMPLETED,
       CheckConclusion.SUCCESS,
       CommitStatusState.SUCCESS,
-      FailureTarget.Job,
       "https://test.com/workflow_run_html_url",
     ],
     [
       CheckStatus.COMPLETED,
       CheckConclusion.FAILURE,
       CommitStatusState.FAILURE,
-      FailureTarget.Job,
       "https://test.com/job_html_url?pr=123",
-    ],
-    [
-      CheckStatus.COMPLETED,
-      CheckConclusion.FAILURE,
-      CommitStatusState.FAILURE,
-      FailureTarget.Run,
-      "https://test.com/workflow_run_html_url",
     ],
     [
       CheckStatus.IN_PROGRESS,
       null,
       CommitStatusState.PENDING,
-      FailureTarget.Job,
       "https://test.com/workflow_run_html_url",
     ],
-    [null, null, CommitStatusState.PENDING, FailureTarget.Job, "https://test.com/set_status_url"],
-  ])(
-    "(%s, %s, %s, %s) => %s",
-    async (checkStatus, checkConclusion, commitStatusState, failureTarget, targetUrl) => {
-      if (checkStatus) {
-        github.rest.actions.listWorkflowRunsForRepo.mockResolvedValue({
+    [null, null, CommitStatusState.PENDING, "https://test.com/set_status_url"],
+  ])("(%s, %s, %s) => %s", async (checkStatus, checkConclusion, commitStatusState, targetUrl) => {
+    if (checkStatus) {
+      github.rest.actions.listWorkflowRunsForRepo.mockResolvedValue({
+        data: [
+          {
+            name: "[TEST-IGNORE] Swagger Avocado - Analyze Code",
+            status: checkStatus,
+            conclusion: checkConclusion,
+            updated_at: "2025-01-01",
+            html_url: "https://test.com/workflow_run_html_url",
+          },
+        ],
+      });
+
+      if (
+        checkConclusion === CheckConclusion.SUCCESS ||
+        checkConclusion === CheckConclusion.FAILURE
+      ) {
+        github.rest.actions.listJobsForWorkflowRun.mockResolvedValue({
           data: [
             {
-              name: "[TEST-IGNORE] Swagger Avocado - Analyze Code",
-              status: checkStatus,
               conclusion: checkConclusion,
-              updated_at: "2025-01-01",
-              html_url: "https://test.com/workflow_run_html_url",
+              html_url: "https://test.com/job_html_url",
             },
           ],
         });
-
-        if (
-          checkConclusion === CheckConclusion.SUCCESS ||
-          checkConclusion === CheckConclusion.FAILURE
-        ) {
-          github.rest.actions.listJobsForWorkflowRun.mockResolvedValue({
-            data: [
-              {
-                conclusion: checkConclusion,
-                html_url: "https://test.com/job_html_url",
-              },
-            ],
-          });
-        }
       }
+    }
 
-      await expect(
-        setStatusImpl({
-          owner: "test-owner",
-          repo: "test-repo",
-          head_sha: "test-head-sha",
-          issue_number: 123,
-          target_url: "https://test.com/set_status_url",
-          github,
-          core,
-          monitoredWorkflowName: "[TEST-IGNORE] Swagger Avocado - Analyze Code",
-          requiredStatusName: "[TEST-IGNORE] Swagger Avocado",
-          overridingLabel: "Approved-Avocado",
-          failureTarget,
-        }),
-      ).resolves.toBeUndefined();
-
-      expect(github.rest.repos.createCommitStatus).toBeCalledWith({
+    await expect(
+      setStatusImpl({
         owner: "test-owner",
         repo: "test-repo",
-        sha: "test-head-sha",
-        state: commitStatusState,
-        context: "[TEST-IGNORE] Swagger Avocado",
-        target_url: targetUrl,
-      });
-    },
-  );
+        head_sha: "test-head-sha",
+        issue_number: 123,
+        target_url: "https://test.com/set_status_url",
+        github,
+        core,
+        monitoredWorkflowName: "[TEST-IGNORE] Swagger Avocado - Analyze Code",
+        requiredStatusName: "[TEST-IGNORE] Swagger Avocado",
+        overridingLabel: "Approved-Avocado",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(github.rest.repos.createCommitStatus).toBeCalledWith({
+      owner: "test-owner",
+      repo: "test-repo",
+      sha: "test-head-sha",
+      state: commitStatusState,
+      context: "[TEST-IGNORE] Swagger Avocado",
+      target_url: targetUrl,
+    });
+  });
 });

--- a/.github/workflows/test/set-status.test.js
+++ b/.github/workflows/test/set-status.test.js
@@ -220,72 +220,91 @@ describe("setStatusImpl", () => {
       CheckStatus.COMPLETED,
       CheckConclusion.SUCCESS,
       CommitStatusState.SUCCESS,
+      [],
       "https://test.com/workflow_run_html_url",
     ],
     [
       CheckStatus.COMPLETED,
       CheckConclusion.FAILURE,
       CommitStatusState.FAILURE,
+      [],
       "https://test.com/job_html_url?pr=123",
+    ],
+    [
+      CheckStatus.COMPLETED,
+      CheckConclusion.FAILURE,
+      CommitStatusState.FAILURE,
+      ["job-status"],
+      "https://test.com/workflow_run_html_url",
     ],
     [
       CheckStatus.IN_PROGRESS,
       null,
       CommitStatusState.PENDING,
+      [],
       "https://test.com/workflow_run_html_url",
     ],
-    [null, null, CommitStatusState.PENDING, "https://test.com/set_status_url"],
-  ])("(%s, %s, %s) => %s", async (checkStatus, checkConclusion, commitStatusState, targetUrl) => {
-    if (checkStatus) {
-      github.rest.actions.listWorkflowRunsForRepo.mockResolvedValue({
-        data: [
-          {
-            name: "[TEST-IGNORE] Swagger Avocado - Analyze Code",
-            status: checkStatus,
-            conclusion: checkConclusion,
-            updated_at: "2025-01-01",
-            html_url: "https://test.com/workflow_run_html_url",
-          },
-        ],
-      });
-
-      if (
-        checkConclusion === CheckConclusion.SUCCESS ||
-        checkConclusion === CheckConclusion.FAILURE
-      ) {
-        github.rest.actions.listJobsForWorkflowRun.mockResolvedValue({
+    [null, null, CommitStatusState.PENDING, [], "https://test.com/set_status_url"],
+  ])(
+    "(%s, %s, %s, %o) => %s",
+    async (checkStatus, checkConclusion, commitStatusState, artifactNames, targetUrl) => {
+      if (checkStatus) {
+        github.rest.actions.listWorkflowRunsForRepo.mockResolvedValue({
           data: [
             {
+              name: "[TEST-IGNORE] Swagger Avocado - Analyze Code",
+              status: checkStatus,
               conclusion: checkConclusion,
-              html_url: "https://test.com/job_html_url",
+              updated_at: "2025-01-01",
+              html_url: "https://test.com/workflow_run_html_url",
             },
           ],
         });
-      }
-    }
 
-    await expect(
-      setStatusImpl({
+        github.rest.actions.listWorkflowRunArtifacts.mockResolvedValue({
+          data: artifactNames.map((n) => ({
+            name: n,
+          })),
+        });
+
+        if (
+          checkConclusion === CheckConclusion.SUCCESS ||
+          checkConclusion === CheckConclusion.FAILURE
+        ) {
+          github.rest.actions.listJobsForWorkflowRun.mockResolvedValue({
+            data: [
+              {
+                conclusion: checkConclusion,
+                html_url: "https://test.com/job_html_url",
+              },
+            ],
+          });
+        }
+      }
+
+      await expect(
+        setStatusImpl({
+          owner: "test-owner",
+          repo: "test-repo",
+          head_sha: "test-head-sha",
+          issue_number: 123,
+          target_url: "https://test.com/set_status_url",
+          github,
+          core,
+          monitoredWorkflowName: "[TEST-IGNORE] Swagger Avocado - Analyze Code",
+          requiredStatusName: "[TEST-IGNORE] Swagger Avocado",
+          overridingLabel: "Approved-Avocado",
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(github.rest.repos.createCommitStatus).toBeCalledWith({
         owner: "test-owner",
         repo: "test-repo",
-        head_sha: "test-head-sha",
-        issue_number: 123,
-        target_url: "https://test.com/set_status_url",
-        github,
-        core,
-        monitoredWorkflowName: "[TEST-IGNORE] Swagger Avocado - Analyze Code",
-        requiredStatusName: "[TEST-IGNORE] Swagger Avocado",
-        overridingLabel: "Approved-Avocado",
-      }),
-    ).resolves.toBeUndefined();
-
-    expect(github.rest.repos.createCommitStatus).toBeCalledWith({
-      owner: "test-owner",
-      repo: "test-repo",
-      sha: "test-head-sha",
-      state: commitStatusState,
-      context: "[TEST-IGNORE] Swagger Avocado",
-      target_url: targetUrl,
-    });
-  });
+        sha: "test-head-sha",
+        state: commitStatusState,
+        context: "[TEST-IGNORE] Swagger Avocado",
+        target_url: targetUrl,
+      });
+    },
+  );
 });


### PR DESCRIPTION
- Reverts #35682
- set-status now checks for existence of "job-summary" artifact
- artifact can be set dynamically by upstream workflow
- artifact should contain summary markdown (future use)
