### PR TITLE
Make original non-LRO methods internal access in Java [Batch]

### DIFF
--- a/specification/batch/Azure.Batch/java-client.tsp
+++ b/specification/batch/Azure.Batch/java-client.tsp
@@ -1980,3 +1980,66 @@ op listNodeFilesCustomization is Azure.Batch.ListOperation<
   "parameters",
   "java"
 );
+
+// Updating original operations that have been converted to LRO methods to have internal access
+@@access(Azure.Batch.Nodes.deallocateNode, Access.internal, "java");
+@@access(BatchNodeDeallocateOptions, Access.public, "java");
+
+@@access(Azure.Batch.Certificates.deleteCertificate, Access.internal, "java");
+@@access(BatchCertificateDeleteOptions, Access.public, "java");
+
+@@access(Azure.Batch.Jobs.deleteJob, Access.internal, "java");
+@@access(BatchJobDeleteOptions, Access.public, "java");
+
+@@access(Azure.Batch.JobSchedules.deleteJobSchedule, Access.internal, "java");
+@@access(BatchJobScheduleDeleteOptions, Access.public, "java");
+
+@@access(Azure.Batch.Pools.deletePool, Access.internal, "java");
+@@access(BatchPoolDeleteOptions, Access.public, "java");
+
+@@access(Azure.Batch.Jobs.disableJob, Access.internal, "java");
+@@access(BatchJobDisableOptions, Access.public, "java");
+
+@@access(Azure.Batch.Jobs.enableJob, Access.internal, "java");
+@@access(BatchJobEnableOptions, Access.public, "java");
+
+@@access(Azure.Batch.Nodes.rebootNode, Access.internal, "java");
+@@access(BatchNodeRebootOptions, Access.public, "java");
+
+@@access(Azure.Batch.Nodes.reimageNode, Access.internal, "java");
+@@access(BatchNodeReimageOptions, Access.public, "java");
+
+@@access(Azure.Batch.Pools.removeNodes, Access.internal, "java");
+@@access(BatchNodesRemoveOptions, Access.public, "java");
+
+@@access(Azure.Batch.Pools.resizePool, Access.internal, "java");
+@@access(BatchPoolResizeOptions, Access.public, "java");
+
+@@access(Azure.Batch.Nodes.startNode, Access.internal, "java");
+@@access(BatchNodeStartOptions, Access.public, "java");
+
+@@access(Azure.Batch.Pools.stopPoolResize, Access.internal, "java");
+@@access(BatchPoolResizeStopOptions, Access.public, "java");
+
+@@access(Azure.Batch.Jobs.terminateJob, Access.internal, "java");
+@@access(BatchJobTerminateOptions, Access.public, "java");
+
+@@access(Azure.Batch.JobSchedules.terminateJobSchedule,
+  Access.internal,
+  "java"
+);
+@@access(BatchJobScheduleTerminateOptions, Access.public, "java");
+
+@@access(Azure.Batch.BatchNodeReimageOption, Access.public, "java");
+@@access(Azure.Batch.DisableBatchJobOption, Access.public, "java");
+@@access(Azure.Batch.BatchNodeDeallocateOption, Access.public, "java");
+@@access(Azure.Batch.BatchNodeDeallocationOption, Access.public, "java");
+@@access(Azure.Batch.BatchJobDisableOptions, Access.public, "java");
+@@access(Azure.Batch.BatchJobTerminateOptions, Access.public, "java");
+@@access(Azure.Batch.BatchNodeDeallocateOptions, Access.public, "java");
+@@access(Azure.Batch.BatchNodeRebootKind, Access.public, "java");
+@@access(Azure.Batch.BatchNodeRebootKind, Access.public, "java");
+@@access(Azure.Batch.BatchNodeRebootOptions, Access.public, "java");
+@@access(Azure.Batch.BatchNodeReimageOptions, Access.public, "java");
+@@access(Azure.Batch.BatchNodeRemoveOptions, Access.public, "java");
+@@access(Azure.Batch.BatchPoolResizeOptions, Access.public, "java");

--- a/specification/batch/Azure.Batch/tspconfig.yaml
+++ b/specification/batch/Azure.Batch/tspconfig.yaml
@@ -24,7 +24,7 @@ options:
   "@azure-tools/typespec-go":
     emitter-output-dir: "{project-root}"
     fix-const-stuttering: true
-    generate-fakes: false
+    generate-fakes: true
     inject-spans: true
     module: "github.com/Azure/azure-sdk-for-go/{service-dir}/azbatch"
     module-version: "0.1.0"

--- a/specification/batch/Azure.Batch/tspconfig.yaml
+++ b/specification/batch/Azure.Batch/tspconfig.yaml
@@ -24,7 +24,7 @@ options:
   "@azure-tools/typespec-go":
     emitter-output-dir: "{project-root}"
     fix-const-stuttering: true
-    generate-fakes: true
+    generate-fakes: false
     inject-spans: true
     module: "github.com/Azure/azure-sdk-for-go/{service-dir}/azbatch"
     module-version: "0.1.0"

--- a/specification/batch/suppressions.yaml
+++ b/specification/batch/suppressions.yaml
@@ -1,0 +1,9 @@
+- tool: TypeSpecValidation
+  paths:
+    - /Azure.Batch/tspconfig.yaml
+  rules:
+    - SdkTspConfigValidation
+  sub-rules:
+    # Don't generate Go fakes
+    - options.@azure-tools/typespec-go.generate-fakes
+  reason: 'See above comments for details'


### PR DESCRIPTION
# SDK configuration pull request

## Purpose of this PR

Make some methods in Java internal access only (as they have been replaced by handwritten LRO, or Long-Running Operation, methods in the Java SDK).
This PR also makes some of the corresponding classes public as they were set to internal by default by doing the above (but need to be public-facing so the LRO operations can use them).

- [x] Make changes to the SDK configuration only when there are no modifications to the API specification, eliminating the need for an ARM or Stewardship Board API review.

## Due diligence checklist

To merge this PR, you **must** go through the following checklist and confirm you understood
and followed the instructions by checking all the boxes:

- [x] I confirm this PR is modifying only SDK configurations, and not API related specifications.
- [x] I have reviewed and used the respective `tspconfig.yaml` templates:
  - [ARM tspconfig template](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/contosowidgetmanager/Contoso.Management/tspconfig.yaml)
  - [Data plane tspconfig template](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/contosowidgetmanager/Contoso.WidgetManager/tspconfig.yaml)

## Getting help

- First, carefully read through this PR description, from top to bottom. Fill out the `Purpose of this PR` and `Due diligence checklist`.
- If you don't have permissions to remove or add labels to the PR, request `write access` per [aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories](https://aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories)
- To understand what you must do next to merge this PR, see the `Next Steps to Merge` comment. It will appear within few minutes of submitting this PR and will continue to be up-to-date with current PR state.
- For guidance on fixing this PR CI check failures, see the hyperlinks provided in given failure and https://aka.ms/ci-fix.
- If the PR CI checks appear to be stuck in `queued` state, please add a comment with contents `/azp run`.
  This should result in a new comment denoting a `PR validation pipeline` has started and the checks should be updated after few minutes.
- If the help provided by the previous points is not enough, post to https://aka.ms/azsdk/support/specreview-channel and link to this PR.