### PR TITLE
[changed-files] return absolute platform paths

### DIFF
--- a/.github/shared/src/changed-files.js
+++ b/.github/shared/src/changed-files.js
@@ -56,7 +56,6 @@ export async function getChangedFilesStatuses(options = {}) {
     modifications: /** @type {string[]} */ ([]),
     deletions: /** @type {string[]} */ ([]),
     renames: /** @type {{from: string, to: string}[]} */ ([]),
-
     total: 0,
   };
 

--- a/.github/shared/src/changed-files.js
+++ b/.github/shared/src/changed-files.js
@@ -156,8 +156,6 @@ export function readme(file) {
   return typeof file === "string" && file.toLowerCase().endsWith("readme.md");
 }
 
-// Following need repoRoot parameter
-
 /**
  * @param {string} [file]
  * @param {Object} [options]

--- a/.github/shared/src/changed-files.js
+++ b/.github/shared/src/changed-files.js
@@ -13,7 +13,7 @@ debug.enable("simple-git");
  * @param {string} [options.cwd] Current working directory.  Default: process.cwd().
  * @param {string} [options.headCommitish] Default: "HEAD".
  * @param {import('./logger.js').ILogger} [options.logger]
- * @returns {Promise<string[]>} List of changed files as platform-specific absolute paths. Example: ["/hom/users/specs/specification/foo/Microsoft.Foo/main.tsp"].
+ * @returns {Promise<string[]>} List of changed files as platform-specific absolute paths. Example: ["/home/users/specs/specification/foo/Microsoft.Foo/main.tsp"].
  */
 export async function getChangedFiles(options = {}) {
   const { baseCommitish = "HEAD^", cwd, headCommitish = "HEAD", logger } = options;

--- a/.github/shared/src/changed-files.js
+++ b/.github/shared/src/changed-files.js
@@ -164,63 +164,81 @@ export function readme(file) {
  * @param {string} [options.repoRoot] Root directory of repository.  Default: process.cwd().
  * @returns {boolean}
  */
-export function specification(file, options) {
+export function specification(file, options = {}) {
   // Folder name "specification" should match case, since it already exists in repo
   return (
     typeof file === "string" &&
-    relativeCwd(file, { cwd: options?.repoRoot }).startsWith("specification/")
+    relativeCwd(file, { cwd: options.repoRoot }).startsWith("specification/")
   );
 }
 
 /**
  * @param {string} [file]
+ * @param {Object} [options]
+ * @param {string} [options.repoRoot] Root directory of repository.  Default: process.cwd().
  * @returns {boolean}
  */
-export function dataPlane(file) {
+export function dataPlane(file, options = {}) {
   // Folder name "data-plane" should match case for consistency across specs
-  return typeof file === "string" && specification(file) && file.includes("/data-plane/");
+  return typeof file === "string" && specification(file, options) && file.includes("/data-plane/");
 }
 
 /**
  * @param {string} [file]
+ * @param {Object} [options]
+ * @param {string} [options.repoRoot] Root directory of repository.  Default: process.cwd().
  * @returns {boolean}
  */
-export function resourceManager(file) {
+export function resourceManager(file, options = {}) {
   // Folder name "resource-manager" should match case for consistency across specs
-  return typeof file === "string" && specification(file) && file.includes("/resource-manager/");
-}
-
-/**
- * @param {string} [file]
- * @returns {boolean}
- */
-export function example(file) {
-  // Folder name "examples" should match case for consistency across specs
   return (
-    typeof file === "string" && json(file) && specification(file) && file.includes("/examples/")
+    typeof file === "string" && specification(file, options) && file.includes("/resource-manager/")
   );
 }
 
 /**
  * @param {string} [file]
+ * @param {Object} [options]
+ * @param {string} [options.repoRoot] Root directory of repository.  Default: process.cwd().
  * @returns {boolean}
  */
-export function swagger(file) {
+export function example(file, options = {}) {
+  // Folder name "examples" should match case for consistency across specs
   return (
     typeof file === "string" &&
     json(file) &&
-    (dataPlane(file) || resourceManager(file)) &&
-    !example(file) &&
-    !scenario(file)
+    specification(file, options) &&
+    file.includes("/examples/")
   );
 }
 
 /**
  * @param {string} [file]
+ * @param {Object} [options]
+ * @param {string} [options.repoRoot] Root directory of repository.  Default: process.cwd().
  * @returns {boolean}
  */
-export function scenario(file) {
+export function swagger(file, options = {}) {
   return (
-    typeof file === "string" && json(file) && specification(file) && file.includes("/scenarios/")
+    typeof file === "string" &&
+    json(file) &&
+    (dataPlane(file, options) || resourceManager(file, options)) &&
+    !example(file, options) &&
+    !scenario(file, options)
+  );
+}
+
+/**
+ * @param {string} [file]
+ * @param {Object} [options]
+ * @param {string} [options.repoRoot] Root directory of repository.  Default: process.cwd().
+ * @returns {boolean}
+ */
+export function scenario(file, options = {}) {
+  return (
+    typeof file === "string" &&
+    json(file) &&
+    specification(file, options) &&
+    file.includes("/scenarios/")
   );
 }

--- a/.github/shared/src/path.js
+++ b/.github/shared/src/path.js
@@ -1,15 +1,6 @@
 // @ts-check
 
-import { relative, resolve, sep } from "path";
-
-/**
- * @param {string} path
- * @param {string} folder
- * @returns {boolean} True if path contains the named folder
- */
-export function includesFolder(path, folder) {
-  return resolve(path).includes(sep + folder + sep);
-}
+import { relative, resolve } from "path";
 
 /**
  * Resolves {path} against {options.cwd} (if specified), or the current directory

--- a/.github/shared/src/path.js
+++ b/.github/shared/src/path.js
@@ -1,13 +1,40 @@
 // @ts-check
 
-import { resolve, sep } from "path";
+import { relative, resolve, sep } from "path";
 
 /**
- *
  * @param {string} path
  * @param {string} folder
  * @returns {boolean} True if path contains the named folder
  */
 export function includesFolder(path, folder) {
   return resolve(path).includes(sep + folder + sep);
+}
+
+/**
+ * Resolves {path} against {options.cwd} (if specified), or the current directory
+ *
+ * @param {string} path
+ * @param {Object} [options]
+ * @param {string} [options.cwd] Current working directory.  Default: process.cwd().
+ * @returns {string}
+ */
+export function resolveCwd(path, options = {}) {
+  // Could also set cwd="", but I think it's more correct to call resolve with one path
+  const { cwd } = options;
+  return cwd === undefined ? resolve(path) : resolve(cwd, path);
+}
+
+/**
+ * Solve the relative path from {from} to {options.cwd} (if specified), or the current directory
+ *
+ * @param {string} path
+ * @param {Object} [options]
+ * @param {string} [options.cwd] Current working directory.  Default: process.cwd().
+ * @returns {string}
+ */
+export function relativeCwd(path, options = {}) {
+  // relative() requires two paths, but "" means "current directory"
+  const { cwd = "" } = options;
+  return relative(cwd, path);
 }

--- a/.github/shared/src/path.js
+++ b/.github/shared/src/path.js
@@ -26,7 +26,7 @@ export function resolveCwd(path, options = {}) {
 }
 
 /**
- * Solve the relative path from {from} to {options.cwd} (if specified), or the current directory
+ * Solve the relative path from {path} to {options.cwd} (if specified), or the current directory
  *
  * @param {string} path
  * @param {Object} [options]

--- a/.github/shared/src/spec-model.js
+++ b/.github/shared/src/spec-model.js
@@ -3,6 +3,7 @@
 import { readdir } from "fs/promises";
 import { resolve } from "path";
 import { flatMapAsync, mapAsync } from "./array.js";
+import { readme } from "./changed-files.js";
 import { Readme } from "./readme.js";
 
 /** @type {Map<string, SpecModel>} */
@@ -177,7 +178,7 @@ export class SpecModel {
 
       const readmePaths = files
         // filter before resolve to (slightly) improve perf, since filter only needs filename
-        .filter(readme)
+        .filter((f) => readme(f))
         .map((p) => resolve(this.#folder, p));
 
       this.#logger?.debug(`Found ${readmePaths.length} readme files`);
@@ -225,15 +226,4 @@ export class SpecModel {
   toString() {
     return `SpecModel(${this.#folder}, {logger: ${this.#logger}}})`;
   }
-}
-
-// TODO: Remove duplication with changed-files.js (which currently requires paths relative to repo root)
-
-/**
- * @param {string} [file]
- * @returns {boolean}
- */
-function readme(file) {
-  // Filename "readme.md" with any case is a valid README file
-  return typeof file === "string" && file.toLowerCase().endsWith("readme.md");
 }

--- a/.github/shared/src/swagger.js
+++ b/.github/shared/src/swagger.js
@@ -4,7 +4,7 @@ import $RefParser, { ResolverError } from "@apidevtools/json-schema-ref-parser";
 import { readFile } from "fs/promises";
 import { dirname, relative, resolve } from "path";
 import { mapAsync } from "./array.js";
-import { includesFolder } from "./path.js";
+import { example } from "./changed-files.js";
 import { SpecModelError } from "./spec-model-error.js";
 
 /**
@@ -220,26 +220,6 @@ export class Swagger {
   toString() {
     return `Swagger(${this.#path}, {logger: ${this.#logger}})`;
   }
-}
-
-// TODO: Remove duplication with changed-files.js (which currently requires paths relative to repo root)
-
-/**
- * @param {string} [file]
- * @returns {boolean}
- */
-function example(file) {
-  // Folder name "examples" should match case for consistency across specs
-  return typeof file === "string" && json(file) && includesFolder(file, "examples");
-}
-
-/**
- * @param {string} [file]
- * @returns {boolean}
- */
-function json(file) {
-  // Extension "json" with any case is a valid JSON file
-  return typeof file === "string" && file.toLowerCase().endsWith(".json");
 }
 
 // API version lifecycle stages

--- a/.github/shared/test/changed-files.test.js
+++ b/.github/shared/test/changed-files.test.js
@@ -40,7 +40,9 @@ describe("changedFiles", () => {
 
     vi.mocked(simpleGit.simpleGit().diff).mockResolvedValue(files.join("\n"));
 
-    await expect(getChangedFiles(options)).resolves.toEqual(files.map((f) => resolve(f)));
+    await expect(
+      getChangedFiles(options).then((items) => items.map((i) => relativeCwd(i))),
+    ).resolves.toEqual(files);
   });
 
   const files = [

--- a/.github/shared/test/changed-files.test.js
+++ b/.github/shared/test/changed-files.test.js
@@ -88,15 +88,17 @@ describe("changedFiles", () => {
       "specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/stable/2021-11-01/contoso.json",
       "specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/stable/2021-11-01/examples/Employees_Get.json",
       "specification/contosowidgetmanager/Contoso.Management/scenarios/2021-11-01/Employees_Get.json",
-    ];
+    ].map((f) => resolve(f));
 
-    expect(files.filter(specification)).toEqual(expected);
+    expect(files.filter((f) => specification(f))).toEqual(expected);
   });
 
   it("filter:data-plane", () => {
-    const expected = ["specification/contosowidgetmanager/data-plane/readme.md"];
+    const expected = ["specification/contosowidgetmanager/data-plane/readme.md"].map((f) =>
+      resolve(f),
+    );
 
-    expect(files.filter(dataPlane)).toEqual(expected);
+    expect(files.filter((f) => dataPlane(f))).toEqual(expected);
   });
 
   it("filter:resource-manager", () => {
@@ -104,34 +106,34 @@ describe("changedFiles", () => {
       "specification/contosowidgetmanager/resource-manager/readme.md",
       "specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/stable/2021-11-01/contoso.json",
       "specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/stable/2021-11-01/examples/Employees_Get.json",
-    ];
+    ].map((f) => resolve(f));
 
-    expect(files.filter(resourceManager)).toEqual(expected);
+    expect(files.filter((f) => resourceManager(f))).toEqual(expected);
   });
 
   it("filter:example", () => {
     const expected = [
       "specification/contosowidgetmanager/Contoso.Management/examples/2021-11-01/Employees_Get.json",
       "specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/stable/2021-11-01/examples/Employees_Get.json",
-    ];
+    ].map((f) => resolve(f));
 
-    expect(files.filter(example)).toEqual(expected);
+    expect(files.filter((f) => example(f))).toEqual(expected);
   });
 
   it("filter:scenarios", () => {
     const expected = [
       "specification/contosowidgetmanager/Contoso.Management/scenarios/2021-11-01/Employees_Get.json",
-    ];
+    ].map((f) => resolve(f));
 
-    expect(files.filter(scenario)).toEqual(expected);
+    expect(files.filter((f) => scenario(f))).toEqual(expected);
   });
 
   it("filter:swagger", () => {
     const expected = [
       "specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/stable/2021-11-01/contoso.json",
-    ];
+    ].map((f) => resolve(f));
 
-    expect(files.filter(swagger)).toEqual(expected);
+    expect(files.filter((f) => swagger(f))).toEqual(expected);
   });
 
   describe("getChangedFilesStatuses", () => {

--- a/.github/shared/test/changed-files.test.js
+++ b/.github/shared/test/changed-files.test.js
@@ -8,6 +8,7 @@ vi.mock("simple-git", () => ({
   }),
 }));
 
+import { resolve } from "path";
 import * as simpleGit from "simple-git";
 import {
   dataPlane,
@@ -38,7 +39,7 @@ describe("changedFiles", () => {
 
     vi.mocked(simpleGit.simpleGit().diff).mockResolvedValue(files.join("\n"));
 
-    await expect(getChangedFiles(options)).resolves.toEqual(files);
+    await expect(getChangedFiles(options)).resolves.toEqual(files.map((f) => resolve(f)));
   });
 
   const files = [
@@ -53,7 +54,7 @@ describe("changedFiles", () => {
     "specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/stable/2021-11-01/contoso.json",
     "specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/stable/2021-11-01/examples/Employees_Get.json",
     "specification/contosowidgetmanager/Contoso.Management/scenarios/2021-11-01/Employees_Get.json",
-  ];
+  ].map((f) => resolve(f));
 
   it("filter:json", () => {
     const expected = [
@@ -63,7 +64,7 @@ describe("changedFiles", () => {
       "specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/stable/2021-11-01/contoso.json",
       "specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/stable/2021-11-01/examples/Employees_Get.json",
       "specification/contosowidgetmanager/Contoso.Management/scenarios/2021-11-01/Employees_Get.json",
-    ];
+    ].map((f) => resolve(f));
 
     expect(files.filter(json)).toEqual(expected);
   });
@@ -73,7 +74,7 @@ describe("changedFiles", () => {
       "README.MD",
       "specification/contosowidgetmanager/data-plane/readme.md",
       "specification/contosowidgetmanager/resource-manager/readme.md",
-    ];
+    ].map((f) => resolve(f));
 
     expect(files.filter(readme)).toEqual(expected);
   });

--- a/.github/shared/test/changed-files.test.js
+++ b/.github/shared/test/changed-files.test.js
@@ -141,6 +141,7 @@ describe("changedFiles", () => {
 
   describe("getChangedFilesStatuses", () => {
     /**
+     * Converts a result to an equivalent result with relative paths
      *
      * @param {{additions: string[], modifications: string[], deletions: string[], renames: {from: string, to: string}[], total: number}} result
      * @returns {{additions: string[], modifications: string[], deletions: string[], renames: {from: string, to: string}[], total: number}}

--- a/.github/shared/test/path.test.js
+++ b/.github/shared/test/path.test.js
@@ -3,17 +3,7 @@
 import { tmpdir } from "os";
 import { resolve } from "path";
 import { describe, expect, it } from "vitest";
-import { includesFolder, relativeCwd, resolveCwd } from "../src/path.js";
-
-describe("includesFolder", () => {
-  it("should return true when path contains the specified folder", () => {
-    expect(includesFolder("/path/to/examples/file.json", "examples")).toEqual(true);
-  });
-
-  it("should return false when path does not contain the specified folder", () => {
-    expect(includesFolder("/path/to/swagger/file.json", "examples")).toEqual(false);
-  });
-});
+import { relativeCwd, resolveCwd } from "../src/path.js";
 
 describe("relativeCwd", () => {
   it("relative to current dir by default", () => {

--- a/.github/shared/test/path.test.js
+++ b/.github/shared/test/path.test.js
@@ -1,45 +1,27 @@
 // @ts-check
 
-import { describe, it, beforeEach, afterEach } from "vitest";
-import { includesFolder } from "../src/path.js";
 import { strict as assert } from "assert";
-import { join, dirname } from "path";
-import { fileURLToPath } from "url";
-import { mkdirSync, rmSync, existsSync } from "fs";
+import { describe, it } from "vitest";
+import { includesFolder } from "../src/path.js";
 
-// Get the directory of this test file
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-/**
- * Unit tests for path.js utility functions
- */
-describe("Path utilities", () => {
-  let tempTestDir;
-
-  beforeEach(() => {
-    // Create a temporary directory for test files
-    tempTestDir = join(__dirname, "temp-path-tests");
-    if (existsSync(tempTestDir)) {
-      rmSync(tempTestDir, { recursive: true, force: true });
-    }
-    mkdirSync(tempTestDir, { recursive: true });
+describe("includesFolder", () => {
+  it("should return true when path contains the specified folder", () => {
+    assert.equal(includesFolder("/path/to/examples/file.json", "examples"), true);
   });
 
-  afterEach(() => {
-    // Clean up temporary directory
-    if (existsSync(tempTestDir)) {
-      rmSync(tempTestDir, { recursive: true, force: true });
-    }
+  it("should return false when path does not contain the specified folder", () => {
+    assert.equal(includesFolder("/path/to/swagger/file.json", "examples"), false);
   });
+});
 
-  describe("includesFolder", () => {
-    it("should return true when path contains the specified folder", () => {
-      assert.equal(includesFolder("/path/to/examples/file.json", "examples"), true);
-    });
+describe("relativeCwd", () => {
+  it("TODO", () => {
+    assert.fail();
+  });
+});
 
-    it("should return false when path does not contain the specified folder", () => {
-      assert.equal(includesFolder("/path/to/swagger/file.json", "examples"), false);
-    });
+describe("resolveCwd", () => {
+  it("TODO", () => {
+    assert.fail();
   });
 });

--- a/.github/shared/test/path.test.js
+++ b/.github/shared/test/path.test.js
@@ -1,27 +1,38 @@
 // @ts-check
 
-import { strict as assert } from "assert";
-import { describe, it } from "vitest";
-import { includesFolder } from "../src/path.js";
+import { tmpdir } from "os";
+import { resolve } from "path";
+import { describe, expect, it } from "vitest";
+import { includesFolder, relativeCwd, resolveCwd } from "../src/path.js";
 
 describe("includesFolder", () => {
   it("should return true when path contains the specified folder", () => {
-    assert.equal(includesFolder("/path/to/examples/file.json", "examples"), true);
+    expect(includesFolder("/path/to/examples/file.json", "examples")).toEqual(true);
   });
 
   it("should return false when path does not contain the specified folder", () => {
-    assert.equal(includesFolder("/path/to/swagger/file.json", "examples"), false);
+    expect(includesFolder("/path/to/swagger/file.json", "examples")).toEqual(false);
   });
 });
 
 describe("relativeCwd", () => {
-  it("TODO", () => {
-    assert.fail();
+  it("relative to current dir by default", () => {
+    const abs = resolve("foo.json");
+    expect(relativeCwd(abs)).toEqual("foo.json");
+  });
+
+  it("relative to options.cwd if set", () => {
+    const abs = resolve(tmpdir(), "foo.json");
+    expect(relativeCwd(abs, { cwd: tmpdir() })).toEqual("foo.json");
   });
 });
 
 describe("resolveCwd", () => {
-  it("TODO", () => {
-    assert.fail();
+  it("resolves against current dir by default", () => {
+    expect(resolveCwd("foo.json")).toEqual(resolve("foo.json"));
+  });
+
+  it("resolves against options.cwd if set", () => {
+    expect(resolveCwd("foo.json", { cwd: tmpdir() })).toEqual(resolve(tmpdir(), "foo.json"));
   });
 });


### PR DESCRIPTION
First attempt.  I don't like adding the `options` bag to the filters, it also makes them always require a lambda to use.

To make the filters most reusable, I thinke we need to decompose them, to their minimal parts, so callers can decide if they need to combine checks with `startsWithSpecification(repoRoot)`.

It would also be better, if we could filter the call to `getChangedFiles()` to the spec folder initially, when it makes sense.  This way, maybe the filters never need to check for "starts with spec" vs "spec folder nested under test dir".