### PR TITLE
Adding code and properties field in ErrorDetail model

### DIFF
--- a/specification/loadtestservice/LoadTestService/models.tsp
+++ b/specification/loadtestservice/LoadTestService/models.tsp
@@ -960,9 +960,19 @@ model TestRunInsightColumn {
 
 @doc("Error details if there is any failure in load test run")
 model ErrorDetails {
+  @doc("Error code if there is any failure in load test run.")
+  @visibility(Lifecycle.Read)
+  @added(APIVersions.v2025_03_01_preview)
+  code?: string;
+
   @doc("Error details in case test run was not successfully run.")
   @visibility(Lifecycle.Read)
   message?: string;
+
+  @added(APIVersions.v2025_03_01_preview)
+  @doc("A dictionary for storing additional error information for better context. Each key is a property name (e.g., \"Description\", \"Resolution\", \"Category\", \"Region\"), and its value is an array of strings with relevant details.")
+  @visibility(Lifecycle.Read)
+  properties?: Record<string[]>;
 }
 
 @doc("Test run statistics.")

--- a/specification/loadtestservice/data-plane/loadtesting/preview/2023-04-01-preview/loadtestservice.json
+++ b/specification/loadtestservice/data-plane/loadtesting/preview/2023-04-01-preview/loadtestservice.json
@@ -1794,8 +1794,7 @@
           "description": "An array of details about specific errors that led to this reported error.",
           "items": {
             "$ref": "#/definitions/Azure.Core.Foundations.Error"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "innererror": {
           "$ref": "#/definitions/Azure.Core.Foundations.InnerError",
@@ -2063,8 +2062,7 @@
           "description": "List of dimensions",
           "items": {
             "$ref": "#/definitions/NameAndDescription"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "description": {
           "type": "string",
@@ -2098,8 +2096,7 @@
           "description": "Metric availability specifies the time grain (aggregation interval or\nfrequency).",
           "items": {
             "$ref": "#/definitions/MetricAvailability"
-          },
-          "x-ms-identifiers": []
+          }
         }
       }
     },
@@ -2112,8 +2109,7 @@
           "description": "the values for the metric definitions.",
           "items": {
             "$ref": "#/definitions/MetricDefinition"
-          },
-          "x-ms-identifiers": []
+          }
         }
       },
       "required": [
@@ -2143,8 +2139,7 @@
           "description": "The values for the metric namespaces.",
           "items": {
             "$ref": "#/definitions/MetricNamespace"
-          },
-          "x-ms-identifiers": []
+          }
         }
       },
       "required": [
@@ -2160,8 +2155,7 @@
           "description": "Get metrics for specific dimension values. Example: Metric contains dimension\nlike SamplerName, Error. To retrieve all the time series data where SamplerName\nis equals to HTTPRequest1 or HTTPRequest2, the DimensionFilter value will be\n{\"SamplerName\", [\"HTTPRequest1\", \"HTTPRequest2\"}",
           "items": {
             "$ref": "#/definitions/DimensionFilter"
-          },
-          "x-ms-identifiers": []
+          }
         }
       }
     },
@@ -2250,8 +2244,7 @@
           "description": "The TimeSeriesElement items on this page",
           "items": {
             "$ref": "#/definitions/TimeSeriesElement"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -2363,8 +2356,7 @@
           "description": "The Test items on this page",
           "items": {
             "$ref": "#/definitions/Test"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -2385,8 +2377,7 @@
           "description": "The TestFileInfo items on this page",
           "items": {
             "$ref": "#/definitions/TestFileInfo"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -2407,8 +2398,7 @@
           "description": "The TestRun items on this page",
           "items": {
             "$ref": "#/definitions/TestRun"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -3048,8 +3038,7 @@
           "items": {
             "$ref": "#/definitions/TestFileInfo"
           },
-          "readOnly": true,
-          "x-ms-identifiers": []
+          "readOnly": true
         }
       }
     },
@@ -3121,8 +3110,7 @@
           "items": {
             "$ref": "#/definitions/ErrorDetails"
           },
-          "readOnly": true,
-          "x-ms-identifiers": []
+          "readOnly": true
         },
         "testRunStatistics": {
           "type": "object",
@@ -3436,8 +3424,7 @@
           "items": {
             "$ref": "#/definitions/TestRunFileInfo"
           },
-          "readOnly": true,
-          "x-ms-identifiers": []
+          "readOnly": true
         }
       }
     },
