### PR TITLE
[LintDiff] Report generator shows when "before" state has errors

### DIFF
--- a/eng/tools/lint-diff/src/generateReport.ts
+++ b/eng/tools/lint-diff/src/generateReport.ts
@@ -49,8 +49,8 @@ export async function generateLintDiffReport(
 
   outputMarkdown += `\n\n`;
 
-  for(const [, {before,}] of runCorrelations.entries()) {
-    if (before && before.error) { 
+  for (const [, { before }] of runCorrelations.entries()) {
+    if (before && before.error) {
       outputMarkdown += `> [!WARNING]\n`;
       outputMarkdown += `> Autorest failed checking before state of ${relative(before.rootPath, before.readme.path)} ${before.tag}\n\n`;
     }
@@ -286,8 +286,8 @@ export function getPath(result: AutorestRunResult) {
   return tag ? `${readmePathRelative}#tag-${tag}` : readmePathRelative;
 }
 
-export function getAutoRestFailedMessage(result: AutorestRunResult | null) : string { 
-  if (result?.error) { 
+export function getAutoRestFailedMessage(result: AutorestRunResult | null): string {
+  if (result?.error) {
     return "Autorest Failed";
   }
   return "";

--- a/eng/tools/lint-diff/src/lint-diff.ts
+++ b/eng/tools/lint-diff/src/lint-diff.ts
@@ -146,7 +146,10 @@ async function runLintDiff(
 
   // It may be possible to run these in parallel as they're running against
   // different directories.
+  console.log("Running checks on before state...");
   const beforeChecks = await runChecks(beforePath, beforeList);
+
+  console.log("Running checks on after state...");
   const afterChecks = await runChecks(afterPath, afterList);
 
   // If afterChecks has AutoRest errors, fail the run.

--- a/eng/tools/lint-diff/test/generateReport.test.ts
+++ b/eng/tools/lint-diff/test/generateReport.test.ts
@@ -496,50 +496,52 @@ describe("generateLintDiffReport", () => {
     `);
   });
 
-  test.skipIf(isWindows())("passes and displays warning if before has errors", async ({ expect }) => {
-    const afterViolation = {
-      extensionName: "@microsoft.azure/openapi-validator",
-      level: "warning",
-      code: "SomeCode",
-      message: "A warning occurred",
-      source: [],
-      details: {},
-    };
+  test.skipIf(isWindows())(
+    "passes and displays warning if before has errors",
+    async ({ expect }) => {
+      const afterViolation = {
+        extensionName: "@microsoft.azure/openapi-validator",
+        level: "warning",
+        code: "SomeCode",
+        message: "A warning occurred",
+        source: [],
+        details: {},
+      };
 
-    const beforeResult = {
-      error: new Error("Autorest failed"),
-      stdout: "",
-      stderr: "",
-      rootPath: "",
-      readme: new Readme("file1.md"),
-      tag: "",
-    } as AutorestRunResult;
-    const afterResult = {
-      error: null,
-      stdout: JSON.stringify(afterViolation),
-      stderr: "",
-      rootPath: "",
-      readme: new Readme("file1.md"),
-      tag: "",
-    } as AutorestRunResult;
+      const beforeResult = {
+        error: new Error("Autorest failed"),
+        stdout: "",
+        stderr: "",
+        rootPath: "",
+        readme: new Readme("file1.md"),
+        tag: "",
+      } as AutorestRunResult;
+      const afterResult = {
+        error: null,
+        stdout: JSON.stringify(afterViolation),
+        stderr: "",
+        rootPath: "",
+        readme: new Readme("file1.md"),
+        tag: "",
+      } as AutorestRunResult;
 
-    const runCorrelations = new Map<string, BeforeAfter>([
-      ["file1.md", { before: beforeResult, after: afterResult }],
-    ]);
+      const runCorrelations = new Map<string, BeforeAfter>([
+        ["file1.md", { before: beforeResult, after: afterResult }],
+      ]);
 
-    const outFile = "test-output-fatal.md";
-    const actual = await generateLintDiffReport(
-      runCorrelations,
-      new Set<string>([
-        "specification/contosowidgetmanager/data-plane/Azure.Contoso.WidgetManager/stable/2022-12-01/widgets.json",
-      ]),
-      outFile,
-      "baseBranch",
-      "compareSha",
-      "repo/path",
-    );
-    expect(actual).toBe(true);
-    expect(await readFile(outFile, { encoding: "utf-8" })).toMatchInlineSnapshot(`
+      const outFile = "test-output-fatal.md";
+      const actual = await generateLintDiffReport(
+        runCorrelations,
+        new Set<string>([
+          "specification/contosowidgetmanager/data-plane/Azure.Contoso.WidgetManager/stable/2022-12-01/widgets.json",
+        ]),
+        outFile,
+        "baseBranch",
+        "compareSha",
+        "repo/path",
+      );
+      expect(actual).toBe(true);
+      expect(await readFile(outFile, { encoding: "utf-8" })).toMatchInlineSnapshot(`
       "| Compared specs ([v1.0.0](https://www.npmjs.com/package/@microsoft.azure/openapi-validator/v/1.0.0)) | new version | base version |
       | --- | --- | --- |
       | default | [default](https://github.com/repo/path/blob/compareSha/file1.md) | [default](https://github.com/repo/path/blob/baseBranch/file1.md) Autorest Failed|
@@ -550,7 +552,8 @@ describe("generateLintDiffReport", () => {
 
       "
     `);
-  });
+    },
+  );
 
   test.skipIf(isWindows())(
     "passes if new violations do not include an error (warnings only)",
@@ -687,4 +690,3 @@ describe("generateAutoRestErrorReport", () => {
     `);
   });
 });
-

--- a/eng/tools/lint-diff/test/generateReport.test.ts
+++ b/eng/tools/lint-diff/test/generateReport.test.ts
@@ -3,6 +3,7 @@ import {
   compareLintDiffViolations,
   generateAutoRestErrorReport,
   generateLintDiffReport,
+  getAutoRestFailedMessage,
   getDocUrl,
   getFile,
   getFileLink,
@@ -48,6 +49,36 @@ describe("iconFor", () => {
     { input: "info", expected: ":warning:" },
   ])(`iconFor($input) returns $expected`, ({ input, expected }) => {
     expect(iconFor(input)).toEqual(expected);
+  });
+});
+
+describe("getAutoRestFailedMessage", () => {
+  test("returns empty string when result is null", () => {
+    expect(getAutoRestFailedMessage(null)).toEqual("");
+  });
+
+  test("returns empty string when result has no error", () => {
+    const result: AutorestRunResult = {
+      error: null,
+      rootPath: "",
+      readme: new Readme("file.md"),
+      tag: "default",
+      stdout: "",
+      stderr: "",
+    };
+    expect(getAutoRestFailedMessage(result)).toEqual("");
+  });
+
+  test("returns 'Autorest Failed' when result has an error", () => {
+    const result: AutorestRunResult = {
+      error: new Error("Autorest failed"),
+      rootPath: "",
+      readme: new Readme("file.md"),
+      tag: "default",
+      stdout: "",
+      stderr: "",
+    };
+    expect(getAutoRestFailedMessage(result)).toEqual("Autorest Failed");
   });
 });
 
@@ -465,6 +496,62 @@ describe("generateLintDiffReport", () => {
     `);
   });
 
+  test.skipIf(isWindows())("passes and displays warning if before has errors", async ({ expect }) => {
+    const afterViolation = {
+      extensionName: "@microsoft.azure/openapi-validator",
+      level: "warning",
+      code: "SomeCode",
+      message: "A warning occurred",
+      source: [],
+      details: {},
+    };
+
+    const beforeResult = {
+      error: new Error("Autorest failed"),
+      stdout: "",
+      stderr: "",
+      rootPath: "",
+      readme: new Readme("file1.md"),
+      tag: "",
+    } as AutorestRunResult;
+    const afterResult = {
+      error: null,
+      stdout: JSON.stringify(afterViolation),
+      stderr: "",
+      rootPath: "",
+      readme: new Readme("file1.md"),
+      tag: "",
+    } as AutorestRunResult;
+
+    const runCorrelations = new Map<string, BeforeAfter>([
+      ["file1.md", { before: beforeResult, after: afterResult }],
+    ]);
+
+    const outFile = "test-output-fatal.md";
+    const actual = await generateLintDiffReport(
+      runCorrelations,
+      new Set<string>([
+        "specification/contosowidgetmanager/data-plane/Azure.Contoso.WidgetManager/stable/2022-12-01/widgets.json",
+      ]),
+      outFile,
+      "baseBranch",
+      "compareSha",
+      "repo/path",
+    );
+    expect(actual).toBe(true);
+    expect(await readFile(outFile, { encoding: "utf-8" })).toMatchInlineSnapshot(`
+      "| Compared specs ([v1.0.0](https://www.npmjs.com/package/@microsoft.azure/openapi-validator/v/1.0.0)) | new version | base version |
+      | --- | --- | --- |
+      | default | [default](https://github.com/repo/path/blob/compareSha/file1.md) | [default](https://github.com/repo/path/blob/baseBranch/file1.md) Autorest Failed|
+
+
+      > [!WARNING]
+      > Autorest failed checking before state of file1.md 
+
+      "
+    `);
+  });
+
   test.skipIf(isWindows())(
     "passes if new violations do not include an error (warnings only)",
     async ({ expect }) => {
@@ -600,3 +687,4 @@ describe("generateAutoRestErrorReport", () => {
     `);
   });
 });
+


### PR DESCRIPTION
Fixes #36082

Example PR with swagger changes and autorest failing in the `before` state. In this case the table notes "Autorest failed" and there's a warning. Since there are no prior violations to compare (because of the autorest failure) all violations in the `after` state are treated as "new": 
 
https://github.com/Azure/azure-rest-api-specs/actions/runs/16475273232

<img width="780" height="496" alt="image" src="https://github.com/user-attachments/assets/b47d8d4f-dfac-411f-b782-b706cb965118" />


Example PR with fixes to `readme.md`. In this case, the PR did not change any swagger files. LintDiff only surfaces errors for affected swaggers which, when no swagger files are edited, is an empty set.

https://github.com/Azure/azure-rest-api-specs/actions/runs/16475290346?pr=36137

<img width="768" height="322" alt="image" src="https://github.com/user-attachments/assets/af0a007b-5447-401b-ab4b-f0c76dd70d5f" />


