### PR TITLE
Control check for two files

### DIFF
--- a/specification/deviceprovisioningservices/DeviceProvisioningServices.Management/models.tsp
+++ b/specification/deviceprovisioningservices/DeviceProvisioningServices.Management/models.tsp
@@ -134,7 +134,7 @@ union PrivateLinkServiceConnectionStatus {
 }
 
 /**
- * Device Registry Namespace MI authentication type: UserAssigned, SystemAssigned.
+ * Device Registry Namespace MI authentication type: UserAssigned, and SystemAssigned.
  */
 union DeviceRegistryNamespaceAuthenticationType {
   string,

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/preview/2025-02-01-preview/iotdps.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/preview/2025-02-01-preview/iotdps.json
@@ -1813,7 +1813,7 @@
     },
     "DeviceRegistryNamespaceAuthenticationType": {
       "type": "string",
-      "description": "Device Registry Namespace MI authentication type: UserAssigned, SystemAssigned.",
+      "description": "Device Registry Namespace MI authentication type: UserAssigned, and SystemAssigned.",
       "enum": [
         "UserAssigned",
         "SystemAssigned"


### PR DESCRIPTION
Want to ensure a [warning](https://github.com/Azure/azure-rest-api-specs/actions/runs/17143726509/job/48635869830?pr=36872#step:4:13) I am seeing on new OAV version is showing up on old.

It is [indeed present](https://github.com/Azure/azure-rest-api-specs/actions/runs/17162624700/job/48695373322?pr=36887#step:4:18)