@@ -3803,16 +3790,14 @@
           "description": "An array of data points representing the metric values.",
           "items": {
             "$ref": "#/definitions/MetricValue"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "dimensionValues": {
           "type": "array",
           "description": "The dimension values ",
           "items": {
             "$ref": "#/definitions/DimensionValue"
-          },
-          "x-ms-identifiers": []
+          }
         }
       }
     }

--- a/specification/loadtestservice/data-plane/loadtesting/preview/2024-03-01-preview/loadtestservice.json
+++ b/specification/loadtestservice/data-plane/loadtesting/preview/2024-03-01-preview/loadtestservice.json
@@ -1800,8 +1800,7 @@
           "description": "An array of details about specific errors that led to this reported error.",
           "items": {
             "$ref": "#/definitions/Azure.Core.Foundations.Error"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "innererror": {
           "$ref": "#/definitions/Azure.Core.Foundations.InnerError",
@@ -2063,8 +2062,7 @@
           "description": "Region distribution configuration for the load test.",
           "items": {
             "$ref": "#/definitions/RegionalConfiguration"
-          },
-          "x-ms-identifiers": []
+          }
         }
       }
     },
@@ -2087,8 +2085,7 @@
           "description": "List of dimensions",
           "items": {
             "$ref": "#/definitions/NameAndDescription"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "description": {
           "type": "string",
@@ -2122,8 +2119,7 @@
           "description": "Metric availability specifies the time grain (aggregation interval or\nfrequency).",
           "items": {
             "$ref": "#/definitions/MetricAvailability"
-          },
-          "x-ms-identifiers": []
+          }
         }
       }
     },
@@ -2136,8 +2132,7 @@
           "description": "the values for the metric definitions.",
           "items": {
             "$ref": "#/definitions/MetricDefinition"
-          },
-          "x-ms-identifiers": []
+          }
         }
       },
       "required": [
@@ -2167,8 +2162,7 @@
           "description": "The values for the metric namespaces.",
           "items": {
             "$ref": "#/definitions/MetricNamespace"
-          },
-          "x-ms-identifiers": []
+          }
         }
       },
       "required": [
@@ -2184,8 +2178,7 @@
           "description": "Get metrics for specific dimension values. Example: Metric contains dimension\nlike SamplerName, Error. To retrieve all the time series data where SamplerName\nis equals to HTTPRequest1 or HTTPRequest2, the DimensionFilter value will be\n{\"SamplerName\", [\"HTTPRequest1\", \"HTTPRequest2\"}",
           "items": {
             "$ref": "#/definitions/DimensionFilter"
-          },
-          "x-ms-identifiers": []
+          }
         }
       }
     },
@@ -2274,8 +2267,7 @@
           "description": "The TimeSeriesElement items on this page",
           "items": {
             "$ref": "#/definitions/TimeSeriesElement"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -2387,8 +2379,7 @@
           "description": "The Test items on this page",
           "items": {
             "$ref": "#/definitions/Test"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -2409,8 +2400,7 @@
           "description": "The TestFileInfo items on this page",
           "items": {
             "$ref": "#/definitions/TestFileInfo"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -2431,8 +2421,7 @@
           "description": "The TestRun items on this page",
           "items": {
             "$ref": "#/definitions/TestRun"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -3091,8 +3080,7 @@
           "items": {
             "$ref": "#/definitions/TestFileInfo"
           },
-          "readOnly": true,
-          "x-ms-identifiers": []
+          "readOnly": true
         }
       }
     },
@@ -3170,8 +3158,7 @@
           "items": {
             "$ref": "#/definitions/ErrorDetails"
           },
-          "readOnly": true,
-          "x-ms-identifiers": []
+          "readOnly": true
         },
         "testRunStatistics": {
           "type": "object",
@@ -3493,8 +3480,7 @@
           "items": {
             "$ref": "#/definitions/TestRunFileInfo"
           },
-          "readOnly": true,
-          "x-ms-identifiers": []
+          "readOnly": true
         }
       }
     },
