### PR TITLE
Fix `summarize-impact` failure to import lodash

### DIFF
--- a/eng/tools/summarize-impact/src/impact.ts
+++ b/eng/tools/summarize-impact/src/impact.ts
@@ -6,7 +6,7 @@ import * as path from "path";
 
 import * as commonmark from "commonmark";
 import yaml from "js-yaml";
-import * as _ from "lodash";
+import { isEqual } from "lodash";
 
 import {
   ChangeHandler,
@@ -509,7 +509,7 @@ export function diffSuppression(readmeBefore: string, readmeAfter: string) {
     const properties = ["suppress", "from", "where", "code", "reason"];
     if (
       -1 ===
-      beforeSuppressions.findIndex((s) => properties.every((p) => _.isEqual(s[p], suppression[p])))
+      beforeSuppressions.findIndex((s) => properties.every((p) => isEqual(s[p], suppression[p])))
     ) {
       newSuppressions.push(suppression);
     }

--- a/eng/tools/summarize-impact/src/impact.ts
+++ b/eng/tools/summarize-impact/src/impact.ts
@@ -6,7 +6,8 @@ import * as path from "path";
 
 import * as commonmark from "commonmark";
 import yaml from "js-yaml";
-import { isEqual } from "lodash";
+import pkg from "lodash";
+const { isEqual } = pkg;
 
 import {
   ChangeHandler,


### PR DESCRIPTION
Avoiding digging in to why it's necessary in favor of fixing actual issues for now. @mikeharder after this week I'm good with revisit to properly fix.

The failure I'm chasing appears [here](https://github.com/Azure/azure-rest-api-specs/actions/runs/16584357910/job/46906716218?pr=36265)

`lodash` is a CommonJS module, so you have to import it slightly different when in a `ES Module` package.