### PR TITLE
[update-labels] throw if empty label name

### DIFF
--- a/.github/workflows/src/update-labels.js
+++ b/.github/workflows/src/update-labels.js
@@ -85,6 +85,11 @@ export async function updateLabelsImpl({
 
       if (key.startsWith("label-")) {
         const name = key.substring("label-".length);
+
+        if (!name) {
+          throw new Error(`Invalid value for label name: '${name}'`);
+        }
+
         if (value === "true") {
           labelsToAdd.push(name);
         } else if (value === "false") {


### PR DESCRIPTION
- Fixes #36549
- Behavior is still a no-op
- Failure is more clear
- Avoids unnecessary REST API call(s)