@@ -3860,16 +3846,14 @@
           "description": "An array of data points representing the metric values.",
           "items": {
             "$ref": "#/definitions/MetricValue"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "dimensionValues": {
           "type": "array",
           "description": "The dimension values ",
           "items": {
             "$ref": "#/definitions/DimensionValue"
-          },
-          "x-ms-identifiers": []
+          }
         }
       }
     }

--- a/specification/loadtestservice/data-plane/loadtesting/preview/2024-05-01-preview/loadtestservice.json
+++ b/specification/loadtestservice/data-plane/loadtesting/preview/2024-05-01-preview/loadtestservice.json
@@ -2350,8 +2350,7 @@
           "description": "An array of details about specific errors that led to this reported error.",
           "items": {
             "$ref": "#/definitions/Azure.Core.Foundations.Error"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "innererror": {
           "$ref": "#/definitions/Azure.Core.Foundations.InnerError",
@@ -2686,8 +2685,7 @@
           "description": "Region distribution configuration for the load test.",
           "items": {
             "$ref": "#/definitions/RegionalConfiguration"
-          },
-          "x-ms-identifiers": []
+          }
         }
       }
     },
@@ -2710,8 +2708,7 @@
           "description": "List of dimensions",
           "items": {
             "$ref": "#/definitions/NameAndDescription"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "description": {
           "type": "string",
@@ -2745,8 +2742,7 @@
           "description": "Metric availability specifies the time grain (aggregation interval or\nfrequency).",
           "items": {
             "$ref": "#/definitions/MetricAvailability"
-          },
-          "x-ms-identifiers": []
+          }
         }
       }
     },
@@ -2759,8 +2755,7 @@
           "description": "the values for the metric definitions.",
           "items": {
             "$ref": "#/definitions/MetricDefinition"
-          },
-          "x-ms-identifiers": []
+          }
         }
       },
       "required": [
@@ -2790,8 +2785,7 @@
           "description": "The values for the metric namespaces.",
           "items": {
             "$ref": "#/definitions/MetricNamespace"
-          },
-          "x-ms-identifiers": []
+          }
         }
       },
       "required": [
@@ -2807,8 +2801,7 @@
           "description": "Get metrics for specific dimension values. Example: Metric contains dimension\nlike SamplerName, Error. To retrieve all the time series data where SamplerName\nis equals to HTTPRequest1 or HTTPRequest2, the DimensionFilter value will be\n{\"SamplerName\", [\"HTTPRequest1\", \"HTTPRequest2\"}",
           "items": {
             "$ref": "#/definitions/DimensionFilter"
-          },
-          "x-ms-identifiers": []
+          }
         }
       }
     },
@@ -2897,8 +2890,7 @@
           "description": "The TimeSeriesElement items on this page",
           "items": {
             "$ref": "#/definitions/TimeSeriesElement"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -3010,8 +3002,7 @@
           "description": "The Test items on this page",
           "items": {
             "$ref": "#/definitions/Test"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -3032,8 +3023,7 @@
           "description": "The TestFileInfo items on this page",
           "items": {
             "$ref": "#/definitions/TestFileInfo"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -3054,8 +3044,7 @@
           "description": "The TestProfile items on this page",
           "items": {
             "$ref": "#/definitions/TestProfile"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -3076,8 +3065,7 @@
           "description": "The TestProfileRun items on this page",
           "items": {
             "$ref": "#/definitions/TestProfileRun"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -3098,8 +3086,7 @@
           "description": "The TestRun items on this page",
           "items": {
             "$ref": "#/definitions/TestRun"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -3896,8 +3883,7 @@
           "items": {
             "$ref": "#/definitions/TestFileInfo"
           },
-          "readOnly": true,
-          "x-ms-identifiers": []
+          "readOnly": true
         }
       }
     },
@@ -4096,8 +4082,7 @@
           "items": {
             "$ref": "#/definitions/ErrorDetails"
           },
-          "readOnly": true,
-          "x-ms-identifiers": []
+          "readOnly": true
         },
         "startDateTime": {
           "type": "string",
@@ -4131,8 +4116,7 @@
           "items": {
             "$ref": "#/definitions/TestProfileRunRecommendation"
           },
-          "readOnly": true,
-          "x-ms-identifiers": []
+          "readOnly": true
         },
         "createdDateTime": {
           "type": "string",
@@ -4305,8 +4289,7 @@
           "items": {
             "$ref": "#/definitions/ErrorDetails"
           },
-          "readOnly": true,
-          "x-ms-identifiers": []
+          "readOnly": true
         },
         "testRunStatistics": {
           "type": "object",
@@ -4670,8 +4653,7 @@
           "items": {
             "$ref": "#/definitions/TestRunFileInfo"
           },
-          "readOnly": true,
-          "x-ms-identifiers": []
+          "readOnly": true
         }
       }
     },
