### PR TITLE
[Devex Agent] /prompts not working copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -212,7 +212,7 @@ Do not skip the step that choose SDK generation method to ensure the user select
 6. **Choose SDK Generation Method**: Determine how to generate SDKs (locally or via pipeline). Only Python is supported for local SDK generation at this time.
 7. **Generate SDKs via Pipeline**:  Generate SDKs using `/run-sdk-gen-pipeline` prompt, monitor the pipeline status and displaying generated SDK PR links.
 8. **Show generated SDK PR**: Display the generated SDK pull request links for review.
-9. **Create a release plan**: Create a release plan for the generated SDKs using spec pull request.
+9. **Create a release plan**: To create a release plan refer to #file:.\prompts\create-release-plan.prompt.md
 10. **Prompt user to change spec pull request to ready for review from draft status**: Update spec pull request to change it to ready for review.
 11. **Release package**: Release the SDK package using `ReleaseSdkPackage` tool.
 

--- a/.github/prompts/create-release-plan.prompt.md
+++ b/.github/prompts/create-release-plan.prompt.md
@@ -27,8 +27,8 @@ If any details are missing, prompt the user accordingly:
     - Private Preview
     - Public Preview  
     - GA (Generally Available)
-- **Service Tree ID**: GUID format identifier for the service in Service Tree.
-- **Product Service Tree ID**: GUID format identifier for the product in Service Tree.
+- **Service Tree ID**: GUID format identifier for the service in Service Tree. Before creating release plan, always show the value to user and ask them to confirm it's a valid value in service tree.
+- **Product Service Tree ID**: GUID format identifier for the product in Service Tree. Before creating release plan, always show the value to user and ask them to confirm it's a valid value in service tree.
 - **Expected Release Timeline**: Format must be in "Month YYYY"
 - **API Version**: The version of the API being released
 - **SDK Release Type**: Value must be beta or stable.

--- a/.github/prompts/create-release-plan.prompt.md
+++ b/.github/prompts/create-release-plan.prompt.md
@@ -20,16 +20,15 @@ Follow these steps in order to create or manage a release plan for an API specif
 - If no release plan exists, proceed to Step 3
 
 ## Step 3: Gather Release Plan Information
-Collect the following required information from the user. Do not use non GUID valid for product and service tree Id. Do not create release plan with temporary values.
-Do not assume or use default for service tree Id and product service tree Id. Always show the values to user and ask them to confirm it's a valid value in service tree.
+Collect the following required information from the user. Do not create a release plan with temporary values. Confirm the values with the user before proceeding to create the release plan.
 If any details are missing, prompt the user accordingly:
 
 - **API Lifecycle Stage**: Must be one of:
     - Private Preview
     - Public Preview  
     - GA (Generally Available)
-- **Service Tree ID**: GUID format identifier for the service in Service Tree. Before creating release plan, always show the value to user and ask them to confirm it's a valid value in service tree.
-- **Product Service Tree ID**: GUID format identifier for the product in Service Tree. Before creating release plan, always show the value to user and ask them to confirm it's a valid value in service tree.
+- **Service Tree ID**: GUID format identifier for the service in Service Tree.
+- **Product Service Tree ID**: GUID format identifier for the product in Service Tree.
 - **Expected Release Timeline**: Format must be in "Month YYYY"
 - **API Version**: The version of the API being released
 - **SDK Release Type**: Value must be beta or stable.


### PR DESCRIPTION
## Summary 
- Refer to prompts with file path instead of referencing through `/prompt`. 
- Removed the must ask for service tree in favor of simpler approach so it is more focused. 