### PR TITLE
[oav-runner] Remove warning messages from formatting output

### DIFF
--- a/eng/tools/oav-runner/src/formatting.ts
+++ b/eng/tools/oav-runner/src/formatting.ts
@@ -56,11 +56,6 @@ export function outputErrorSummary(errors: ReportableOavError[], reportName: str
     checkName = "validate-example";
   }
 
-  builtLines.push(`⚠️ This check is testing a new version of '${reportName}'. ⚠️`);
-  builtLines.push(
-    "Failures are expected, and should be completely ignored by spec authors and reviewers.",
-  );
-  builtLines.push(`Meaningful results for this PR are in required check '${reportName}'.`);
   builtLines.push("| File | Line#Column | Code | Message |");
   builtLines.push("| --- | --- | --- | --- |");
 


### PR DESCRIPTION
- Missed removing these when the check went GA (#36570)

Before:
<img width="1200" height="488" alt="image" src="https://github.com/user-attachments/assets/db1a8512-5e0e-4f02-9ccf-b567d88d6891" />

After:
<img width="1146" height="269" alt="image" src="https://github.com/user-attachments/assets/33681d16-b73b-4698-a3e5-104fde7b8639" />
