### PR TITLE
Support customized branch when create sdk PR

### DIFF
--- a/eng/pipelines/spec-gen-sdk-batch.yml
+++ b/eng/pipelines/spec-gen-sdk-batch.yml
@@ -19,4 +19,3 @@ extends:
     SpecRepoUrl: 'https://github.com/$(Build.Repository.Name)'
     SdkRepoUrl: $(SdkRepoUrl)
     SpecBatchTypes: ${{ parameters.SpecBatchTypes }}
-    SkipPullRequestCreation: true

--- a/eng/pipelines/spec-gen-sdk.yml
+++ b/eng/pipelines/spec-gen-sdk.yml
@@ -1,8 +1,8 @@
 parameters:
-  - name: SdkRepoCommit
+  - name: SdkRepoBranch
     type: string
     default: 'main'
-    displayName: 'SDK repository commit'
+    displayName: 'SDK repository branch'
   - name: ConfigType
     type: string
     values:
@@ -37,7 +37,7 @@ extends:
   parameters:
     SpecRepoUrl: 'https://github.com/$(Build.Repository.Name)'
     SdkRepoUrl: $(SdkRepoUrl)
-    SdkRepoCommit: ${{ parameters.SdkRepoCommit }}
+    SdkRepoBranch: ${{ parameters.SdkRepoBranch }}
     ConfigType: ${{ parameters.ConfigType }}
     ConfigPath: ${{ parameters.ConfigPath }}
     ApiVersion: ${{ parameters.ApiVersion }}

--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -317,7 +317,6 @@ stages:
             CommitMsg: $(GeneratedSDKInformation)
             TargetRepoOwner: $(SdkRepoOwner)
             TargetRepoName: $(SdkRepoName)
-            PushArgs: "--force"
             WorkingDirectory: $(SdkRepoDirectory)
             ScriptDirectory: $(SdkRepoDirectory)/eng/common/scripts
 

--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -115,16 +115,11 @@ stages:
           Write-Host "Will use commitish for SDK repo checkout: '$checkoutCommitish'"
         displayName: "Create Run Time Variables"
 
-      - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(parameters.CreatePullRequest, true), ne(variables['Build.Reason'], 'PullRequest')) }}:
+      - ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
         - pwsh: |
             $sdkRepoBranch = '${{ parameters.SdkRepoBranch }}'
             $sdkRepoUrl = '${{ parameters.SdkRepoUrl }}'
             Write-Host "Validating SDK repo branch: '$SdkRepoBranch'"
-
-            if ($sdkRepoBranch.contains(":")) {
-              Write-Host "##vso[task.logissue type=error]'SDK repository branch' must be a commit SHA or branch name without ':'"
-              Exit 1
-            }
 
             if (($sdkRepoBranch -ne 'main') -and (-not [string]::IsNullOrWhiteSpace($sdkRepoBranch))) {
 
@@ -135,7 +130,7 @@ stages:
               }
 
               # Validate branch name
-              if ($sdkRepoBranch -match '^/|/$|//|\.\.|^@$|\.$/|[\x00-\x1F\x7F~^:?*@\[\]\\s]') {
+              if ($sdkRepoBranch -notmatch '^(?!/)(?!.*//)(?!.*\.\.)(?!.*\.lock$)(?!@$)(?!.*\.$)(?!.*\/$)(?!.*\\)(?!.*[~^:?*\[\]\s])[\u0020-\u007E]+$') {
                   Write-Host "##vso[task.logissue type=error]The provided SDK branch name '$sdkRepoBranch' is invalid."
                   Exit 1
               }
@@ -152,17 +147,16 @@ stages:
               $gitExitCode = $LASTEXITCODE
 
               if ($gitExitCode -ne 0) {
-                  Write-Host "##vso[task.logissue type=error]Failed to validate branch remotely (git exit code: $gitExitCode)"
-                  Exit $gitExitCode
+                Write-Host "##vso[task.logissue type=error]Failed to validate branch remotely (git exit code: $gitExitCode)"
+                Exit $gitExitCode
               }
 
               if ([string]::IsNullOrEmpty($branchExists)) {
-                  Write-Host "Branch '$SdkRepoBranch' does not exist in remote repository"
-                  Write-Host "Will checkout 'main'"
-                  $checkoutCommitish = 'main'
+                Write-Host "Branch '$SdkRepoBranch' does not exist in remote repository"
+                $checkoutCommitish = 'main'
               } else {
-                  Write-Host "Branch '$SdkRepoBranch' exists in remote repository"
-                  $checkoutCommitish = $SdkRepoBranch
+                Write-Host "Branch '$SdkRepoBranch' exists in remote repository"
+                $checkoutCommitish = $SdkRepoBranch
               }
             } else {
               Write-Host "Using commitish as-is: '$SdkRepoBranch' (main branch)"

--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -130,7 +130,7 @@ stages:
               }
 
               # Validate branch name
