### PR TITLE
Update suppressions.yaml for python

### DIFF
--- a/specification/suppressions.yaml
+++ b/specification/suppressions.yaml
@@ -459,15 +459,6 @@
   reason: Suppress until next PR changing spec
   rules: [SdkTspConfigValidation]
   sub-rules:
-    - options.@azure-tools/typespec-python.*
-  paths:
-    - containerservice/Fleet.Management/tspconfig.yaml
-
-- tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
-  rules: [SdkTspConfigValidation]
-  sub-rules:
     - options.@azure-tools/typespec-go.*
     - options.@azure-tools/typespec-java.*
     - options.@azure-tools/typespec-python.*


### PR DESCRIPTION
After https://github.com/Azure/azure-rest-api-specs/pull/35773 merged, we could remove the suppressions for python.