### PR TITLE
[summarize-impact] Remove direct dep on @ts-common/commonmark-to-markdown

### DIFF
--- a/eng/tools/summarize-impact/package.json
+++ b/eng/tools/summarize-impact/package.json
@@ -19,7 +19,6 @@
     "@azure-tools/specs-shared": "file:../../../.github/shared",
     "@azure/openapi-markdown": "0.9.4",
     "@octokit/rest": "^22.0.0",
-    "@ts-common/commonmark-to-markdown": "^2.0.2",
     "commonmark": "0.31.2",
     "glob": "^11.0.3",
     "js-yaml": "^4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -534,7 +534,6 @@
         "@azure-tools/specs-shared": "file:../../../.github/shared",
         "@azure/openapi-markdown": "0.9.4",
         "@octokit/rest": "^22.0.0",
-        "@ts-common/commonmark-to-markdown": "^2.0.2",
         "commonmark": "0.31.2",
         "glob": "^11.0.3",
         "js-yaml": "^4.1.0",
@@ -14647,6 +14646,7 @@
       "version": "4.0.13",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.13.tgz",
       "integrity": "sha512-jv+zRxuZQxTrFHzxZ46ezL2FtnE+M4HIJHJEwLsZ7UjrXHltdG6HrxvqM0twoVCWxJiYf8WqKjAcjztegpkB+Q==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"


### PR DESCRIPTION
- Never imported directly
- Included as dep of @azure/openapi-markdown
