### PR TITLE
[update-labels] Update labels even on non-success runs

### DIFF
--- a/.github/workflows/update-labels.yaml
+++ b/.github/workflows/update-labels.yaml
@@ -19,9 +19,6 @@ jobs:
   update-labels:
     name: Update Labels
 
-    # Only process labels from successful workflows
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-
     runs-on: ubuntu-24.04
 
     steps:


### PR DESCRIPTION
- Required to update labels for BrCh-Code when it fails