-              if ($sdkRepoBranch -notmatch '^(?!/)(?!.*//)(?!.*\.\.)(?!.*\.lock$)(?!@$)(?!.*\.$)(?!.*\/$)(?!.*\\)(?!.*[~^:?*\[\]\s])[\u0020-\u007E]+$') {
+              if ($sdkRepoBranch -notmatch '^(?!refs/)(?!/)(?!.*//)(?!.*\.\.)(?!.*\.lock$)(?!@$)(?!.*\.$)(?!.*\/$)(?!.*\\)(?!.*[~^:?*\[\]\s])[\u0020-\u007E]+$') {
                   Write-Host "##vso[task.logissue type=error]The provided SDK branch name '$sdkRepoBranch' is invalid."
                   Exit 1
               }

--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -3,7 +3,7 @@ parameters:
     type: string
   - name: SdkRepoUrl
     type: string
-  - name: SdkRepoCommit
+  - name: SdkRepoBranch
     type: string
     default: 'main'
   - name: ConfigType
@@ -110,66 +110,68 @@ stages:
             Exit 1
           }
 
-          $checkoutCommitish = '${{ parameters.SdkRepoCommit }}'
+          $checkoutCommitish = '${{ parameters.SdkRepoBranch }}'
           Write-Host "##vso[task.setvariable variable=CheckoutCommitish]$checkoutCommitish"
           Write-Host "Will use commitish for SDK repo checkout: '$checkoutCommitish'"
         displayName: "Create Run Time Variables"
 
       - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(parameters.CreatePullRequest, true), ne(variables['Build.Reason'], 'PullRequest')) }}:
         - pwsh: |
-            $sdkRepoCommitish = '${{ parameters.SdkRepoCommit }}'
+            $sdkRepoBranch = '${{ parameters.SdkRepoBranch }}'
             $sdkRepoUrl = '${{ parameters.SdkRepoUrl }}'
-            Write-Host "Validating SDK repo commitish: '$sdkRepoCommitish'"
-            # Check if it's a commit SHA
-            $commitShaPattern = '^[a-fA-F0-9]{7,40}$'
+            Write-Host "Validating SDK repo branch: '$SdkRepoBranch'"
 
