### PR TITLE
Trying to get around the possibility of huge # of checksuites

### DIFF
--- a/.github/workflows/src/summarize-checks/summarize-checks.js
+++ b/.github/workflows/src/summarize-checks/summarize-checks.js
@@ -732,7 +732,23 @@ export async function getCheckRunTuple(
         per_page: PER_PAGE_MAX,
       });
 
-      impactAssessmentWorkflowRun = workflowRuns[0].id;
+      if (workflowRuns.length === 0) {
+        core.warning(
+          `No workflow runs found for check suite ID: ${latestCheck._originalData.check_suite.id}`,
+        );
+      } else {
+        // Sort by updated_at to get the most recent run
+        const sortedRuns = workflowRuns.sort(
+          (a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
+        );
+        impactAssessmentWorkflowRun = sortedRuns[0].id;
+
+        if (workflowRuns.length > 1) {
+          core.info(
+            `Found ${workflowRuns.length} workflow runs for check suite ID: ${latestCheck._originalData.check_suite.id}, using most recent: ${sortedRuns[0].id}`,
+          );
+        }
+      }
     }
 
     // Create clean CheckRunData without temporary properties

--- a/.github/workflows/src/summarize-checks/summarize-checks.js
+++ b/.github/workflows/src/summarize-checks/summarize-checks.js
@@ -24,6 +24,7 @@ import { extractInputs } from "../context.js";
 import { execFile } from "../../../shared/src/exec.js";
 import { CheckConclusion, PER_PAGE_MAX } from "../../../shared/src/github.js";
 import { intersect } from "../../../shared/src/set.js";
