### PR TITLE
java, dpg, tspconfig, remove wrong emitter-output-dir

### DIFF
--- a/specification/communication/Communication.JobRouter/tspconfig.yaml
+++ b/specification/communication/Communication.JobRouter/tspconfig.yaml
@@ -46,7 +46,6 @@ options:
     generate-test: true
     generate-sample: true
   "@azure-tools/typespec-java":
-    emitter-output-dir: "{java-sdk-folder}/sdk/{service-directory-name}/azure-communication-jobrouter"
     package-dir: "azure-communication-jobrouter"
     namespace: com.azure.communication.jobrouter
     partial-update: true

--- a/specification/eventgrid/Azure.Messaging.EventGrid.SystemEvents/tspconfig.yaml
+++ b/specification/eventgrid/Azure.Messaging.EventGrid.SystemEvents/tspconfig.yaml
@@ -49,7 +49,6 @@ options:
     slice-elements-byval: true
     flavor: "azure"
   "@azure-tools/typespec-java":
-    emitter-output-dir: "{project-root}"
     namespace: com.azure.messaging.eventgrid.systemevents
     package-dir: azure-messaging-eventgrid-systemevents
     customization-class: customization/src/main/java/EventGridSystemEventsCustomization.java

--- a/specification/eventgrid/Azure.Messaging.EventGrid/tspconfig.yaml
+++ b/specification/eventgrid/Azure.Messaging.EventGrid/tspconfig.yaml
@@ -34,7 +34,6 @@ options:
     namespace: Azure.Messaging.EventGrid.Namespaces
     model-namespace: false
   "@azure-tools/typespec-java":
-    emitter-output-dir: "{project-root}/.."
     namespace: "com.azure.messaging.eventgrid.namespaces"
     package-dir: azure-messaging-eventgrid-namespaces
     partial-update: true


### PR DESCRIPTION
Latest tsp-client (0.28.0) now honors the `emitter-output-dir` in tspconfig.yaml https://github.com/Azure/azure-sdk-tools/pull/11626

And for this 3, the `emitter-output-dir` in java emitter was wrong, and now causing failure in SDK when running `tsp-client update`.
(`{project-root}` would be at `/azure-sdk-for-java/sdk/communication/azure-communication-jobrouter/TempTypeSpecFiles/Communication.JobRouter`, none of these form can get back to the correct folder of `/azure-sdk-for-java/sdk/communication/azure-communication-jobrouter` -- the nearest one would be `{project-root}/../..`)

And it would cause tsp giving emitter wrong output dir.

# SDK configuration pull request

## Purpose of this PR

- [x] Make changes to the SDK configuration only when there are no modifications to the API specification, eliminating the need for an ARM or Stewardship Board API review.

## Due diligence checklist

To merge this PR, you **must** go through the following checklist and confirm you understood
and followed the instructions by checking all the boxes:

- [x] I confirm this PR is modifying only SDK configurations, and not API related specifications.
- [x] I have reviewed and used the respective `tspconfig.yaml` templates:
  - [ARM tspconfig template](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/contosowidgetmanager/Contoso.Management/tspconfig.yaml)
  - [Data plane tspconfig template](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/contosowidgetmanager/Contoso.WidgetManager/tspconfig.yaml)

## Getting help

- First, carefully read through this PR description, from top to bottom. Fill out the `Purpose of this PR` and `Due diligence checklist`.
- If you don't have permissions to remove or add labels to the PR, request `write access` per [aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories](https://aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories)
- To understand what you must do next to merge this PR, see the `Next Steps to Merge` comment. It will appear within few minutes of submitting this PR and will continue to be up-to-date with current PR state.
- For guidance on fixing this PR CI check failures, see the hyperlinks provided in given failure and https://aka.ms/ci-fix.
- If the PR CI checks appear to be stuck in `queued` state, please add a comment with contents `/azp run`.
  This should result in a new comment denoting a `PR validation pipeline` has started and the checks should be updated after few minutes.
- If the help provided by the previous points is not enough, post to https://aka.ms/azsdk/support/specreview-channel and link to this PR.