### PR TITLE
Multiple `summarize` logic updates / fixes

### DIFF
--- a/.github/workflows/src/summarize-checks/labelling.js
+++ b/.github/workflows/src/summarize-checks/labelling.js
@@ -496,7 +496,9 @@ export async function processImpactAssessment(
 
   const newApiVersionLabel = new Label("new-api-version", labelContext.present);
   const resourceManagerLabel = new Label("resource-manager", labelContext.present);
+  resourceManagerLabel.shouldBePresent = resourceManagerLabelShouldBePresent;
   const dataplaneLabel = new Label("data-plane", labelContext.present);
+  dataplaneLabel.shouldBePresent = dataPlaneLabelShouldBePresent;
 
   // By default this label should not be present. We may determine later in this function that it should be present after all.
   newApiVersionLabel.shouldBePresent = false;
@@ -530,18 +532,6 @@ export async function processImpactAssessment(
       rpaasExceptionLabelShouldBePresent,
       ciRpaasRPNotInPrivateRepoLabelShouldBePresent,
     );
-  }
-
-  if (resourceManagerLabelShouldBePresent) {
-    resourceManagerLabel.shouldBePresent = true;
-  } else {
-    resourceManagerLabel.shouldBePresent = false;
-  }
-
-  if (dataPlaneLabelShouldBePresent) {
-    dataplaneLabel.shouldBePresent = true;
-  } else {
-    dataplaneLabel.shouldBePresent = false;
   }
 
   dataplaneLabel.applyStateChange(labelContext.toAdd, labelContext.toRemove);

