### PR TITLE
Add `Update Labels` to triggering WF for `summarize-checks.yaml`

### DIFF
--- a/.github/workflows/summarize-checks.yaml
+++ b/.github/workflows/summarize-checks.yaml
@@ -9,6 +9,7 @@ on:
       - "Swagger Avocado - Set Status"
       - "Swagger LintDiff - Set Status"
       - "SDK Validation Status"
+      - "Update Labels"
     types:
       - completed
   pull_request_target: # when a PR is labeled. NOT pull_request, because that would run on the PR branch, not the base branch.


### PR DESCRIPTION
See title. We should wait to merge this until `Update-Labels` flows through `head_sha` and `issue_number` artifacts, which @mikeharder is working on in another PR.