@@ -5077,16 +5059,14 @@
           "description": "An array of data points representing the metric values.",
           "items": {
             "$ref": "#/definitions/MetricValue"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "dimensionValues": {
           "type": "array",
           "description": "The dimension values ",
           "items": {
             "$ref": "#/definitions/DimensionValue"
-          },
-          "x-ms-identifiers": []
+          }
         }
       }
     }

--- a/specification/loadtestservice/data-plane/loadtesting/preview/2024-07-01-preview/loadtestservice.json
+++ b/specification/loadtestservice/data-plane/loadtesting/preview/2024-07-01-preview/loadtestservice.json
@@ -2572,8 +2572,7 @@
           "description": "An array of details about specific errors that led to this reported error.",
           "items": {
             "$ref": "#/definitions/Azure.Core.Foundations.Error"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "innererror": {
           "$ref": "#/definitions/Azure.Core.Foundations.InnerError",
@@ -3054,8 +3053,7 @@
           "description": "Region distribution configuration for the load test.",
           "items": {
             "$ref": "#/definitions/RegionalConfiguration"
-          },
-          "x-ms-identifiers": []
+          }
         }
       }
     },
@@ -3078,8 +3076,7 @@
           "description": "List of dimensions",
           "items": {
             "$ref": "#/definitions/NameAndDescription"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "description": {
           "type": "string",
@@ -3113,8 +3110,7 @@
           "description": "Metric availability specifies the time grain (aggregation interval or\nfrequency).",
           "items": {
             "$ref": "#/definitions/MetricAvailability"
-          },
-          "x-ms-identifiers": []
+          }
         }
       }
     },
@@ -3127,8 +3123,7 @@
           "description": "the values for the metric definitions.",
           "items": {
             "$ref": "#/definitions/MetricDefinition"
-          },
-          "x-ms-identifiers": []
+          }
         }
       },
       "required": [
@@ -3158,8 +3153,7 @@
           "description": "The values for the metric namespaces.",
           "items": {
             "$ref": "#/definitions/MetricNamespace"
-          },
-          "x-ms-identifiers": []
+          }
         }
       },
       "required": [
@@ -3175,8 +3169,7 @@
           "description": "Get metrics for specific dimension values. Example: Metric contains dimension\nlike SamplerName, Error. To retrieve all the time series data where SamplerName\nis equals to HTTPRequest1 or HTTPRequest2, the DimensionFilter value will be\n{\"SamplerName\", [\"HTTPRequest1\", \"HTTPRequest2\"}",
           "items": {
             "$ref": "#/definitions/DimensionFilter"
-          },
-          "x-ms-identifiers": []
+          }
         }
       }
     },