-            if ($sdkRepoCommitish.contains(":")) {
-              Write-Host "##vso[task.logissue type=error]'SDK repository commit' must be a commit SHA or branch name without ':'"
+            if ($sdkRepoBranch.contains(":")) {
+              Write-Host "##vso[task.logissue type=error]'SDK repository branch' must be a commit SHA or branch name without ':'"
               Exit 1
             }
 
-            if (($sdkRepoCommitish -ne 'main') -and ($sdkRepoCommitish -notmatch $commitShaPattern)) {
-                # set repo owner to 'azure-sdk' when customized branch is provided
-                $sdkRepoOwner = 'azure-sdk'
-                Write-Host "##vso[task.setvariable variable=SdkRepoOwner]$sdkRepoOwner"
-                Write-Host "SdkRepoOwner variable set to: $sdkRepoOwner"
-                $sdkRepoUrl = "https://github.com/azure-sdk/$(SdkRepoName)"
-                # Check if branch exists remotely
-                Write-Host "Checking if branch '$sdkRepoCommitish' exists in remote repository '$sdkRepoUrl'..."
+            if (($sdkRepoBranch -ne 'main') -and (-not [string]::IsNullOrWhiteSpace($sdkRepoBranch))) {
 
-                $branchExists = git ls-remote --heads $sdkRepoUrl "refs/heads/$sdkRepoCommitish"
-                $gitExitCode = $LASTEXITCODE
+              # GitHub's limit is around 250 characters
+              if ($sdkRepoBranch.Length -gt 250) {
+                Write-Host "##vso[task.logissue type=error]The provided SDK branch name exceeds 250 characters."
+                Exit 1
+              }
 
-                if ($gitExitCode -ne 0) {
-                    Write-Host "##vso[task.logissue type=error]Failed to validate branch remotely (git exit code: $gitExitCode)"
-                    Exit $gitExitCode
-                }
+              # Validate branch name
+              if ($sdkRepoBranch -match '^/|/$|//|\.\.|^@$|\.$/|[\x00-\x1F\x7F~^:?*@\[\]\\s]') {
+                  Write-Host "##vso[task.logissue type=error]The provided SDK branch name '$sdkRepoBranch' is invalid."
+                  Exit 1
+              }
 
-                if ([string]::IsNullOrEmpty($branchExists)) {
-                    Write-Host "Branch '$sdkRepoCommitish' does not exist in remote repository"
-                    Write-Host "Will checkout 'main' and create new branch '$sdkRepoCommitish' later"
+              # Set repo owner to 'azure-sdk' when customized branch is provided
+              $sdkRepoOwner = 'azure-sdk'
+              Write-Host "##vso[task.setvariable variable=SdkRepoOwner]$sdkRepoOwner"
+              Write-Host "SdkRepoOwner variable set to: $sdkRepoOwner"
+              $sdkRepoUrl = "https://github.com/azure-sdk/$(SdkRepoName)"
 
-                    # Set flags for post-checkout processing
-                    Write-Host "##vso[task.setvariable variable=CreateNewBranch]true"
-                    Write-Host "##vso[task.setvariable variable=NewBranchName]$sdkRepoCommitish"
+              # Check if branch exists remotely
+              Write-Host "Checking if branch '$SdkRepoBranch' exists in remote repository '$sdkRepoUrl'..."
+              $branchExists = git ls-remote --heads $sdkRepoUrl "refs/heads/$SdkRepoBranch"
+              $gitExitCode = $LASTEXITCODE
 
-                    # Use 'main' for initial checkout
-                    $checkoutCommitish = 'main'
-                } else {
-                    Write-Host "Branch '$sdkRepoCommitish' exists in remote repository"
-                    Write-Host "##vso[task.setvariable variable=CreateNewBranch]false"
-                    $checkoutCommitish = $sdkRepoCommitish
-                }
+              if ($gitExitCode -ne 0) {
+                  Write-Host "##vso[task.logissue type=error]Failed to validate branch remotely (git exit code: $gitExitCode)"
+                  Exit $gitExitCode
+              }
+
+              if ([string]::IsNullOrEmpty($branchExists)) {
+                  Write-Host "Branch '$SdkRepoBranch' does not exist in remote repository"
+                  Write-Host "Will checkout 'main'"
+                  $checkoutCommitish = 'main'
+              } else {
+                  Write-Host "Branch '$SdkRepoBranch' exists in remote repository"
+                  $checkoutCommitish = $SdkRepoBranch
+              }
             } else {
-                Write-Host "Using commitish as-is: '$sdkRepoCommitish' (main branch or commit SHA)"
-                Write-Host "##vso[task.setvariable variable=CreateNewBranch]false"
-                $checkoutCommitish = $sdkRepoCommitish
+              Write-Host "Using commitish as-is: '$SdkRepoBranch' (main branch)"
+              $checkoutCommitish = $SdkRepoBranch
             }
 
             Write-Host "##vso[task.setvariable variable=CheckoutCommitish]$checkoutCommitish"
             Write-Host "Will use commitish for SDK repo checkout: '$checkoutCommitish'"
           displayName: "Validate and update SDK repository commitish"
-
 
       - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
         parameters:
@@ -190,39 +192,6 @@ stages:
           ${{ if and(eq(variables['System.TeamProject'], 'internal'), endsWith(variables['Build.Repository.Name'], '-pr')) }}:
             TokenToUseForAuth: $(azuresdk-github-pat)
             PreserveAuthToken: true
-
-      - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(parameters.CreatePullRequest, true), ne(variables['Build.Reason'], 'PullRequest')) }}:
-        - pwsh: |
-            if ('$(CreateNewBranch)' -eq 'true') {
-                $newBranchName = '$(NewBranchName)'
-                Write-Host "Creating new branch '$newBranchName' based on current checkout (main)"
-
-                # Verify we're on main branch
-                $currentBranch = git branch --show-current
-                Write-Host "Current branch before creating new branch: $currentBranch"
-
-                # Create and switch to the new branch
-                git checkout -b $newBranchName
-
-                # Verify the branch creation
-                $newCurrentBranch = git branch --show-current
-                Write-Host "Successfully created and switched to branch: $newCurrentBranch"
-
-                if ($newCurrentBranch -eq $newBranchName) {
-                    Write-Host "##vso[task.setvariable variable=ActualSdkBranch]$newBranchName"
-                    Write-Host "Branch creation successful"
-                } else {
-                    Write-Host "##vso[task.logissue type=error]Failed to create or switch to branch '$newBranchName'. Current branch: $newCurrentBranch"
-                    exit 1
-                }
-            } else {
-                # Use the original commitish as the actual branch
-                $actualBranch = '${{ parameters.SdkRepoCommit }}'
-                Write-Host "Using existing commitish: $actualBranch"
-                Write-Host "##vso[task.setvariable variable=ActualSdkBranch]$actualBranch"
-            }
-          workingDirectory: $(SdkRepoDirectory)
-          displayName: "Create new branch for SDK repo if needed"
 
       - task: NodeTool@0
         inputs:
