### PR TITLE
[Storage] `find_blobs_by_tags` for BlobServiceClient&BlobContainerClient TypeSpec Changes

### DIFF
--- a/specification/storage/Microsoft.BlobStorage/models.tsp
+++ b/specification/storage/Microsoft.BlobStorage/models.tsp
@@ -2189,7 +2189,7 @@ alias FilterBlobsIncludeParameter = {
 alias FilterBlobsWhereParameter = {
   /** Filters the results to return only to return only blobs whose tags match the specified expression. */
   @query
-  where?: string;
+  where: string;
 };
 
 /** The Content-Length header. */

--- a/specification/storage/Microsoft.BlobStorage/models.tsp
+++ b/specification/storage/Microsoft.BlobStorage/models.tsp
@@ -2189,6 +2189,7 @@ alias FilterBlobsIncludeParameter = {
 alias FilterBlobsWhereParameter = {
   /** Filters the results to return only to return only blobs whose tags match the specified expression. */
   @query
+  @clientName("filterExpression")
   where: string;
 };
 

--- a/specification/storage/Microsoft.BlobStorage/routes.tsp
+++ b/specification/storage/Microsoft.BlobStorage/routes.tsp
@@ -440,7 +440,7 @@ namespace Storage.Blob {
     #suppress "@azure-tools/typespec-azure-core/use-standard-names" "Existing API"
     @get
     @route("{containerName}?restype=container&comp=blobs")
-    op filterBlobs is StorageOperation<
+    op findBlobsByTags is StorageOperation<
       {
         ...ContainerNamePathParameter;
         ...TimeoutParameter;
@@ -450,8 +450,6 @@ namespace Storage.Blob {
         ...FilterBlobsIncludeParameter;
       },
       {
-        ...DateResponseHeader;
-
         /** The container filter blob enumeration results */
         @body
         enumerationResults: FilterBlobSegment;

--- a/specification/storage/Microsoft.BlobStorage/routes.tsp
+++ b/specification/storage/Microsoft.BlobStorage/routes.tsp
@@ -184,7 +184,7 @@ namespace Storage.Blob {
   #suppress "@azure-tools/typespec-azure-core/use-standard-names" "Existing API"
   @get
   @route("?comp=blobs")
-  op filterBlobs is StorageOperation<
+  op findBlobsByTags is StorageOperation<
     {
       ...TimeoutParameter;
       ...FilterBlobsWhereParameter;
@@ -193,8 +193,6 @@ namespace Storage.Blob {
       ...FilterBlobsIncludeParameter;
     },
     {
-      ...DateResponseHeader;
-
       /** The filter blobs enumeration results */
       @body
       enumerationResults: FilterBlobSegment;


### PR DESCRIPTION
- Renames `filterBlobs` to `findBlobsByTags`
- Makes `where` a required parameter