### PR TITLE
[Storage] Prep `.tsp` for `v0.3.0` release of Blob Storage SDK

### DIFF
--- a/specification/storage/Microsoft.BlobStorage/client.tsp
+++ b/specification/storage/Microsoft.BlobStorage/client.tsp
@@ -31,10 +31,6 @@ model BlobServiceClientParameters {
 );
 @@clientName(Storage.Blob.Container.Blob.BlockBlob, "BlockBlobClient", "rust");
 @@clientName(Storage.Blob.Container.Blob.PageBlob, "PageBlobClient", "rust");
-@@clientName(Storage.Blob.Container.Blob.setHttpHeaders,
-  "SetProperties",
-  "rust"
-);
 
 @@clientInitialization(Storage.Blob.Container,
   {

--- a/specification/storage/Microsoft.BlobStorage/models.tsp
+++ b/specification/storage/Microsoft.BlobStorage/models.tsp
@@ -504,57 +504,6 @@ union AccessTier {
   string,
 }
 
-/** The access tiers. */
-union AccessTierOptional {
-  /** The hot P4 tier. */
-  P4: "P4",
-
-  /** The hot P6 tier. */
-  P6: "P6",
-
-  /** The hot P10 tier. */
-  P10: "P10",
-
-  /** The hot P15 tier. */
-  P15: "P15",
-
-  /** The hot P20 tier. */
-  P20: "P20",
-
-  /** The hot P30 tier. */
-  P30: "P30",
-
-  /** The hot P40 tier. */
-  P40: "P40",
-
-  /** The hot P50 tier. */
-  P50: "P50",
-
-  /** The hot P60 tier. */
-  P60: "P60",
-
-  /** The hot P70 tier. */
-  P70: "P70",
-
-  /** The hot P80 tier. */
-  P80: "P80",
-
-  /** The hot access tier. */
-  Hot: "Hot",
-
-  /** The cool access tier. */
-  Cool: "Cool",
-
-  /** The archive access tier. */
-  Archive: "Archive",
-
-  /** The Cold access tier. */
-  Cold: "Cold",
-
-  /** Extensible */
-  string,
-}
-
 /** The archive status. */
 union ArchiveStatus {
   /** The archive status is rehydrating pending to hot. */
@@ -1786,10 +1735,10 @@ alias ContentCrc64Parameter = {
 };
 
 /** The access tier optional parameter. */
-alias AccessTierOptionalHeader = {
+alias AccessTierHeader = {
   /** The tier to be set on the blob. */
   @header("x-ms-access-tier")
-  tier?: AccessTierOptional;
+  tier?: AccessTier;
 };
 
 /** The content MD5 parameter. */

--- a/specification/storage/Microsoft.BlobStorage/routes.tsp
+++ b/specification/storage/Microsoft.BlobStorage/routes.tsp
@@ -962,7 +962,7 @@ namespace Storage.Blob {
       #suppress "@azure-tools/typespec-azure-core/use-standard-names" "Existing API"
       @put
       @route("{blobName}?comp=properties&SetHTTPHeaders")
-      op setHttpHeaders is StorageOperation<
+      op setProperties is StorageOperation<
         {
           ...ContainerNamePathParameter;
           ...BlobPathParameter;

--- a/specification/storage/Microsoft.BlobStorage/routes.tsp
+++ b/specification/storage/Microsoft.BlobStorage/routes.tsp
@@ -1271,7 +1271,7 @@ namespace Storage.Blob {
           ...BlobPathParameter;
           ...TimeoutParameter;
           ...MetadataHeaders;
-          ...AccessTierOptionalHeader;
+          ...AccessTierHeader;
           ...RehydratePriorityHeader;
           ...SourceIfModifiedSinceParameter;
           ...SourceIfUnmodifiedSinceParameter;
@@ -1322,7 +1322,7 @@ namespace Storage.Blob {
           ...BlobPathParameter;
           ...TimeoutParameter;
           ...MetadataHeaders;
-          ...AccessTierOptionalHeader;
+          ...AccessTierHeader;
           ...SourceIfModifiedSinceParameter;
           ...SourceIfUnmodifiedSinceParameter;
           ...SourceIfMatchParameter;
@@ -1411,7 +1411,7 @@ namespace Storage.Blob {
 
           /** Indicates the tier to be set on the blob. */
           @header("x-ms-access-tier")
-          tier: AccessTierOptional;
+          tier: AccessTier;
 
           ...RehydratePriorityHeader;
           ...LeaseIdOptionalParameter;
@@ -2097,7 +2097,7 @@ namespace Storage.Blob {
             ...EncryptionKeySha256Parameter;
             ...EncryptionAlgorithmParameter;
             ...EncryptionScopeParameter;
-            ...AccessTierOptionalHeader;
+            ...AccessTierHeader;
             ...IfModifiedSinceParameter;
             ...IfUnmodifiedSinceParameter;
             ...IfNoneMatchParameter;
@@ -2156,7 +2156,7 @@ namespace Storage.Blob {
             ...EncryptionKeySha256Parameter;
             ...EncryptionAlgorithmParameter;
             ...EncryptionScopeParameter;
-            ...AccessTierOptionalHeader;
+            ...AccessTierHeader;
             ...IfModifiedSinceParameter;
             ...IfUnmodifiedSinceParameter;
             ...IfNoneMatchParameter;
@@ -2299,7 +2299,7 @@ namespace Storage.Blob {
             ...EncryptionKeySha256Parameter;
             ...EncryptionAlgorithmParameter;
             ...EncryptionScopeParameter;
-            ...AccessTierOptionalHeader;
+            ...AccessTierHeader;
             ...IfModifiedSinceParameter;
             ...IfUnmodifiedSinceParameter;
             ...IfNoneMatchParameter;


### PR DESCRIPTION
This PR introduces the following:

- Removes the necessity of the client per-language rename using the decorator, and instead propagates that change to the `routes.tsp`
- Removes `AccessTierOptional`, and changes all instances to one single enum, `AccessTier`.