+import { byDate, invert } from "../../../shared/src/sort.js";
 import {
   brChRevApproval,
   getViolatedRequiredLabelsRules,
@@ -57,7 +58,7 @@ import path from "path";
  * @typedef {Object} CheckRunData
  * @property {string} name
  * @property {string} status
- * @property {string} conclusion
+ * @property {string | null} conclusion
  * @property {CheckMetadata} checkInfo
  */
 
@@ -568,129 +569,24 @@ export function updateLabels(existingLabels, impactAssessment) {
 
 // #endregion
 // #region checks
-
 /**
- * A GraphQL query to GitHub API that returns all check runs for given commit, with "isRequired" field for given PR.
- *
- * If you want to see example response, copy the query body into this:
- * https://docs.github.com/en/graphql/overview/explorer
- * Example inputs:
- * resourceUrl: "https://github.com/test-repo-billy/azure-rest-api-specs/commit/c2789c5bde1b3f4fa34f76a8eeaaed479df23c4d"
- * prNumber: 2996
- *
- * Reference:
- * https://docs.github.com/en/graphql/reference/queries#resource
- * https://docs.github.com/en/graphql/guides/using-global-node-ids#3-do-a-direct-node-lookup-in-graphql
- * https://docs.github.com/en/graphql/reference/objects#checkrun
- * Rate limit:
- * https://docs.github.com/en/graphql/overview/resource-limitations#rate-limit
- * https://docs.github.com/en/graphql/reference/objects#ratelimit
- *
- * Note: here, for "checkRuns(first: ..)", maybe we should add a filter that filters to LATEST, per:
- * https://docs.github.com/en/graphql/reference/input-objects#checkrunfilter
- * https://docs.github.com/en/graphql/reference/enums#checkruntype
- **/
-/**
- * Fetch all check suites for a commit with pagination
- * @param {import('@actions/github-script').AsyncFunctionArguments['github']} github
- * @param {typeof import("@actions/core")} core
- * @param {string} owner
- * @param {string} repo
- * @param {string} sha
- * @param {number} prNumber
- * @returns {Promise<any>} Complete GraphQL response with all check suites
+ * Extracts required status check context names from GitHub branch rules response.
+ * @param {import('@octokit/rest').RestEndpointMethodTypes['repos']['getBranchRules']['response']} checkResponseObj - The GitHub branch rules API response object
+ * @returns {string[]} Array of required status check context names (e.g., ["license/cla", "Swagger LintDiff"])
  */
-async function getAllCheckSuites(github, core, owner, repo, sha, prNumber) {
-  // First, get the total count using REST API to avoid expensive GraphQL if there are too many suites
-  const { data: checkSuitesResponse } = await github.rest.checks.listSuitesForRef({
-    owner,
-    repo,
-    ref: sha,
-    per_page: 1, // We only need the count, not the actual data
-  });
+export function getRequiredChecksFromBranchRuleOutput(checkResponseObj) {
+  const requiredChecks = [];
 
-  const totalCheckSuites = checkSuitesResponse.total_count;
-
-  // Bail if too many check suites to avoid burning GraphQL rate limits
-  if (totalCheckSuites > 500) {
-    throw new Error(
-      `Too many check suites (${totalCheckSuites}) for ${owner}/${repo}#${prNumber}@${sha}. Summarize-Checks ending with error to avoid exhausting graphQL resources.`,
-    );
-  } else {
-    core.info(`Found ${totalCheckSuites} total check suites`);
-  }
-
-  // Now proceed with GraphQL pagination
-  const resourceUrl = `https://github.com/${owner}/${repo}/commit/${sha}`;
-  let allCheckSuites = [];
-  let hasNextPage = true;
-  let cursor = null;
-  let lastResponse = null;
-
-  while (hasNextPage) {
-    /** @type {string} */
-    const query = `
-      {
-        resource(url: "${resourceUrl}") {
-          ... on Commit {
-            checkSuites(first: 100${cursor ? `, after: "${cursor}"` : ""}) {
-              pageInfo {
-                hasNextPage
-                endCursor
-              }
-              nodes {
-                workflowRun {
-                  id
-                  databaseId
-                  workflow {
-                    name
-                  }
-                }
-                checkRuns(first: 100) {
-                  nodes {
-                    name
-                    status
-                    conclusion
-                    isRequired(pullRequestNumber: ${prNumber})
-                  }
-                }
-              }
-            }
-          }
-        }
-        rateLimit {
-          limit
-          cost
-          used
-          remaining
-          resetAt
-        }
+  // Look through all rules for required_status_checks type
+  for (const rule of checkResponseObj.data) {
+    if (rule.type === "required_status_checks" && rule.parameters?.required_status_checks) {
+      for (const statusCheck of rule.parameters.required_status_checks) {
+        requiredChecks.push(statusCheck.context);
       }
-    `;
-
-    /** @type {any} */
-    const response = await github.graphql(query);
-    lastResponse = response;
-    core.info(`GraphQL Rate Limit Information: ${JSON.stringify(response.rateLimit)}`);
-
-    if (response.resource?.checkSuites?.nodes) {
-      allCheckSuites.push(...response.resource.checkSuites.nodes);
-      hasNextPage = response.resource.checkSuites.pageInfo.hasNextPage;
-      cursor = response.resource.checkSuites.pageInfo.endCursor;
-    } else {
-      hasNextPage = false;
     }
   }
 
-  // Return a response object that matches the original structure
-  return {
-    resource: {
-      checkSuites: {
-        nodes: allCheckSuites,
-      },
-    },
-    rateLimit: lastResponse?.rateLimit,
-  };
+  return requiredChecks;
 }
 
 /**
@@ -714,10 +610,8 @@ export async function getCheckRunTuple(
 ) {
   // This function was originally a version of getRequiredAndFyiAndAutomatedMergingRequirementsMetCheckRuns
   // but has been simplified for clarity and purpose.
-  /** @type {CheckRunData[]} */
-  let reqCheckRuns = [];
-  /** @type {CheckRunData[]} */
-  let fyiCheckRuns = [];
+  /** @type {string[]} */
+  let requiredCheckNames = [];
 
   /** @type {number | undefined} */
   let impactAssessmentWorkflowRun = undefined;
@@ -725,11 +619,134 @@ export async function getCheckRunTuple(
   /** @type { import("./labelling.js").ImpactAssessment | undefined } */
   let impactAssessment = undefined;
 
-  const response = await getAllCheckSuites(github, core, owner, repo, head_sha, prNumber);
-  core.info(`GraphQL Rate Limit Information: ${JSON.stringify(response.rateLimit)}`);
+  const allCheckRuns = await github.paginate(github.rest.checks.listForRef, {
+    owner: owner,
+    repo: repo,
+    ref: head_sha,
+    per_page: PER_PAGE_MAX,
+  });
 
-  [reqCheckRuns, fyiCheckRuns, impactAssessmentWorkflowRun] =
-    extractRunsFromGraphQLResponse(response);
+  const allCommitStatuses = await github.paginate(github.rest.repos.listCommitStatusesForRef, {
+    owner: owner,
+    repo: repo,
+    ref: head_sha,
+    per_page: PER_PAGE_MAX,
+  });
+
+  // Process allCheckRuns and allCommitStatuses into unified CheckRunData array
+  // all checks will be considered as "FYI" until we have an impact assessment, so we can
+  // determine the target branch, and from there pull branch protect rulesets to ensure we
+  // are marking the required checks correctly.
+  /** @type {Array<CheckRunData & {_originalData: any, _source: string}>} */
+  const allChecks = [];
+
+  allCheckRuns.forEach((checkRun) => {
+    allChecks.push({
+      name: checkRun.name,
+      status: checkRun.status,
+      conclusion: checkRun.conclusion || null,
+      checkInfo: getCheckInfo(checkRun.name),
+      // Store original object for date sorting
+      _originalData: checkRun,
+      _source: "checkRun",
+    });
+  });
+
+  allCommitStatuses.forEach((status) => {
+    // Map commit status state to check run conclusion
+    let conclusion = null;
+    let checkStatus = "completed";
+
+    switch (status.state) {
+      case "success":
+        conclusion = "success";
+        break;
+      case "failure":
+        conclusion = "failure";
+        break;
+      case "error":
+        conclusion = "failure";
+        break;
+      case "pending":
+        checkStatus = "in_progress";
+        conclusion = null;
+        break;
+    }
+
+    allChecks.push({
+      name: status.context,
+      status: checkStatus,
+      conclusion: conclusion,
+      checkInfo: getCheckInfo(status.context),
+      // Store original object for date sorting and data access
+      _originalData: status,
+      _source: "commitStatus",
+    });
+  });
+
+  // Group by name and take the latest for each
+  const checksByName = new Map();
+
+  allChecks.forEach((check) => {
+    const name = check.name;
+    if (!checksByName.has(name)) {
+      checksByName.set(name, []);
+    }
+    checksByName.get(name).push(check);
+  });
+
+  // For each group, sort by date (newest first) and take the first one
+  const unifiedCheckRuns = [];
+  for (const [, checks] of checksByName) {
+    // Sort by date - newest first using invert(byDate(...))
+    const sortedChecks = checks.sort(
+      invert(
+        byDate((check) => {
+          if (check._source === "checkRun") {
+            // Check runs have started_at, completed_at, etc. Use the most recent available date
+            return (
+              check._originalData.completed_at ||
+              check._originalData.started_at ||
+              check._originalData.created_at
+            );
+          } else {
+            // Commit statuses have created_at and updated_at
+            return check._originalData.updated_at || check._originalData.created_at;
+          }
+        }),
+      ),
+    );
+
+    const latestCheck = sortedChecks[0];
+
+    // just handling both for ease of integration testing
+    if (
+      latestCheck.name === "[TEST-IGNORE] Summarize PR Impact" ||
+      latestCheck.name === "Summarize PR Impact"
+    ) {
+      const workflowRuns = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
+        owner,
+        repo,
+        head_sha: head_sha,
+        check_suite_id: latestCheck._originalData.check_suite.id,
+        per_page: PER_PAGE_MAX,
+      });
+
+      impactAssessmentWorkflowRun = workflowRuns[0].id;
+    }
+
+    // Create clean CheckRunData without temporary properties
+    unifiedCheckRuns.push({
+      name: latestCheck.name,
+      status: latestCheck.status,
+      conclusion: latestCheck.conclusion,
+      checkInfo: latestCheck.checkInfo,
+    });
+  }
+
+  core.info(
+    `Processed ${allCheckRuns.length} check runs and ${allCommitStatuses.length} commit statuses into ${unifiedCheckRuns.length} unified checks`,
+  );
 
   if (impactAssessmentWorkflowRun) {
     core.info(
@@ -742,13 +759,27 @@ export async function getCheckRunTuple(
       repo,
       impactAssessmentWorkflowRun,
     );
+
+    const branchRules = await github.rest.repos.getBranchRules({
+      owner: owner,
+      repo: repo,
+      branch: impactAssessment.targetBranch,
+    });
+
+    if (branchRules) {
+      requiredCheckNames = getRequiredChecksFromBranchRuleOutput(branchRules);
+    }
   }
 
-  const filteredReqCheckRuns = reqCheckRuns.filter(
-    (checkRun) => !excludedCheckNames.includes(checkRun.name),
+  const filteredReqCheckRuns = unifiedCheckRuns.filter(
+    (checkRun) =>
+      !excludedCheckNames.includes(checkRun.name) && requiredCheckNames.includes(checkRun.name),
   );
-  const filteredFyiCheckRuns = fyiCheckRuns.filter(
-    (checkRun) => !excludedCheckNames.includes(checkRun.name),
+  const filteredFyiCheckRuns = unifiedCheckRuns.filter(
+    (checkRun) =>
+      !excludedCheckNames.includes(checkRun.name) &&
+      !requiredCheckNames.includes(checkRun.name) &&
+      FYI_CHECK_NAMES.includes(checkRun.name),
   );
 
   return [filteredReqCheckRuns, filteredFyiCheckRuns, impactAssessment];
@@ -775,76 +806,6 @@ export function checkRunIsSuccessful(checkRun) {
   return conclusion === "success" || conclusion === "neutral";
 }
 
-/**
- * @param {any} response - GraphQL response data
- * @returns {[CheckRunData[], CheckRunData[], number | undefined]}
- */
-export function extractRunsFromGraphQLResponse(response) {
-  /** @type {CheckRunData[]} */
-  const reqCheckRuns = [];
-  /** @type {CheckRunData[]} */
-  const fyiCheckRuns = [];
-
-  /** @type {number | undefined} */
-  let impactAssessmentWorkflowRun = undefined;
-
-  // Define the automated merging requirements check name
-
-  if (response.resource?.checkSuites?.nodes) {
-    response.resource.checkSuites.nodes.forEach(
-      /** @param {{ workflowRun?: WorkflowRunInfo, checkRuns?: { nodes?: any[] } }} checkSuiteNode */
-      (checkSuiteNode) => {
-        if (checkSuiteNode.checkRuns?.nodes) {
-          checkSuiteNode.checkRuns.nodes.forEach((checkRunNode) => {
-            if (checkRunNode.isRequired) {
-              reqCheckRuns.push({
-                name: checkRunNode.name,
-                status: checkRunNode.status,
-                conclusion: checkRunNode.conclusion,
-                checkInfo: getCheckInfo(checkRunNode.name),
-              });
-            }
-            // Note the "else" here. It means that:
-            // A GH check will be bucketed into "failing FYI check run" if:
-            // - It is failing
-            // - AND it is is NOT marked as 'required' in GitHub branch policy
-            // - AND it is marked as 'FYI' in this file's FYI_CHECK_NAMES array
-            else if (FYI_CHECK_NAMES.includes(checkRunNode.name)) {
-              fyiCheckRuns.push({
-                name: checkRunNode.name,
-                status: checkRunNode.status,
-                conclusion: checkRunNode.conclusion,
-                checkInfo: getCheckInfo(checkRunNode.name),
-              });
-            }
-          });
-        }
-      },
-    );
-  }
-
-  // extract the ImpactAssessment check run if it is completed and successful
-  if (response.resource?.checkSuites?.nodes) {
-    response.resource.checkSuites.nodes.forEach(
-      /** @param {{ workflowRun?: WorkflowRunInfo, checkRuns?: { nodes?: any[] } }} checkSuiteNode */
-      (checkSuiteNode) => {
-        if (checkSuiteNode.checkRuns?.nodes) {
-          checkSuiteNode.checkRuns.nodes.forEach((checkRunNode) => {
-            if (
-              checkRunNode.name === "[TEST-IGNORE] Summarize PR Impact" &&
-              checkRunNode.status?.toLowerCase() === "completed" &&
-              checkRunNode.conclusion?.toLowerCase() === "success"
-            ) {
-              // Assign numeric databaseId, not the string node ID
-              impactAssessmentWorkflowRun = checkSuiteNode.workflowRun?.databaseId;
-            }
-          });
-        }
-      },
-    );
-  }
-  return [reqCheckRuns, fyiCheckRuns, impactAssessmentWorkflowRun];
-}
 /**
  * Get metadata for a specific check from our index.
  * @param {string} checkName
@@ -1131,55 +1092,51 @@ function buildViolatedLabelRulesNextStepsText(violatedRequiredLabelsRules) {
  * @param {string} owner
  * @param {string} repo
  * @param {number} runId - The workflow run databaseId
- * @returns {Promise<import("./labelling.js").ImpactAssessment | undefined>} The parsed job summary data
+ * @returns {Promise<import("./labelling.js").ImpactAssessment>} The parsed job summary data
  */
 export async function getImpactAssessment(github, core, owner, repo, runId) {
-  try {
-    // List artifacts for provided workflow run
-    const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
-      owner,
-      repo,
-      run_id: runId,
-    });
+  // List artifacts for provided workflow run
+  const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+    owner,
+    repo,
+    run_id: runId,
+  });
 
-    // Find the job-summary artifact
-    const jobSummaryArtifact = artifacts.data.artifacts.find(
-      (artifact) => artifact.name === "job-summary",
+  // Find the job-summary artifact
+  const jobSummaryArtifact = artifacts.data.artifacts.find(
+    (artifact) => artifact.name === "job-summary",
+  );
+
+  if (!jobSummaryArtifact) {
+    throw new Error(
+      `Unable to find job-summary artifact for run ID: ${runId}. This should never happen, as this section of code should only run with a valid runId.`,
     );
-
-    if (!jobSummaryArtifact) {
-      core.info("No job-summary artifact found");
-      return undefined;
-    }
-
-    // Download the artifact as a zip archive
-    const download = await github.rest.actions.downloadArtifact({
-      owner,
-      repo,
-      artifact_id: jobSummaryArtifact.id,
-      archive_format: "zip",
-    });
-
-    core.info(`Successfully downloaded job-summary artifact ID: ${jobSummaryArtifact.id}`);
-
-    // Write zip buffer to temp file and extract JSON
-    const tmpZip = path.join(process.env.RUNNER_TEMP || os.tmpdir(), `job-summary-${runId}.zip`);
-    // Convert ArrayBuffer to Buffer
-    // Convert ArrayBuffer (download.data) to Node Buffer
-    const arrayBuffer = /** @type {ArrayBuffer} */ (download.data);
-    const zipBuffer = Buffer.from(new Uint8Array(arrayBuffer));
-    await fs.writeFile(tmpZip, zipBuffer);
-    // Extract JSON content from zip archive
-    const { stdout: jsonContent } = await execFile("unzip", ["-p", tmpZip]);
-    await fs.unlink(tmpZip);
-
-    /** @type {import("./labelling.js").ImpactAssessment} */
-    // todo: we need to zod this to ensure the structure is correct, however we do not have zod installed at time of run
-    const impact = JSON.parse(jsonContent);
-    return impact;
-  } catch (/** @type {any} */ error) {
-    core.error(`Failed to download job summary artifact: ${error.message}`);
-    return undefined;
   }
+
+  // Download the artifact as a zip archive
+  const download = await github.rest.actions.downloadArtifact({
+    owner,
+    repo,
+    artifact_id: jobSummaryArtifact.id,
+    archive_format: "zip",
+  });
+
+  core.info(`Successfully downloaded job-summary artifact ID: ${jobSummaryArtifact.id}`);
+
+  // Write zip buffer to temp file and extract JSON
+  const tmpZip = path.join(process.env.RUNNER_TEMP || os.tmpdir(), `job-summary-${runId}.zip`);
+  // Convert ArrayBuffer to Buffer
+  // Convert ArrayBuffer (download.data) to Node Buffer
+  const arrayBuffer = /** @type {ArrayBuffer} */ (download.data);
+  const zipBuffer = Buffer.from(new Uint8Array(arrayBuffer));
+  await fs.writeFile(tmpZip, zipBuffer);
+  // Extract JSON content from zip archive
+  const { stdout: jsonContent } = await execFile("unzip", ["-p", tmpZip]);
+  await fs.unlink(tmpZip);
+
+  /** @type {import("./labelling.js").ImpactAssessment} */
+  // todo: we need to zod this to ensure the structure is correct, however we do not have zod installed at time of run
+  const impact = JSON.parse(jsonContent);
+  return impact;
 }
 // #endregion

--- a/.github/workflows/test/summarize-checks/summarize-checks.test.js
+++ b/.github/workflows/test/summarize-checks/summarize-checks.test.js
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest";
 import { processArmReviewLabels } from "../../src/summarize-checks/labelling.js";
 import {
   createNextStepsComment,
-  extractRunsFromGraphQLResponse,
   getCheckInfo,
   getCheckRunTuple,
   getExistingLabels,
@@ -105,6 +104,7 @@ describe("Summarize Checks Integration Tests", () => {
           pr.base.ref,
           requiredCheckRuns,
           fyiCheckRuns,
+          impactAssessment !== undefined,
         );
 
         const actualLabels = [...labelContext.toAdd, ...labelContext.present];
@@ -853,22 +853,6 @@ describe("Summarize Checks Unit Tests", () => {
       );
 
       expect(automatedCheckOutput).toEqual(expectedCheckOutput);
-    });
-
-    it("should extract check info from raw check response data", async () => {
-      const expectedCheckRunId = 16582733356;
-      const response = await import("./fixtures/RawGraphQLResponse.json", {
-        assert: { type: "json" },
-      });
-      const [requiredCheckRuns, fyiCheckRuns, impactAssessmentWorkflowId] =
-        await extractRunsFromGraphQLResponse(response);
-
-      expect(requiredCheckRuns).toBeDefined();
-      expect(fyiCheckRuns).toBeDefined();
-      expect(impactAssessmentWorkflowId).toBeDefined();
-      expect(requiredCheckRuns.length).toEqual(11);
-      expect(fyiCheckRuns.length).toEqual(0);
-      expect(impactAssessmentWorkflowId).toEqual(expectedCheckRunId);
     });
   });
 


### PR DESCRIPTION
See title. We're using `listForRef` which should limit to the most recent 1k.

I have confirmed that this handles the pathological case originally mentioned in #36378 -- specifically sha `251ac2d3a8392258548facaaae3416ca681cd45c` triggered for pr `36377`. We now know _why_ that SHA triggered, and it's related to what #36479 is fixing!

That being said, our code will now properly handle those pathological cases if they pop up again.