### PR TITLE
Explicitly handle 0 required checks

### DIFF
--- a/.github/workflows/src/summarize-checks/summarize-checks.js
+++ b/.github/workflows/src/summarize-checks/summarize-checks.js
@@ -885,11 +885,10 @@ export async function createNextStepsComment(
   // if there are NO required runs, we also consider this to be a "requirements met" situation.
   // there is a possibility that this will be a false positive, but it is better than
   // assuming that the requirements are not met when they actually are.
-  const requiredCheckInfosPresent =
-    !requiredRuns.some((run) => {
-      const status = run.status.toLowerCase();
-      return status !== "completed";
-    }) || requiredRuns.length === 0;
+  const requiredCheckInfosPresent = requiredRuns.every((run) => {
+    const status = run.status.toLowerCase();
+    return status === "completed";
+  });
 
   const fyiCheckInfos = fyiRuns
     .filter((run) => checkRunIsSuccessful(run) === false)

--- a/.github/workflows/src/summarize-checks/summarize-checks.js
+++ b/.github/workflows/src/summarize-checks/summarize-checks.js
@@ -882,10 +882,12 @@ export async function createNextStepsComment(
 
   // determine if required runs have any in-progress or queued runs
   // if there are any, we consider the requirements not met.
-  const requiredCheckInfosPresent = requiredRuns.some((run) => {
-    const status = run.status.toLowerCase();
-    return status !== "queued" && status !== "in_progress";
-  });
+  const requiredCheckInfosPresent =
+    requiredRuns.some((run) => {
+      const status = run.status.toLowerCase();
+      return status !== "queued" && status !== "in_progress";
+    }) || requiredCheckInfos.length === 0;
+
   const fyiCheckInfos = fyiRuns
     .filter((run) => checkRunIsSuccessful(run) === false)
     .map((run) => run.checkInfo);

--- a/.github/workflows/src/summarize-checks/summarize-checks.js
+++ b/.github/workflows/src/summarize-checks/summarize-checks.js
@@ -882,6 +882,9 @@ export async function createNextStepsComment(
 
   // determine if required runs have any in-progress or queued runs
   // if there are any, we consider the requirements not met.
+  // if there are NO required runs, we also consider this to be a "requirements met" situation.
+  // there is a possibility that this will be a false positive, but it is better than
+  // assuming that the requirements are not met when they actually are.
   const requiredCheckInfosPresent =
     requiredRuns.some((run) => {
       const status = run.status.toLowerCase();

--- a/.github/workflows/src/summarize-checks/summarize-checks.js
+++ b/.github/workflows/src/summarize-checks/summarize-checks.js
@@ -876,7 +876,7 @@ export async function createNextStepsComment(
   assessmentCompleted,
 ) {
   // select just the metadata that we need about the runs.
-  const requiredCheckInfos = requiredRuns
+  const failingCheckInfos = requiredRuns
     .filter((run) => checkRunIsSuccessful(run) === false)
     .map((run) => run.checkInfo);
 
@@ -886,10 +886,10 @@ export async function createNextStepsComment(
   // there is a possibility that this will be a false positive, but it is better than
   // assuming that the requirements are not met when they actually are.
   const requiredCheckInfosPresent =
-    requiredRuns.some((run) => {
+    !requiredRuns.some((run) => {
       const status = run.status.toLowerCase();
-      return status !== "queued" && status !== "in_progress";
-    }) || requiredCheckInfos.length === 0;
+      return status !== "completed";
+    }) || requiredRuns.length === 0;
 
   const fyiCheckInfos = fyiRuns
     .filter((run) => checkRunIsSuccessful(run) === false)
@@ -900,7 +900,7 @@ export async function createNextStepsComment(
     labels,
     `${repo}/${targetBranch}`,
     requiredCheckInfosPresent,
-    requiredCheckInfos,
+    failingCheckInfos,
     fyiCheckInfos,
     assessmentCompleted,
   );

--- a/.github/workflows/test/summarize-checks/summarize-checks.test.js
+++ b/.github/workflows/test/summarize-checks/summarize-checks.test.js
@@ -247,18 +247,18 @@ describe("Summarize Checks Unit Tests", () => {
       expect(output).toEqual(expectedOutput);
     });
 
-    it("should generate pending summary for no matched check suites", async () => {
+    it("should generate completed summary for no matched check suites", async () => {
       const repo = "azure-rest-api-specs";
       const targetBranch = "main";
       const labelNames = [];
       const fyiCheckRuns = [];
       const requiredCheckRuns = [];
       const expectedOutput = [
-        "<h2>Next Steps to Merge</h2>⌛ Please wait. Next steps to merge this PR are being evaluated by automation. ⌛",
+        '<h2>Next Steps to Merge</h2>✅ All automated merging requirements have been met! To get your PR merged, see <a href="https://aka.ms/azsdk/specreview/merge">aka.ms/azsdk/specreview/merge</a>.',
         {
           name: "[TEST-IGNORE] Automated merging requirements met",
-          result: "pending",
-          summary: "The requirements for merging this PR are still being evaluated. Please wait.",
+          result: "SUCCESS",
+          summary: `✅ All automated merging requirements have been met.<br/>To merge this PR, refer to <a href="https://aka.ms/azsdk/specreview/merge">aka.ms/azsdk/specreview/merge</a>.<br/>For help, consult comments on this PR and see [aka.ms/azsdk/pr-getting-help](https://aka.ms/azsdk/pr-getting-help).`,
         },
       ];
 
@@ -667,6 +667,102 @@ describe("Summarize Checks Unit Tests", () => {
             troubleshootingGuide:
               "Refer to the check in the PR's 'Checks' tab for details on how to fix it and consult the <a href=\"https://aka.ms/ci-fix\">aka.ms/ci-fix</a> guide",
           },
+        },
+      ];
+
+      const output = await createNextStepsComment(
+        mockCore,
+        repo,
+        labelNames,
+        targetBranch,
+        requiredCheckRuns,
+        fyiCheckRuns,
+        true, // assessmentCompleted
+      );
+
+      expect(output).toEqual(expectedOutput);
+    });
+
+    it("should generate pending summary when checks are partially in progress", async () => {
+      const repo = "azure-rest-api-specs";
+      const targetBranch = "main";
+      const labelNames = [];
+      const fyiCheckRuns = [];
+      const expectedOutput = [
+        "<h2>Next Steps to Merge</h2>⌛ Please wait. Next steps to merge this PR are being evaluated by automation. ⌛",
+        {
+          name: "[TEST-IGNORE] Automated merging requirements met",
+          result: "pending",
+          summary: "The requirements for merging this PR are still being evaluated. Please wait.",
+        },
+      ];
+
+      const requiredCheckRuns = [
+        {
+          name: "TypeSpec Validation",
+          status: "IN_PROGRESS",
+          conclusion: null,
+          checkInfo: getCheckInfo("TypeSpec Validation"),
+        },
+        {
+          name: "Swagger Avocado",
+          status: "COMPLETED",
+          conclusion: "SUCCESS",
+          checkInfo: getCheckInfo("Swagger Avocado"),
+        },
+        {
+          name: "license/cla",
+          status: "IN_PROGRESS",
+          conclusion: null,
+          checkInfo: getCheckInfo("license/cla"),
+        },
+      ];
+
+      const output = await createNextStepsComment(
+        mockCore,
+        repo,
+        labelNames,
+        targetBranch,
+        requiredCheckRuns,
+        fyiCheckRuns,
+        true, // assessmentCompleted
+      );
+
+      expect(output).toEqual(expectedOutput);
+    });
+
+    it("should generate pending summary when checks are in progress", async () => {
+      const repo = "azure-rest-api-specs";
+      const targetBranch = "main";
+      const labelNames = [];
+      const fyiCheckRuns = [];
+      const expectedOutput = [
+        "<h2>Next Steps to Merge</h2>⌛ Please wait. Next steps to merge this PR are being evaluated by automation. ⌛",
+        {
+          name: "[TEST-IGNORE] Automated merging requirements met",
+          result: "pending",
+          summary: "The requirements for merging this PR are still being evaluated. Please wait.",
+        },
+      ];
+
+      const requiredCheckRuns = [
+        {
+          name: "TypeSpec Validation",
+          status: "IN_PROGRESS",
+          conclusion: null,
+          checkInfo: getCheckInfo("TypeSpec Validation"),
+        },
+        {
+          name: "Swagger Avocado",
+          status: "QUEUED",
+          conclusion: null,
+          checkInfo: getCheckInfo("Swagger Avocado"),
+        },
+        {
+          name: "license/cla",
+          status: "IN_PROGRESS",
+          conclusion: null,
+          checkInfo: getCheckInfo("license/cla"),
         },
       ];
 

--- a/.github/workflows/test/summarize-checks/summarize-checks.test.js
+++ b/.github/workflows/test/summarize-checks/summarize-checks.test.js
@@ -808,7 +808,7 @@ describe("Summarize Checks Unit Tests", () => {
         },
       ];
 
-      const [ , automatedCheckOutput] = await createNextStepsComment(
+      const [, automatedCheckOutput] = await createNextStepsComment(
         mockCore,
         repo,
         labelNames,
@@ -842,7 +842,7 @@ describe("Summarize Checks Unit Tests", () => {
         },
       ];
 
-      const [ , automatedCheckOutput] = await createNextStepsComment(
+      const [, automatedCheckOutput] = await createNextStepsComment(
         mockCore,
         repo,
         labelNames,

--- a/.github/workflows/test/summarize-checks/summarize-checks.test.js
+++ b/.github/workflows/test/summarize-checks/summarize-checks.test.js
@@ -808,7 +808,7 @@ describe("Summarize Checks Unit Tests", () => {
         },
       ];
 
-      const [_, automatedCheckOutput] = await createNextStepsComment(
+      const [ , automatedCheckOutput] = await createNextStepsComment(
         mockCore,
         repo,
         labelNames,
@@ -842,7 +842,7 @@ describe("Summarize Checks Unit Tests", () => {
         },
       ];
 
-      const [_, automatedCheckOutput] = await createNextStepsComment(
+      const [ , automatedCheckOutput] = await createNextStepsComment(
         mockCore,
         repo,
         labelNames,

--- a/.github/workflows/test/summarize-checks/summarize-checks.test.js
+++ b/.github/workflows/test/summarize-checks/summarize-checks.test.js
@@ -44,7 +44,7 @@ describe("Summarize Checks Integration Tests", () => {
       async () => {
         const issue_number = 36258;
         const owner = "Azure";
-        const repo = "azure-rest-api-specs";
+        const repo = "azure-rest-api-specs-pr";
 
         const ignorableLabels = [
           "VersioningReviewRequired",
@@ -518,6 +518,129 @@ describe("Summarize Checks Unit Tests", () => {
               "Refer to the check in the PR's 'Checks' tab for details on how to fix it and consult the <a href=\"https://aka.ms/ci-fix\">aka.ms/ci-fix</a> guide",
           },
         },
+        {
+          name: "Swagger Avocado",
+          status: "QUEUED",
+          conclusion: null,
+          checkInfo: {
+            precedence: 1,
+            name: "Swagger Avocado",
+            suppressionLabels: [],
+            troubleshootingGuide:
+              "Refer to the check in the PR's 'Checks' tab for details on how to fix it and consult the <a href=\"https://aka.ms/ci-fix\">aka.ms/ci-fix</a> guide",
+          },
+        },
+        {
+          name: "license/cla",
+          status: "IN_PROGRESS",
+          conclusion: null,
+          checkInfo: {
+            precedence: 0,
+            name: "license/cla",
+            suppressionLabels: [],
+            troubleshootingGuide:
+              "Refer to the check in the PR's 'Checks' tab for details on how to fix it and consult the <a href=\"https://aka.ms/ci-fix\">aka.ms/ci-fix</a> guide",
+          },
+        },
+      ];
+
+      const output = await createNextStepsComment(
+        mockCore,
+        repo,
+        labelNames,
+        targetBranch,
+        requiredCheckRuns,
+        fyiCheckRuns,
+        true, // assessmentCompleted
+      );
+
+      expect(output).toEqual(expectedOutput);
+    });
+
+    it("should generate completed summary with completed required checks but in-progress FYI", async () => {
+      const repo = "azure-rest-api-specs";
+      const targetBranch = "main";
+      const labelNames = [];
+      const expectedOutput = [
+        '<h2>Next Steps to Merge</h2>✅ All automated merging requirements have been met! To get your PR merged, see <a href="https://aka.ms/azsdk/specreview/merge">aka.ms/azsdk/specreview/merge</a>.',
+        {
+          name: "[TEST-IGNORE] Automated merging requirements met",
+          result: "SUCCESS",
+          summary: `✅ All automated merging requirements have been met.<br/>To merge this PR, refer to <a href="https://aka.ms/azsdk/specreview/merge">aka.ms/azsdk/specreview/merge</a>.<br/>For help, consult comments on this PR and see [aka.ms/azsdk/pr-getting-help](https://aka.ms/azsdk/pr-getting-help).`,
+        },
+      ];
+
+      const requiredCheckRuns = [
+        {
+          name: "SpellCheck",
+          status: "COMPLETED",
+          conclusion: "SUCCESS",
+          checkInfo: getCheckInfo("SpellCheck"),
+        },
+        {
+          name: "TypeSpec Requirement",
+          status: "COMPLETED",
+          conclusion: "SUCCESS",
+          checkInfo: getCheckInfo("TypeSpec Requirement"),
+        },
+      ];
+
+      const fyiCheckRuns = [
+        {
+          name: "Swagger Avocado",
+          status: "QUEUED",
+          conclusion: null,
+          checkInfo: {
+            precedence: 1,
+            name: "Swagger Avocado",
+            suppressionLabels: [],
+            troubleshootingGuide:
+              "Refer to the check in the PR's 'Checks' tab for details on how to fix it and consult the <a href=\"https://aka.ms/ci-fix\">aka.ms/ci-fix</a> guide",
+          },
+        },
+        {
+          name: "license/cla",
+          status: "IN_PROGRESS",
+          conclusion: null,
+          checkInfo: {
+            precedence: 0,
+            name: "license/cla",
+            suppressionLabels: [],
+            troubleshootingGuide:
+              "Refer to the check in the PR's 'Checks' tab for details on how to fix it and consult the <a href=\"https://aka.ms/ci-fix\">aka.ms/ci-fix</a> guide",
+          },
+        },
+      ];
+
+      const output = await createNextStepsComment(
+        mockCore,
+        repo,
+        labelNames,
+        targetBranch,
+        requiredCheckRuns,
+        fyiCheckRuns,
+        true, // assessmentCompleted
+      );
+
+      expect(output).toEqual(expectedOutput);
+    });
+
+    it("should generate completed summary with 0 required checks but in-progress FYI", async () => {
+      const repo = "azure-rest-api-specs";
+      const targetBranch = "main";
+      const labelNames = [];
+      const expectedOutput = [
+        '<h2>Next Steps to Merge</h2>✅ All automated merging requirements have been met! To get your PR merged, see <a href="https://aka.ms/azsdk/specreview/merge">aka.ms/azsdk/specreview/merge</a>.',
+        {
+          name: "[TEST-IGNORE] Automated merging requirements met",
+          result: "SUCCESS",
+          summary: `✅ All automated merging requirements have been met.<br/>To merge this PR, refer to <a href="https://aka.ms/azsdk/specreview/merge">aka.ms/azsdk/specreview/merge</a>.<br/>For help, consult comments on this PR and see [aka.ms/azsdk/pr-getting-help](https://aka.ms/azsdk/pr-getting-help).`,
+        },
+      ];
+
+      const requiredCheckRuns = [];
+
+      const fyiCheckRuns = [
         {
           name: "Swagger Avocado",
           status: "QUEUED",

--- a/.github/workflows/test/summarize-checks/summarize-checks.test.js
+++ b/.github/workflows/test/summarize-checks/summarize-checks.test.js
@@ -779,6 +779,82 @@ describe("Summarize Checks Unit Tests", () => {
       expect(output).toEqual(expectedOutput);
     });
 
+    it("should generate error summary with a failed required check, and in-progress FYI checks", async () => {
+      const repo = "azure-rest-api-specs";
+      const targetBranch = "main";
+      const labelNames = [];
+      const expectedCheckOutput = {
+        name: "[TEST-IGNORE] Automated merging requirements met",
+        result: "FAILURE",
+        summary:
+          "❌ This PR cannot be merged because some requirements are not met. See the details.",
+      };
+
+      const fyiCheckRuns = [
+        {
+          name: "TypeSpec Validation",
+          status: "IN_PROGRESS",
+          conclusion: null,
+          checkInfo: getCheckInfo("TypeSpec Validation"),
+        },
+      ];
+
+      const requiredCheckRuns = [
+        {
+          name: "Swagger BreakingChange",
+          status: "COMPLETED",
+          conclusion: "FAILURE",
+          checkInfo: getCheckInfo("Swagger BreakingChange"),
+        },
+      ];
+
+      const [_, automatedCheckOutput] = await createNextStepsComment(
+        mockCore,
+        repo,
+        labelNames,
+        targetBranch,
+        requiredCheckRuns,
+        fyiCheckRuns,
+        true, // assessmentCompleted
+      );
+
+      expect(automatedCheckOutput).toEqual(expectedCheckOutput);
+    });
+
+    it("should generate error summary when checks are in error state", async () => {
+      const repo = "azure-rest-api-specs";
+      const targetBranch = "main";
+      const labelNames = [];
+      const fyiCheckRuns = [];
+      const expectedCheckOutput = {
+        name: "[TEST-IGNORE] Automated merging requirements met",
+        result: "FAILURE",
+        summary:
+          "❌ This PR cannot be merged because some requirements are not met. See the details.",
+      };
+
+      const requiredCheckRuns = [
+        {
+          name: "Swagger BreakingChange",
+          status: "COMPLETED",
+          conclusion: "FAILURE",
+          checkInfo: getCheckInfo("Swagger BreakingChange"),
+        },
+      ];
+
+      const [_, automatedCheckOutput] = await createNextStepsComment(
+        mockCore,
+        repo,
+        labelNames,
+        targetBranch,
+        requiredCheckRuns,
+        fyiCheckRuns,
+        true, // assessmentCompleted
+      );
+
+      expect(automatedCheckOutput).toEqual(expectedCheckOutput);
+    });
+
     it("should extract check info from raw check response data", async () => {
       const expectedCheckRunId = 16582733356;
       const response = await import("./fixtures/RawGraphQLResponse.json", {

--- a/.github/workflows/test/summarize-checks/summarize-checks.test.js
+++ b/.github/workflows/test/summarize-checks/summarize-checks.test.js
@@ -44,7 +44,7 @@ describe("Summarize Checks Integration Tests", () => {
       async () => {
         const issue_number = 36258;
         const owner = "Azure";
-        const repo = "azure-rest-api-specs-pr";
+        const repo = "azure-rest-api-specs";
 
         const ignorableLabels = [
           "VersioningReviewRequired",
@@ -625,6 +625,9 @@ describe("Summarize Checks Unit Tests", () => {
       expect(output).toEqual(expectedOutput);
     });
 
+    // this case should NEVER occur in practice, due to Summarize PR Impact being made a "required" check, but in cases
+    // where the user is targeting a branch that is not the main branch, we may have no required checks
+    // but still have FYI checks in progress. This is a regression test to ensure we handle this case correctly.
     it("should generate completed summary with 0 required checks but in-progress FYI", async () => {
       const repo = "azure-rest-api-specs";
       const targetBranch = "main";


### PR DESCRIPTION
This is addressing a case I see much more often in `azure-rest-api-specs-pr`, where there ARE NO required checks due to targeting different branches than `RPSaaSMain/Dev or main`.

