### PR TITLE
[summarize-checks] Trigger on workflow "TypeSpec Validation"

### DIFF
--- a/.github/workflows/summarize-checks.yaml
+++ b/.github/workflows/summarize-checks.yaml
@@ -9,6 +9,7 @@ on:
       - "Swagger Avocado - Set Status"
       - "Swagger LintDiff - Set Status"
       - "SDK Validation Status"
+      - "TypeSpec Validation"
       - "Update Labels"
     types:
       - completed


### PR DESCRIPTION
- Necessary if this required check finishes last

Example where NSTM didn't update after TSV:

https://github.com/Azure/azure-rest-api-specs-pr/pull/24129