### PR TITLE
[KeyVault] Updating Go Configuration

### DIFF
--- a/specification/keyvault/Security.KeyVault.BackupRestore/client.tsp
+++ b/specification/keyvault/Security.KeyVault.BackupRestore/client.tsp
@@ -26,16 +26,25 @@ interface Client {
   preFullRestore is KeyVault.preFullRestoreOperation;
 }
 
-@@clientName(KeyVault.SASTokenParameter, "SASTokenParameters", "go");
-@@clientName(KeyVault.RestoreOperationParameters.sasTokenParameters,
+using KeyVault;
+
+@@clientName(SASTokenParameter, "SASTokenParameters", "go");
+@@clientName(RestoreOperationParameters.sasTokenParameters,
   "SASTokenParameters",
   "go"
 );
-@@clientName(KeyVault.SelectiveKeyRestoreOperationParameters.sasTokenParameters,
+@@clientName(SelectiveKeyRestoreOperationParameters.sasTokenParameters,
   "SASTokenParameters",
   "go"
 );
-@@clientName(KeyVault.PreRestoreOperationParameters.sasTokenParameters,
+@@clientName(PreRestoreOperationParameters.sasTokenParameters,
   "SASTokenParameters",
   "go"
 );
+
+@@alternateType(FullBackupOperation.status, string, "go");
+@@alternateType(RestoreOperation.status, string, "go");
+@@alternateType(SelectiveKeyRestoreOperation.status, string, "go");
+@@alternateType(FullBackupOperation.error, string, "go");
+@@alternateType(RestoreOperation.error, string, "go");
+@@alternateType(SelectiveKeyRestoreOperation.error, string, "go");

--- a/specification/keyvault/Security.KeyVault.BackupRestore/tspconfig.yaml
+++ b/specification/keyvault/Security.KeyVault.BackupRestore/tspconfig.yaml
@@ -28,6 +28,8 @@ options:
     containing-module: "github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azadmin"
     service-dir: "sdk/security/keyvault"
     emitter-output-dir: "{output-dir}/{service-dir}/azadmin/backup"
+    go-generate: build.go
+    api-version: "7.6"
     inject-spans: true
     single-client: true
     generate-fakes: true

--- a/specification/keyvault/Security.KeyVault.Certificates/client.tsp
+++ b/specification/keyvault/Security.KeyVault.Certificates/client.tsp
@@ -235,6 +235,9 @@ op listDeletedCertificateProperties is KeyVaultOperation<
 @@clientName(JsonWebKeyCurveName, "CurveName", "go");
 @@clientName(JsonWebKeyType, "KeyType", "go");
 
+@@alternateType(CertificateAttributes.recoveryLevel, string, "go");
+@@alternateType(CertificateOperation.error, string, "go");
+
 // Rust configuration
 @@clientName(setCertificateContacts, "SetContacts", "rust");
 

--- a/specification/keyvault/Security.KeyVault.Certificates/tspconfig.yaml
+++ b/specification/keyvault/Security.KeyVault.Certificates/tspconfig.yaml
@@ -53,6 +53,8 @@ options:
     module: "github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azcertificates"
     service-dir: "sdk/security/keyvault"
     emitter-output-dir: "{output-dir}/{service-dir}/azcertificates"
+    go-generate: build.go
+    api-version: "7.6"
     single-client: true
     inject-spans: true
     generate-fakes: true

--- a/specification/keyvault/Security.KeyVault.Keys/client.tsp
+++ b/specification/keyvault/Security.KeyVault.Keys/client.tsp
@@ -484,6 +484,9 @@ op listDeletedKeyProperties is KeyVaultOperation<{}, DeletedKeyListResult>;
 
 @@clientName(KeyAttestation.certificatePemFile, "CertificatePEMFile", "go");
 
+@@alternateType(JsonWebKey.keyOps, JsonWebKeyOperation[], "go");
+@@alternateType(KeyAttributes.recoveryLevel, string, "go");
+
 // JS configuration
 @@clientName(JsonWebKeyCurveName.P256_K, "P256K", "javascript");
 @@clientName(JsonWebKeySignatureAlgorithm.RSNULL, "Rsnull", "javascript");

--- a/specification/keyvault/Security.KeyVault.Keys/tspconfig.yaml
+++ b/specification/keyvault/Security.KeyVault.Keys/tspconfig.yaml
@@ -52,6 +52,8 @@ options:
     module: "github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys"
     service-dir: "sdk/security/keyvault"
     emitter-output-dir: "{output-dir}/{service-dir}/azkeys"
+    go-generate: build.go
+    api-version: "7.6"
     single-client: true
     inject-spans: true
     generate-fakes: true

--- a/specification/keyvault/Security.KeyVault.RBAC/client.tsp
+++ b/specification/keyvault/Security.KeyVault.RBAC/client.tsp
@@ -1,5 +1,4 @@
 import "./main.tsp";
-import "@azure-tools/typespec-client-generator-core";
 
 using Azure.ClientGenerator.Core;
 

--- a/specification/keyvault/Security.KeyVault.RBAC/routes.tsp
+++ b/specification/keyvault/Security.KeyVault.RBAC/routes.tsp
@@ -1,8 +1,10 @@
 import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-client-generator-core";
 import "@typespec/rest";
 import "./models.tsp";
 
 using TypeSpec.Http;
+using Azure.ClientGenerator.Core;
 
 namespace KeyVault;
 
@@ -18,6 +20,7 @@ interface RoleDefinitions {
       /**
        * The scope of the role definition to delete. Managed HSM only supports '/'.
        */
+      @alternateType(RoleScope, "go")
       scope: string;
 
       /**
@@ -39,6 +42,7 @@ interface RoleDefinitions {
       /**
        * The scope of the role definition to create or update. Managed HSM only supports '/'.
        */
+      @alternateType(RoleScope, "go")
       scope: string;
 
       /**
@@ -66,6 +70,7 @@ interface RoleDefinitions {
       /**
        * The scope of the role definition to get. Managed HSM only supports '/'.
        */
+      @alternateType(RoleScope, "go")
       scope: string;
 
       /**
@@ -88,6 +93,7 @@ interface RoleDefinitions {
       /**
        * The scope of the role definition.
        */
+      @alternateType(RoleScope, "go")
       scope: string;
 
       /**
@@ -112,6 +118,7 @@ interface RoleAssignments {
       /**
        * The scope of the role assignment to delete.
        */
+      @alternateType(RoleScope, "go")
       scope: string;
 
       /**
@@ -133,6 +140,7 @@ interface RoleAssignments {
       /**
        * The scope of the role assignment to create.
        */
+      @alternateType(RoleScope, "go")
       scope: string;
 
       /**
@@ -160,6 +168,7 @@ interface RoleAssignments {
       /**
        * The scope of the role assignment.
        */
+      @alternateType(RoleScope, "go")
       scope: string;
 
       /**
@@ -182,6 +191,7 @@ interface RoleAssignments {
       /**
        * The scope of the role assignments.
        */
+      @alternateType(RoleScope, "go")
       scope: string;
 
       /**

--- a/specification/keyvault/Security.KeyVault.RBAC/tspconfig.yaml
+++ b/specification/keyvault/Security.KeyVault.RBAC/tspconfig.yaml
@@ -28,6 +28,8 @@ options:
     containing-module: "github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azadmin"
     service-dir: "sdk/security/keyvault"
     emitter-output-dir: "{output-dir}/{service-dir}/azadmin/rbac"
+    go-generate: build.go
+    api-version: "7.6"
     inject-spans: true
     single-client: true
     generate-fakes: true

--- a/specification/keyvault/Security.KeyVault.Secrets/client.tsp
+++ b/specification/keyvault/Security.KeyVault.Secrets/client.tsp
@@ -134,7 +134,7 @@ op listSecretPropertiesVersions is KeyVaultOperation<
 @@clientName(getDeletedSecrets, "ListDeletedSecretProperties", "go");
 @@clientName(getSecrets, "ListSecretProperties", "go");
 @@clientName(getSecretVersions, "ListSecretPropertiesVersions", "go");
-@@clientName(updateSecret, "UpdateSecretProperties", "go");
+@@clientName(KeyVault.updateSecret, "UpdateSecretProperties", "go");
 
 // renaming SecretItem to SecretProperties.
 // renaming existing SecretProperties to something else
@@ -155,6 +155,7 @@ op listSecretPropertiesVersions is KeyVaultOperation<
 @@clientName(SecretListResult, "SecretPropertiesListResult", "go");
 @@clientName(SecretRestoreParameters.secretBundleBackup, "SecretBackup", "go");
 @@clientName(SecretBundle.kid, "KID", "go");
+@@alternateType(SecretAttributes.recoveryLevel, string, "go");
 
 // Rust configuration
 @@clientName(SecretProperties, "OmitSecretProperties", "rust");

--- a/specification/keyvault/Security.KeyVault.Secrets/tspconfig.yaml
+++ b/specification/keyvault/Security.KeyVault.Secrets/tspconfig.yaml
@@ -51,6 +51,8 @@ options:
     module: "github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
     service-dir: "sdk/security/keyvault"
     emitter-output-dir: "{output-dir}/{service-dir}/azsecrets"
+    go-generate: build.go
+    api-version: "7.6"
     single-client: true
     inject-spans: true
     generate-fakes: true

--- a/specification/keyvault/Security.KeyVault.Settings/tspconfig.yaml
+++ b/specification/keyvault/Security.KeyVault.Settings/tspconfig.yaml
@@ -28,6 +28,7 @@ options:
     containing-module: "github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azadmin"
     service-dir: "sdk/security/keyvault"
     emitter-output-dir: "{output-dir}/{service-dir}/azadmin/settings"
+    api-version: "7.6"
     inject-spans: true
     single-client: true
     generate-fakes: true


### PR DESCRIPTION
Updating Go configuration.

Adding the `go-generate` option to the tspconfig.yaml which allows go's post generation processing to run automatically when a user generates with tsp-client