### PR TITLE
[botservice] Modify the optionality of 'location'

### DIFF
--- a/specification/botservice/BotService.Management/Bot.tsp
+++ b/specification/botservice/BotService.Management/Bot.tsp
@@ -13,13 +13,26 @@ namespace Microsoft.BotService;
 /**
  * Bot resource definition
  */
-model Bot is Azure.ResourceManager.TrackedResource<BotProperties> {
+model Bot is Azure.ResourceManager.ProxyResource<BotProperties> {
   ...ResourceNameParameter<
     Resource = Bot,
     KeyName = "resourceName",
     SegmentName = "botServices",
     NamePattern = "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
   >;
+
+  /**
+   * Specifies the location of the resource.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+  location?: string;
+
+  /**
+   * Contains resource tags defined as key/value pairs.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+  tags?: Record<string>;
 
   /**
    * Gets or sets the SKU of the resource.

--- a/specification/botservice/BotService.Management/BotChannel.tsp
+++ b/specification/botservice/BotService.Management/BotChannel.tsp
@@ -15,13 +15,26 @@ namespace Microsoft.BotService;
  * Bot channel resource definition
  */
 @parentResource(Bot)
-model BotChannel is Azure.ResourceManager.TrackedResource<Channel> {
+model BotChannel is Azure.ResourceManager.ProxyResource<Channel> {
   ...ResourceNameParameter<
     Resource = BotChannel,
     KeyName = "channelName",
     SegmentName = "channels",
     NamePattern = "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
   >;
+
+  /**
+   * Specifies the location of the resource.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+  location?: string;
+
+  /**
+   * Contains resource tags defined as key/value pairs.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+  tags?: Record<string>;
 
   /**
    * Gets or sets the SKU of the resource.

--- a/specification/botservice/BotService.Management/tspconfig.yaml
+++ b/specification/botservice/BotService.Management/tspconfig.yaml
@@ -29,7 +29,8 @@ options:
     flavor: azure
   "@azure-tools/typespec-ts":
     package-dir: "arm-botservice"
-    is-modular-library: true
+    typespec-title-map:
+      BotServiceClient: "AzureBotService"
     flavor: "azure"
     experimental-extensible-enums: true
     package-details:

--- a/specification/botservice/resource-manager/Microsoft.BotService/preview/2023-09-15-preview/botservice.json
+++ b/specification/botservice/resource-manager/Microsoft.BotService/preview/2023-09-15-preview/botservice.json
@@ -2112,6 +2112,17 @@
           "$ref": "#/definitions/BotProperties",
           "description": "The set of properties specific to bot resource"
         },
+        "location": {
+          "type": "string",
+          "description": "Specifies the location of the resource."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Contains resource tags defined as key/value pairs.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "sku": {
           "$ref": "#/definitions/Sku",
           "description": "Gets or sets the SKU of the resource."
@@ -2135,7 +2146,7 @@
       },
       "allOf": [
         {
-          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/TrackedResource"
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
         }
       ]
     },
@@ -2147,6 +2158,17 @@
           "$ref": "#/definitions/Channel",
           "description": "The set of properties specific to bot channel resource"
         },
+        "location": {
+          "type": "string",
+          "description": "Specifies the location of the resource."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Contains resource tags defined as key/value pairs.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "sku": {
           "$ref": "#/definitions/Sku",
           "description": "Gets or sets the SKU of the resource."
@@ -2170,7 +2192,7 @@
       },
       "allOf": [
         {
-          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/TrackedResource"
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
         }
       ]
     },


### PR DESCRIPTION
In the previous convert, `location` property was mistakenly set as `required`. This PR corrects it to the proper configuration.
convert pr：[#34585](https://github.com/Azure/azure-rest-api-specs/pull/34585)