### PR TITLE
[Monitor] Update resource operations route

### DIFF
--- a/specification/monitor/Monitor.Query.Logs/models.tsp
+++ b/specification/monitor/Monitor.Query.Logs/models.tsp
@@ -122,8 +122,8 @@ model ErrorResponse {
 }
 
 /**
- * The Analytics query. Learn more about the [Analytics query
- * syntax](https://azure.microsoft.com/documentation/articles/app-insights-analytics-reference/)
+ * The Analytics query. Learn more about the
+ * [Analytics query syntax](https://azure.microsoft.com/documentation/articles/app-insights-analytics-reference/)
  */
 model QueryBody {
   /** The query to execute. */
@@ -617,8 +617,8 @@ model BatchQueryRequest {
   headers?: Record<string>;
 
   /**
-   * The Analytics query. Learn more about the [Analytics query
-   * syntax](https://azure.microsoft.com/documentation/articles/app-insights-analytics-reference/)
+   * The Analytics query. Learn more about the
+   * [Analytics query syntax](https://azure.microsoft.com/documentation/articles/app-insights-analytics-reference/)
    */
   body: QueryBody;
 

--- a/specification/monitor/Monitor.Query.Logs/routes.tsp
+++ b/specification/monitor/Monitor.Query.Logs/routes.tsp
@@ -81,7 +81,7 @@ interface Query {
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Doesn't fit standard ops"
   #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "This service uses path param to specify API version"
   @summary("Execute an Analytics query using resource URI")
-  @route("/{resourceId}/query")
+  @route("/{+resourceId}/query")
   @get
   getWithResourceId(
     /** The identifier of the resource. */
@@ -112,7 +112,7 @@ interface Query {
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Doesn't fit standard ops"
   #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "This service uses path param to specify API version"
   @summary("Execute an Analytics query using resource ID")
-  @route("/{resourceId}/query")
+  @route("/{+resourceId}/query")
   @post
   executeWithResourceId(
     /** The identifier of the resource. */

--- a/specification/monitor/data-plane/Microsoft.OperationalInsights/stable/v1/OperationalInsights.json
+++ b/specification/monitor/data-plane/Microsoft.OperationalInsights/stable/v1/OperationalInsights.json
@@ -85,7 +85,8 @@
             "in": "path",
             "description": "The identifier of the resource.",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "x-ms-skip-url-encoding": true
           },
           {
             "name": "query",
@@ -133,7 +134,8 @@
             "in": "path",
             "description": "The identifier of the resource.",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "x-ms-skip-url-encoding": true
           },
           {
             "name": "Prefer",

--- a/specification/monitor/data-plane/Microsoft.OperationalInsights/stable/v1/OperationalInsights.json
+++ b/specification/monitor/data-plane/Microsoft.OperationalInsights/stable/v1/OperationalInsights.json
@@ -406,7 +406,7 @@
         },
         "body": {
           "$ref": "#/definitions/QueryBody",
-          "description": "The Analytics query. Learn more about the [Analytics query\nsyntax](https://azure.microsoft.com/documentation/articles/app-insights-analytics-reference/)"
+          "description": "The Analytics query. Learn more about the\n[Analytics query syntax](https://azure.microsoft.com/documentation/articles/app-insights-analytics-reference/)"
         },
         "path": {
           "type": "string",
@@ -1534,7 +1534,7 @@
     },
     "QueryBody": {
       "type": "object",
-      "description": "The Analytics query. Learn more about the [Analytics query\nsyntax](https://azure.microsoft.com/documentation/articles/app-insights-analytics-reference/)",
+      "description": "The Analytics query. Learn more about the\n[Analytics query syntax](https://azure.microsoft.com/documentation/articles/app-insights-analytics-reference/)",
       "properties": {
         "query": {
           "type": "string",


### PR DESCRIPTION
We need to ensure that the resourceId (which is an ARM resource identifier) is not encoded when the request URL is constructed.

Here, we do [reserved expansion](https://datatracker.ietf.org/doc/html/rfc6570#section-3.2.3) on the route to allow reserved characters.