@@ -303,7 +272,7 @@ stages:
 
             # use the user provided branch name when SdkRepoOwner is set as 'azure-sdk'
             if ('$(SdkRepoOwner)' -eq 'azure-sdk') {
-              $sdkPrBranchName = '$(ActualSdkBranch)'
+              $sdkPrBranchName = '${{ parameters.SdkRepoBranch }}'
             }
             Write-Host "Branch name is set to: $sdkPrBranchName"
             Write-Host "##vso[task.setvariable variable=SdkPullRequestSourceBranch]$sdkPrBranchName"

--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -93,16 +93,6 @@ stages:
             }
 
             $sdkRepoOwner = $Matches['organization']
-            # set repo owner to 'azure-sdk' when customized branch is provided
-            $sdkRepoCommitish = '${{ parameters.SdkRepoCommit }}'
-            $commitShaPattern = '^[a-fA-F0-9]{7,40}$'
-            if ($sdkRepoCommitish.contains(":")) {
-              Write-Host "##vso[task.logissue type=error]'SDK repository commit' must be a commit SHA or branch name without ':'"
-              Exit 1
-            }
-            if (($sdkRepoCommitish -ne 'main') -and ($sdkRepoCommitish -notmatch $commitShaPattern)) {
-              $sdkRepoOwner = 'azure-sdk'
-            }
             Write-Host "##vso[task.setvariable variable=SdkRepoOwner]$sdkRepoOwner"
             Write-Host "SdkRepoOwner variable set to: $sdkRepoOwner"
 
@@ -119,7 +109,67 @@ stages:
             Write-Host "##vso[task.logissue type=error]One or more required variables is empty or invalid. Ensure that SpecRepoUrl and SdkRepoUrl are set to valid GitHub repository URLs."
             Exit 1
           }
+
+          $checkoutCommitish = '${{ parameters.SdkRepoCommit }}'
+          Write-Host "##vso[task.setvariable variable=CheckoutCommitish]$checkoutCommitish"
+          Write-Host "Will use commitish for SDK repo checkout: '$checkoutCommitish'"
         displayName: "Create Run Time Variables"