@@ -3265,8 +3258,7 @@
           "description": "The TimeSeriesElement items on this page",
           "items": {
             "$ref": "#/definitions/TimeSeriesElement"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -3494,8 +3486,7 @@
           "description": "The Test items on this page",
           "items": {
             "$ref": "#/definitions/Test"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -3516,8 +3507,7 @@
           "description": "The TestFileInfo items on this page",
           "items": {
             "$ref": "#/definitions/TestFileInfo"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -3538,8 +3528,7 @@
           "description": "The TestProfile items on this page",
           "items": {
             "$ref": "#/definitions/TestProfile"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -3560,8 +3549,7 @@
           "description": "The TestProfileRun items on this page",
           "items": {
             "$ref": "#/definitions/TestProfileRun"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -3582,8 +3570,7 @@
           "description": "The TestRun items on this page",
           "items": {
             "$ref": "#/definitions/TestRun"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -3604,8 +3591,7 @@
           "description": "The Trigger items on this page",
           "items": {
             "$ref": "#/definitions/Trigger"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -4722,8 +4708,7 @@
           "items": {
             "$ref": "#/definitions/TestFileInfo"
           },
-          "readOnly": true,
-          "x-ms-identifiers": []
+          "readOnly": true
         }
       }
     },
@@ -4922,8 +4907,7 @@
           "items": {
             "$ref": "#/definitions/ErrorDetails"
           },
-          "readOnly": true,
-          "x-ms-identifiers": []
+          "readOnly": true
         },
         "startDateTime": {
           "type": "string",
@@ -4957,8 +4941,7 @@
           "items": {
             "$ref": "#/definitions/TestProfileRunRecommendation"
           },
-          "readOnly": true,
-          "x-ms-identifiers": []
+          "readOnly": true
         },
         "createdDateTime": {
           "type": "string",
@@ -5131,8 +5114,7 @@
           "items": {
             "$ref": "#/definitions/ErrorDetails"
           },
-          "readOnly": true,
-          "x-ms-identifiers": []
+          "readOnly": true
         },
         "testRunStatistics": {
           "type": "object",
@@ -5510,8 +5492,7 @@
           "items": {
             "$ref": "#/definitions/TestRunFileInfo"
           },
-          "readOnly": true,
-          "x-ms-identifiers": []
+          "readOnly": true
         }
       }
     },
@@ -5917,16 +5898,14 @@
           "description": "An array of data points representing the metric values.",
           "items": {
             "$ref": "#/definitions/MetricValue"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "dimensionValues": {
           "type": "array",
           "description": "The dimension values ",
           "items": {
             "$ref": "#/definitions/DimensionValue"
-          },
-          "x-ms-identifiers": []
+          }
         }
       }
     },

--- a/specification/loadtestservice/data-plane/loadtesting/preview/2024-12-01-preview/loadtestservice.json
+++ b/specification/loadtestservice/data-plane/loadtesting/preview/2024-12-01-preview/loadtestservice.json
@@ -2791,8 +2791,7 @@
           "description": "An array of details about specific errors that led to this reported error.",
           "items": {
             "$ref": "#/definitions/Azure.Core.Foundations.Error"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "innererror": {
           "$ref": "#/definitions/Azure.Core.Foundations.InnerError",
@@ -3273,8 +3272,7 @@
           "description": "Region distribution configuration for the load test.",
           "items": {
             "$ref": "#/definitions/RegionalConfiguration"
-          },
-          "x-ms-identifiers": []
+          }
         }
       }
     },
@@ -3321,8 +3319,7 @@
           "description": "List of dimensions",
           "items": {
             "$ref": "#/definitions/NameAndDescription"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "description": {
           "type": "string",
@@ -3356,8 +3353,7 @@
           "description": "Metric availability specifies the time grain (aggregation interval or\nfrequency).",
           "items": {
             "$ref": "#/definitions/MetricAvailability"
-          },
-          "x-ms-identifiers": []
+          }
         }
       }
     },
@@ -3370,8 +3366,7 @@
           "description": "the values for the metric definitions.",
           "items": {
             "$ref": "#/definitions/MetricDefinition"
-          },
-          "x-ms-identifiers": []
+          }
         }
       },
       "required": [
@@ -3401,8 +3396,7 @@
           "description": "The values for the metric namespaces.",
           "items": {
             "$ref": "#/definitions/MetricNamespace"
-          },
-          "x-ms-identifiers": []
+          }
         }
       },
       "required": [
@@ -3418,8 +3412,7 @@
           "description": "Get metrics for specific dimension values. Example: Metric contains dimension\nlike SamplerName, Error. To retrieve all the time series data where SamplerName\nis equals to HTTPRequest1 or HTTPRequest2, the DimensionFilter value will be\n{\"SamplerName\", [\"HTTPRequest1\", \"HTTPRequest2\"}",
           "items": {
             "$ref": "#/definitions/DimensionFilter"
-          },
-          "x-ms-identifiers": []
+          }
         }
       }
     },
