### PR TITLE
Fix Centralized Labelling - Page GraphQL

### DIFF
--- a/.github/workflows/src/summarize-checks/labelling.js
+++ b/.github/workflows/src/summarize-checks/labelling.js
@@ -463,47 +463,59 @@ This function does the following, **among other things**:
 
 - Calls the "processARMReviewWorkflowLabels" function if "ARMReview" label applies.
 */
-// todo: refactor to take context: PRContext as input instead of IValidatorContext.
-// All downstream usage appears to be using "context.contextConfig() as PRContext".
 /**
- * @param {string} targetBranch
  * @param {LabelContext} labelContext
- * @param {boolean} resourceManagerLabelShouldBePresent
- * @param {boolean} dataPlaneLabelShouldBePresent
- * @param {boolean} ciNewRPNamespaceWithoutRpaaSLabelShouldBePresent
- * @param {boolean} rpaasExceptionLabelShouldBePresent
- * @param {boolean} ciRpaasRPNotInPrivateRepoLabelShouldBePresent
- * @param {boolean} isNewApiVersion
- * @param {boolean} isDraft
+ * @param {ImpactAssessment} impactAssessment
  * @returns {Promise<{armReviewLabelShouldBePresent: boolean}>}
  */
-export async function processImpactAssessment(
-  targetBranch,
-  labelContext,
-  resourceManagerLabelShouldBePresent,
-  dataPlaneLabelShouldBePresent,
-  ciNewRPNamespaceWithoutRpaaSLabelShouldBePresent,
-  rpaasExceptionLabelShouldBePresent,
-  ciRpaasRPNotInPrivateRepoLabelShouldBePresent,
-  isNewApiVersion,
-  isDraft,
-) {
+export async function processImpactAssessment(labelContext, impactAssessment) {
   console.log("ENTER definition processARMReview");
 
+  // By default these two should not be present. We may determine later in this function that they should be present after all.
   const armReviewLabel = new Label("ARMReview", labelContext.present);
-  // By default this label should not be present. We may determine later in this function that it should be present after all.
   armReviewLabel.shouldBePresent = false;
-
   const newApiVersionLabel = new Label("new-api-version", labelContext.present);
-  const resourceManagerLabel = new Label("resource-manager", labelContext.present);
-  resourceManagerLabel.shouldBePresent = resourceManagerLabelShouldBePresent;
-  const dataplaneLabel = new Label("data-plane", labelContext.present);
-  dataplaneLabel.shouldBePresent = dataPlaneLabelShouldBePresent;
-
-  // By default this label should not be present. We may determine later in this function that it should be present after all.
   newApiVersionLabel.shouldBePresent = false;
 
-  const branch = targetBranch;
+  const resourceManagerLabel = new Label("resource-manager", labelContext.present);
+  resourceManagerLabel.shouldBePresent = impactAssessment.resourceManagerRequired || false;
+
+  const dataplaneLabel = new Label("data-plane", labelContext.present);
+  dataplaneLabel.shouldBePresent = impactAssessment.dataPlaneRequired || false;
+
+  const typeSpecLabel = new Label("TypeSpec", labelContext.present);
+  typeSpecLabel.shouldBePresent = impactAssessment.typeSpecChanged || false;
+
+  const suppressionReviewRequiredLabel = new Label(
+    "SuppressionReviewRequired",
+    labelContext.present,
+  );
+  suppressionReviewRequiredLabel.shouldBePresent =
+    impactAssessment.suppressionReviewRequired || false;
+
+  const rpassReviewRequiredLabel = new Label("RPaaS", labelContext.present);
+  rpassReviewRequiredLabel.shouldBePresent = impactAssessment.rpaasChange || false;
+
+  const newRPNamespaceLabel = new Label("new-rp-namespace", labelContext.present);
+  newRPNamespaceLabel.shouldBePresent = impactAssessment.newRP || false;
+
+  const ciNewRPNamespaceWithoutRpaaSLabel = new Label(
+    "CI-NewRPNamespaceWithoutRPaaS",
+    labelContext.present,
+  );
+  ciNewRPNamespaceWithoutRpaaSLabel.shouldBePresent = impactAssessment.rpaasRPMissing || false;
+
+  const rpaasExceptionLabel = new Label("RPaaSException", labelContext.present);
+  rpaasExceptionLabel.shouldBePresent = impactAssessment.rpaasExceptionRequired || false;
+
+  const ciRpaasRPNotInPrivateRepoLabel = new Label(
+    "CI-RpaaSRPNotInPrivateRepo",
+    labelContext.present,
+  );
+  ciRpaasRPNotInPrivateRepoLabel.shouldBePresent =
+    impactAssessment.rpaasRpNotInPrivateRepo || false;
+
+  const branch = impactAssessment.targetBranch;
   const isReleaseBranchVal = isReleaseBranch(branch);
 
   // we used to also calculate if the branch name was from ShiftLeft, in which case we would or that
@@ -511,26 +523,26 @@ export async function processImpactAssessment(
   // so we only check if the branch is a release branch.
   // const prTitle = await getPrTitle(owner, repo, prNumber)
   // const isShiftLeftPRWithRPSaaSDevVal = isShiftLeftPRWithRPSaaSDev(prTitle, branch)
-  const isBranchInScopeOfSpecReview = isReleaseBranchVal; // || isShiftLeftPRWithRPSaaSDevVal
+  const isBranchInScopeOfSpecReview = isReleaseBranchVal;
 
   // 'specReviewApplies' means that either ARM or data-plane review applies. Downstream logic
   // determines which kind of review exactly we need.
-  let specReviewApplies = !isDraft && isBranchInScopeOfSpecReview;
+  let specReviewApplies = !impactAssessment.isDraft && isBranchInScopeOfSpecReview;
   if (specReviewApplies) {
-    if (isNewApiVersion) {
+    if (impactAssessment.isNewApiVersion) {
       // Note that in case of data-plane PRs, the addition of this label will result
       // in API stewardship board review being required.
       // See requiredLabelsRules.ts.
       newApiVersionLabel.shouldBePresent = true;
     }
 
-    armReviewLabel.shouldBePresent = resourceManagerLabelShouldBePresent;
+    armReviewLabel.shouldBePresent = impactAssessment.resourceManagerRequired;
     await processARMReviewWorkflowLabels(
       labelContext,
       armReviewLabel.shouldBePresent,
-      ciNewRPNamespaceWithoutRpaaSLabelShouldBePresent,
-      rpaasExceptionLabelShouldBePresent,
-      ciRpaasRPNotInPrivateRepoLabelShouldBePresent,
+      impactAssessment.rpaasRPMissing,
+      impactAssessment.rpaasExceptionRequired,
+      impactAssessment.rpaasRpNotInPrivateRepo,
     );
   }
 
@@ -538,6 +550,13 @@ export async function processImpactAssessment(
   resourceManagerLabel.applyStateChange(labelContext.toAdd, labelContext.toRemove);
   newApiVersionLabel.applyStateChange(labelContext.toAdd, labelContext.toRemove);
   armReviewLabel.applyStateChange(labelContext.toAdd, labelContext.toRemove);
+  typeSpecLabel.applyStateChange(labelContext.toAdd, labelContext.toRemove);
+  suppressionReviewRequiredLabel.applyStateChange(labelContext.toAdd, labelContext.toRemove);
+  rpassReviewRequiredLabel.applyStateChange(labelContext.toAdd, labelContext.toRemove);
+  newRPNamespaceLabel.applyStateChange(labelContext.toAdd, labelContext.toRemove);
+  ciNewRPNamespaceWithoutRpaaSLabel.applyStateChange(labelContext.toAdd, labelContext.toRemove);
+  rpaasExceptionLabel.applyStateChange(labelContext.toAdd, labelContext.toRemove);
+  ciRpaasRPNotInPrivateRepoLabel.applyStateChange(labelContext.toAdd, labelContext.toRemove);
 
   // this is the only labelling that was part of original pipelinebot logic, it handles the rotation of
   // ARMChangesRequested, WaitForArmFeedback, and ARMSignedOff labels. The thing is, we only want to make
@@ -548,9 +567,10 @@ export async function processImpactAssessment(
   console.log(
     `RETURN definition processARMReview. ` +
       `isReleaseBranch: ${isReleaseBranchVal}, ` +
+      `isArmReview: ${armReviewLabel.shouldBePresent}, ` +
       `isBranchInScopeOfArmReview: ${isBranchInScopeOfSpecReview}, ` +
-      `isNewApiVersion: ${isNewApiVersion}, ` +
-      `isDraft: ${isDraft}, ` +
+      `isNewApiVersion: ${impactAssessment.isNewApiVersion}, ` +
+      `isDraft: ${impactAssessment.isDraft}, ` +
       `newApiVersionLabel.shouldBePresent: ${newApiVersionLabel.shouldBePresent}, ` +
       `armReviewLabel.shouldBePresent: ${armReviewLabel.shouldBePresent}.`,
   );

--- a/.github/workflows/src/summarize-checks/summarize-checks.js
+++ b/.github/workflows/src/summarize-checks/summarize-checks.js
@@ -420,75 +420,6 @@ export async function getExistingLabels(github, owner, repo, issue_number) {
   return labels.map((/** @type {{ name: string; }} */ label) => label.name);
 }
 
-/**
- * A GraphQL query to GitHub API that returns all check runs for given commit, with "isRequired" field for given PR.
- *
- * If you want to see example response, copy the query body into this:
- * https://docs.github.com/en/graphql/overview/explorer
- * Example inputs:
- * resourceUrl: "https://github.com/test-repo-billy/azure-rest-api-specs/commit/c2789c5bde1b3f4fa34f76a8eeaaed479df23c4d"
- * prNumber: 2996
- *
- * Reference:
- * https://docs.github.com/en/graphql/reference/queries#resource
- * https://docs.github.com/en/graphql/guides/using-global-node-ids#3-do-a-direct-node-lookup-in-graphql
- * https://docs.github.com/en/graphql/reference/objects#checkrun
- * Rate limit:
- * https://docs.github.com/en/graphql/overview/resource-limitations#rate-limit
- * https://docs.github.com/en/graphql/reference/objects#ratelimit
- *
- * Note: here, for "checkRuns(first: ..)", maybe we should add a filter that filters to LATEST, per:
- * https://docs.github.com/en/graphql/reference/input-objects#checkrunfilter
- * https://docs.github.com/en/graphql/reference/enums#checkruntype
- **/
-/**
- * Returns a GraphQL query string for the given resource URL and PR number.
- *
- * @param {string} owner - The URL of the GitHub resource (commit).
- * @param {string} repo - The URL of the GitHub resource (commit).
- * @param {string} sha - targeted commit. context.pr!.headInfo.sha
- * @param {number} prNumber - The pull request number.
- * @returns {string} The GraphQL query string.
- */
-function getGraphQLQuery(owner, repo, sha, prNumber) {
-  const resourceUrl = `https://github.com/${owner}/${repo}/commit/${sha}`;
-
-  return `
-    {
-      resource(url: "${resourceUrl}") {
-        ... on Commit {
-          checkSuites(first: 20) {
-            nodes {
-              workflowRun {
-                id
-                databaseId
-                workflow {
-                  name
-                }
-              }
-              checkRuns(first: 30) {
-                nodes {
-                  name
-                  status
-                  conclusion
-                  isRequired(pullRequestNumber: ${prNumber})
-                }
-              }
-            }
-          }
-        }
-      }
-      rateLimit {
-        limit
-        cost
-        used
-        remaining
-        resetAt
-      }
-    }
-  `;
-}
-
 // #endregion
 // #region label update
 /**
@@ -531,17 +462,7 @@ export function updateLabels(existingLabels, impactAssessment) {
     console.log(`Downloaded impact assessment: ${JSON.stringify(impactAssessment)}`);
 
     // will further update the label context if necessary
-    processImpactAssessment(
-      impactAssessment.targetBranch,
-      labelContext,
-      impactAssessment.resourceManagerRequired,
-      impactAssessment.dataPlaneRequired,
-      impactAssessment.rpaasRPMissing,
-      impactAssessment.rpaasExceptionRequired,
-      impactAssessment.rpaasRpNotInPrivateRepo,
-      impactAssessment.isNewApiVersion,
-      impactAssessment.isDraft,
-    );
+    processImpactAssessment(labelContext, impactAssessment);
   }
 
   warnIfLabelSetsIntersect(labelContext.toAdd, labelContext.toRemove);
@@ -550,6 +471,111 @@ export function updateLabels(existingLabels, impactAssessment) {
 
 // #endregion
 // #region checks
+
+/**
+ * A GraphQL query to GitHub API that returns all check runs for given commit, with "isRequired" field for given PR.
+ *
+ * If you want to see example response, copy the query body into this:
+ * https://docs.github.com/en/graphql/overview/explorer
+ * Example inputs:
+ * resourceUrl: "https://github.com/test-repo-billy/azure-rest-api-specs/commit/c2789c5bde1b3f4fa34f76a8eeaaed479df23c4d"
+ * prNumber: 2996
+ *
+ * Reference:
+ * https://docs.github.com/en/graphql/reference/queries#resource
+ * https://docs.github.com/en/graphql/guides/using-global-node-ids#3-do-a-direct-node-lookup-in-graphql
+ * https://docs.github.com/en/graphql/reference/objects#checkrun
+ * Rate limit:
+ * https://docs.github.com/en/graphql/overview/resource-limitations#rate-limit
+ * https://docs.github.com/en/graphql/reference/objects#ratelimit
+ *
+ * Note: here, for "checkRuns(first: ..)", maybe we should add a filter that filters to LATEST, per:
+ * https://docs.github.com/en/graphql/reference/input-objects#checkrunfilter
+ * https://docs.github.com/en/graphql/reference/enums#checkruntype
+ **/
+/**
+ * Fetch all check suites for a commit with pagination
+ * @param {import('@actions/github-script').AsyncFunctionArguments['github']} github
+ * @param {typeof import("@actions/core")} core
+ * @param {string} owner
+ * @param {string} repo
+ * @param {string} sha
+ * @param {number} prNumber
+ * @returns {Promise<any>} Complete GraphQL response with all check suites
+ */
+async function getAllCheckSuites(github, core, owner, repo, sha, prNumber) {
+  const resourceUrl = `https://github.com/${owner}/${repo}/commit/${sha}`;
+  let allCheckSuites = [];
+  let hasNextPage = true;
+  let cursor = null;
+  let lastResponse = null;
+
+  while (hasNextPage) {
+    /** @type {string} */
+    const query = `
+      {
+        resource(url: "${resourceUrl}") {
+          ... on Commit {
+            checkSuites(first: 100${cursor ? `, after: "${cursor}"` : ""}) {
+              pageInfo {
+                hasNextPage
+                endCursor
+              }
+              nodes {
+                workflowRun {
+                  id
+                  databaseId
+                  workflow {
+                    name
+                  }
+                }
+                checkRuns(first: 100) {
+                  nodes {
+                    name
+                    status
+                    conclusion
+                    isRequired(pullRequestNumber: ${prNumber})
+                  }
+                }
+              }
+            }
+          }
+        }
+        rateLimit {
+          limit
+          cost
+          used
+          remaining
+          resetAt
+        }
+      }
+    `;
+
+    /** @type {any} */
+    const response = await github.graphql(query);
+    lastResponse = response;
+    core.info(`GraphQL Rate Limit Information: ${JSON.stringify(response.rateLimit)}`);
+
+    if (response.resource?.checkSuites?.nodes) {
+      allCheckSuites.push(...response.resource.checkSuites.nodes);
+      hasNextPage = response.resource.checkSuites.pageInfo.hasNextPage;
+      cursor = response.resource.checkSuites.pageInfo.endCursor;
+    } else {
+      hasNextPage = false;
+    }
+  }
+
+  // Return a response object that matches the original structure
+  return {
+    resource: {
+      checkSuites: {
+        nodes: allCheckSuites,
+      },
+    },
+    rateLimit: lastResponse?.rateLimit,
+  };
+}
+
 /**
  * @param {import('@actions/github-script').AsyncFunctionArguments['github']} github
  * @param {typeof import("@actions/core")} core
@@ -582,7 +608,7 @@ export async function getCheckRunTuple(
   /** @type { import("./labelling.js").ImpactAssessment | undefined } */
   let impactAssessment = undefined;
 
-  const response = await github.graphql(getGraphQLQuery(owner, repo, head_sha, prNumber));
+  const response = await getAllCheckSuites(github, core, owner, repo, head_sha, prNumber);
   core.info(`GraphQL Rate Limit Information: ${JSON.stringify(response.rateLimit)}`);
 
   [reqCheckRuns, fyiCheckRuns, impactAssessmentWorkflowRun] =


### PR DESCRIPTION
This PR fixes two issues:

- The first page of check_suites isn't enough to get a valid `ImpactAssessment`, as the check `Summarize PR Impact` may not be in the set of check_suites we query. Add paging of the `graphQL` query to fix this limitation.
- In a previous PR we stopped honoring the tagging decisions of the PR Impact detector. This PR adds the explicit handling of whatever labels may have been handled there. This should cover the remainder of any miss-alignment on labels that I've been chasing.

