### PR TITLE
Add new SecurityOperators API Version to support creating SecurityOperators under subscription and Management Groups

### DIFF
--- a/specification/security/resource-manager/Microsoft.Security/preview/2023-01-01-preview/examples/SecurityOperators/ListSecurityOperators_example.json
+++ b/specification/security/resource-manager/Microsoft.Security/preview/2023-01-01-preview/examples/SecurityOperators/ListSecurityOperators_example.json
@@ -18,7 +18,8 @@
               "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
             }
           }
-        ]
+        ],
+        "nextLink": null
       }
     }
   }

--- a/specification/security/resource-manager/Microsoft.Security/preview/2025-10-01-preview/examples/SecurityOperators/DeleteSecurityOperatorByName_example.json
+++ b/specification/security/resource-manager/Microsoft.Security/preview/2025-10-01-preview/examples/SecurityOperators/DeleteSecurityOperatorByName_example.json
@@ -1,0 +1,11 @@
+{
+  "parameters": {
+    "api-version": "2025-10-01-preview",
+    "scope": "/providers/Microsoft.Management/managementGroups/mg1",
+    "securityOperatorName": "DefenderForCloudSecurityOperator"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  }
+}

--- a/specification/security/resource-manager/Microsoft.Security/preview/2025-10-01-preview/examples/SecurityOperators/DeleteSecurityOperatorByName_example.json
+++ b/specification/security/resource-manager/Microsoft.Security/preview/2025-10-01-preview/examples/SecurityOperators/DeleteSecurityOperatorByName_example.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2025-10-01-preview",
-    "scope": "/providers/Microsoft.Management/managementGroups/mg1",
+    "scope": "providers/Microsoft.Management/managementGroups/mg1",
     "securityOperatorName": "DefenderForCloudSecurityOperator"
   },
   "responses": {

--- a/specification/security/resource-manager/Microsoft.Security/preview/2025-10-01-preview/examples/SecurityOperators/GetSecurityOperatorByName_example.json
+++ b/specification/security/resource-manager/Microsoft.Security/preview/2025-10-01-preview/examples/SecurityOperators/GetSecurityOperatorByName_example.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2025-10-01-preview",
+    "scope": "providers/Microsoft.Management/managementGroups/mg1",
+    "securityOperatorName": "DefenderForCloudSecurityOperator"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/providers/Microsoft.Management/managementGroups/mg1/providers/Microsoft.Security/securityOperators/DefenderForCloudSecurityOperator",
+        "name": "DefenderForCloudSecurityOperator",
+        "type": "Microsoft.Security/securityOperators",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "44ee8e7e-7f52-4750-b937-27490fbf7663",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        }
+      }
+    }
+  }
+}

--- a/specification/security/resource-manager/Microsoft.Security/preview/2025-10-01-preview/examples/SecurityOperators/ListSecurityOperators_example.json
+++ b/specification/security/resource-manager/Microsoft.Security/preview/2025-10-01-preview/examples/SecurityOperators/ListSecurityOperators_example.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "api-version": "2025-10-01-preview",
+    "scope": "subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/providers/Microsoft.Security/securityOperators/DefenderForCloudSecurityOperator",
+            "name": "DefenderForCloudSecurityOperator",
+            "type": "Microsoft.Security/securityOperators",
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "44ee8e7e-7f52-4750-b937-27490fbf7663",
+              "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/security/resource-manager/Microsoft.Security/preview/2025-10-01-preview/examples/SecurityOperators/PutSecurityOperatorByName_example.json
+++ b/specification/security/resource-manager/Microsoft.Security/preview/2025-10-01-preview/examples/SecurityOperators/PutSecurityOperatorByName_example.json
@@ -16,6 +16,18 @@
           "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
         }
       }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/providers/Microsoft.Security/securityOperators/DefenderForCloudSecurityOperator",
+        "name": "DefenderForCloudSecurityOperator",
+        "type": "Microsoft.Security/securityOperators",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "44ee8e7e-7f52-4750-b937-27490fbf7663",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        }
+      }
     }
   }
 }

