### PR TITLE
[maintenance] Modify the optionality of 'location'

### DIFF
--- a/specification/maintenance/Maintenance.Management/MaintenanceConfiguration.tsp
+++ b/specification/maintenance/Maintenance.Management/MaintenanceConfiguration.tsp
@@ -32,6 +32,7 @@ model MaintenanceConfiguration
    * Gets or sets tags of the resource
    */
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
   tags?: Record<string>;
 }
 

--- a/specification/maintenance/Maintenance.Management/MaintenanceConfiguration.tsp
+++ b/specification/maintenance/Maintenance.Management/MaintenanceConfiguration.tsp
@@ -14,13 +14,25 @@ namespace Microsoft.Maintenance;
  * Maintenance configuration record type
  */
 model MaintenanceConfiguration
-  is Azure.ResourceManager.TrackedResource<MaintenanceConfigurationProperties> {
+  is Azure.ResourceManager.ProxyResource<MaintenanceConfigurationProperties> {
   ...ResourceNameParameter<
     Resource = MaintenanceConfiguration,
     KeyName = "resourceName",
     SegmentName = "publicMaintenanceConfigurations",
     NamePattern = ""
   >;
+
+  /**
+   * Gets or sets location of the resource
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+  location?: string;
+
+  /**
+   * Gets or sets tags of the resource
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+  tags?: Record<string>;
 }
 
 @armResourceOperations

--- a/specification/maintenance/resource-manager/Microsoft.Maintenance/preview/2023-10-01-preview/Maintenance.json
+++ b/specification/maintenance/resource-manager/Microsoft.Maintenance/preview/2023-10-01-preview/Maintenance.json
@@ -2534,11 +2534,22 @@
           "$ref": "#/definitions/MaintenanceConfigurationProperties",
           "description": "Gets or sets properties of the resource",
           "x-ms-client-flatten": true
+        },
+        "location": {
+          "type": "string",
+          "description": "Gets or sets location of the resource"
+        },
+        "tags": {
+          "type": "object",
+          "description": "Gets or sets tags of the resource",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       },
       "allOf": [
         {
-          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
         }
       ]
     },


### PR DESCRIPTION
In the previous convert, `location` property was mistakenly set as `required`. This PR corrects it to the proper configuration.
convert pr：[#34496](https://github.com/Azure/azure-rest-api-specs/pull/34496)