### PR TITLE
[TEST] Add API version 2025-09-01 and getAnalyzeResultPng operation to DocumentIntelligence

### DIFF
--- a/specification/ai/DocumentIntelligence/client.tsp
+++ b/specification/ai/DocumentIntelligence/client.tsp
@@ -20,6 +20,8 @@ interface DocumentIntelligenceClient {
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Doesn't fit standard ops"
   getAnalyzeResultPdf is DocumentModels.getAnalyzeResultPdf;
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Doesn't fit standard ops"
+  getAnalyzeResultPng is DocumentModels.getAnalyzeResultPng;
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Doesn't fit standard ops"
   getAnalyzeResultFigure is DocumentModels.getAnalyzeResultFigure;
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Doesn't fit standard ops"
   deleteAnalyzeResult is DocumentModels.deleteAnalyzeResult;

--- a/specification/ai/DocumentIntelligence/main.tsp
+++ b/specification/ai/DocumentIntelligence/main.tsp
@@ -35,4 +35,7 @@ namespace DocumentIntelligence;
 enum Versions {
   @doc("The 2024-11-30 GA version of the DocumentIntelligence service.")
   v2024_11_30: "2024-11-30",
+
+  @doc("The 2025-09-01 version of the DocumentIntelligence service.")
+  v2025_09_01: "2025-09-01",
 }

--- a/specification/ai/DocumentIntelligence/routes.tsp
+++ b/specification/ai/DocumentIntelligence/routes.tsp
@@ -183,6 +183,33 @@ interface DocumentModels {
   >;
 
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Doesn't fit standard ops"
+  @doc("Gets the generated searchable PNG output from document analysis.")
+  @route("/documentModels/{modelId}/analyzeResults/{resultId}/png")
+  @get
+  getAnalyzeResultPng is DocumentIntelligenceOperation<
+    {
+      @doc("Unique document model name.")
+      @path
+      @pattern("^[a-zA-Z0-9][a-zA-Z0-9._~-]{1,63}$")
+      @maxLength(64)
+      modelId: string;
+
+      @doc("Analyze operation result ID.")
+      @path
+      resultId: uuid;
+    },
+    {
+      @doc("Response content type.")
+      @header
+      contentType: "image/png";
+
+      @doc("Response PNG.")
+      @body
+      png: bytes;
+    }
+  >;
+
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Doesn't fit standard ops"
   @doc("Gets the generated cropped image of specified figure from document analysis.")
   @route("/documentModels/{modelId}/analyzeResults/{resultId}/figures/{figureId}")
   @get

--- a/specification/ai/DocumentIntelligence/tspconfig.yaml
+++ b/specification/ai/DocumentIntelligence/tspconfig.yaml
@@ -4,17 +4,16 @@ parameters:
 
 emit:
   - "@azure-tools/typespec-autorest"
-    # - "@azure-tools/typespec-csharp",
-    # - "@azure-tools/typespec-python",
-    # - "@azure-tools/typespec-ts"
+  # SDK emitters are used only during pipeline generation:
+  # - "@azure-tools/typespec-csharp"
+  # - "@azure-tools/typespec-python"
+  # - "@azure-tools/typespec-ts"
+  # - "@azure-tools/typespec-java"
+  # - "@azure-tools/typespec-go"
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/data-plane"
 options:
-  "@azure-typespec/http-client-csharp":
-    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
-    namespace: Azure.AI.DocumentIntelligence
-    model-namespace: false
   "@azure-tools/typespec-autorest":
     azure-resource-provider-folder: "data-plane"
     emit-lro-options: "none"
@@ -51,6 +50,7 @@ options:
   "@azure-tools/typespec-csharp":
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     namespace: "Azure.AI.DocumentIntelligence"
+    clear-output-folder: true
     model-namespace: false
     flavor: azure
   "@azure-tools/typespec-ts":
@@ -62,4 +62,14 @@ options:
       name: "@azure-rest/ai-document-intelligence"
       description: "Document Intelligence Rest Client"
       version: "1.0.0"
+    flavor: azure
+  "@azure-tools/typespec-go":
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/azdocumentintelligence"
+    service-dir: "sdk/documentintelligence"
+    package-dir: "azdocumentintelligence"
+    module-version: "1.0.0"
+    generate-fakes: true
+    inject-spans: true
+    single-client: true
+    slice-elements-byval: true
     flavor: azure

--- a/specification/ai/data-plane/DocumentIntelligence/stable/2025-09-01/DocumentIntelligence.json
+++ b/specification/ai/data-plane/DocumentIntelligence/stable/2025-09-01/DocumentIntelligence.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "Document Intelligence (formerly Form Recognizer)",
-    "version": "2024-11-30",
+    "version": "2025-09-01",
     "description": "Extracts content, layout, and structured data from documents.",
     "x-typespec-generated": [
       {
@@ -95,11 +95,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "Get Document Classifiers": {
-            "$ref": "./examples/GetDocumentClassifiers.json"
-          }
-        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -146,11 +141,6 @@
               "$ref": "#/definitions/DocumentIntelligenceErrorResponse"
             }
           }
-        },
-        "x-ms-examples": {
-          "Get Document Classifier": {
-            "$ref": "./examples/GetDocumentClassifier.json"
-          }
         }
       },
       "delete": {
@@ -189,11 +179,6 @@
             "schema": {
               "$ref": "#/definitions/DocumentIntelligenceErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "Delete Document Classifier": {
-            "$ref": "./examples/DeleteDocumentClassifier.json"
           }
         }
       }