@@ -3508,8 +3501,7 @@
           "description": "The TimeSeriesElement items on this page",
           "items": {
             "$ref": "#/definitions/TimeSeriesElement"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -3878,8 +3870,7 @@
           "description": "The NotificationRule items on this page",
           "items": {
             "$ref": "#/definitions/NotificationRule"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -3900,8 +3891,7 @@
           "description": "The Test items on this page",
           "items": {
             "$ref": "#/definitions/Test"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -3922,8 +3912,7 @@
           "description": "The TestFileInfo items on this page",
           "items": {
             "$ref": "#/definitions/TestFileInfo"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -3944,8 +3933,7 @@
           "description": "The TestProfile items on this page",
           "items": {
             "$ref": "#/definitions/TestProfile"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -3966,8 +3954,7 @@
           "description": "The TestProfileRun items on this page",
           "items": {
             "$ref": "#/definitions/TestProfileRun"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -3988,8 +3975,7 @@
           "description": "The TestRun items on this page",
           "items": {
             "$ref": "#/definitions/TestRun"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -4010,8 +3996,7 @@
           "description": "The Trigger items on this page",
           "items": {
             "$ref": "#/definitions/Trigger"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -5150,8 +5135,7 @@
           "items": {
             "$ref": "#/definitions/TestFileInfo"
           },
-          "readOnly": true,
-          "x-ms-identifiers": []
+          "readOnly": true
         }
       }
     },
@@ -5350,8 +5334,7 @@
           "items": {
             "$ref": "#/definitions/ErrorDetails"
           },
-          "readOnly": true,
-          "x-ms-identifiers": []
+          "readOnly": true
         },
         "startDateTime": {
           "type": "string",
@@ -5385,8 +5368,7 @@
           "items": {
             "$ref": "#/definitions/TestProfileRunRecommendation"
           },
-          "readOnly": true,
-          "x-ms-identifiers": []
+          "readOnly": true
         },
         "createdDateTime": {
           "type": "string",
@@ -5559,8 +5541,7 @@
           "items": {
             "$ref": "#/definitions/ErrorDetails"
           },
-          "readOnly": true,
-          "x-ms-identifiers": []
+          "readOnly": true
         },
         "testRunStatistics": {
           "type": "object",
@@ -5990,8 +5971,7 @@
           "items": {
             "$ref": "#/definitions/TestRunFileInfo"
           },
-          "readOnly": true,
-          "x-ms-identifiers": []
+          "readOnly": true
         }
       }
     },
@@ -6500,16 +6480,14 @@
           "description": "An array of data points representing the metric values.",
           "items": {
             "$ref": "#/definitions/MetricValue"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "dimensionValues": {
           "type": "array",
           "description": "The dimension values ",
           "items": {
             "$ref": "#/definitions/DimensionValue"
-          },
-          "x-ms-identifiers": []
+          }
         }
       }
     },

--- a/specification/loadtestservice/data-plane/loadtesting/preview/2025-03-01-preview/loadtestservice.json
+++ b/specification/loadtestservice/data-plane/loadtesting/preview/2025-03-01-preview/loadtestservice.json
@@ -3048,8 +3048,7 @@
           "description": "An array of details about specific errors that led to this reported error.",
           "items": {
             "$ref": "#/definitions/Azure.Core.Foundations.Error"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "innererror": {
           "$ref": "#/definitions/Azure.Core.Foundations.InnerError",
@@ -3076,7 +3075,7 @@
     },
     "Azure.Core.Foundations.InnerError": {
       "type": "object",
-      "description": "An object containing more specific information about the error. As per Microsoft One API guidelines - https://github.com/Microsoft/api-guidelines/blob/vNext/Guidelines.md#7102-error-condition-responses.",
+      "description": "An object containing more specific information about the error. As per Azure REST API guidelines - https://aka.ms/AzureRestApiGuidelines#handling-errors.",
       "properties": {
         "code": {
           "type": "string",
@@ -3326,9 +3325,25 @@
       "type": "object",
       "description": "Error details if there is any failure in load test run",
       "properties": {
+        "code": {
+          "type": "string",
+          "description": "Error code if there is any failure in load test run.",
+          "readOnly": true
+        },
         "message": {
           "type": "string",
           "description": "Error details in case test run was not successfully run.",
+          "readOnly": true
+        },
+        "properties": {
+          "type": "object",
+          "description": "A dictionary for storing additional error information for better context. Each key is a property name (e.g., \"Description\", \"Resolution\", \"Category\", \"Region\"), and its value is an array of strings with relevant details.",
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
           "readOnly": true
         }
       }
@@ -3609,8 +3624,7 @@
           "description": "Region distribution configuration for the load test.",
           "items": {
             "$ref": "#/definitions/RegionalConfiguration"
-          },
-          "x-ms-identifiers": []
+          }
         }
       }
     },