--- a/.github/workflows/src/summarize-checks/labelling.js
+++ b/.github/workflows/src/summarize-checks/labelling.js
@@ -48,6 +48,7 @@ import {
 /**
  * @typedef {Object} ImpactAssessment
  * @property {boolean} resourceManagerRequired - Whether a resource manager review is required.
+ * @property {boolean} dataPlaneRequired - Whether a data plane review is required.
  * @property {boolean} suppressionReviewRequired - Whether a suppression review is required.
  * @property {boolean} isNewApiVersion - Whether this PR introduces a new API version.
  * @property {boolean} rpaasExceptionRequired - Whether an RPaaS exception is required.
@@ -57,7 +58,6 @@ import {
  * @property {boolean} rpaasRPMissing - Whether the RPaaS RP label is missing.
  * @property {boolean} typeSpecChanged - Whether a TypeSpec file has changed.
  * @property {boolean} isDraft - Whether the PR is a draft.
- * @property {LabelContext} labelContext - The context containing present, to-add, and to-remove labels.
  * @property {string} targetBranch - The name of the target branch for the PR.
  */
 
@@ -411,33 +411,36 @@ export const breakingChangesCheckType = {
  * @returns {void}
  */
 export function processArmReviewLabels(context, existingLabels) {
-  // the important part about how this will work depends how the users use it
-  // EG: if they add the "ARMSignedOff" label, we will remove the "ARMChangesRequested" and "WaitForARMFeedback" labels.
-  // if they add the "ARMChangesRequested" label, we will remove the "WaitForARMFeedback" label.
-  // if they remove the "ARMChangesRequested" label, we will add the "WaitForARMFeedback" label.
-  // so if the user or ARM team actually unlabels `ARMChangesRequested`, then we're actually ok
-  // if we are signed off, we should remove the "ARMChangesRequested" and "WaitForARMFeedback" labels
-  if (includesEvery(existingLabels, ["ARMSignedOff"])) {
-    if (existingLabels.includes("ARMChangesRequested")) {
-      context.toRemove.add("ARMChangesRequested");
+  // only kick this off if the ARMReview label is present
+  if (existingLabels.includes("ARMReview")) {
+    // the important part about how this will work depends how the users use it
+    // EG: if they add the "ARMSignedOff" label, we will remove the "ARMChangesRequested" and "WaitForARMFeedback" labels.
+    // if they add the "ARMChangesRequested" label, we will remove the "WaitForARMFeedback" label.
+    // if they remove the "ARMChangesRequested" label, we will add the "WaitForARMFeedback" label.
+    // so if the user or ARM team actually unlabels `ARMChangesRequested`, then we're actually ok
+    // if we are signed off, we should remove the "ARMChangesRequested" and "WaitForARMFeedback" labels
+    if (includesEvery(existingLabels, ["ARMSignedOff"])) {
+      if (existingLabels.includes("ARMChangesRequested")) {
+        context.toRemove.add("ARMChangesRequested");
+      }
+      if (existingLabels.includes("WaitForARMFeedback")) {
+        context.toRemove.add("WaitForARMFeedback");
+      }
     }
-    if (existingLabels.includes("WaitForARMFeedback")) {
-      context.toRemove.add("WaitForARMFeedback");
+    // if there are ARM changes requested, we should remove the "WaitForARMFeedback" label as the presence indicates that ARM has reviewed
+    else if (
+      includesEvery(existingLabels, ["ARMChangesRequested"]) &&
+      includesNone(existingLabels, ["ARMSignedOff"])
+    ) {
+      if (existingLabels.includes("WaitForARMFeedback")) {
+        context.toRemove.add("WaitForARMFeedback");
+      }
     }
-  }
-  // if there are ARM changes requested, we should remove the "WaitForARMFeedback" label as the presence indicates that ARM has reviewed
-  else if (
-    includesEvery(existingLabels, ["ARMChangesRequested"]) &&
-    includesNone(existingLabels, ["ARMSignedOff"])
-  ) {
-    if (existingLabels.includes("WaitForARMFeedback")) {
-      context.toRemove.add("WaitForARMFeedback");
-    }
-  }
-  // finally, if ARMChangesRequested are not present, and we've gotten here by lac;k of signoff, we should add the "WaitForARMFeedback" label
-  else if (includesNone(existingLabels, ["ARMChangesRequested"])) {
-    if (!existingLabels.includes("WaitForARMFeedback")) {
-      context.toAdd.add("WaitForARMFeedback");
+    // finally, if ARMChangesRequested are not present, and we've gotten here by lac;k of signoff, we should add the "WaitForARMFeedback" label
+    else if (includesNone(existingLabels, ["ARMChangesRequested"])) {
+      if (!existingLabels.includes("WaitForARMFeedback")) {
+        context.toAdd.add("WaitForARMFeedback");
+      }
     }
   }
 }
@@ -466,6 +469,7 @@ This function does the following, **among other things**:
  * @param {string} targetBranch
  * @param {LabelContext} labelContext
  * @param {boolean} resourceManagerLabelShouldBePresent
+ * @param {boolean} dataPlaneLabelShouldBePresent
  * @param {boolean} ciNewRPNamespaceWithoutRpaaSLabelShouldBePresent
  * @param {boolean} rpaasExceptionLabelShouldBePresent
  * @param {boolean} ciRpaasRPNotInPrivateRepoLabelShouldBePresent
@@ -477,6 +481,7 @@ export async function processImpactAssessment(
   targetBranch,
   labelContext,
   resourceManagerLabelShouldBePresent,
+  dataPlaneLabelShouldBePresent,
   ciNewRPNamespaceWithoutRpaaSLabelShouldBePresent,
   rpaasExceptionLabelShouldBePresent,
   ciRpaasRPNotInPrivateRepoLabelShouldBePresent,
@@ -490,6 +495,9 @@ export async function processImpactAssessment(
   armReviewLabel.shouldBePresent = false;
 
   const newApiVersionLabel = new Label("new-api-version", labelContext.present);
+  const resourceManagerLabel = new Label("resource-manager", labelContext.present);
+  const dataplaneLabel = new Label("data-plane", labelContext.present);
+
   // By default this label should not be present. We may determine later in this function that it should be present after all.
   newApiVersionLabel.shouldBePresent = false;
 
@@ -524,8 +532,28 @@ export async function processImpactAssessment(
     );
   }
 
+  if (resourceManagerLabelShouldBePresent) {
+    resourceManagerLabel.shouldBePresent = true;
+  } else {
+    resourceManagerLabel.shouldBePresent = false;
+  }
+
+  if (dataPlaneLabelShouldBePresent) {
+    dataplaneLabel.shouldBePresent = true;
+  } else {
+    dataplaneLabel.shouldBePresent = false;
+  }
+
+  dataplaneLabel.applyStateChange(labelContext.toAdd, labelContext.toRemove);
+  resourceManagerLabel.applyStateChange(labelContext.toAdd, labelContext.toRemove);
   newApiVersionLabel.applyStateChange(labelContext.toAdd, labelContext.toRemove);
   armReviewLabel.applyStateChange(labelContext.toAdd, labelContext.toRemove);
+
+  // this is the only labelling that was part of original pipelinebot logic, it handles the rotation of
+  // ARMChangesRequested, WaitForArmFeedback, and ARMSignedOff labels. The thing is, we only want to make
+  // these changes if the review is actually an ARM review. So we're going to place this after processing an impactAssessment
+  // which will tell us if a the ARMReview label should be present or not.
+  processArmReviewLabels(labelContext, [...labelContext.present, ...labelContext.toAdd]);
 
   console.log(
     `RETURN definition processARMReview. ` +

--- a/.github/workflows/src/summarize-checks/summarize-checks.js
+++ b/.github/workflows/src/summarize-checks/summarize-checks.js
@@ -534,8 +534,8 @@ export function updateLabels(existingLabels, impactAssessment) {
     processImpactAssessment(
       impactAssessment.targetBranch,
       labelContext,
-      impactAssessment.dataPlaneRequired,
       impactAssessment.resourceManagerRequired,
+      impactAssessment.dataPlaneRequired,
       impactAssessment.rpaasRPMissing,
       impactAssessment.rpaasExceptionRequired,
       impactAssessment.rpaasRpNotInPrivateRepo,

--- a/.github/workflows/src/summarize-checks/summarize-checks.js
+++ b/.github/workflows/src/summarize-checks/summarize-checks.js
@@ -26,7 +26,6 @@ import { PER_PAGE_MAX } from "../github.js";
 import {
   brChRevApproval,
   getViolatedRequiredLabelsRules,
-  processArmReviewLabels,
   processImpactAssessment,
   verRevApproval,
 } from "./labelling.js";
@@ -283,13 +282,6 @@ export default async function summarizeChecks({ github, context, core }) {
   const targetBranch = context.payload.pull_request?.base?.ref;
   core.info(`PR target branch: ${targetBranch}`);
 
-  if (!issue_number) {
-    core.info(
-      "This summarize-checks was triggered off a workflow that doesn't provide the issue-number artifact, early exiting.",
-    );
-    return;
-  }
-
   await summarizeChecksImpl(
     github,
     context,
@@ -326,17 +318,9 @@ export async function summarizeChecksImpl(
   event_name,
   targetBranch,
 ) {
-  core.info(
-    `Handling ${event_name} event for PR #${issue_number} in ${owner}/${repo}@${head_sha}.`,
-  );
+  core.info(`Handling ${event_name} event for PR #${issue_number} in ${owner}/${repo}.`);
 
-  // retrieve latest labels state
-  const labels = await github.paginate(github.rest.issues.listLabelsOnIssue, {
-    owner,
-    repo,
-    issue_number: issue_number,
-    per_page: PER_PAGE_MAX,
-  });
+  let labelNames = await getExistingLabels(github, owner, repo, issue_number);
 
   /** @type {[CheckRunData[], CheckRunData[], import("./labelling.js").ImpactAssessment | undefined]} */
   const [requiredCheckRuns, fyiCheckRuns, impactAssessment] = await getCheckRunTuple(
@@ -349,16 +333,13 @@ export async function summarizeChecksImpl(
     EXCLUDED_CHECK_NAMES,
   );
 
-  /** @type {string[]} */
-  let labelNames = labels.map((/** @type {{ name: string; }} */ label) => label.name);
-
   let labelContext = await updateLabels(labelNames, impactAssessment);
 
   core.info(
     `Summarize checks label actions against ${owner}/${repo}#${issue_number}: \n` +
-      `The following labels were present: [${Array.from(labelContext.present).join(", ")}] \n` +
-      `Removing labels: [${Array.from(labelContext.toRemove).join(", ")}] \n` +
-      `Adding labels: [${Array.from(labelContext.toAdd).join(", ")}]`,
+      `The following labels were present: [${Array.from(labelContext.present).join(", ")}]` +
+      `Removing labels [${Array.from(labelContext.toRemove).join(", ")}] then \n` +
+      `Adding labels [${Array.from(labelContext.toAdd).join(", ")}]`,
   );
 
   // for (const label of labelContext.toRemove) {
@@ -416,6 +397,27 @@ export async function summarizeChecksImpl(
   core.info(
     `Summarize checks has identified that status of "Automated merging requirements met" check should be updated to: ${automatedChecksMet}.`,
   );
+}
+
+/**
+ * @param {import('@actions/github-script').AsyncFunctionArguments['github']} github
+ * @param {string} owner
+ * @param {string} repo
+ * @param {number} issue_number
+ * @param {*} owner
+ * @param {*} repo
+ * @param {*} issue_number
+ * @return {Promise<string[]>}
+ */
+export async function getExistingLabels(github, owner, repo, issue_number) {
+  const labels = await github.paginate(github.rest.issues.listLabelsOnIssue, {
+    owner,
+    repo,
+    issue_number: issue_number,
+    per_page: PER_PAGE_MAX,
+  });
+  /** @type {string[]} */
+  return labels.map((/** @type {{ name: string; }} */ label) => label.name);
 }
 
 /**
@@ -527,23 +529,12 @@ export function updateLabels(existingLabels, impactAssessment) {
 
   if (impactAssessment) {
     console.log(`Downloaded impact assessment: ${JSON.stringify(impactAssessment)}`);
-    // Merge impact assessment labels into the main labelContext
-    impactAssessment.labelContext.toAdd.forEach((label) => {
-      labelContext.toAdd.add(label);
-    });
-    impactAssessment.labelContext.toRemove.forEach((label) => {
-      labelContext.toRemove.add(label);
-    });
-  }
 
-  // this is the only labelling that was part of original pipelinebot logic
-  processArmReviewLabels(labelContext, existingLabels);
-
-  if (impactAssessment) {
     // will further update the label context if necessary
     processImpactAssessment(
       impactAssessment.targetBranch,
       labelContext,
+      impactAssessment.dataPlaneRequired,
       impactAssessment.resourceManagerRequired,
       impactAssessment.rpaasRPMissing,
       impactAssessment.rpaasExceptionRequired,
@@ -730,7 +721,6 @@ function extractRunsFromGraphQLResponse(response) {
       },
     );
   }
-
   return [reqCheckRuns, fyiCheckRuns, impactAssessmentWorkflowRun];
 }
 // #endregion

--- a/eng/tools/summarize-impact/src/ImpactAssessment.ts
+++ b/eng/tools/summarize-impact/src/ImpactAssessment.ts
@@ -1,7 +1,6 @@
-import { LabelContext } from "./labelling-types.js";
-
 export type ImpactAssessment = {
   resourceManagerRequired: boolean;
+  dataPlaneRequired: boolean;
   suppressionReviewRequired: boolean;
   isNewApiVersion: boolean;
   rpaasExceptionRequired: boolean;
@@ -11,6 +10,5 @@ export type ImpactAssessment = {
   rpaasRPMissing: boolean;
   typeSpecChanged: boolean;
   isDraft: boolean;
-  labelContext: LabelContext;
   targetBranch: string;
 };

--- a/eng/tools/summarize-impact/src/impact.ts
+++ b/eng/tools/summarize-impact/src/impact.ts
@@ -92,13 +92,15 @@ export async function evaluateImpact(
 
   // examine changed files. if changedpaths includes data-plane, add "data-plane"
   // same for "resource-manager". We care about whether resourcemanager will be present for a later check
-  const { resourceManagerLabelShouldBePresent } = await processPRType(context, labelContext);
+  const { resourceManagerLabelShouldBePresent, dataPlaneShouldBePresent } = await processPRType(
+    context,
+    labelContext,
+  );
 
   // Has to be run in a PR context. Uses addition and update to understand
   // if the suppressions have been changed. If they have, suppressionReviewRequired must be added
   // as a label
   const suppressionRequired = await processSuppression(context, labelContext);
-  console.log(`suppressionRequired: ${suppressionRequired}`);
 
   // needs to examine "after" context to understand if a readme that was changed is RPaaS or not
   const { rpaasLabelShouldBePresent } = await processRPaaS(context, labelContext);
@@ -134,17 +136,17 @@ export async function evaluateImpact(
   const newApiVersion = await isNewApiVersion(context);
 
   return {
-    suppressionReviewRequired: labelContext.toAdd.has("suppressionsReviewRequired"),
+    suppressionReviewRequired: suppressionRequired,
     rpaasChange: rpaasLabelShouldBePresent,
     newRP: newRPNamespaceLabelShouldBePresent,
     rpaasRPMissing: ciNewRPNamespaceWithoutRpaaSLabelShouldBePresent,
     rpaasRpNotInPrivateRepo: ciRpaasRPNotInPrivateRepoLabelShouldBePresent,
     resourceManagerRequired: resourceManagerLabelShouldBePresent,
+    dataPlaneRequired: dataPlaneShouldBePresent,
     rpaasExceptionRequired: rpaasExceptionLabelShouldBePresent,
     typeSpecChanged: typeSpecLabelShouldBePresent,
     isNewApiVersion: newApiVersion,
     isDraft: context.isDraft,
-    labelContext: labelContext,
     targetBranch: context.targetBranch,
   };
 }
@@ -351,7 +353,7 @@ export async function getPRChanges(ctx: PRContext): Promise<PRChange[]> {
 async function processPRType(
   context: PRContext,
   labelContext: LabelContext,
-): Promise<{ resourceManagerLabelShouldBePresent: boolean }> {
+): Promise<{ resourceManagerLabelShouldBePresent: boolean; dataPlaneShouldBePresent: boolean }> {
   console.log("ENTER definition processPRType");
   const types: PRType[] = await getPRType(context);
 
@@ -360,10 +362,10 @@ async function processPRType(
     types,
     labelContext,
   );
-  processPRTypeLabel("data-plane", types, labelContext);
+  const dataPlaneShouldBePresent = processPRTypeLabel("data-plane", types, labelContext);
 
   console.log("RETURN definition processPRType");
-  return { resourceManagerLabelShouldBePresent };
+  return { resourceManagerLabelShouldBePresent, dataPlaneShouldBePresent };
 }
 
 async function getPRType(context: PRContext): Promise<PRType[]> {

--- a/eng/tools/summarize-impact/test/cli.test.ts
+++ b/eng/tools/summarize-impact/test/cli.test.ts
@@ -44,8 +44,9 @@ describe("Check Changes", () => {
 
         expect(result).toBeDefined();
         expect(result.typeSpecChanged).toBeTruthy();
-        expect(result.labelContext.toAdd.has("resource-manager")).toBeTruthy();
-        expect(result.labelContext.toAdd.has("SuppressionReviewRequired")).toBeTruthy();
+        expect(result.dataPlaneRequired).toBeFalsy();
+        expect(result.resourceManagerRequired).toBeTruthy();
+        expect(result.suppressionReviewRequired).toBeTruthy();
         expect(changedFileDetails).toBeDefined();
         expect(changedFileDetails.total).toEqual(293);
       } finally {
@@ -90,12 +91,10 @@ describe("Check Changes", () => {
 
         const result = await evaluateImpact(prContext, labelContext);
         expect(result.isNewApiVersion).toBeTruthy();
-        expect(result.labelContext.toAdd.has("TypeSpec")).toBeTruthy();
-        expect(result.labelContext.toAdd.has("resource-manager")).toBeTruthy();
+        expect(result.typeSpecChanged).toBeTruthy();
+        expect(result.resourceManagerRequired).toBeTruthy();
         expect(result.isNewApiVersion).toBeTruthy();
-        expect(result.labelContext.toAdd.has("ARMReview")).toBeTruthy();
-        expect(result.labelContext.toAdd.has("RPaaS")).toBeTruthy();
-        expect(result.labelContext.toAdd.has("WaitForARMFeedback")).toBeTruthy();
+        expect(result.rpaasChange).toBeTruthy();
         expect(result).toBeDefined();
       } finally {
         // Restore original directory


### PR DESCRIPTION
1. Simplifying the tagging process. The only tagging determination that happens is during `summarize-checks`. Logic of passing the processed labels in the ImpactAssessment has been deprecated for straightforwardness.
2. We should only apply the the ARM process labels when the `ARMReview` label is present, so move `processArmReviewLabels` into code that requires an impactAssessment to be completed before running.
3. We should now properly tag `resource-manager` or `data-plane`
4. Factoring `getLabels` out of an inline implementation to allow for easier mocking

[Test pipeline](https://github.com/scbedd/azure-rest-api-specs/pull/6)

