### PR TITLE
Ensure we properly set `isDraft` flag

### DIFF
--- a/.github/workflows/summarize-impact.yaml
+++ b/.github/workflows/summarize-impact.yaml
@@ -40,7 +40,7 @@ jobs:
             --sha "${{ github.event.pull_request.head.sha }}" \
             --repo "${{ github.event.repository.name }}" \
             --owner "${{ github.repository_owner }}" \
-            --isDraft ${{ github.event.pull_request.draft }}
+            ${{ github.event.pull_request.draft && '--isDraft' || '' }}
         env:
           # We absolutely need to avoid OOM errors due to certain inherited types from openapi-alps
           NODE_OPTIONS: "--max-old-space-size=8192"

--- a/eng/tools/summarize-impact/src/cli.ts
+++ b/eng/tools/summarize-impact/src/cli.ts
@@ -61,6 +61,7 @@ export async function main() {
       isDraft: {
         type: "boolean",
         multiple: false,
+        default: false,
       },
     },
     allowPositionals: true,


### PR DESCRIPTION
We were _always_ setting it. Instead we should only set it when it's actually true.

- [Draft](https://github.com/scbedd/azure-rest-api-specs/actions/runs/16735560257/job/47373535029?pr=9#step:5:199)
- [Non-Draft](https://github.com/scbedd/azure-rest-api-specs/actions/runs/16735490154/job/47373321843#step:5:199)