@@ -3657,8 +3671,7 @@
           "description": "List of dimensions",
           "items": {
             "$ref": "#/definitions/NameAndDescription"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "description": {
           "type": "string",
@@ -3692,8 +3705,7 @@
           "description": "Metric availability specifies the time grain (aggregation interval or\nfrequency).",
           "items": {
             "$ref": "#/definitions/MetricAvailability"
-          },
-          "x-ms-identifiers": []
+          }
         }
       }
     },
@@ -3706,8 +3718,7 @@
           "description": "the values for the metric definitions.",
           "items": {
             "$ref": "#/definitions/MetricDefinition"
-          },
-          "x-ms-identifiers": []
+          }
         }
       },
       "required": [
@@ -3737,8 +3748,7 @@
           "description": "The values for the metric namespaces.",
           "items": {
             "$ref": "#/definitions/MetricNamespace"
-          },
-          "x-ms-identifiers": []
+          }
         }
       },
       "required": [
@@ -3754,8 +3764,7 @@
           "description": "Get metrics for specific dimension values. Example: Metric contains dimension\nlike SamplerName, Error. To retrieve all the time series data where SamplerName\nis equals to HTTPRequest1 or HTTPRequest2, the DimensionFilter value will be\n{\"SamplerName\", [\"HTTPRequest1\", \"HTTPRequest2\"}",
           "items": {
             "$ref": "#/definitions/DimensionFilter"
-          },
-          "x-ms-identifiers": []
+          }
         }
       }
     },
@@ -3844,8 +3853,7 @@
           "description": "The TimeSeriesElement items on this page",
           "items": {
             "$ref": "#/definitions/TimeSeriesElement"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -4260,8 +4268,7 @@
           "description": "The NotificationRule items on this page",
           "items": {
             "$ref": "#/definitions/NotificationRule"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -4282,8 +4289,7 @@
           "description": "The Test items on this page",
           "items": {
             "$ref": "#/definitions/Test"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -4304,8 +4310,7 @@
           "description": "The TestFileInfo items on this page",
           "items": {
             "$ref": "#/definitions/TestFileInfo"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -4326,8 +4331,7 @@
           "description": "The TestProfile items on this page",
           "items": {
             "$ref": "#/definitions/TestProfile"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -4348,8 +4352,7 @@
           "description": "The TestProfileRun items on this page",
           "items": {
             "$ref": "#/definitions/TestProfileRun"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -4370,8 +4373,7 @@
           "description": "The TestRun items on this page",
           "items": {
             "$ref": "#/definitions/TestRun"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -4392,8 +4394,7 @@
           "description": "The Trigger items on this page",
           "items": {
             "$ref": "#/definitions/Trigger"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -5538,8 +5539,7 @@
           "items": {
             "$ref": "#/definitions/TestFileInfo"
           },
-          "readOnly": true,
-          "x-ms-identifiers": []
+          "readOnly": true
         }
       }
     },
@@ -5738,8 +5738,7 @@
           "items": {
             "$ref": "#/definitions/ErrorDetails"
           },
-          "readOnly": true,
-          "x-ms-identifiers": []
+          "readOnly": true
         },
         "startDateTime": {
           "type": "string",
@@ -5773,8 +5772,7 @@
           "items": {
             "$ref": "#/definitions/TestProfileRunRecommendation"
           },
-          "readOnly": true,
-          "x-ms-identifiers": []
+          "readOnly": true
         },
         "createdDateTime": {
           "type": "string",
@@ -5947,8 +5945,7 @@
           "items": {
             "$ref": "#/definitions/ErrorDetails"
           },
-          "readOnly": true,
-          "x-ms-identifiers": []
+          "readOnly": true
         },
         "testRunStatistics": {
           "type": "object",
@@ -6390,8 +6387,7 @@
           "items": {
             "$ref": "#/definitions/TestRunFileInfo"
           },
-          "readOnly": true,
-          "x-ms-identifiers": []
+          "readOnly": true
         }
       }
     },
@@ -6434,8 +6430,7 @@
               "type": "string"
             }
           },
