### PR TITLE
[Test PR] Add Failed state to ProvisioningState union in Contoso Management API

### DIFF
--- a/specification/contosowidgetmanager/Contoso.Management/employee.tsp
+++ b/specification/contosowidgetmanager/Contoso.Management/employee.tsp
@@ -46,6 +46,9 @@ union ProvisioningState {
   /** The resource is being deleted */
   Deleting: "Deleting",
 
+  /** Failed to provision the resource */
+  Failed: "Failed",
+
   /** The resource create request has been accepted */
   Accepted: "Accepted",
 

--- a/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/preview/2021-10-01-preview/contoso.json
+++ b/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/preview/2021-10-01-preview/contoso.json
@@ -521,7 +521,7 @@
           {
             "name": "Failed",
             "value": "Failed",
-            "description": "Resource creation failed."
+            "description": "Failed to provision the resource"
           },
           {
             "name": "Canceled",

--- a/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/stable/2021-11-01/contoso.json
+++ b/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/stable/2021-11-01/contoso.json
@@ -521,7 +521,7 @@
           {
             "name": "Failed",
             "value": "Failed",
-            "description": "Resource creation failed."
+            "description": "Failed to provision the resource"
           },
           {
             "name": "Canceled",


### PR DESCRIPTION
This PR adds a new "Failed" state to the ProvisioningState union in the Contoso Management employee.tsp specification.

## Changes Made:
- Added `Failed: "Failed"` state to the ProvisioningState union in `employee.tsp`
- Updated the description to "Failed to provision the resource" for better clarity
- Generated OpenAPI specifications have been updated accordingly

## Files Modified:
- `specification/contosowidgetmanager/Contoso.Management/employee.tsp` - Added Failed state
- Generated OpenAPI files in both preview and stable versions with updated descriptions

This change provides better error handling and state tracking for employee resource provisioning operations.