### PR TITLE
[Storage] Make `metadata` a parameter for `set_metadata` API, StorageServiceProperties renamed to BlobServiceProperties `.tsp`

### DIFF
--- a/specification/storage/Microsoft.BlobStorage/models.tsp
+++ b/specification/storage/Microsoft.BlobStorage/models.tsp
@@ -783,6 +783,7 @@ model ObjectReplicationMetadata is Record<string>;
 /// Service Properties
 
 /** The service properties. */
+@Xml.name("StorageServiceProperties")
 model BlobServiceProperties {
   /** The logging properties. */
   @Xml.name("Logging") logging?: Logging;

--- a/specification/storage/Microsoft.BlobStorage/models.tsp
+++ b/specification/storage/Microsoft.BlobStorage/models.tsp
@@ -783,7 +783,7 @@ model ObjectReplicationMetadata is Record<string>;
 /// Service Properties
 
 /** The service properties. */
-model StorageServiceProperties {
+model BlobServiceProperties {
   /** The logging properties. */
   @Xml.name("Logging") logging?: Logging;
 
@@ -2133,6 +2133,14 @@ alias ContainerNamePathParameter = {
   /** The name of the container. */
   @path
   containerName: string;
+};
+
+// NOTE: This does not explicitly let emitters know that this is a collection header for metadata. Logic should be handwritten to handle this.
+alias MetadataHeadersParameter = {
+  /** The metadata headers. */
+  @alternateType(Record<string>, "rust")
+  @header("x-ms-meta")
+  metadata: string;
 };
 
 // NOTE: This does not explicitly let emitters know that this is a collection header for metadata. Logic should be handwritten to handle this.

--- a/specification/storage/Microsoft.BlobStorage/routes.tsp
+++ b/specification/storage/Microsoft.BlobStorage/routes.tsp
@@ -1485,7 +1485,7 @@ namespace Storage.Blob {
         },
         {
           @statusCode statusCode: 204;
-          ...DateResponseHeader;
+          ...DateResponseHeaderPrivate;
         }
       >;
 

--- a/specification/storage/Microsoft.BlobStorage/routes.tsp
+++ b/specification/storage/Microsoft.BlobStorage/routes.tsp
@@ -67,7 +67,7 @@ namespace Storage.Blob {
 
       /** The storage service properties to set. */
       @body
-      storageServiceProperties: StorageServiceProperties;
+      blobServiceProperties: BlobServiceProperties;
     },
     {
       @statusCode statusCode: 202;
@@ -78,10 +78,7 @@ namespace Storage.Blob {
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Existing API"
   @get
   @route("?restype=service&comp=properties")
-  op getProperties is StorageOperation<
-    TimeoutParameter,
-    StorageServiceProperties
-  >;
+  op getProperties is StorageOperation<TimeoutParameter, BlobServiceProperties>;
 
   /** Retrieves statistics related to replication for the Blob service. It is only available on the secondary location endpoint when read-access geo-redundant replication is enabled for the storage account. */
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Existing API"
@@ -302,7 +299,7 @@ namespace Storage.Blob {
         ...ContainerNamePathParameter;
         ...TimeoutParameter;
         ...LeaseIdOptionalParameter;
-        ...MetadataHeaders;
+        ...MetadataHeadersParameter;
         ...IfModifiedSinceParameter;
       },
       {


### PR DESCRIPTION
- Makes `metadata` a parmeter for `set_metadata` API
- `StorageServiceProperties` -> `BlobServiceProperties` (this includes preserving the original `@Xml.name` using the decorator)
- Privatizied `date` header for `set_tags`