### PR TITLE
Add `edited`, `ready_for_review`, and `converted_to_draft` to supported `action`s within `context.js`

### DIFF
--- a/.github/workflows/src/context.js
+++ b/.github/workflows/src/context.js
@@ -45,7 +45,10 @@ export async function extractInputs(github, context, core) {
         context.payload.action === "synchronize" ||
         context.payload.action === "reopened" ||
         context.payload.action === "labeled" ||
-        context.payload.action === "unlabeled"))
+        context.payload.action === "unlabeled" ||
+        context.payload.action === "edited" ||
+        context.payload.action === "ready_for_review" ||
+        context.payload.action === "converted_to_draft"))
   ) {
     // Most properties on payload should be the same for both pull_request and pull_request_target
 

--- a/.github/workflows/test/context.test.js
+++ b/.github/workflows/test/context.test.js
@@ -88,6 +88,15 @@ describe("extractInputs", () => {
     context.payload.action = "reopened";
     await expect(extractInputs(github, context, createMockCore())).resolves.toEqual(expected);
 
+    context.payload.action = "ready_for_review";
+    await expect(extractInputs(github, context, createMockCore())).resolves.toEqual(expected);
+
+    context.payload.action = "edited";
+    await expect(extractInputs(github, context, createMockCore())).resolves.toEqual(expected);
+
+    context.payload.action = "converted_to_draft";
+    await expect(extractInputs(github, context, createMockCore())).resolves.toEqual(expected);
+
     // Action not yet supported
     context.payload.action = "assigned";
     await expect(extractInputs(github, context, createMockCore())).rejects.toThrow();


### PR DESCRIPTION
[This is the origin of the error message I am accounting for in this PR](https://github.com/Azure/azure-rest-api-specs/actions/runs/16896085612/job/47866039677?pr=36609)

I edited another PR and suddenly saw an error message.