### PR TITLE
Install azsdk mcp server in copilot setup steps

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -22,3 +22,8 @@ jobs:
           client-id: "936c56f0-298b-467f-b702-3ad5bf4b15c1"
           tenant-id: "72f988bf-86f1-41af-91ab-2d7cd011db47"
           allow-no-subscriptions: true
+
+      - name: Install azsdk mcp server
+        shell: pwsh
+        run: |
+          ./eng/common/mcp/azure-sdk-mcp.ps1 -InstallDirectory $HOME/bin


### PR DESCRIPTION
Install azsdk mcp server in copilot setup steps.

This will pair with this update to the coding agent config in the repo settings:

```
{
  "mcpServers": {
    "azure-sdk-mcp": {
      "type": "local",
      "command": "/home/runner/bin/azsdk",
      "args": [
        "start"
      ],
      "tools": ["*"],
      "type": "local",
      "env": {
        "GITHUB_TOKEN": "GITHUB_PERSONAL_ACCESS_TOKEN"
      }
    }
  }
}
```