+
+      - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(parameters.CreatePullRequest, true), ne(variables['Build.Reason'], 'PullRequest')) }}:
+        - pwsh: |
+            $sdkRepoCommitish = '${{ parameters.SdkRepoCommit }}'
+            $sdkRepoUrl = '${{ parameters.SdkRepoUrl }}'
+            Write-Host "Validating SDK repo commitish: '$sdkRepoCommitish'"
+            # Check if it's a commit SHA
+            $commitShaPattern = '^[a-fA-F0-9]{7,40}$'
+
+            if ($sdkRepoCommitish.contains(":")) {
+              Write-Host "##vso[task.logissue type=error]'SDK repository commit' must be a commit SHA or branch name without ':'"
+              Exit 1
+            }
+
+            if (($sdkRepoCommitish -ne 'main') -and ($sdkRepoCommitish -notmatch $commitShaPattern)) {
+                # set repo owner to 'azure-sdk' when customized branch is provided
+                $sdkRepoOwner = 'azure-sdk'
+                Write-Host "##vso[task.setvariable variable=SdkRepoOwner]$sdkRepoOwner"
+                Write-Host "SdkRepoOwner variable set to: $sdkRepoOwner"
+                $sdkRepoUrl = "https://github.com/azure-sdk/$(SdkRepoName)"
+                # Check if branch exists remotely
+                Write-Host "Checking if branch '$sdkRepoCommitish' exists in remote repository '$sdkRepoUrl'..."
+
+                $branchExists = git ls-remote --heads $sdkRepoUrl "refs/heads/$sdkRepoCommitish"
+                $gitExitCode = $LASTEXITCODE
+
+                if ($gitExitCode -ne 0) {
+                    Write-Host "##vso[task.logissue type=error]Failed to validate branch remotely (git exit code: $gitExitCode)"
+                    Exit $gitExitCode
+                }
+
+                if ([string]::IsNullOrEmpty($branchExists)) {
+                    Write-Host "Branch '$sdkRepoCommitish' does not exist in remote repository"
+                    Write-Host "Will checkout 'main' and create new branch '$sdkRepoCommitish' later"
+
+                    # Set flags for post-checkout processing
+                    Write-Host "##vso[task.setvariable variable=CreateNewBranch]true"
+                    Write-Host "##vso[task.setvariable variable=NewBranchName]$sdkRepoCommitish"
+
+                    # Use 'main' for initial checkout
+                    $checkoutCommitish = 'main'
+                } else {
+                    Write-Host "Branch '$sdkRepoCommitish' exists in remote repository"
+                    Write-Host "##vso[task.setvariable variable=CreateNewBranch]false"
+                    $checkoutCommitish = $sdkRepoCommitish
+                }
+            } else {
+                Write-Host "Using commitish as-is: '$sdkRepoCommitish' (main branch or commit SHA)"
+                Write-Host "##vso[task.setvariable variable=CreateNewBranch]false"
+                $checkoutCommitish = $sdkRepoCommitish
+            }
+
+            Write-Host "##vso[task.setvariable variable=CheckoutCommitish]$checkoutCommitish"
+            Write-Host "Will use commitish for SDK repo checkout: '$checkoutCommitish'"
+          displayName: "Validate and update SDK repository commitish"
+
 
       - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
         parameters:
@@ -134,12 +184,45 @@ stages:
               Commitish: $(SpecRepoCommit)
               WorkingDirectory: $(SpecRepoDirectory)
             - Name: $(SdkRepoOwner)/$(SdkRepoName)
-              Commitish: ${{ parameters.SdkRepoCommit }}
+              Commitish: $(CheckoutCommitish)
               WorkingDirectory: $(SdkRepoDirectory)
           SkipCheckoutNone: true
           ${{ if and(eq(variables['System.TeamProject'], 'internal'), endsWith(variables['Build.Repository.Name'], '-pr')) }}:
             TokenToUseForAuth: $(azuresdk-github-pat)
             PreserveAuthToken: true
+
+      - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(parameters.CreatePullRequest, true), ne(variables['Build.Reason'], 'PullRequest')) }}:
+        - pwsh: |
+            if ('$(CreateNewBranch)' -eq 'true') {
+                $newBranchName = '$(NewBranchName)'
+                Write-Host "Creating new branch '$newBranchName' based on current checkout (main)"
+
+                # Verify we're on main branch
+                $currentBranch = git branch --show-current
+                Write-Host "Current branch before creating new branch: $currentBranch"
+
+                # Create and switch to the new branch
+                git checkout -b $newBranchName
+
+                # Verify the branch creation
+                $newCurrentBranch = git branch --show-current
+                Write-Host "Successfully created and switched to branch: $newCurrentBranch"
+
+                if ($newCurrentBranch -eq $newBranchName) {
+                    Write-Host "##vso[task.setvariable variable=ActualSdkBranch]$newBranchName"
+                    Write-Host "Branch creation successful"
+                } else {
+                    Write-Host "##vso[task.logissue type=error]Failed to create or switch to branch '$newBranchName'. Current branch: $newCurrentBranch"
+                    exit 1
+                }
+            } else {
+                # Use the original commitish as the actual branch
+                $actualBranch = '${{ parameters.SdkRepoCommit }}'
+                Write-Host "Using existing commitish: $actualBranch"
+                Write-Host "##vso[task.setvariable variable=ActualSdkBranch]$actualBranch"
+            }
+          workingDirectory: $(SdkRepoDirectory)
+          displayName: "Create new branch for SDK repo if needed"
 
       - task: NodeTool@0
         inputs:
