### PR TITLE
Alow names to be undefined when sorting `oav` errors

### DIFF
--- a/eng/tools/oav-runner/src/formatting.ts
+++ b/eng/tools/oav-runner/src/formatting.ts
@@ -61,7 +61,7 @@ export function outputErrorSummary(errors: ReportableOavError[], reportName: str
 
   // sort the errors by file name then by error code
   errors.sort((a, b) => {
-    const nameCompare = a.file.localeCompare(b.file);
+    const nameCompare = (a.file || "").localeCompare(b.file || "");
     if (nameCompare !== 0) {
       return nameCompare;
     }


### PR DESCRIPTION
@mikeharder from our discussion.