### PR TITLE
Azure FIrewall Packet Capture Operation Fix with response naming

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2024-10-01/azureFirewall.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2024-10-01/azureFirewall.json
@@ -1429,7 +1429,7 @@
     "AzureFirewallPacketCaptureResponse": {
       "type": "object",
       "properties": {
-        "azureFirewallPacketCaptureResponseCode": {
+        "statusCode": {
           "$ref": "#/definitions/AzureFirewallPacketCaptureResponseCode",
           "description": "The response code of the performed packet capture operation"
         },

--- a/specification/network/resource-manager/Microsoft.Network/stable/2024-10-01/examples/AzureFirewallPacketCaptureOperation.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2024-10-01/examples/AzureFirewallPacketCaptureOperation.json
@@ -56,7 +56,7 @@
     },
     "200": {
       "body": {
-        "azureFirewallPacketCaptureResponseCode": "AzureFirewallPacketCaptureInProgress",
+        "statusCode": "AzureFirewallPacketCaptureInProgress",
         "message": "Packet capture in progress. Please wait till it is finished or stop the current capture before starting another."
       }
     }


### PR DESCRIPTION
2 Line change to rename azurefirewallpacketcaptureresponsecode to statusCode to follow NRP definition. 
Fixing bug from PR: https://github.com/Azure/azure-rest-api-specs/pull/35362