@@ -217,21 +300,15 @@ stages:
       - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(parameters.CreatePullRequest, true), ne(variables['Build.Reason'], 'PullRequest')) }}:
         - pwsh: |
             $sdkPrBranchName = "$(PrBranch)-$(Build.BuildId)"
-            $sdkRepoCommitish = '${{ parameters.SdkRepoCommit }}'
-            if (($sdkRepoCommitish -ne 'HEAD') -and ($sdkRepoCommitish -ne 'main')) {
-              # Query remote branches
-              $result = git ls-remote --heads origin $sdkRepoCommitish
-              if ([string]::IsNullOrEmpty($result)) {
-                Write-Host "'$sdkRepoCommitish' is NOT a branch."
-              } else {
-                Write-Host "'$sdkRepoCommitish' IS a branch."
-                $sdkPrBranchName = $sdkRepoCommitish
-              }
+
+            # use the user provided branch name when SdkRepoOwner is set as 'azure-sdk'
+            if ('$(SdkRepoOwner)' -eq 'azure-sdk') {
+              $sdkPrBranchName = '$(ActualSdkBranch)'
             }
             Write-Host "Branch name is set to: $sdkPrBranchName"
             Write-Host "##vso[task.setvariable variable=SdkPullRequestSourceBranch]$sdkPrBranchName"
           workingDirectory: $(SdkRepoDirectory)
-          displayName: "Set SDK PR branch variable"
+          displayName: "Create SDK PR branch variable"
 
         - template: /eng/common/pipelines/templates/steps/git-push-changes.yml
           parameters:

--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -5,7 +5,7 @@ parameters:
     type: string
   - name: SdkRepoCommit
     type: string
-    default: 'HEAD'
+    default: 'main'
   - name: ConfigType
     type: string
     default: ''
@@ -93,6 +93,16 @@ stages:
             }
 
             $sdkRepoOwner = $Matches['organization']
+            # set repo owner to 'azure-sdk' when customized branch is provided
+            $sdkRepoCommitish = '${{ parameters.SdkRepoCommit }}'
+            $commitShaPattern = '^[a-fA-F0-9]{7,40}$'
+            if ($sdkRepoCommitish.contains(":")) {
+              Write-Host "##vso[task.logissue type=error]'SDK repository commit' must be a commit SHA or branch name without ':'"
+              Exit 1
+            }
+            if (($sdkRepoCommitish -ne 'main') -and ($sdkRepoCommitish -notmatch $commitShaPattern)) {
+              $sdkRepoOwner = 'azure-sdk'
+            }
             Write-Host "##vso[task.setvariable variable=SdkRepoOwner]$sdkRepoOwner"
             Write-Host "SdkRepoOwner variable set to: $sdkRepoOwner"
 
@@ -109,7 +119,6 @@ stages:
             Write-Host "##vso[task.logissue type=error]One or more required variables is empty or invalid. Ensure that SpecRepoUrl and SdkRepoUrl are set to valid GitHub repository URLs."
             Exit 1
           }
-
         displayName: "Create Run Time Variables"
 
       - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
@@ -205,10 +214,28 @@ stages:
           ArtifactPath: $(StagedArtifactsFolder)
           CustomCondition: and(succeededOrFailed(), ne(variables['StagedArtifactsFolder'], ''))
 
+      - pwsh: |
+          $sdkPrBranchName = "$(PrBranch)-$(Build.BuildId)"
+          $sdkRepoCommitish = '${{ parameters.SdkRepoCommit }}'
+          if (($sdkRepoCommitish -ne 'HEAD') -and ($sdkRepoCommitish -ne 'main')) {
+            # Query remote branches
+            $result = git ls-remote --heads origin $sdkRepoCommitish
+            if ([string]::IsNullOrEmpty($result)) {
+              Write-Host "'$sdkRepoCommitish' is NOT a branch."
+            } else {
+              Write-Host "'$sdkRepoCommitish' IS a branch."
+              $sdkPrBranchName = $sdkRepoCommitish
+            }
+          }
+          Write-Host "Branch name is set to: $sdkPrBranchName"
+          Write-Host "##vso[task.setvariable variable=SdkPullRequestSourceBranch]$sdkPrBranchName"
+        workingDirectory: $(SdkRepoDirectory)
+        displayName: "Set SDK PR branch variable"
+
       - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(parameters.CreatePullRequest, true), ne(variables['Build.Reason'], 'PullRequest')) }}:
         - template: /eng/common/pipelines/templates/steps/git-push-changes.yml
           parameters:
