### PR TITLE
Early exit when `summarize-checks` hits an erroneously large # of checks on a given commit SHA

### DIFF
--- a/.github/workflows/src/summarize-checks/summarize-checks.js
+++ b/.github/workflows/src/summarize-checks/summarize-checks.js
@@ -601,13 +601,15 @@ async function getAllCheckSuites(github, core, owner, repo, sha, prNumber) {
   });
 
   const totalCheckSuites = checkSuitesResponse.total_count;
-  core.info(`Found ${totalCheckSuites} total check suites`);
 
   // Bail if too many check suites to avoid burning GraphQL rate limits
   if (totalCheckSuites > 500) {
     throw new Error(
       `Too many check suites (${totalCheckSuites}) for ${owner}/${repo}#${prNumber}@${sha}. Summarize-Checks ending with error to avoid exhausting graphQL resources.`,
     );
+  }
+  else {
+    core.info(`Found ${totalCheckSuites} total check suites`);
   }
 
   // Now proceed with GraphQL pagination

--- a/.github/workflows/src/summarize-checks/summarize-checks.js
+++ b/.github/workflows/src/summarize-checks/summarize-checks.js
@@ -607,8 +607,7 @@ async function getAllCheckSuites(github, core, owner, repo, sha, prNumber) {
     throw new Error(
       `Too many check suites (${totalCheckSuites}) for ${owner}/${repo}#${prNumber}@${sha}. Summarize-Checks ending with error to avoid exhausting graphQL resources.`,
     );
-  }
-  else {
+  } else {
     core.info(`Found ${totalCheckSuites} total check suites`);
   }
 

--- a/.github/workflows/src/summarize-checks/summarize-checks.js
+++ b/.github/workflows/src/summarize-checks/summarize-checks.js
@@ -592,6 +592,25 @@ export function updateLabels(existingLabels, impactAssessment) {
  * @returns {Promise<any>} Complete GraphQL response with all check suites
  */
 async function getAllCheckSuites(github, core, owner, repo, sha, prNumber) {
+  // First, get the total count using REST API to avoid expensive GraphQL if there are too many suites
+  const { data: checkSuitesResponse } = await github.rest.checks.listSuitesForRef({
+    owner,
+    repo,
+    ref: sha,
+    per_page: 1, // We only need the count, not the actual data
+  });
+
+  const totalCheckSuites = checkSuitesResponse.total_count;
+  core.info(`Found ${totalCheckSuites} total check suites`);
+
+  // Bail if too many check suites to avoid burning GraphQL rate limits
+  if (totalCheckSuites > 500) {
+    throw new Error(
+      `Too many check suites (${totalCheckSuites}) for ${owner}/${repo}#${prNumber}@${sha}. Summarize-Checks ending with error to avoid exhausting graphQL resources.`,
+    );
+  }
+
+  // Now proceed with GraphQL pagination
   const resourceUrl = `https://github.com/${owner}/${repo}/commit/${sha}`;
   let allCheckSuites = [];
   let hasNextPage = true;


### PR DESCRIPTION
Error message in practice: 

> Too many check suites (5631) for Azure/azure-rest-api-specs#36381@251ac2d3a8392258548facaaae3416ca681cd45c. Summarize-Checks ending with error to avoid exhausting graphQL resources.