@@ -258,11 +243,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "Classify Document from Url": {
-            "$ref": "./examples/ClassifyDocument_Stream.json"
-          }
-        },
         "x-ms-long-running-operation": true
       }
     },
@@ -316,11 +296,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "Copy Document Classifier To": {
-            "$ref": "./examples/CopyDocumentClassifierTo.json"
-          }
-        },
         "x-ms-long-running-operation": true
       }
     },
@@ -363,11 +338,6 @@
               "$ref": "#/definitions/DocumentIntelligenceErrorResponse"
             }
           }
-        },
-        "x-ms-examples": {
-          "Get Classify Document Result": {
-            "$ref": "./examples/GetClassifyDocumentResult.json"
-          }
         }
       }
     },
@@ -401,11 +371,6 @@
             "schema": {
               "$ref": "#/definitions/DocumentIntelligenceErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "Authorize Copy of Document Classifier": {
-            "$ref": "./examples/AuthorizeCopyDocumentClassifier.json"
           }
         }
       }
@@ -451,11 +416,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "Build Document Classifier": {
-            "$ref": "./examples/BuildDocumentClassifier.json"
-          }
-        },
         "x-ms-long-running-operation": true
       }
     },
@@ -490,11 +450,6 @@
             "schema": {
               "$ref": "#/definitions/DocumentIntelligenceErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "Get Document Models": {
-            "$ref": "./examples/GetDocumentModels.json"
           }
         },
         "x-ms-pageable": {
@@ -574,11 +529,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "Analyze Document from Url": {
-            "$ref": "./examples/AnalyzeDocument_Stream.json"
-          }
-        },
         "x-ms-long-running-operation": true
       }
     },
@@ -647,11 +597,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "Analyze Batch Documents": {
-            "$ref": "./examples/AnalyzeBatchDocuments.json"
-          }
-        },
         "x-ms-long-running-operation": true
       }
     },
@@ -695,14 +640,6 @@
               "$ref": "#/definitions/DocumentIntelligenceErrorResponse"
             }
           }
-        },
-        "x-ms-examples": {
-          "Get Custom Document Model": {
-            "$ref": "./examples/GetDocumentModel_Custom.json"
-          },
-          "Get Prebuilt Document Model": {
-            "$ref": "./examples/GetDocumentModel_Prebuilt.json"
-          }
         }
       },
       "delete": {
@@ -740,11 +677,6 @@
             "schema": {
               "$ref": "#/definitions/DocumentIntelligenceErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "Delete Document Model": {
-            "$ref": "./examples/DeleteDocumentModel.json"
           }
         }
       }
@@ -799,11 +731,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "Copy Document Model To": {
-            "$ref": "./examples/CopyDocumentModelTo.json"
-          }
-        },
         "x-ms-long-running-operation": true
       }
     },
@@ -837,11 +764,6 @@
             "schema": {
               "$ref": "#/definitions/DocumentIntelligenceErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "List Analyze Batch Documents Results": {
-            "$ref": "./examples/GetAnalyzeBatchDocumentsResults.json"
           }
         },
         "x-ms-pageable": {
@@ -888,11 +810,6 @@
               "$ref": "#/definitions/DocumentIntelligenceErrorResponse"
             }
           }
-        },
-        "x-ms-examples": {
-          "Get Analyze Batch Documents Result": {
-            "$ref": "./examples/GetAnalyzeBatchDocumentsResult.json"
-          }
         }
       },
       "delete": {
@@ -929,11 +846,6 @@
             "schema": {
               "$ref": "#/definitions/DocumentIntelligenceErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "Delete Analyze Batch Documents Result": {
-            "$ref": "./examples/DeleteAnalyzeBatchDocumentsResult.json"
           }
         }
       }
@@ -977,11 +889,6 @@
               "$ref": "#/definitions/DocumentIntelligenceErrorResponse"
             }
           }
-        },
-        "x-ms-examples": {
-          "Get Analyze Document Result": {
-            "$ref": "./examples/GetAnalyzeDocumentResult.json"
-          }
         }
       },
       "delete": {
@@ -1018,11 +925,6 @@
             "schema": {
               "$ref": "#/definitions/DocumentIntelligenceErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "Delete Analyze Result": {
-            "$ref": "./examples/DeleteAnalyzeDocumentResult.json"
           }
         }
       }
