### PR TITLE
[Storage] `upload_blob_from_url` TypeSpec Changes

### DIFF
--- a/specification/storage/Microsoft.BlobStorage/routes.tsp
+++ b/specification/storage/Microsoft.BlobStorage/routes.tsp
@@ -2141,7 +2141,6 @@ namespace Storage.Blob {
             ...BlobPathParameter;
             ...TimeoutParameter;
             ...ContentMd5Parameter;
-            ...ContentLengthParameter;
             ...BlobContentTypeParameter;
             ...BlobContentEncodingParameter;
             ...BlobContentLanguageParameter;
@@ -2167,6 +2166,7 @@ namespace Storage.Blob {
             ...SourceContentMd5Parameter;
             ...BlobTagsHeaderParameter;
             ...CopySourceParameter;
+            ...ContentLengthParameter;
             ...CopySourceBlobPropertiesParameter;
             ...CopySourceAuthorizationParameter;
             ...CopySourceTagsParameter;

--- a/specification/storage/Microsoft.BlobStorage/routes.tsp
+++ b/specification/storage/Microsoft.BlobStorage/routes.tsp
@@ -2134,7 +2134,7 @@ namespace Storage.Blob {
         @put
         @sharedRoute
         @route("{blobName}?BlockBlob&fromUrl")
-        op putBlobFromUrl is StorageOperationNoBody<
+        op uploadBlobFromUrl is StorageOperationNoBody<
           {
             ...MetadataHeaders;
             ...ContainerNamePathParameter;

--- a/specification/storage/Microsoft.BlobStorage/routes.tsp
+++ b/specification/storage/Microsoft.BlobStorage/routes.tsp
@@ -2166,7 +2166,11 @@ namespace Storage.Blob {
             ...SourceContentMd5Parameter;
             ...BlobTagsHeaderParameter;
             ...CopySourceParameter;
-            ...ContentLengthParameter;
+
+            /** Required to be 0 for Put Blob from URL operation. */
+            @header("Content-Length")
+            contentLength: 0;
+
             ...CopySourceBlobPropertiesParameter;
             ...CopySourceAuthorizationParameter;
             ...CopySourceTagsParameter;

--- a/specification/storage/Microsoft.BlobStorage/routes.tsp
+++ b/specification/storage/Microsoft.BlobStorage/routes.tsp
@@ -2183,7 +2183,7 @@ namespace Storage.Blob {
             ...LastModifiedResponseHeader;
             ...ContentMd5ResponseHeader;
             ...VersionIdResponseHeader;
-            ...DateResponseHeader;
+            ...DateResponseHeaderPrivate;
             ...RequestServerEncryptedResponseHeader;
             ...EncryptionKeySha256ResponseHeader;
             ...EncryptionScopeResponseHeader;


### PR DESCRIPTION
Uses private Date for `BlockBlobClientPutBlobFromUrlOptions`
Makes `Content-Length` always a 0, required as stated in the REST docs.