### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,9 +5,9 @@
 # Specification
 #########
 
-#########
-# Codeowner assignments are made from the _last_ matching entry in CODEOWNERS, so catch-all entries must come first
-#########
+####################
+# Client Libraries
+####################
 
 # PRLabel: %Schema Registry
 /specification/schemaregistry/ @hmlam @nickghardwick @lmazuel @deyaaeldeen @JoshLove-msft @swathipil @conniey @minhanh-phan
@@ -268,6 +268,10 @@
 /profile/ @shahabhijeet
 
 /specification/contosowidgetmanager/ @mikeharder @raych1 @maririos
+
+####################
+# Management Libraries
+####################
 
 ###########
 # Eng Sys


### PR DESCRIPTION
# Request for a standard CODEOWNERS file across all SDK Language Repositories.

CODEOWNER changes:
Client SDKs renamed to Client Libraries and added Management Libraries as well. This change is to add standard category headers to ensure MCP Tools can access and edit CODEOWNERS files.