-          "readOnly": true,
-          "x-ms-identifiers": []
+          "readOnly": true
         },
         "version": {
           "type": "integer",
@@ -6955,16 +6950,14 @@
           "description": "An array of data points representing the metric values.",
           "items": {
             "$ref": "#/definitions/MetricValue"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "dimensionValues": {
           "type": "array",
           "description": "The dimension values ",
           "items": {
             "$ref": "#/definitions/DimensionValue"
-          },
-          "x-ms-identifiers": []
+          }
         }
       }
     },

--- a/specification/loadtestservice/data-plane/loadtesting/stable/2022-11-01/loadtestservice.json
+++ b/specification/loadtestservice/data-plane/loadtesting/stable/2022-11-01/loadtestservice.json
@@ -1743,8 +1743,7 @@
           "description": "An array of details about specific errors that led to this reported error.",
           "items": {
             "$ref": "#/definitions/Azure.Core.Foundations.Error"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "innererror": {
           "$ref": "#/definitions/Azure.Core.Foundations.InnerError",
@@ -1995,8 +1994,7 @@
           "description": "List of dimensions",
           "items": {
             "$ref": "#/definitions/NameAndDescription"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "description": {
           "type": "string",
@@ -2030,8 +2028,7 @@
           "description": "Metric availability specifies the time grain (aggregation interval or\nfrequency).",
           "items": {
             "$ref": "#/definitions/MetricAvailability"
-          },
-          "x-ms-identifiers": []
+          }
         }
       }
     },
@@ -2044,8 +2041,7 @@
           "description": "the values for the metric definitions.",
           "items": {
             "$ref": "#/definitions/MetricDefinition"
-          },
-          "x-ms-identifiers": []
+          }
         }
       },
       "required": [
@@ -2075,8 +2071,7 @@
           "description": "The values for the metric namespaces.",
           "items": {
             "$ref": "#/definitions/MetricNamespace"
-          },
-          "x-ms-identifiers": []
+          }
         }
       },
       "required": [
@@ -2092,8 +2087,7 @@
           "description": "Get metrics for specific dimension values. Example: Metric contains dimension\nlike SamplerName, Error. To retrieve all the time series data where SamplerName\nis equals to HTTPRequest1 or HTTPRequest2, the DimensionFilter value will be\n{\"SamplerName\", [\"HTTPRequest1\", \"HTTPRequest2\"}",
           "items": {
             "$ref": "#/definitions/DimensionFilter"
-          },
-          "x-ms-identifiers": []
+          }
         }
       }
     },
@@ -2182,8 +2176,7 @@
           "description": "The TimeSeriesElement items on this page",
           "items": {
             "$ref": "#/definitions/TimeSeriesElement"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -2285,8 +2278,7 @@
           "description": "The Test items on this page",
           "items": {
             "$ref": "#/definitions/Test"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -2307,8 +2299,7 @@
           "description": "The TestFileInfo items on this page",
           "items": {
             "$ref": "#/definitions/TestFileInfo"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -2329,8 +2320,7 @@
           "description": "The TestRun items on this page",
           "items": {
             "$ref": "#/definitions/TestRun"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",
@@ -2934,8 +2924,7 @@
           "items": {
             "$ref": "#/definitions/TestFileInfo"
           },
-          "readOnly": true,
-          "x-ms-identifiers": []
+          "readOnly": true
         }
       }
     },
@@ -2979,8 +2968,7 @@
           "items": {
             "$ref": "#/definitions/ErrorDetails"
           },
-          "readOnly": true,
-          "x-ms-identifiers": []
+          "readOnly": true
         },
         "testRunStatistics": {
           "type": "object",
@@ -3276,8 +3264,7 @@
           "items": {
             "$ref": "#/definitions/TestRunFileInfo"
           },
-          "readOnly": true,
-          "x-ms-identifiers": []
+          "readOnly": true
         }
       }
     },
@@ -3639,16 +3626,14 @@
           "description": "An array of data points representing the metric values.",
           "items": {
             "$ref": "#/definitions/MetricValue"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "dimensionValues": {
           "type": "array",
           "description": "The dimension values ",
           "items": {
             "$ref": "#/definitions/DimensionValue"
-          },
-          "x-ms-identifiers": []
+          }
         }
       }
     }


### PR DESCRIPTION
Existing model only had message property. 
Adding code and properties field to enhance actionable error experience for users.

