### PR TITLE
[Common-Types] Add v6/mobo.json for Managed-On-Behalf-Of configuration

### DIFF
--- a/specification/common-types/resource-management/v6/mobo.json
+++ b/specification/common-types/resource-management/v6/mobo.json
@@ -1,0 +1,38 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Common types",
+    "version": "6.0"
+  },
+  "paths": {},
+  "definitions": {
+    "ManagedOnBehalfOfConfiguration": {
+      "type": "object",
+      "description": "Managed-On-Behalf-Of configuration properties. This configuration exists for the resources where a resource provider manages those resources on behalf of the resource owner.",
+      "properties": {
+        "moboBrokerResources": {
+          "type": "array",
+          "description": "Managed-On-Behalf-Of broker resources",
+          "items": {
+            "$ref": "#/definitions/MoboBrokerResource"
+          },
+          "x-ms-identifiers": [
+            "id"
+          ]
+        }
+      },
+      "readOnly": true
+    },
+    "MoboBrokerResource": {
+      "type": "object",
+      "description": "Managed-On-Behalf-Of broker resource. This resource is created by the Resource Provider to manage some resources on behalf of the user.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Resource identifier of a Managed-On-Behalf-Of broker resource"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Context:
mobo.json exists in [v5](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/common-types/resource-management/v5/mobo.json) but missing in v6 so I add it to umblock typespec migration of Appconfiguration.

