### PR TITLE
Fixed issues in renaming file scenario to look for the candidate version for comparison

### DIFF
--- a/.github/shared/src/spec-model.js
+++ b/.github/shared/src/spec-model.js
@@ -202,17 +202,7 @@ export class SpecModel {
     const tags = await flatMapAsync(readmes, async (r) => [...(await r.getTags()).values()]);
     const swaggers = tags.flatMap((t) => [...t.inputFiles.values()]);
     const refs = await flatMapAsync(swaggers, async (s) => [...(await s.getRefs()).values()]);
-    const allSwaggers = [...swaggers, ...refs];
-    
-    // Deduplicate by path
-    const seen = new Set();
-    return allSwaggers.filter(swagger => {
-      if (seen.has(swagger.path)) {
-        return false;
-      }
-      seen.add(swagger.path);
-      return true;
-    });
+    return [...swaggers, ...refs];
   }
 
   /**

--- a/.github/shared/src/spec-model.js
+++ b/.github/shared/src/spec-model.js
@@ -201,7 +201,18 @@ export class SpecModel {
     const readmes = [...(await this.getReadmes()).values()];
     const tags = await flatMapAsync(readmes, async (r) => [...(await r.getTags()).values()]);
     const swaggers = tags.flatMap((t) => [...t.inputFiles.values()]);
-    return swaggers;
+    const refs = await flatMapAsync(swaggers, async (s) => [...(await s.getRefs()).values()]);
+    const allSwaggers = [...swaggers, ...refs];
+    
+    // Deduplicate by path
+    const seen = new Set();
+    return allSwaggers.filter(swagger => {
+      if (seen.has(swagger.path)) {
+        return false;
+      }
+      seen.add(swagger.path);
+      return true;
+    });
   }
 
   /**

--- a/.github/shared/test/fixtures/swagger/specification/common-types/resource-management/v2/types.json
+++ b/.github/shared/test/fixtures/swagger/specification/common-types/resource-management/v2/types.json
@@ -1,0 +1,26 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Common Types",
+    "version": "v2"
+  },
+  "definitions": {
+    "Resource": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    }
+  }
+}

--- a/.github/shared/test/fixtures/swagger/specification/common-types/resource-management/v3/types.json
+++ b/.github/shared/test/fixtures/swagger/specification/common-types/resource-management/v3/types.json
@@ -1,0 +1,69 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Common Types - Resource Management",
+    "version": "v3",
+    "description": "Common types for resource management APIs"
+  },
+  "host": "management.azure.com",
+  "schemes": ["https"],
+  "consumes": ["application/json"],
+  "produces": ["application/json"],
+  "definitions": {
+    "Resource": {
+      "type": "object",
+      "description": "Common fields that are returned in the response for all Azure Resource Manager resources",
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}"
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The name of the resource"
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The type of the resource. E.g. \"Microsoft.Compute/virtualMachines\" or \"Microsoft.Storage/storageAccounts\""
+        }
+      }
+    },
+    "ProxyResource": {
+      "type": "object",
+      "description": "The resource model definition for a Azure Resource Manager proxy resource.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        }
+      ]
+    },
+    "TrackedResource": {
+      "type": "object",
+      "description": "The resource model definition for an Azure Resource Manager tracked top level resource",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        }
+      ],
+      "properties": {
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Resource tags."
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives"
+        }
+      },
+      "required": [
+        "location"
+      ]
+    }
+  }
+}

--- a/.github/shared/test/spec-model.test.js
+++ b/.github/shared/test/spec-model.test.js
@@ -449,7 +449,7 @@ describe("getSwaggers", () => {
     const specModel = new SpecModel(folder, options);
     const swaggers = await specModel.getSwaggers();
     // Should return an array (may be empty if no valid readmes in this fixture)
-    expect(swaggers.length).toBe(5);
+    expect(swaggers.length).toBe(9);
 
     // If swaggers are found, they should have the expected structure
     for (const swagger of swaggers) {

--- a/eng/tools/openapi-diff-runner/src/detect-breaking-change.ts
+++ b/eng/tools/openapi-diff-runner/src/detect-breaking-change.ts
@@ -416,7 +416,28 @@ export function getSpecModel(specRepoFolder: string, swaggerPath: string): SpecM
     throw new Error(`Could not determine readme folder for swagger path: ${swaggerPath}`);
   }
 
-  const fullFolderPath = path.join(specRepoFolder, folder);
+  let fullFolderPath = path.join(specRepoFolder, folder);
+  // If the initial folder doesn't exist, search upward for a folder with readme.md
+  while (
+    !existsSync(fullFolderPath) &&
+    !fullFolderPath.endsWith("resource-manager") &&
+    !fullFolderPath.endsWith("data-plane")
+  ) {
+    const parent = path.dirname(fullFolderPath);
+
+    // Prevent infinite loop if we reach the root
+    if (parent === fullFolderPath) {
+      break;
+    }
+
+    fullFolderPath = parent;
+    const readmePath = path.join(fullFolderPath, "readme.md");
+
+    // If we find a readme.md, use this folder
+    if (existsSync(readmePath)) {
+      break;
+    }
+  }
 
   // Return if the readme folder is not found which means it's a new RP
   if (!existsSync(fullFolderPath)) {

--- a/eng/tools/openapi-diff-runner/src/detect-breaking-change.ts
+++ b/eng/tools/openapi-diff-runner/src/detect-breaking-change.ts
@@ -423,7 +423,11 @@ export function getSpecModel(specRepoFolder: string, swaggerPath: string): SpecM
   }
 
   // If the initial folder doesn't exist, search upward for a folder with readme.md
-  while (!fullFolderPath.endsWith("resource-manager") && !fullFolderPath.endsWith("data-plane")) {
+  while (
+    isNewRp &&
+    !fullFolderPath.endsWith("resource-manager") &&
+    !fullFolderPath.endsWith("data-plane")
+  ) {
     const parent = path.dirname(fullFolderPath);
 
     // Prevent infinite loop if we reach the root

--- a/eng/tools/openapi-diff-runner/src/detect-breaking-change.ts
+++ b/eng/tools/openapi-diff-runner/src/detect-breaking-change.ts
@@ -416,13 +416,14 @@ export function getSpecModel(specRepoFolder: string, swaggerPath: string): SpecM
     throw new Error(`Could not determine readme folder for swagger path: ${swaggerPath}`);
   }
 
+  let isNewRp = false;
   let fullFolderPath = path.join(specRepoFolder, folder);
+  if (!existsSync(fullFolderPath)) {
+    isNewRp = true;
+  }
+
   // If the initial folder doesn't exist, search upward for a folder with readme.md
-  while (
-    !existsSync(fullFolderPath) &&
-    !fullFolderPath.endsWith("resource-manager") &&
-    !fullFolderPath.endsWith("data-plane")
-  ) {
+  while (!fullFolderPath.endsWith("resource-manager") && !fullFolderPath.endsWith("data-plane")) {
     const parent = path.dirname(fullFolderPath);
 
     // Prevent infinite loop if we reach the root
@@ -435,12 +436,13 @@ export function getSpecModel(specRepoFolder: string, swaggerPath: string): SpecM
 
     // If we find a readme.md, use this folder
     if (existsSync(readmePath)) {
+      isNewRp = false;
       break;
     }
   }
 
   // Return if the readme folder is not found which means it's a new RP
-  if (!existsSync(fullFolderPath)) {
+  if (isNewRp) {
     logMessage(
       `getSpecModel: this is a new RP as ${fullFolderPath} folder does not exist in the base branch of spec repo.`,
     );

--- a/eng/tools/openapi-diff-runner/src/detect-breaking-change.ts
+++ b/eng/tools/openapi-diff-runner/src/detect-breaking-change.ts
@@ -38,7 +38,11 @@ import { applyRules } from "./utils/apply-rules.js";
 import { OadMessage, OadTraceData, addOadTrace } from "./types/oad-types.js";
 import { runOad } from "./run-oad.js";
 import { processAndAppendOadMessages } from "./utils/oad-message-processor.js";
-import { getExistedVersionOperations, getPrecedingSwaggers } from "./utils/spec.js";
+import {
+  deduplicateSwaggers,
+  getExistedVersionOperations,
+  getPrecedingSwaggers,
+} from "./utils/spec.js";
 import { logError, LogLevel, logMessage } from "./log.js";
 import { BREAKING_CHANGES_CHECK_TYPES } from "@azure-tools/specs-shared/breaking-change";
 import { SpecModel } from "@azure-tools/specs-shared/spec-model";
@@ -182,7 +186,8 @@ export async function checkCrossVersionBreakingChange(
       continue;
     }
 
-    const availableSwaggers = await specModel.getSwaggers();
+    const originalReturnedSwaggers = await specModel.getSwaggers();
+    const availableSwaggers = deduplicateSwaggers(originalReturnedSwaggers);
     logMessage(
       `checkCrossVersionBreakingChange: swaggerPath: ${swaggerPath}, availableSwaggers.length: ${availableSwaggers?.length}`,
     );

--- a/eng/tools/openapi-diff-runner/src/utils/common-utils.ts
+++ b/eng/tools/openapi-diff-runner/src/utils/common-utils.ts
@@ -1,5 +1,6 @@
 import { FilePosition } from "../types/message.js";
 import { Context } from "../types/breaking-change.js";
+import { existsSync, readFileSync } from "node:fs";
 
 export function blobHref(repo: string, sha: string, file: string): string {
   return `https://github.com/${repo}/blob/${sha}/${file}`;
@@ -111,13 +112,11 @@ export function getVersionFromInputFile(filePath: string, withPreview = false): 
     }
   }
 
-  // If no regex match found, return the immediate folder name (parent directory of the file)
-  if (segments && segments.length > 1) {
-    // Get the folder name that contains the file (last segment before filename)
-    const folderName = segments[segments.length - 2];
-    if (folderName) {
-      return folderName;
-    }
+  // If no regex match found, try to read version from file content
+  if (existsSync(filePath)) {
+    const fileContent = readFileSync(filePath, "utf8");
+    const parsedContent = JSON.parse(fileContent);
+    return parsedContent?.info?.version || "";
   }
 
   return "";

--- a/eng/tools/openapi-diff-runner/src/utils/spec.ts
+++ b/eng/tools/openapi-diff-runner/src/utils/spec.ts
@@ -157,3 +157,20 @@ export function getBaseNameForSwagger(filePath: string, version: string = ""): s
   }
   return basename(filePath);
 }
+
+/**
+ * Deduplicate swagger objects in an array by their path.
+ * @param swaggers The array of swagger objects to deduplicate.
+ * @returns A new array with duplicate swagger objects removed.
+ */
+export function deduplicateSwaggers(swaggers: Swagger[]): Swagger[] {
+  // Deduplicate by path
+  const seen = new Set();
+  return swaggers.filter((swagger) => {
+    if (seen.has(swagger.path)) {
+      return false;
+    }
+    seen.add(swagger.path);
+    return true;
+  });
+}

