### PR TITLE
fix(elasticsan): resolve Go SDK breaking changes by moving restoreVolume to Management client

### DIFF
--- a/specification/elasticsan/ElasticSan.Management/client.tsp
+++ b/specification/elasticsan/ElasticSan.Management/client.tsp
@@ -67,3 +67,6 @@ using Azure.Core;
 @@clientName(PrivateLinkResource, "ElasticSanPrivateLinkResource", "csharp");
 @@usage(PrivateLinkResource, Usage.input, "csharp");
 @@clientName(restoreVolume, "RestoreVolume", "csharp");
+
+// Move restoreVolume operation to Management client for Go to maintain compatibility
+@@clientLocation(Microsoft.ElasticSan.restoreVolume, "Management", "go");


### PR DESCRIPTION
## Description

This PR resolves breaking changes in the Azure Go SDK for ElasticSan.Management service that occurred during the TypeSpec migration.

## Changes Made

- Added `@@clientLocation(Microsoft.ElasticSan.restoreVolume, \"Management\", \"go\")` to `client.tsp`
- This decorator moves the `restoreVolume` operation to the Management client specifically for Go SDK generation

## Breaking Changes Resolved

The following breaking changes have been resolved:
1. `*ClientFactory.NewManagementClient` has been removed
2. `NewManagementClient` has been removed  
3. `*ManagementClient.BeginRestoreVolume` has been removed

## Rationale

- **Pattern**: Client Organization Changes (Pattern 4 from the Azure Go SDK Breaking Changes Guide)
- **Root Cause**: TypeSpec uses different logic for organizing client operations compared to Swagger
- **Resolution**: Used `@clientLocation` decorator to maintain backward compatibility by keeping the operation in the Management client

## Validation

- ✅ SDK generation completed successfully with 0 breaking changes after the fix
- ✅ All environment checks passed
- ✅ Generated SDK version: `1.2.0-beta.3`
- ✅ API Version: `2024-07-01-preview`

## Impact

- Maintains backward compatibility for existing Go SDK consumers
- No impact on other language SDKs (C#, Python, Java, TypeScript)
- Follows established patterns from the breaking changes resolution guide