### PR TITLE
Update condition on job for `summarize-checks`

### DIFF
--- a/.github/workflows/summarize-checks.yaml
+++ b/.github/workflows/summarize-checks.yaml
@@ -29,6 +29,7 @@ permissions:
 
 jobs:
   run-summarize-checks:
+    if: ${{ github.event_name == 'pull_request_target' || github.event.workflow_run.conclusion != 'skipped' }}
     name: "[TEST-IGNORE] Summarize Checks"
     runs-on: ubuntu-24.04
 
@@ -54,7 +55,6 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            console.log('=== TRIGGERING EVENT METADATA ===');
             console.log(`Event name: ${context.eventName}`);
             console.log(`Action: ${context.payload.action}`);
 


### PR DESCRIPTION
When triggered by `workflow_run` that was skipped, we can skip. Otherwise run as normal.