--- a/eng/tools/openapi-diff-runner/src/utils/spec.ts
+++ b/eng/tools/openapi-diff-runner/src/utils/spec.ts
@@ -36,7 +36,9 @@ async function getPrecedingSwaggerByType(
     swagger,
     version: getVersionFromInputFile(swagger.path),
     fileName: getBaseNameForSwagger(swagger.path, getVersionFromInputFile(swagger.path)),
-    versionKind: swagger.versionKind,
+    versionKind: getVersionFromInputFile(swagger.path, true).includes("preview")
+      ? ApiVersionLifecycleStage.PREVIEW
+      : ApiVersionLifecycleStage.STABLE,
   }));
 
   const versionsOfType = swaggersWithVersions.filter(

--- a/eng/tools/openapi-diff-runner/test/detect-breaking-change.test.ts
+++ b/eng/tools/openapi-diff-runner/test/detect-breaking-change.test.ts
@@ -262,30 +262,65 @@ describe("detect-breaking-change", () => {
   });
 
   describe("getReadmeFolder", () => {
-    it("should extract folder path up to resource-manager", () => {
+    it("should return first readme.md found when searching upward", () => {
       const testPath = TEST_CONSTANTS.PATHS.network;
+
+      // Mock existsSync to return true only for the resource-manager level
+      vi.mocked(existsSync).mockImplementation((pathArg: any) => {
+        return pathArg
+          .toString()
+          .endsWith(path.join("specification", "network", "resource-manager", "readme.md"));
+      });
+
       const result = getReadmeFolder(testPath);
-      expect(result).toBe("specification/network/resource-manager");
+      expect(result).toBe(path.join("specification", "network", "resource-manager"));
     });
 
-    it("should extract folder path up to data-plane", () => {
+    it("should find readme.md at data-plane level", () => {
       const testPath =
         "specification/cognitiveservices/data-plane/TextAnalytics/preview/v3.1/textanalytics.json";
+
+      vi.mocked(existsSync).mockImplementation((pathArg: any) => {
+        return pathArg
+          .toString()
+          .endsWith(path.join("specification", "cognitiveservices", "data-plane", "readme.md"));
+      });
+
       const result = getReadmeFolder(testPath);
-      expect(result).toBe("specification/cognitiveservices/data-plane");
+      expect(result).toBe(path.join("specification", "cognitiveservices", "data-plane"));
     });
 
-    it("should return first 3 segments as fallback", () => {
-      const testPath = "specification/someservice/other/file.json";
+    it("should fall back to boundary when no readme.md found", () => {
+      const testPath = TEST_CONSTANTS.PATHS.network;
+
+      // No readme.md files exist
+      vi.mocked(existsSync).mockReturnValue(false);
+
       const result = getReadmeFolder(testPath);
-      expect(result).toBe("specification/someservice/other");
+      expect(result).toBe(path.join("specification", "network", "resource-manager"));
+    });
+
+    it("should fall back to first 3 segments when no boundary found", () => {
+      const testPath = "specification/someservice/other/deep/path/file.json";
+
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      const result = getReadmeFolder(testPath);
+      expect(result).toBe(path.join("specification", "someservice", "other"));
     });
 
     it("should handle dev folder conversion", () => {
       const testPath =
         "dev/network/resource-manager/Microsoft.Network/stable/2019-11-01/network.json";
+
+      vi.mocked(existsSync).mockImplementation((pathArg: any) => {
+        return pathArg
+          .toString()
+          .endsWith(path.join("specification", "network", "resource-manager", "readme.md"));
+      });
+
       const result = getReadmeFolder(testPath);
-      expect(result).toBe("specification/network/resource-manager");
+      expect(result).toBe(path.join("specification", "network", "resource-manager"));
     });
 
     it("should return undefined for short paths", () => {
@@ -294,11 +329,35 @@ describe("detect-breaking-change", () => {
       expect(result).toBeUndefined();
     });
 
-    it("should handle paths with backslashes", () => {
+    it("should handle backslashes in paths", () => {
       const testPath =
         "specification\\network\\resource-manager\\Microsoft.Network\\stable\\2019-11-01\\network.json";
+
+      vi.mocked(existsSync).mockImplementation((pathArg: any) => {
+        return pathArg
+          .toString()
+          .endsWith(path.join("specification", "network", "resource-manager", "readme.md"));
+      });
+
       const result = getReadmeFolder(testPath);
-      expect(result).toBe("specification/network/resource-manager");
+      expect(result).toBe(path.join("specification", "network", "resource-manager"));
+    });
+
+    it("should find readme.md within boundary search range", () => {
+      const testPath =
+        "specification/network/resource-manager/Microsoft.Network/stable/2019-11-01/network.json";
+
+      // Simulate readme.md at Microsoft.Network level (within search range)
+      vi.mocked(existsSync).mockImplementation((pathArg: any) => {
+        const pathStr = pathArg.toString();
+        return pathStr.includes(path.join("Microsoft.Network", "readme.md"));
+      });
+
+      // Should find readme.md at Microsoft.Network level since it's within the search range
+      const result = getReadmeFolder(testPath);
+      expect(result).toBe(
+        path.join("specification", "network", "resource-manager", "Microsoft.Network"),
+      );
     });
   });
 
@@ -317,13 +376,21 @@ describe("detect-breaking-change", () => {
   describe("getSpecModel", () => {
     beforeEach(() => {
       MockSetup.resetAllMocks();
-      vi.mocked(existsSync).mockReturnValue(true);
     });
 
     it("should create and cache SpecModel for new folder", async () => {
       const mockSpecModelInstance = TestFixtures.createMockSpecModel();
       MockSetup.setupSpecModelMock(mockSpecModelInstance);
-      vi.mocked(existsSync).mockReturnValue(true);
+
+      // Mock existsSync for both getReadmeFolder (readme.md check) and getSpecModel (folder check)
+      vi.mocked(existsSync).mockImplementation((path: any) => {
+        const pathStr = path.toString();
+        // Return true for resource-manager readme.md and the folder itself
+        return (
+          pathStr.includes("resource-manager/readme.md") ||
+          pathStr.endsWith("specification/network/resource-manager")
+        );
+      });
 
       const repoFolder = "/path/to/repo";
       const result1 = getSpecModel(repoFolder, TEST_CONSTANTS.PATHS.network);
@@ -331,36 +398,46 @@ describe("detect-breaking-change", () => {
 
       expect(result1).toBe(result2);
       expect(result1).toBeDefined();
-      expect(vi.mocked(existsSync)).toHaveBeenCalledWith(
-        path.join("/path/to/repo", "specification/network/resource-manager"),
-      );
     });
 
     it("should return undefined when folder does not exist", async () => {
       const mockSpecModelInstance = TestFixtures.createMockSpecModel();
       MockSetup.setupSpecModelMock(mockSpecModelInstance);
-      vi.mocked(existsSync).mockReturnValue(false);
+
+      // Mock existsSync to return false for the final folder check only
+      vi.mocked(existsSync).mockImplementation((path: any) => {
+        const pathStr = path.toString();
+        // Allow readme.md to be found but make folder check fail
+        if (pathStr.includes("resource-manager/readme.md")) return true;
+        if (pathStr.endsWith("specification/network/resource-manager")) return false;
+        return false;
+      });
 
       const repoFolder = "/path/to/repo";
       const result = getSpecModel(repoFolder, TEST_CONSTANTS.PATHS.network);
 
       expect(result).toBeUndefined();
-      expect(vi.mocked(existsSync)).toHaveBeenCalledWith(
-        path.join("/path/to/repo", "specification/network/resource-manager"),
-      );
     });
 
     it("should not cache when folder does not exist", async () => {
       const mockSpecModelInstance = TestFixtures.createMockSpecModel();
       MockSetup.setupSpecModelMock(mockSpecModelInstance);
-      vi.mocked(existsSync).mockReturnValue(false);
+
+      // Mock existsSync to return false for folder checks
+      vi.mocked(existsSync).mockImplementation((path: any) => {
+        const pathStr = path.toString();
+        // Allow readme.md to be found but make folder check fail
+        if (pathStr.includes("resource-manager/readme.md")) return true;
+        if (pathStr.endsWith("specification/network/resource-manager")) return false;
+        return false;
+      });
 
       const result1 = getSpecModel("/path/to/repo", TEST_CONSTANTS.PATHS.network);
       const result2 = getSpecModel("/path/to/repo", TEST_CONSTANTS.PATHS.network);
 
       expect(result1).toBeUndefined();
       expect(result2).toBeUndefined();
-      expect(vi.mocked(existsSync)).toHaveBeenCalledTimes(2); // Called twice, no caching for undefined
+      // Note: We can't reliably check call count due to getReadmeFolder also using existsSync
     });
 
     it("should create different SpecModels for different folders", async () => {

--- a/eng/tools/openapi-diff-runner/test/detect-breaking-change.test.ts
+++ b/eng/tools/openapi-diff-runner/test/detect-breaking-change.test.ts
@@ -20,6 +20,7 @@ vi.mock("@azure-tools/specs-shared/spec-model", () => ({
 vi.mock("../src/utils/spec.js", () => ({
   getExistedVersionOperations: vi.fn(),
   getPrecedingSwaggers: vi.fn(),
+  deduplicateSwaggers: vi.fn(),
 }));
 
 vi.mock("node:fs", async (importOriginal) => {

--- a/eng/tools/openapi-diff-runner/test/utils/common-utils.test.ts
+++ b/eng/tools/openapi-diff-runner/test/utils/common-utils.test.ts
@@ -16,6 +16,17 @@ import {
   convertRawErrorToUnifiedMsg,
 } from "../../src/utils/common-utils.js";
 import { Context } from "../../src/types/breaking-change.js";
+import { existsSync, readFileSync } from "node:fs";
+
+// Mock node:fs module for file content parsing tests
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+    readFileSync: vi.fn(),
+  };
+});
 
 describe("common-utils", () => {
   let originalEnv: NodeJS.ProcessEnv;
@@ -225,6 +236,11 @@ describe("common-utils", () => {
   });
 
   describe("getVersionFromInputFile", () => {
+    beforeEach(() => {
+      vi.mocked(existsSync).mockReset();
+      vi.mocked(readFileSync).mockReset();
+    });
+
     it("should extract version from data-plane path", () => {
       const result = getVersionFromInputFile(TEST_CONSTANTS.DATA_PLANE_PATH);
       expect(result).toBe(TEST_CONSTANTS.VERSION);
@@ -245,9 +261,96 @@ describe("common-utils", () => {
       expect(result).toBe("");
     });
 
-    it("should return folder name when no valid API version found", () => {
+    it("should return empty string when no valid API version found", () => {
       const result = getVersionFromInputFile("invalid/path.json");
-      expect(result).toBe("invalid");
+      expect(result).toBe("");
+    });
+
+    it("should extract version from file content when path regex fails and file exists", () => {
+      const filePath = "some/custom/path/spec.json";
+      const mockFileContent = JSON.stringify({
+        info: {
+          version: "2023-05-01",
+        },
+      });
+
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue(mockFileContent);
+
+      const result = getVersionFromInputFile(filePath);
+      expect(result).toBe("2023-05-01");
+      expect(vi.mocked(existsSync)).toHaveBeenCalledWith(filePath);
+      expect(vi.mocked(readFileSync)).toHaveBeenCalledWith(filePath, "utf8");
+    });
+
+    it("should extract preview version from file content when includePreview is true", () => {
+      const filePath = "some/custom/path/spec.json";
+      const mockFileContent = JSON.stringify({
+        info: {
+          version: "2023-05-01-preview",
+        },
+      });
+
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue(mockFileContent);
+
+      const result = getVersionFromInputFile(filePath, true);
+      expect(result).toBe("2023-05-01-preview");
+      expect(vi.mocked(existsSync)).toHaveBeenCalledWith(filePath);
+      expect(vi.mocked(readFileSync)).toHaveBeenCalledWith(filePath, "utf8");
+    });
+
+    it("should return empty string when file content has no version", () => {
+      const filePath = "some/custom/path/spec.json";
+      const mockFileContent = JSON.stringify({
+        info: {
+          title: "Test API",
+        },
+      });
+
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue(mockFileContent);
+
+      const result = getVersionFromInputFile(filePath);
+      expect(result).toBe("");
+      expect(vi.mocked(existsSync)).toHaveBeenCalledWith(filePath);
+      expect(vi.mocked(readFileSync)).toHaveBeenCalledWith(filePath, "utf8");
+    });
+
+    it("should throw error when file content is invalid JSON", () => {
+      const filePath = "some/custom/path/spec.json";
+      const mockFileContent = "invalid json content";
+
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue(mockFileContent);
+
+      expect(() => getVersionFromInputFile(filePath)).toThrow();
+      expect(vi.mocked(existsSync)).toHaveBeenCalledWith(filePath);
+      expect(vi.mocked(readFileSync)).toHaveBeenCalledWith(filePath, "utf8");
+    });
+
+    it("should return empty string when file does not exist and path regex fails", () => {
+      const filePath = "non/existent/path/spec.json";
+
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      const result = getVersionFromInputFile(filePath);
+      expect(result).toBe("");
+      expect(vi.mocked(existsSync)).toHaveBeenCalledWith(filePath);
+      expect(vi.mocked(readFileSync)).not.toHaveBeenCalled();
+    });
+
+    it("should throw error when file read fails", () => {
+      const filePath = "some/custom/path/spec.json";
+
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockImplementation(() => {
+        throw new Error("File read error");
+      });
+
+      expect(() => getVersionFromInputFile(filePath)).toThrow("File read error");
+      expect(vi.mocked(existsSync)).toHaveBeenCalledWith(filePath);
+      expect(vi.mocked(readFileSync)).toHaveBeenCalledWith(filePath, "utf8");
     });
   });
 

--- a/eng/tools/openapi-diff-runner/test/utils/spec.test.ts
+++ b/eng/tools/openapi-diff-runner/test/utils/spec.test.ts
@@ -4,6 +4,7 @@ import {
   getExistedVersionOperations,
   type Swagger,
   getBaseNameForSwagger,
+  deduplicateSwaggers,
 } from "../../src/utils/spec.js";
 import { ApiVersionLifecycleStage } from "../../src/types/breaking-change.js";
 
@@ -264,6 +265,98 @@ describe("Helper functions for version analysis", () => {
     it("should handle paths without version segments", () => {
       const result = getBaseNameForSwagger("specification/network/test.json");
       expect(result).toBe("test.json");
+    });
+  });
+
+  describe("deduplicateSwaggers", () => {
+    it("should return empty array for empty input", () => {
+      const result = deduplicateSwaggers([]);
+      expect(result).toEqual([]);
+    });
+
+    it("should return the same array when no duplicates exist", () => {
+      const mockSwaggers: MockSwagger[] = [
+        createMockSwagger(TEST_PATHS.stable2020_07_02),
+        createMockSwagger(TEST_PATHS.stable2020_08_04),
+        createMockSwagger(TEST_PATHS.preview2020_07_02),
+      ];
+
+      const result = deduplicateSwaggers(mockSwaggers);
+
+      expect(result).toHaveLength(3);
+      expect(result[0].path).toBe(TEST_PATHS.stable2020_07_02);
+      expect(result[1].path).toBe(TEST_PATHS.stable2020_08_04);
+      expect(result[2].path).toBe(TEST_PATHS.preview2020_07_02);
+    });
+
+    it("should remove duplicate swaggers with same path", () => {
+      const mockSwaggers: MockSwagger[] = [
+        createMockSwagger(TEST_PATHS.stable2020_07_02),
+        createMockSwagger(TEST_PATHS.stable2020_08_04),
+        createMockSwagger(TEST_PATHS.stable2020_07_02), // duplicate
+        createMockSwagger(TEST_PATHS.preview2020_07_02),
+        createMockSwagger(TEST_PATHS.stable2020_08_04), // duplicate
+      ];
+
+      const result = deduplicateSwaggers(mockSwaggers);
+
+      expect(result).toHaveLength(3);
+      expect(result.map((s) => s.path)).toEqual([
+        TEST_PATHS.stable2020_07_02,
+        TEST_PATHS.stable2020_08_04,
+        TEST_PATHS.preview2020_07_02,
+      ]);
+    });
+
+    it("should preserve the first occurrence when duplicates exist", () => {
+      const swagger1 = createMockSwagger(TEST_PATHS.stable2020_07_02);
+      const swagger2 = createMockSwagger(TEST_PATHS.stable2020_07_02); // same path, different object
+      swagger1.versionKind = ApiVersionLifecycleStage.STABLE;
+      swagger2.versionKind = ApiVersionLifecycleStage.PREVIEW;
+
+      const mockSwaggers: MockSwagger[] = [swagger1, swagger2];
+
+      const result = deduplicateSwaggers(mockSwaggers);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBe(swagger1); // First occurrence preserved
+      expect(result[0].versionKind).toBe(ApiVersionLifecycleStage.STABLE);
+    });
+
+    it("should handle single swagger", () => {
+      const mockSwaggers: MockSwagger[] = [createMockSwagger(TEST_PATHS.stable2020_07_02)];
+
+      const result = deduplicateSwaggers(mockSwaggers);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].path).toBe(TEST_PATHS.stable2020_07_02);
+    });
+
+    it("should handle all duplicates scenario", () => {
+      const mockSwaggers: MockSwagger[] = [
+        createMockSwagger(TEST_PATHS.stable2020_07_02),
+        createMockSwagger(TEST_PATHS.stable2020_07_02),
+        createMockSwagger(TEST_PATHS.stable2020_07_02),
+      ];
+
+      const result = deduplicateSwaggers(mockSwaggers);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].path).toBe(TEST_PATHS.stable2020_07_02);
+    });
+
+    it("should not mutate the original array", () => {
+      const mockSwaggers: MockSwagger[] = [
+        createMockSwagger(TEST_PATHS.stable2020_07_02),
+        createMockSwagger(TEST_PATHS.stable2020_07_02),
+      ];
+      const originalLength = mockSwaggers.length;
+
+      const result = deduplicateSwaggers(mockSwaggers);
+
+      expect(mockSwaggers).toHaveLength(originalLength); // Original unchanged
+      expect(result).not.toBe(mockSwaggers); // Different array instance
+      expect(result).toHaveLength(1);
     });
   });
 });


### PR DESCRIPTION
* Updated `SpecModel` to include references from Swagger files in addition to the Swagger files themselves when returning results. 

* Enhanced `getVersionFromInputFile` to extract the version directly from Swagger file content if regex-based detection fails. 

* Improved `getReadmeFolder` to search upward for the closest `readme.md` file

* Updated tests