### PR TITLE
Update for KeyVault CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -134,13 +134,13 @@
 /specification/iothub/ @rkmanda
 
 # PRLabel: %KeyVault
-/specification/keyvault/resource-manager/ @vickm @chen-karen @cheathamb36 @lgonsoulin
+/specification/keyvault/resource-manager/ @vickm @chen-karen @cheathamb36 @Azure/azure-sdk-write-keyvault
 
 # PRLabel: %KeyVault
-/specification/keyvault/Security.*/ @vickm @chen-karen @cheathamb36 @lgonsoulin @heaths @chlowell
+/specification/keyvault/Security.*/ @vickm @chen-karen @cheathamb36 @Azure/azure-sdk-write-keyvault @heaths @chlowell
 
 # PRLabel: %KeyVault
-/specification/keyvault/data-plane/ @vickm @chen-karen @cheathamb36 @lgonsoulin @heaths
+/specification/keyvault/data-plane/ @vickm @chen-karen @cheathamb36 @Azure/azure-sdk-write-keyvault @heaths
 
 # PRLabel: %Logic App
 /specification/logic/ @pankajsn @tonytang-microsoft-com


### PR DESCRIPTION
This replaces lgonsoulin with the `azure-sdk-write-keyvault` team as code owners.