### PR TITLE
[EngSys] Revert SdkTspConfigValidation suppressions back to permanent

### DIFF
--- a/specification/suppressions.yaml
+++ b/specification/suppressions.yaml
@@ -68,8 +68,7 @@
     - awsconnector/*/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -86,8 +85,7 @@
     - ai/Azure.AI.Agents/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -96,8 +94,7 @@
     - ai/Azure.AI.Projects/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -111,8 +108,7 @@
     - ai/ContentUnderstanding/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -128,8 +124,7 @@
     - ai/ImageAnalysis/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -145,8 +140,7 @@
     - ai/ModelInference/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -162,8 +156,7 @@
     - ai/OpenAI.Assistants/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -175,8 +168,7 @@
     - apicenter/ApiCenter.DataApi/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.*
@@ -188,8 +180,7 @@
     - apicenter/ApiCenter.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -204,8 +195,7 @@
     - app/Microsoft.App.DynamicSessions/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.*
@@ -214,8 +204,7 @@
     - appcomplianceautomation/AppComplianceAutomation.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -228,8 +217,7 @@
     - appconfiguration/AppConfiguration/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -242,8 +230,7 @@
     - applicationinsights/ApplicationInsights.LiveMetrics/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.*
@@ -255,8 +242,7 @@
     - azuredatatransfer/AzureDataTransfer.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.generate-samples
@@ -264,8 +250,7 @@
     - azuredependencymap/DependencyMap.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.*
@@ -277,8 +262,7 @@
     - azurelargeinstance/AzureLargeInstance.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.*
@@ -290,8 +274,7 @@
     - azurestackhci/AzureStackHCI.StackHCIVM.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.*
@@ -303,8 +286,7 @@
     - azurestackhci/Operations.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -316,8 +298,7 @@
     - batch/Azure.Batch/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -331,8 +312,7 @@
     - cognitiveservices/AnomalyDetector/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -345,8 +325,7 @@
     - cognitiveservices/ContentSafety/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -368,8 +347,7 @@
     - cognitiveservices/Speech.VideoTranslation/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -385,8 +363,7 @@
     - cognitiveservices/OpenAI.Inference/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -400,8 +377,7 @@
     - communication/Communication.Messages/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.*
@@ -413,8 +389,7 @@
     - communitytraining/Community.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -427,8 +402,7 @@
     - confidentialledger/Microsoft.CodeTransparency/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -444,8 +418,7 @@
     - confidentialledger/Microsoft.ManagedCcf/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.generate-samples
@@ -455,8 +428,7 @@
     - connectedcache/ConnectedCache.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-python.*
@@ -464,8 +436,7 @@
     - containerservice/Fleet.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.*
@@ -477,8 +448,7 @@
     - containerstorage/ContainerStorage.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.generate-samples
@@ -486,8 +456,7 @@
     - databasefleetmanager/DatabaseFleetManager.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-java.namespace
@@ -495,8 +464,7 @@
     - dell/Dell.Storage.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.*
@@ -508,8 +476,7 @@
     - desktopvirtualization/DesktopVirtualization.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -522,8 +489,7 @@
     - devcenter/DevCenter/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-java.service-name
@@ -531,8 +497,7 @@
     - edge/Microsoft.Edge.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-csharp.*
@@ -542,8 +507,7 @@
     - edge/Microsoft.Edge.Configurations.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.generate-fakes
@@ -556,8 +520,7 @@
     - eventgrid/Azure.Messaging.EventGrid.SystemEvents/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-java.service-name
@@ -565,8 +528,7 @@
     - fabric/Microsoft.Fabric.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.*
@@ -578,8 +540,7 @@
     - github-network/GitHub.Network.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -595,8 +556,7 @@
     - healthdataaiservices/HealthDataAIServices.DeidServices/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.*
@@ -604,8 +564,7 @@
     - informatica/Informatica.DataManagement.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.*
@@ -617,8 +576,7 @@
     - iotoperationsdataprocessor/IoTOperationsDataProcessor.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.*
@@ -630,8 +588,7 @@
     - iotoperationsmq/IoTOperationsMQ.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.*
@@ -643,8 +600,7 @@
     - iotoperationsorchestrator/IoTOperationsOrchestrator.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -661,8 +617,7 @@
     - keyvault/Security.KeyVault.Administration/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -675,8 +630,7 @@
     - keyvault/Security.KeyVault.Settings/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -691,8 +645,7 @@
     - keyvault/Security.KeyVault.Secrets/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -708,8 +661,7 @@
     - keyvault/Security.KeyVault.SecurityDomain/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.*
@@ -717,8 +669,7 @@
     - kubernetesruntime/KubernetesRuntime.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.*
@@ -727,8 +678,7 @@
     - liftrastronomer/Astronomer.Astro.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.*
@@ -737,8 +687,7 @@
     - liftrqumulo/Qumulo.Storage.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -747,8 +696,7 @@
     - loadtestservice/LoadTestService/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.generate-samples
@@ -757,8 +705,7 @@
     - loadtestservice/Playwright.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -773,8 +720,7 @@
     - machinelearning/Azure.AI.ChatProtocol/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -787,8 +733,7 @@
     - machinelearningservices/AzureAI.Assets/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.*
@@ -800,8 +745,7 @@
     - manufacturingplatform/Manufacturingplatform.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.*
@@ -818,8 +762,7 @@
     - migrate/AssessmentProjects.Management/MachineAssessments.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.*
@@ -827,8 +770,7 @@
     - migrate/AssessmentProjects.Management/AssessmentProjects.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.*
@@ -837,8 +779,7 @@
     - monitor/Microsoft.Monitor.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.*
@@ -851,8 +792,7 @@
     - monitor/Microsoft.Monitor.PipelineGroups.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -863,8 +803,7 @@
     - onlineexperimentation/Azure.Analytics.OnlineExperimentation/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -878,8 +817,7 @@
     - orbital/Microsoft.PlanetaryComputer/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -894,8 +832,7 @@
     - playwrighttesting/PlaywrightTesting.AuthManager/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.*
@@ -903,8 +840,7 @@
     - playwrighttesting/PlaywrightTesting.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.*
@@ -917,8 +853,7 @@
     - portal/TenantConfiguration.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.*
@@ -930,8 +865,7 @@
     - portalservices/Extension.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -944,8 +878,7 @@
     - programmableconnectivity/Azure.ProgrammableConnectivity/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.*
@@ -953,8 +886,7 @@
     - programmableconnectivity/ProgrammableConnectivity.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -967,8 +899,7 @@
     - purview/Azure.Analytics.Purview.DataMap/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.*
@@ -980,8 +911,7 @@
     - purviewpolicy/PurviewPolicy.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.*
@@ -993,8 +923,7 @@
     - quantum/Microsoft.Quantum.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -1010,8 +939,7 @@
     - quantum/Quantum.Workspace/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.generate-samples
@@ -1019,8 +947,7 @@
     - recoveryservicesdatareplication/DataReplication.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - parameters.service-dir.default
@@ -1028,8 +955,7 @@
     - relationships/Relationships.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-java.namespace
@@ -1037,8 +963,7 @@
     - resources/Bicep.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -1052,8 +977,7 @@
     - riskiq/Easm/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -1068,8 +992,7 @@
     - schemaregistry/SchemaRegistry/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.*
@@ -1078,8 +1001,7 @@
     - scvmm/ScVmm.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -1088,8 +1010,7 @@
     - servicefabricmanagedclusters/ServiceFabricManagedClusters.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.*
@@ -1101,8 +1022,7 @@
     - sovereign/Sovereign.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.*
@@ -1111,8 +1031,7 @@
     - sphere/Sphere.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.*
@@ -1124,8 +1043,7 @@
     - splitio/SplitIO.Experimentation.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -1140,8 +1058,7 @@
     - translation/Azure.AI.DocumentTranslation/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -1154,8 +1071,7 @@
     - translation/Azure.AI.TextTranslation/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -1168,8 +1084,7 @@
     - trustedsigning/TrustedSigning/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.*
@@ -1178,8 +1093,7 @@
     - verifiedid/Microsoft.VerifiedId.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.flavor
@@ -1194,8 +1108,7 @@
     - voiceservices/VoiceServices.Provisioning/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.*
@@ -1207,8 +1120,7 @@
     - workloads/Workloads.Operations.Management/tspconfig.yaml
 
 - tool: TypeSpecValidation
-  if: checkingAllSpecs
-  reason: Suppress until next PR changing spec
+  reason: Suppress until spec can be updated
   rules: [SdkTspConfigValidation]
   sub-rules:
     - options.@azure-tools/typespec-go.*


### PR DESCRIPTION
- Too many spec PRs are being blocked
- Reverts part of #35605