### PR TITLE
[.github] Remove issue-number artifact from pull_request WFs

### DIFF
--- a/.github/workflows/breaking-change-code.yaml
+++ b/.github/workflows/breaking-change-code.yaml
@@ -56,15 +56,3 @@ jobs:
           name: "${{ steps.swagger-breaking-change-analyze-code.outputs.versioningReviewLabelName }}"
           # Convert "add/remove" to "true/false"
           value: "${{ steps.swagger-breaking-change-analyze-code.outputs.versioningReviewLabelValue == 'true' }}"
-
-      # Upload artifact with issue number if labels are present and PR number is valid
-      - if: |
-          always() &&
-          (steps.swagger-breaking-change-analyze-code.outputs.breakingChangeReviewLabelName != '' ||
-          steps.swagger-breaking-change-analyze-code.outputs.versioningReviewLabelName != '') &&
-          github.event.pull_request.number > 0
-        name: Upload artifact with issue number
-        uses: ./.github/actions/add-empty-artifact
-        with:
-          name: "issue-number"
-          value: "${{ github.event.pull_request.number }}"

--- a/.github/workflows/breaking-change-cross-version-code.yaml
+++ b/.github/workflows/breaking-change-cross-version-code.yaml
@@ -56,15 +56,3 @@ jobs:
         with:
           name: "${{ steps.breaking-change-cross-version-analyze-code.outputs.versioningReviewLabelName }}"
           value: "${{ steps.breaking-change-cross-version-analyze-code.outputs.versioningReviewLabelValue == 'true' }}"
-
-      # Upload artifact with issue number if labels are present and PR number is valid
-      - if: |
-          always() &&
-          (steps.breaking-change-cross-version-analyze-code.outputs.breakingChangeReviewLabelName != '' ||
-          steps.breaking-change-cross-version-analyze-code.outputs.versioningReviewLabelName != '') &&
-          github.event.pull_request.number > 0
-        name: Upload artifact with issue number
-        uses: ./.github/actions/add-empty-artifact
-        with:
-          name: "issue-number"
-          value: "${{ github.event.pull_request.number }}"

--- a/.github/workflows/summarize-impact.yaml
+++ b/.github/workflows/summarize-impact.yaml
@@ -55,12 +55,3 @@ jobs:
           path: ${{ steps.summarize-impact.outputs.summary }}
           # If the file doesn't exist, just don't add the artifact
           if-no-files-found: ignore
-
-      - if: |
-          always() &&
-          github.event.pull_request.number > 0
-        name: Upload artifact with issue number
-        uses: ./after/.github/actions/add-empty-artifact
-        with:
-          name: "issue-number"
-          value: "${{ github.event.pull_request.number }}"

--- a/.github/workflows/test/context.test.js
+++ b/.github/workflows/test/context.test.js
@@ -295,6 +295,10 @@ describe("extractInputs", () => {
         commit_sha: "abc123",
         per_page: PER_PAGE_MAX,
       });
+
+      // For pull_request, do NOT attempt to extract the issue number from an artifact, since this could be modified
+      // in a fork PR.
+      expect(github.rest.actions.listWorkflowRunArtifacts).toHaveBeenCalledTimes(0);
     },
   );
 


### PR DESCRIPTION
Unless I'm missing something, I believe `issue-number` artifacts are intentionally **ignored** for workflows triggered by `pull_request` or `pull-request-target`:

https://github.com/Azure/azure-rest-api-specs/blob/6e3155d6fef2da96b083c871fd74fcd99e03c05e/.github/workflows/src/context.js#L99-L112

The artifact is only used if the trigger was one of these:

https://github.com/Azure/azure-rest-api-specs/blob/6e3155d6fef2da96b083c871fd74fcd99e03c05e/.github/workflows/src/context.js#L182-L194