### PR TITLE
Revert "Bump @microsoft.azure/openapi-validator-rulesets (#36894)"

### DIFF
--- a/eng/tools/lint-diff/package.json
+++ b/eng/tools/lint-diff/package.json
@@ -23,7 +23,7 @@
     "@azure-tools/specs-shared": "file:../../../.github/shared",
     "@microsoft.azure/openapi-validator": "2.2.4",
     "@microsoft.azure/openapi-validator-core": "1.0.6",
-    "@microsoft.azure/openapi-validator-rulesets": "2.1.8",
+    "@microsoft.azure/openapi-validator-rulesets": "2.1.7",
     "autorest": "^3.7.2",
     "axios": "^1.8.3",
     "change-case": "^5.4.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@azure/avocado": "^0.9.1",
         "@microsoft.azure/openapi-validator": "2.2.4",
         "@microsoft.azure/openapi-validator-core": "1.0.6",
-        "@microsoft.azure/openapi-validator-rulesets": "2.1.8",
+        "@microsoft.azure/openapi-validator-rulesets": "2.1.7",
         "@typespec/compiler": "1.3.0",
         "@typespec/events": "0.73.0",
         "@typespec/http": "1.3.0",
@@ -113,7 +113,7 @@
         "@azure-tools/specs-shared": "file:../../../.github/shared",
         "@microsoft.azure/openapi-validator": "2.2.4",
         "@microsoft.azure/openapi-validator-core": "1.0.6",
-        "@microsoft.azure/openapi-validator-rulesets": "2.1.8",
+        "@microsoft.azure/openapi-validator-rulesets": "2.1.7",
         "autorest": "^3.7.2",
         "axios": "^1.8.3",
         "change-case": "^5.4.4",
@@ -3582,9 +3582,9 @@
       "license": "MIT"
     },
     "node_modules/@microsoft.azure/openapi-validator-rulesets": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@microsoft.azure/openapi-validator-rulesets/-/openapi-validator-rulesets-2.1.8.tgz",
-      "integrity": "sha512-thfiYHgawReMszfZFaF47jRwS9dZAVSYXbMRNkaRaAcJtnYDhq6o0bptQNIQZWMECRUGjkS9A/8g8l4qUUVeyQ==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@microsoft.azure/openapi-validator-rulesets/-/openapi-validator-rulesets-2.1.7.tgz",
+      "integrity": "sha512-GQ/ZDLwIpH17fa+a/UZ9bJELe8xcUITtVDJSfbgAELSSRf3nQ+/+YolCY+A0Aow0SJAvIyIUfxdEXYykoYdGoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@azure/avocado": "^0.9.1",
     "@microsoft.azure/openapi-validator": "2.2.4",
     "@microsoft.azure/openapi-validator-core": "1.0.6",
-    "@microsoft.azure/openapi-validator-rulesets": "2.1.8",
+    "@microsoft.azure/openapi-validator-rulesets": "2.1.7",
     "@typespec/compiler": "1.3.0",
     "@typespec/http": "1.3.0",
     "@typespec/sse": "0.73.0",


### PR DESCRIPTION
- Reverts commit 8b16c315f3a8e04d4c7fd24e01662ddda334b257
- New rule LroAzureAsyncOperationHeader appears to be blocking PRs incorrectly
- https://github.com/Azure/azure-openapi-validator/pull/749