### PR TITLE
Check issue_number in status script

### DIFF
--- a/.github/workflows/src/set-status.js
+++ b/.github/workflows/src/set-status.js
@@ -25,6 +25,11 @@ export default async function setStatus(
 ) {
   const { owner, repo, head_sha, issue_number } = await extractInputs(github, context, core);
 
+  if (!Number.isInteger(issue_number) || issue_number <= 0) {
+    core.warning("issue_number must be a positive integer");
+    return;
+  }
+
   // Default target is this run itself
   let target_url =
     `https://github.com/${context.repo.owner}/${context.repo.repo}` +

--- a/.github/workflows/src/set-status.js
+++ b/.github/workflows/src/set-status.js
@@ -72,7 +72,7 @@ export async function setStatusImpl({
   overridingLabel,
 }) {
   if (!Number.isInteger(issue_number) || issue_number <= 0) {
-    throw new Error("issue_number must be a positive integer");
+    throw new Error(`issue_number must be a positive integer: ${issue_number}`);
   }
 
   core.setOutput("issue_number", issue_number);

--- a/.github/workflows/src/set-status.js
+++ b/.github/workflows/src/set-status.js
@@ -25,11 +25,6 @@ export default async function setStatus(
 ) {
   const { owner, repo, head_sha, issue_number } = await extractInputs(github, context, core);
 
-  if (!Number.isInteger(issue_number) || issue_number <= 0) {
-    core.warning("issue_number must be a positive integer");
-    return;
-  }
-
   // Default target is this run itself
   let target_url =
     `https://github.com/${context.repo.owner}/${context.repo.repo}` +
@@ -76,6 +71,10 @@ export async function setStatusImpl({
   requiredStatusName,
   overridingLabel,
 }) {
+  if (!Number.isInteger(issue_number) || issue_number <= 0) {
+    throw new Error("issue_number must be a positive integer");
+  }
+
   core.setOutput("issue_number", issue_number);
 
   // TODO: Try to extract labels from context (when available) to avoid unnecessary API call

--- a/.github/workflows/test/set-status.test.js
+++ b/.github/workflows/test/set-status.test.js
@@ -1,136 +1,10 @@
 // @ts-check
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import setStatus, { setStatusImpl } from "../src/set-status.js";
+import { beforeEach, describe, expect, it } from "vitest";
+import { setStatusImpl } from "../src/set-status.js";
 
 import { CheckConclusion, CheckStatus, CommitStatusState } from "../../shared/src/github.js";
 import { createMockCore, createMockGithub } from "./mocks.js";
-
-// Mock the extractInputs function
-vi.mock("../src/context.js", () => ({
-  extractInputs: vi.fn(),
-}));
-
-import { extractInputs } from "../src/context.js";
-const mockExtractInputs = vi.mocked(extractInputs);
-
-describe("setStatus", () => {
-  let core;
-  let github;
-  let context;
-
-  beforeEach(() => {
-    core = createMockCore();
-    github = createMockGithub();
-    context = {
-      repo: { owner: "test-owner", repo: "test-repo" },
-      runId: "123456",
-    };
-    vi.clearAllMocks();
-  });
-
-  it("returns early with warning when issue_number is null", async () => {
-    mockExtractInputs.mockResolvedValue({
-      owner: "test-owner",
-      repo: "test-repo",
-      head_sha: "test-sha",
-      // @ts-expect-error - Testing invalid input
-      issue_number: null,
-      run_id: 123,
-    });
-
-    await setStatus({ github, context, core }, "test-workflow", "test-status", "test-label");
-
-    expect(core.warning).toHaveBeenCalledWith("issue_number must be a positive integer");
-    expect(github.rest.repos.createCommitStatus).not.toHaveBeenCalled();
-  });
-
-  it("returns early with warning when issue_number is undefined", async () => {
-    mockExtractInputs.mockResolvedValue({
-      owner: "test-owner",
-      repo: "test-repo",
-      head_sha: "test-sha",
-      // @ts-expect-error - Testing invalid input
-      issue_number: undefined,
-      run_id: 123,
-    });
-
-    await setStatus({ github, context, core }, "test-workflow", "test-status", "test-label");
-
-    expect(core.warning).toHaveBeenCalledWith("issue_number must be a positive integer");
-    expect(github.rest.repos.createCommitStatus).not.toHaveBeenCalled();
-  });
-
-  it("returns early with warning when issue_number is NaN", async () => {
-    mockExtractInputs.mockResolvedValue({
-      owner: "test-owner",
-      repo: "test-repo",
-      head_sha: "test-sha",
-      issue_number: NaN,
-      run_id: 123,
-    });
-
-    await setStatus({ github, context, core }, "test-workflow", "test-status", "test-label");
-
-    expect(core.warning).toHaveBeenCalledWith("issue_number must be a positive integer");
-    expect(github.rest.repos.createCommitStatus).not.toHaveBeenCalled();
-  });
-
-  it("returns early with warning when issue_number is zero", async () => {
-    mockExtractInputs.mockResolvedValue({
-      owner: "test-owner",
-      repo: "test-repo",
-      head_sha: "test-sha",
-      issue_number: 0,
-      run_id: 123,
-    });
-
-    await setStatus({ github, context, core }, "test-workflow", "test-status", "test-label");
-
-    expect(core.warning).toHaveBeenCalledWith("issue_number must be a positive integer");
-    expect(github.rest.repos.createCommitStatus).not.toHaveBeenCalled();
-  });
-
-  it("returns early with warning when issue_number is negative", async () => {
-    mockExtractInputs.mockResolvedValue({
-      owner: "test-owner",
-      repo: "test-repo",
-      head_sha: "test-sha",
-      issue_number: -1,
-      run_id: 123,
-    });
-
-    await setStatus({ github, context, core }, "test-workflow", "test-status", "test-label");
-
-    expect(core.warning).toHaveBeenCalledWith("issue_number must be a positive integer");
-    expect(github.rest.repos.createCommitStatus).not.toHaveBeenCalled();
-  });
-
-  it("proceeds to setStatusImpl when issue_number is valid positive integer", async () => {
-    mockExtractInputs.mockResolvedValue({
-      owner: "test-owner",
-      repo: "test-repo",
-      head_sha: "test-sha",
-      issue_number: 123,
-      run_id: 456,
-    });
-
-    // Mock successful label check to avoid complex setup
-    github.rest.issues.listLabelsOnIssue.mockResolvedValue({
-      data: [{ name: "test-label" }],
-    });
-
-    await setStatus({ github, context, core }, "test-workflow", "test-status", "test-label");
-
-    expect(core.warning).not.toHaveBeenCalled();
-    expect(github.rest.issues.listLabelsOnIssue).toHaveBeenCalledWith({
-      owner: "test-owner",
-      repo: "test-repo",
-      issue_number: 123,
-      per_page: 100,
-    });
-  });
-});
 
 describe("setStatusImpl", () => {
   let core;
@@ -143,6 +17,93 @@ describe("setStatusImpl", () => {
 
   it("throws if inputs null", async () => {
     await expect(setStatusImpl({})).rejects.toThrow();
+  });
+
+  it("throws when issue_number is null", async () => {
+    await expect(
+      setStatusImpl({
+        owner: "test-owner",
+        repo: "test-repo",
+        head_sha: "test-head-sha",
+        // @ts-expect-error - Testing invalid input
+        issue_number: null,
+        target_url: "https://test.com/set_status_url",
+        github,
+        core,
+        monitoredWorkflowName: "test-workflow",
+        requiredStatusName: "test-status",
+        overridingLabel: "test-label",
+      }),
+    ).rejects.toThrow("issue_number must be a positive integer");
+  });
+
+  it("throws when issue_number is undefined", async () => {
+    await expect(
+      setStatusImpl({
+        owner: "test-owner",
+        repo: "test-repo",
+        head_sha: "test-head-sha",
+        // @ts-expect-error - Testing invalid input
+        issue_number: undefined,
+        target_url: "https://test.com/set_status_url",
+        github,
+        core,
+        monitoredWorkflowName: "test-workflow",
+        requiredStatusName: "test-status",
+        overridingLabel: "test-label",
+      }),
+    ).rejects.toThrow("issue_number must be a positive integer");
+  });
+
+  it("throws when issue_number is NaN", async () => {
+    await expect(
+      setStatusImpl({
+        owner: "test-owner",
+        repo: "test-repo",
+        head_sha: "test-head-sha",
+        issue_number: NaN,
+        target_url: "https://test.com/set_status_url",
+        github,
+        core,
+        monitoredWorkflowName: "test-workflow",
+        requiredStatusName: "test-status",
+        overridingLabel: "test-label",
+      }),
+    ).rejects.toThrow("issue_number must be a positive integer");
+  });
+
+  it("throws when issue_number is zero", async () => {
+    await expect(
+      setStatusImpl({
+        owner: "test-owner",
+        repo: "test-repo",
+        head_sha: "test-head-sha",
+        issue_number: 0,
+        target_url: "https://test.com/set_status_url",
+        github,
+        core,
+        monitoredWorkflowName: "test-workflow",
+        requiredStatusName: "test-status",
+        overridingLabel: "test-label",
+      }),
+    ).rejects.toThrow("issue_number must be a positive integer");
+  });
+
+  it("throws when issue_number is negative", async () => {
+    await expect(
+      setStatusImpl({
+        owner: "test-owner",
+        repo: "test-repo",
+        head_sha: "test-head-sha",
+        issue_number: -1,
+        target_url: "https://test.com/set_status_url",
+        github,
+        core,
+        monitoredWorkflowName: "test-workflow",
+        requiredStatusName: "test-status",
+        overridingLabel: "test-label",
+      }),
+    ).rejects.toThrow("issue_number must be a positive integer");
   });
 
   it("sets success if approved by label", async () => {


### PR DESCRIPTION
Issue_number will be set with invalid value now in `context.js` and it needs to be checked by downstream scripts. 

Throwing the error to fail the status check to save the unnecessary API call.

To address the error reported in status check like below:
```
No open PRs found for commit 961f75397963fe3446e3df9337f035bae5894738
Could not find PR for 961f75397963fe3446e3df9337f035bae5894738 in markcowl:azure-rest-api-specs from either the "commits" or "search" REST APIs
inputs: {"owner":"Azure","repo":"azure-rest-api-specs","head_sha":"961f75397963fe3446e3df9337f035bae5894738","issue_number":null,"run_id":16688626603}
RequestError [HttpError]: Not Found
    at /home/runner/work/_actions/actions/github-script/v7/dist/index.js:9537:21
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Object.next (/home/runner/work/_actions/actions/github-script/v7/dist/index.js:6790:28)
    at async setStatusImpl (file:///home/runner/work/azure-rest-api-specs/azure-rest-api-specs/.github/workflows/src/set-status.js:77:18)
    at async setStatus (file:///home/runner/work/azure-rest-api-specs/azure-rest-api-specs/.github/workflows/src/set-status.js:33:10)
    at async eval (eval at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v7/dist/index.js:35424:16), <anonymous>:5:8)
    at async main (/home/runner/work/_actions/actions/github-script/v7/dist/index.js:35522:20) {
  status: 404,
  response: {
    url: 'https://api.github.com/repos/Azure/azure-rest-api-specs/issues/NaN/labels?per_page=100',
    status: 404,
```
https://github.com/Azure/azure-rest-api-specs/actions/runs/16688645662/job/47242703329