### PR TITLE
Updated the repo owner of SDK PR in step of creating branch and PR

### DIFF
--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -278,7 +278,7 @@ stages:
             BaseRepoBranch: $(SdkPullRequestSourceBranch)
             BaseRepoOwner: azure-sdk
             CommitMsg: $(GeneratedSDKInformation)
-            TargetRepoOwner: $(SdkRepoOwner)
+            TargetRepoOwner: azure
             TargetRepoName: $(SdkRepoName)
             WorkingDirectory: $(SdkRepoDirectory)
             ScriptDirectory: $(SdkRepoDirectory)/eng/common/scripts
@@ -291,7 +291,7 @@ stages:
             workingDirectory: $(SdkRepoDirectory)
             filePath: $(SdkRepoDirectory)/eng/common/scripts/Submit-PullRequest.ps1
             arguments: >
-              -RepoOwner "$(SdkRepoOwner)"
+              -RepoOwner "azure"
               -RepoName "$(SdkRepoName)"
               -BaseBranch "main"
               -PROwner "azure-sdk"


### PR DESCRIPTION
We cannot use the `SdkRepoOwner` variable because it will be overwritten to `azure-sdk` when SDK branch is specified.

Although we have the code to parse `SdkRepoUrl` variable to get the repo owner, current pipelines set them to 'azure' SDK repos. 

I'd rather to hardcode its value to 'azure' in both `push-code` step and `create-PR` step.

Here's a test PR created.
https://github.com/Azure/azure-sdk-for-go/pull/25144