### PR TITLE
[Test] Update Microsoft.CodeTransparency spec and generated swagger

### DIFF
--- a/specification/confidentialledger/Microsoft.CodeTransparency/main.tsp
+++ b/specification/confidentialledger/Microsoft.CodeTransparency/main.tsp
@@ -110,6 +110,12 @@ model CreateEntryCreated {
   @statusCode
   statusCode: 201;
 
+  /**
+   * The title of the content returned in the response.
+   */
+  @header("Content-Title")
+  contentTitle?: string;
+  
   @doc("The MIME content type a Cose body is application/cose, containing a CoseSign1 signature.")
   @header("Content-Type")
   contentType: "application/cose";

--- a/specification/confidentialledger/data-plane/Microsoft.CodeTransparency/preview/2025-01-31-preview/cts.json
+++ b/specification/confidentialledger/data-plane/Microsoft.CodeTransparency/preview/2025-01-31-preview/cts.json
@@ -114,6 +114,10 @@
               "type": "file"
             },
             "headers": {
+              "Content-Title": {
+                "type": "string",
+                "description": "The title of the content returned in the response."
+              },
               "Location": {
                 "type": "string",
                 "description": "Location of the receipt"


### PR DESCRIPTION
- Updated the TypeSpec for Microsoft.CodeTransparency
- Regenerated the swagger (cts.json) for 2025-01-31-preview
- Fixed property casing and added documentation as per linter requirements

Please review the changes for correctness and compliance.