--- a/specification/security/resource-manager/Microsoft.Security/preview/2025-10-01-preview/examples/SecurityOperators/PutSecurityOperatorByName_example.json
+++ b/specification/security/resource-manager/Microsoft.Security/preview/2025-10-01-preview/examples/SecurityOperators/PutSecurityOperatorByName_example.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2025-10-01-preview",
+    "scope": "subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23",
+    "securityOperatorName": "DefenderForCloudSecurityOperator"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/20ff7fc3-e762-44dd-bd96-b71116dcdc23/providers/Microsoft.Security/securityOperators/DefenderForCloudSecurityOperator",
+        "name": "DefenderForCloudSecurityOperator",
+        "type": "Microsoft.Security/securityOperators",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "44ee8e7e-7f52-4750-b937-27490fbf7663",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        }
+      }
+    }
+  }
+}

--- a/specification/security/resource-manager/Microsoft.Security/preview/2025-10-01-preview/securityOperators.json
+++ b/specification/security/resource-manager/Microsoft.Security/preview/2025-10-01-preview/securityOperators.json
@@ -211,6 +211,7 @@
         "nextLink": {
           "readOnly": true,
           "type": "string",
+          "format": "uri",
           "description": "The URI to fetch the next page."
         }
       }

--- a/specification/security/resource-manager/Microsoft.Security/preview/2025-10-01-preview/securityOperators.json
+++ b/specification/security/resource-manager/Microsoft.Security/preview/2025-10-01-preview/securityOperators.json
@@ -58,7 +58,7 @@
           "200": {
             "description": "Succeeded",
             "schema": {
-              "$ref": "#/definitions/SecurityOperator"
+              "$ref": "#/definitions/SecurityOperatorList"
             }
           },
           "default": {

--- a/specification/security/resource-manager/Microsoft.Security/preview/2025-10-01-preview/securityOperators.json
+++ b/specification/security/resource-manager/Microsoft.Security/preview/2025-10-01-preview/securityOperators.json
@@ -60,7 +60,6 @@
             "schema": {
               "$ref": "#/definitions/SecurityOperator"
             }
-          }
           },
           "default": {
             "description": "Error response describing why the operation failed.",

--- a/specification/security/resource-manager/Microsoft.Security/preview/2025-10-01-preview/securityOperators.json
+++ b/specification/security/resource-manager/Microsoft.Security/preview/2025-10-01-preview/securityOperators.json
@@ -67,6 +67,9 @@
               "$ref": "../../../common/v1/types.json#/definitions/CloudError"
             }
           }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
         }
       }
     },
@@ -95,7 +98,13 @@
         ],
         "responses": {
           "200": {
-            "description": "OK",
+            "description": "Suceeded",
+            "schema": {
+              "$ref": "#/definitions/SecurityOperator"
+            }
+          },
+          "201": {
+            "description": "Created",
             "schema": {
               "$ref": "#/definitions/SecurityOperator"
             }
@@ -198,6 +207,11 @@
           "items": {
             "$ref": "#/definitions/SecurityOperator"
           }
+        },
+        "nextLink": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The URI to fetch the next page."
         }
       }
     },