@@ -1077,11 +979,6 @@
               "$ref": "#/definitions/DocumentIntelligenceErrorResponse"
             }
           }
-        },
-        "x-ms-examples": {
-          "Get Analyze Document Result Figure": {
-            "$ref": "./examples/GetAnalyzeDocumentResultFigure.json"
-          }
         }
       }
     },
@@ -1127,11 +1024,6 @@
             "schema": {
               "$ref": "#/definitions/DocumentIntelligenceErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "Get Analyze Document Result PDF": {
-            "$ref": "./examples/GetAnalyzeDocumentResultFPdf.json"
           }
         }
       }
@@ -1213,11 +1105,6 @@
               "$ref": "#/definitions/DocumentIntelligenceErrorResponse"
             }
           }
-        },
-        "x-ms-examples": {
-          "Authorize Copy of Document Model": {
-            "$ref": "./examples/AuthorizeCopyDocumentModel.json"
-          }
         }
       }
     },
@@ -1260,11 +1147,6 @@
             "schema": {
               "$ref": "#/definitions/DocumentIntelligenceErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "Build Document Model": {
-            "$ref": "./examples/BuildDocumentModel.json"
           }
         },
         "x-ms-long-running-operation": true
@@ -1311,11 +1193,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "Compose Document Model": {
-            "$ref": "./examples/ComposeDocumentModel.json"
-          }
-        },
         "x-ms-long-running-operation": true
       }
     },
@@ -1340,11 +1217,6 @@
             "schema": {
               "$ref": "#/definitions/DocumentIntelligenceErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "Get Resource Details": {
-            "$ref": "./examples/GetResourceDetails.json"
           }
         }
       }
@@ -1380,11 +1252,6 @@
             "schema": {
               "$ref": "#/definitions/DocumentIntelligenceErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "Get Operations": {
-            "$ref": "./examples/GetOperations.json"
           }
         },
         "x-ms-pageable": {
@@ -1430,11 +1297,6 @@
             "schema": {
               "$ref": "#/definitions/DocumentIntelligenceErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "Get Operation - Document Model Build": {
-            "$ref": "./examples/GetOperation_DocumentModelBuild.json"
           }
         }
       }
@@ -1492,11 +1354,6 @@
             "schema": {
               "$ref": "#/definitions/DocumentIntelligenceErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "Classify Document from Url": {
-            "$ref": "./examples/ClassifyDocument_Url.json"
           }
         },
         "x-ms-long-running-operation": true
@@ -1567,14 +1424,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "Analyze Document from Base64": {
-            "$ref": "./examples/AnalyzeDocument_Base64.json"
-          },
-          "Analyze Document from Url": {
-            "$ref": "./examples/AnalyzeDocument_Url.json"
-          }
-        },
         "x-ms-long-running-operation": true
       }
     },
@@ -1616,11 +1465,6 @@
             "schema": {
               "$ref": "#/definitions/DocumentIntelligenceErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "Get Operation - Document Model Compose": {
-            "$ref": "./examples/GetOperation_DocumentModelCompose.json"
           }
         }
       }
@@ -1664,11 +1508,6 @@
               "$ref": "#/definitions/DocumentIntelligenceErrorResponse"
             }
           }
-        },
-        "x-ms-examples": {
-          "Get Operation - Document Model Copy To": {
-            "$ref": "./examples/GetOperation_DocumentModelCopyTo.json"
-          }
         }
       }
     },
@@ -1710,11 +1549,6 @@
             "schema": {
               "$ref": "#/definitions/DocumentIntelligenceErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "Get Operation - Document Classifier Copy To": {
-            "$ref": "./examples/GetOperation_DocumentClassifierCopyTo.json"
           }
         }
       }
@@ -1758,11 +1592,6 @@
               "$ref": "#/definitions/DocumentIntelligenceErrorResponse"
             }
           }
-        },
-        "x-ms-examples": {
-          "Get Operation - Document Classifier Build": {
-            "$ref": "./examples/GetOperation_DocumentClassifierBuild.json"
-          }
         }
       }
     },
@@ -1804,11 +1633,6 @@
             "schema": {
               "$ref": "#/definitions/DocumentIntelligenceErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "Get Operation": {
-            "$ref": "./examples/GetOperation.json"
           }
         }
       }


### PR DESCRIPTION
**FOR TESTING PURPOSES ONLY - DO NOT MERGE**

This PR adds:
- New API version 2025-09-01 to DocumentIntelligence TypeSpec  
- New getAnalyzeResultPng operation with identical signature to getAnalyzeResultPdf
- Updated client interface to include the new PNG operation

This is for SDK generation testing and tutorial purposes. Please do not merge.