### PR TITLE
when extracting `Summarize PR Impact` workflowrunId, we should only examine successful completed runs

### DIFF
--- a/.github/workflows/src/summarize-checks/summarize-checks.js
+++ b/.github/workflows/src/summarize-checks/summarize-checks.js
@@ -723,7 +723,8 @@ export async function getCheckRunTuple(
     if (
       (latestCheck.name === "[TEST-IGNORE] Summarize PR Impact" ||
         latestCheck.name === "Summarize PR Impact") &&
-      latestCheck.status === "completed" && latestCheck.conclusion === "success"
+      latestCheck.status === "completed" &&
+      latestCheck.conclusion === "success"
     ) {
       const workflowRuns = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
         owner,
@@ -786,8 +787,7 @@ export async function getCheckRunTuple(
     if (branchRules) {
       requiredCheckNames = getRequiredChecksFromBranchRuleOutput(branchRules);
     }
-  }
-  else {
+  } else {
     requiredCheckNames = ["Summarize PR Impact", "[TEST-IGNORE] Summarize PR Impact"];
   }
 

--- a/.github/workflows/src/summarize-checks/summarize-checks.js
+++ b/.github/workflows/src/summarize-checks/summarize-checks.js
@@ -719,11 +719,11 @@ export async function getCheckRunTuple(
 
     const latestCheck = sortedChecks[0];
 
-    // just handling both for ease of integration testing
+    // just handling both names for ease of integration testing
     if (
       (latestCheck.name === "[TEST-IGNORE] Summarize PR Impact" ||
         latestCheck.name === "Summarize PR Impact") &&
-      latestCheck.status === "completed"
+      latestCheck.status === "completed" && latestCheck.conclusion === "success"
     ) {
       const workflowRuns = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
         owner,
@@ -786,6 +786,9 @@ export async function getCheckRunTuple(
     if (branchRules) {
       requiredCheckNames = getRequiredChecksFromBranchRuleOutput(branchRules);
     }
+  }
+  else {
+    requiredCheckNames = ["Summarize PR Impact", "[TEST-IGNORE] Summarize PR Impact"];
   }
 
   const filteredReqCheckRuns = unifiedCheckRuns.filter(

--- a/.github/workflows/src/summarize-checks/summarize-checks.js
+++ b/.github/workflows/src/summarize-checks/summarize-checks.js
@@ -721,8 +721,9 @@ export async function getCheckRunTuple(
 
     // just handling both for ease of integration testing
     if (
-      latestCheck.name === "[TEST-IGNORE] Summarize PR Impact" ||
-      latestCheck.name === "Summarize PR Impact"
+      (latestCheck.name === "[TEST-IGNORE] Summarize PR Impact" ||
+        latestCheck.name === "Summarize PR Impact") &&
+      latestCheck.status === "completed"
     ) {
       const workflowRuns = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
         owner,


### PR DESCRIPTION
Otherwise we'll attempt to list artifacts for a build that is not yet complete. Which will 404.

We will also default the required checks to the impact assessment workflow. That's how we get the target branch, which is data we NEED To have to understand which checks are required.