--- a/specification/security/resource-manager/Microsoft.Security/preview/2025-10-01-preview/securityOperators.json
+++ b/specification/security/resource-manager/Microsoft.Security/preview/2025-10-01-preview/securityOperators.json
@@ -1,0 +1,251 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Microsoft Defender for Cloud",
+    "description": "API spec for Microsoft.Security (Microsoft Defender for Cloud) resource provider",
+    "version": "2025-10-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/{scope}/providers/Microsoft.Security/securityOperators": {
+      "get": {
+        "x-ms-examples": {
+          "List SecurityOperators": {
+            "$ref": "./examples/SecurityOperators/ListSecurityOperators_example.json"
+          }
+        },
+        "tags": [
+          "SecurityOperators"
+        ],
+        "description": "Lists Microsoft Defender for Cloud securityOperators created directly under the specified scope. Valid scopes are subscriptions and management groups.",
+        "operationId": "SecurityOperators_List",
+        "parameters": [
+          {
+            "$ref": "../../../common/v1/types.json#/parameters/ApiVersion"
+          },
+          {
+            "$ref": "#/parameters/Scope"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/SecurityOperatorList"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../common/v1/types.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/{scope}/providers/Microsoft.Security/securityOperators/{securityOperatorName}": {
+      "get": {
+        "x-ms-examples": {
+          "Get a specific security operator by scope and securityOperatorName": {
+            "$ref": "./examples/SecurityOperators/GetSecurityOperatorByName_example.json"
+          }
+        },
+        "tags": [
+          "SecurityOperators"
+        ],
+        "description": "Get a specific security operator for the requested scope.",
+        "operationId": "SecurityOperators_Get",
+        "parameters": [
+          {
+            "$ref": "../../../common/v1/types.json#/parameters/ApiVersion"
+          },
+          {
+            "$ref": "#/parameters/Scope"
+          },
+          {
+            "$ref": "#/parameters/SecurityOperatorName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/SecurityOperator"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../common/v1/types.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "x-ms-examples": {
+          "Create a security operator on the given scope": {
+            "$ref": "./examples/SecurityOperators/PutSecurityOperatorByName_example.json"
+          }
+        },
+        "tags": [
+          "SecurityOperators"
+        ],
+        "description": "Creates Microsoft Defender for Cloud security operator on the given scope.",
+        "operationId": "SecurityOperators_CreateOrUpdate",
+        "parameters": [
+          {
+            "$ref": "../../../common/v1/types.json#/parameters/ApiVersion"
+          },
+          {
+            "$ref": "#/parameters/Scope"
+          },
+          {
+            "$ref": "#/parameters/SecurityOperatorName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful request to put Security Operator.",
+            "schema": {
+              "$ref": "#/definitions/SecurityOperator"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../common/v1/types.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "x-ms-examples": {
+          "Delete SecurityOperator on specified scope": {
+            "$ref": "./examples/SecurityOperators/DeleteSecurityOperatorByName_example.json"
+          }
+        },
+        "tags": [
+          "SecurityOperators"
+        ],
+        "description": "Delete Microsoft Defender for Cloud securityOperator under the specified scope.",
+        "operationId": "SecurityOperators_Delete",
+        "parameters": [
+          {
+            "$ref": "../../../common/v1/types.json#/parameters/ApiVersion"
+          },
+          {
+            "$ref": "#/parameters/Scope"
+          },
+          {
+            "$ref": "#/parameters/SecurityOperatorName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK - Security Operator was deleted"
+          },
+          "204": {
+            "description": "No Content - Security Operator does not exist"
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../common/v1/types.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "SecurityOperatorList": {
+      "type": "object",
+      "description": "List of SecurityOperator response.",
+      "required": [
+        "value"
+      ],
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "List of SecurityOperator configurations",
+          "items": {
+            "$ref": "#/definitions/SecurityOperator"
+          }
+        }
+      }
+    },
+    "SecurityOperator": {
+      "type": "object",
+      "description": "Security operator under a given scope",
+      "properties": {
+        "identity": {
+          "$ref": "../../../../../common-types/resource-management/v2/types.json#/definitions/Identity"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../common/v1/types.json#/definitions/Resource"
+        }
+      ]
+    }
+  },
+  "parameters": {
+    "Scope": {
+      "name": "scope",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "Scope of the resource. Valid scopes are: subscription (format: 'subscriptions/{subscriptionId}') or management group (format: 'providers/Microsoft.Management/managementGroups/{managementGroupId}')",
+      "x-ms-parameter-location": "method",
+      "x-ms-skip-url-encoding": true
+    },
+    "SecurityOperatorName": {
+      "name": "securityOperatorName",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "name of the securityOperator",
+      "pattern": "^[a-zA-Z][a-zA-Z0-9_]+$",
+      "minLength": 3,
+      "maxLength": 63,
+      "x-ms-parameter-location": "method"
+    },
+    "SecurityOperator": {
+      "name": "SecurityOperator",
+      "in": "body",
+      "required": true,
+      "description": "SecurityOperator object",
+      "schema": {
+        "$ref": "#/definitions/SecurityOperator"
+      },
+      "x-ms-parameter-location": "method"
+    }
+  }
+}

--- a/specification/security/resource-manager/Microsoft.Security/preview/2025-10-01-preview/securityOperators.json
+++ b/specification/security/resource-manager/Microsoft.Security/preview/2025-10-01-preview/securityOperators.json
@@ -60,12 +60,7 @@
             "schema": {
               "$ref": "#/definitions/SecurityOperator"
             }
-          },
-          "201": {
-            "description": "Created.",
-            "schema": {
-              "$ref": "#/definitions/SecurityOperator"
-            }
+          }
           },
           "default": {
             "description": "Error response describing why the operation failed.",

--- a/specification/security/resource-manager/Microsoft.Security/preview/2025-10-01-preview/securityOperators.json
+++ b/specification/security/resource-manager/Microsoft.Security/preview/2025-10-01-preview/securityOperators.json
@@ -56,9 +56,15 @@
         ],
         "responses": {
           "200": {
-            "description": "OK",
+            "description": "Succeeded",
             "schema": {
-              "$ref": "#/definitions/SecurityOperatorList"
+              "$ref": "#/definitions/SecurityOperator"
+            }
+          },
+          "201": {
+            "description": "Created.",
+            "schema": {
+              "$ref": "#/definitions/SecurityOperator"
             }
           },
           "default": {
@@ -98,13 +104,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Suceeded",
-            "schema": {
-              "$ref": "#/definitions/SecurityOperator"
-            }
-          },
-          "201": {
-            "description": "Created",
+            "description": "Succeeded",
             "schema": {
               "$ref": "#/definitions/SecurityOperator"
             }
@@ -141,7 +141,13 @@
         ],
         "responses": {
           "200": {
-            "description": "Successful request to put Security Operator.",
+            "description": "Succeeded",
+            "schema": {
+              "$ref": "#/definitions/SecurityOperator"
+            }
+          },
+          "201": {
+            "description": "Created",
             "schema": {
               "$ref": "#/definitions/SecurityOperator"
             }

--- a/specification/security/resource-manager/readme.md
+++ b/specification/security/resource-manager/readme.md
@@ -106,6 +106,15 @@ tag: package-composite-v3
 
 The following packages may be composed from multiple api-versions.
 
+### Tag: package-preview-2025-10
+
+These settings apply only when `--tag=package-preview-2025-10` is specified on the command line.
+
+```yaml $(tag) == 'package-preview-2025-10'
+input-file:
+  - Microsoft.Security/preview/2025-10-01-preview/securityOperators.json
+```
+
 ### Tag: package-preview-2025-09-01-preview
 
 These settings apply only when `--tag=package-preview-2025-09-01-preview` is specified on the command line.
@@ -612,6 +621,7 @@ input-file:
 - Microsoft.Security/preview/2025-05-04-preview/assessmentMetadata.json
 - Microsoft.Security/preview/2025-05-04-preview/assessments.json
 - Microsoft.Security/preview/2025-09-01-preview/privateLinks.json
+- Microsoft.Security/preview/2025-10-01-preview/securityOperators.json
 - Microsoft.Security/stable/2017-08-01/complianceResults.json
 - Microsoft.Security/stable/2019-01-01/advancedThreatProtectionSettings.json
 - Microsoft.Security/stable/2019-08-01/deviceSecurityGroups.json


### PR DESCRIPTION
Add new SecurityOperators API Version to support creating SecurityOperators under subscription and Management Groups

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.