### PR TITLE
[Key Vault Administration] go updates

### DIFF
--- a/specification/keyvault/Security.KeyVault.BackupRestore/client.tsp
+++ b/specification/keyvault/Security.KeyVault.BackupRestore/client.tsp
@@ -3,7 +3,7 @@ import "@azure-tools/typespec-client-generator-core";
 
 using Azure.ClientGenerator.Core;
 
-@TypeSpec.Versioning.useDependency(KeyVault.Versions.`v7.5`)
+@TypeSpec.Versioning.useDependency(KeyVault.Versions.`v7.6`)
 namespace ClientCustomizations;
 
 @client(
@@ -26,16 +26,26 @@ interface Client {
   preFullRestore is KeyVault.preFullRestoreOperation;
 }
 
-@@clientName(KeyVault.SASTokenParameter, "SASTokenParameters", "go");
-@@clientName(KeyVault.RestoreOperationParameters.sasTokenParameters,
+using KeyVault;
+
+@@clientName(SASTokenParameter, "SASTokenParameters", "go");
+@@clientName(RestoreOperationParameters.sasTokenParameters,
   "SASTokenParameters",
   "go"
 );
-@@clientName(KeyVault.SelectiveKeyRestoreOperationParameters.sasTokenParameters,
+@@clientName(SelectiveKeyRestoreOperationParameters.sasTokenParameters,
   "SASTokenParameters",
   "go"
 );
-@@clientName(KeyVault.PreRestoreOperationParameters.sasTokenParameters,
+@@clientName(PreRestoreOperationParameters.sasTokenParameters,
   "SASTokenParameters",
   "go"
 );
+
+@@alternateType(FullBackupOperation.status, string, "go");
+@@alternateType(RestoreOperation.status, string, "go");
+@@alternateType(SelectiveKeyRestoreOperation.status, string, "go");
+
+@@alternateType(FullBackupOperation.error, string, "go");
+@@alternateType(RestoreOperation.error, string, "go");
+@@alternateType(SelectiveKeyRestoreOperation.error, string, "go");

--- a/specification/keyvault/Security.KeyVault.BackupRestore/tspconfig.yaml
+++ b/specification/keyvault/Security.KeyVault.BackupRestore/tspconfig.yaml
@@ -27,11 +27,12 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/security/keyvault"
     package-dir: "azadmin/backup"
+    containing-module: "github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azadmin"
+    go-generate: post-generate.go
+    api-version: "7.6"
     inject-spans: true
     single-client: true
     generate-fakes: true
-    module: "github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azadmin"
-    module-version: "0.0.1"
   "@azure-tools/typespec-client-generator-cli":
     additionalDirectories:
       - "specification/keyvault/Security.KeyVault.Common/"

--- a/specification/keyvault/Security.KeyVault.RBAC/routes.tsp
+++ b/specification/keyvault/Security.KeyVault.RBAC/routes.tsp
@@ -1,7 +1,10 @@
 import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-client-generator-core";
+import "@typespec/openapi";
 import "@typespec/rest";
 import "./models.tsp";
 
+using Azure.ClientGenerator.Core;
 using TypeSpec.Http;
 
 namespace KeyVault;
@@ -18,6 +21,7 @@ interface RoleDefinitions {
       /**
        * The scope of the role definition to delete. Managed HSM only supports '/'.
        */
+      @alternateType(RoleScope, "go")
       scope: string;
 
       /**
@@ -39,6 +43,7 @@ interface RoleDefinitions {
       /**
        * The scope of the role definition to create or update. Managed HSM only supports '/'.
        */
+      @alternateType(RoleScope, "go")
       scope: string;
 
       /**
@@ -66,6 +71,7 @@ interface RoleDefinitions {
       /**
        * The scope of the role definition to get. Managed HSM only supports '/'.
        */
+      @alternateType(RoleScope, "go")
       scope: string;
 
       /**
@@ -88,6 +94,7 @@ interface RoleDefinitions {
       /**
        * The scope of the role definition.
        */
+      @alternateType(RoleScope, "go")
       scope: string;
 
       /**
@@ -112,6 +119,7 @@ interface RoleAssignments {
       /**
        * The scope of the role assignment to delete.
        */
+      @alternateType(RoleScope, "go")
       scope: string;
 
       /**
@@ -133,6 +141,7 @@ interface RoleAssignments {
       /**
        * The scope of the role assignment to create.
        */
+      @alternateType(RoleScope, "go")
       scope: string;
 
       /**
@@ -160,6 +169,7 @@ interface RoleAssignments {
       /**
        * The scope of the role assignment.
        */
+      @alternateType(RoleScope, "go")
       scope: string;
 
       /**
@@ -182,6 +192,7 @@ interface RoleAssignments {
       /**
        * The scope of the role assignments.
        */
+      @alternateType(RoleScope, "go")
       scope: string;
 
       /**

--- a/specification/keyvault/Security.KeyVault.RBAC/tspconfig.yaml
+++ b/specification/keyvault/Security.KeyVault.RBAC/tspconfig.yaml
@@ -27,11 +27,12 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/security/keyvault"
     package-dir: "azadmin/rbac"
+    containing-module: "github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azadmin"
+    go-generate: post-generate.go
+    api-version: "7.6"
     inject-spans: true
     single-client: true
     generate-fakes: true
-    module: "github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azadmin"
-    module-version: "0.0.1"
   "@azure-tools/typespec-client-generator-cli":
     additionalDirectories:
       - "specification/keyvault/Security.KeyVault.Common/"

--- a/specification/keyvault/Security.KeyVault.Settings/tspconfig.yaml
+++ b/specification/keyvault/Security.KeyVault.Settings/tspconfig.yaml
@@ -27,11 +27,11 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/security/keyvault"
     package-dir: "azadmin/settings"
+    containing-module: "github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azadmin"
+    api-version: "7.6"
     inject-spans: true
     single-client: true
     generate-fakes: true
-    module: "github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azadmin"
-    module-version: "0.0.1"
   "@azure-tools/typespec-client-generator-cli":
     additionalDirectories:
       - "specification/keyvault/Security.KeyVault.Common/"


### PR DESCRIPTION
Updating the tspconfig.yaml for Go to use the Go emitter's new `containing-module` and `go-generate` switches