### PR TITLE
Fix regression in Red-Team operations

### DIFF
--- a/specification/ai/Azure.AI.Projects/red-teams/models.tsp
+++ b/specification/ai/Azure.AI.Projects/red-teams/models.tsp
@@ -113,7 +113,6 @@ union RiskCategory {
 @added(Versions.v2025_05_15_preview)
 @removed(Versions.v1)
 model AzureOpenAIModelConfiguration extends TargetConfig {
-  @visibility(Lifecycle.Read)
   type: "AzureOpenAIModel";
 
   @doc("Deployment name for AOAI model. Example: gpt-4o if in AIServices or connection based `connection_name/deployment_name` (e.g. `my-aoai-connection/gpt-4o`).")

--- a/specification/ai/Azure.AI.Projects/tspconfig.yaml
+++ b/specification/ai/Azure.AI.Projects/tspconfig.yaml
@@ -14,7 +14,7 @@ options:
     package-dir: "azure-ai-projects"
     package-name: "{package-dir}"
     namespace: "azure.ai.projects"
-    api-version: "v1"
+    api-version: "2025-05-15-preview"
     flavor: azure
     generate-test: true
     generate-sample: false


### PR DESCRIPTION
Also set the default Python SDK emitter api-version to the latest preview version, since we already released a stable version.