### PR TITLE
[summarize-checks] write summary immediately after add

### DIFF
--- a/.github/workflows/src/summarize-checks/summarize-checks.js
+++ b/.github/workflows/src/summarize-checks/summarize-checks.js
@@ -366,6 +366,8 @@ export async function summarizeChecksImpl(
   const prUrl = `https://github.com/${owner}/${repo}/pull/${issue_number}`;
   core.summary.addRaw("PR: ");
   core.summary.addLink(prUrl, prUrl);
+  core.summary.write();
+  core.setOutput("summary", process.env.GITHUB_STEP_SUMMARY);
 
   let labelNames = await getExistingLabels(github, owner, repo, issue_number);
 
@@ -446,6 +448,7 @@ export async function summarizeChecksImpl(
     `Updating comment '${NEXT_STEPS_COMMENT_ID}' on ${owner}/${repo}#${issue_number} with body: ${commentBody}`,
   );
   core.summary.addRaw(`\n${commentBody}\n\n`);
+  core.summary.write();
 
   // this will remain commented until we're comfortable with the change.
   // await commentOrUpdate(
@@ -465,9 +468,7 @@ export async function summarizeChecksImpl(
   );
   core.summary.addHeading("Automated Checks Met", 2);
   core.summary.addCodeBlock(JSON.stringify(automatedChecksMet, null, 2));
-
   core.summary.write();
-  core.setOutput("summary", process.env.GITHUB_STEP_SUMMARY);
 }
 
 /**


### PR DESCRIPTION
- ensures partial summary is written if exit early
