### PR TITLE
[extract-inputs] If issue-number is invalid, set output to NaN instead of throwing

### DIFF
--- a/.github/workflows/src/context.js
+++ b/.github/workflows/src/context.js
@@ -208,12 +208,13 @@ export async function extractInputs(github, context, core) {
 
           if (key === "issue-number") {
             const parsedValue = Number.parseInt(value);
-            if (parsedValue) {
+            if (parsedValue > 0) {
               issue_number = parsedValue;
-              continue;
             } else {
-              throw new Error(`Invalid issue-number: '${value}' parsed to '${parsedValue}'`);
+              core.info(`Invalid issue-number: '${value}' parsed to '${parsedValue}'`);
+              issue_number = NaN;
             }
+            continue;
           }
         }
       }

--- a/.github/workflows/src/context.js
+++ b/.github/workflows/src/context.js
@@ -198,15 +198,15 @@ export async function extractInputs(github, context, core) {
       core.info(`artifactNames: ${JSON.stringify(artifactNames)}`);
 
       for (const artifactName of artifactNames) {
-        // If artifactName has format "issue-number=number", set issue_number
-        // Else, if artifactName has format "issue-number=other-string", throw an error
+        // If artifactName has format "issue-number=positive-integer", set issue_number=value
+        // Else, if artifactName has format "issue-number=other-string", warn and set issue_number=NaN
+        // - Workflows should probably only set "issue-number" to positive integers, but sometimes set it to "null"
         // Else, if artifactName does not start with "issue-number=", ignore it
         const firstEquals = artifactName.indexOf("=");
         if (firstEquals !== -1) {
           const key = artifactName.substring(0, firstEquals);
-          const value = artifactName.substring(firstEquals + 1);
-
           if (key === "issue-number") {
+            const value = artifactName.substring(firstEquals + 1);
             const parsedValue = Number.parseInt(value);
             if (parsedValue > 0) {
               issue_number = parsedValue;

--- a/.github/workflows/test/context.test.js
+++ b/.github/workflows/test/context.test.js
@@ -333,9 +333,24 @@ describe("extractInputs", () => {
     github.rest.actions.listWorkflowRunArtifacts.mockResolvedValue({
       data: { artifacts: [{ name: "issue-number=not-a-number" }] },
     });
-    await expect(extractInputs(github, context, createMockCore())).rejects.toThrow(
-      /invalid issue-number/i,
-    );
+    await expect(extractInputs(github, context, createMockCore())).resolves.toEqual({
+      owner: "TestRepoOwnerLogin",
+      repo: "TestRepoName",
+      head_sha: "abc123",
+      issue_number: NaN,
+      run_id: 456,
+    });
+
+    github.rest.actions.listWorkflowRunArtifacts.mockResolvedValue({
+      data: { artifacts: [{ name: "issue-number=null" }] },
+    });
+    await expect(extractInputs(github, context, createMockCore())).resolves.toEqual({
+      owner: "TestRepoOwnerLogin",
+      repo: "TestRepoName",
+      head_sha: "abc123",
+      issue_number: NaN,
+      run_id: 456,
+    });
 
     github.rest.actions.listWorkflowRunArtifacts.mockResolvedValue({
       data: { artifacts: [] },


### PR DESCRIPTION
- While this might hide errors like issue-number=foo, it prevents errors in cases like issue-number=null
- It's better to just set issue_number=NaN and let the caller handle it
- Likely, the caller will fail the same, regardless of whether the artifact was set to an invalid value, or if it was never set at all.