-            BaseRepoBranch: $(PrBranch)-$(Build.BuildId)
+            BaseRepoBranch: $(SdkPullRequestSourceBranch)
             BaseRepoOwner: azure-sdk
             CommitMsg: $(GeneratedSDKInformation)
             TargetRepoOwner: $(SdkRepoOwner)
@@ -229,7 +256,7 @@ stages:
               -RepoName "$(SdkRepoName)"
               -BaseBranch "main"
               -PROwner "azure-sdk"
-              -PRBranch "$(PrBranch)-$(Build.BuildId)"
+              -PRBranch "$(SdkPullRequestSourceBranch)"
               -AuthToken "$(azuresdk-github-pat)"
               -PRTitle "$(PrTitle)-generated-from-$(Build.DefinitionName)-$(Build.BuildId)"
               -PRBody "$(GeneratedSDKInformation)"

--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -214,25 +214,25 @@ stages:
           ArtifactPath: $(StagedArtifactsFolder)
           CustomCondition: and(succeededOrFailed(), ne(variables['StagedArtifactsFolder'], ''))
 
-      - pwsh: |
-          $sdkPrBranchName = "$(PrBranch)-$(Build.BuildId)"
-          $sdkRepoCommitish = '${{ parameters.SdkRepoCommit }}'
-          if (($sdkRepoCommitish -ne 'HEAD') -and ($sdkRepoCommitish -ne 'main')) {
-            # Query remote branches
-            $result = git ls-remote --heads origin $sdkRepoCommitish
-            if ([string]::IsNullOrEmpty($result)) {
-              Write-Host "'$sdkRepoCommitish' is NOT a branch."
-            } else {
-              Write-Host "'$sdkRepoCommitish' IS a branch."
-              $sdkPrBranchName = $sdkRepoCommitish
-            }
-          }
-          Write-Host "Branch name is set to: $sdkPrBranchName"
-          Write-Host "##vso[task.setvariable variable=SdkPullRequestSourceBranch]$sdkPrBranchName"
-        workingDirectory: $(SdkRepoDirectory)
-        displayName: "Set SDK PR branch variable"
-
       - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(parameters.CreatePullRequest, true), ne(variables['Build.Reason'], 'PullRequest')) }}:
+        - pwsh: |
+            $sdkPrBranchName = "$(PrBranch)-$(Build.BuildId)"
+            $sdkRepoCommitish = '${{ parameters.SdkRepoCommit }}'
+            if (($sdkRepoCommitish -ne 'HEAD') -and ($sdkRepoCommitish -ne 'main')) {
+              # Query remote branches
+              $result = git ls-remote --heads origin $sdkRepoCommitish
+              if ([string]::IsNullOrEmpty($result)) {
+                Write-Host "'$sdkRepoCommitish' is NOT a branch."
+              } else {
+                Write-Host "'$sdkRepoCommitish' IS a branch."
+                $sdkPrBranchName = $sdkRepoCommitish
+              }
+            }
+            Write-Host "Branch name is set to: $sdkPrBranchName"
+            Write-Host "##vso[task.setvariable variable=SdkPullRequestSourceBranch]$sdkPrBranchName"
+          workingDirectory: $(SdkRepoDirectory)
+          displayName: "Set SDK PR branch variable"
+
         - template: /eng/common/pipelines/templates/steps/git-push-changes.yml
           parameters:
             BaseRepoBranch: $(SdkPullRequestSourceBranch)


### PR DESCRIPTION
**Changes**
* Added logic to determine the correct `SdkRepoOwner` when a custom branch or commit is specified, defaulting to `'azure-sdk'` for non-main.

* Enhanced branch detection logic to check if the provided branch name is valid and set the pull request source branch accordingly.

* Updated `SdkRepoCommit` parameter to `SdkBranchName`.

* Removed the `SkipPullRequestCreation: true` setting in the batch pipeline, allowing PR creation as needed.

**Test pipeline runs and PRs**
SDK PR: https://github.com/Azure/azure-sdk-for-go/pull/25093
Runs: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5231670&view=logs&j=83516c17-6666-5250-abde-63983ce72a49&t=c1986ca5-be0a-5bc2-c78d-61dbd0c1d7fc
This has no impact to spec PR: [example PR](https://github.com/Azure/azure-rest-api-specs/pull/36751)