### PR TITLE
Add a new step to mark SDK generation status as failed in release plan

### DIFF
--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -340,7 +340,7 @@ stages:
                 $prStatus = "Failed to generate SDK."
                 Write-Host "##vso[task.setvariable variable=SdkPrStatus]$prStatus"
               }
-            condition: not(endsWith(variables['SdkRepoName'], '-pr')))
+            condition: not(endsWith(variables['SdkRepoName'], '-pr'))
             displayName: "Set pull request URL variables"
 
           - task: AzureCLI@2

--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -322,17 +322,10 @@ stages:
               -PRBody "$(GeneratedSDKInformation)  $(ReleasePlanInfo)"
               -OpenAsDraft $true
 
-        - pwsh: |
-            Write-Host "Release Info: $(ReleasePlanInfo)"
-            $prStatus = 'Failed to generate SDK.'
-            Write-Host "##vso[task.setvariable variable=SdkPrStatus]$prStatus"
-          displayName: 'Set PR generation status'
-          condition: Failed()
-
         - ${{ if ne(parameters.ReleasePlanWorkItemId, 0) }}:
           - task: AzureCLI@2
             displayName: Link pull request to release plan
-            condition: and(succeededOrFailed(), eq(variables['HasChanges'], 'true'), not(endsWith(variables['SdkRepoName'], '-pr')))
+            condition: and(succeeded(), eq(variables['HasChanges'], 'true'), not(endsWith(variables['SdkRepoName'], '-pr')))
             continueOnError: true
             inputs:
               azureSubscription: opensource-api-connection
@@ -342,7 +335,22 @@ stages:
               arguments: >
                 -ReleasePlanWorkItemId ${{ parameters.ReleasePlanWorkItemId }}
                 -PullRequestUrl "https://github.com/Azure/$(SdkRepoName)/pull/$(Submitted.PullRequest.Number)"
-                -Status "$(SdkPrStatus)"
+                -Status "draft"
+                -SdkRepoName "$(SdkRepoName)"
+
+          - task: AzureCLI@2
+            displayName: Update SDK generation status as failed
+            condition: and(Failed(), not(endsWith(variables['SdkRepoName'], '-pr')))
+            continueOnError: true
+            inputs:
+              azureSubscription: opensource-api-connection
+              scriptType: pscore
+              scriptLocation: scriptPath
+              scriptPath: $(SpecRepoDirectory)/eng/scripts/Update-PullRequest-In-ReleasePlan.ps1
+              arguments: >
+                -ReleasePlanWorkItemId ${{ parameters.ReleasePlanWorkItemId }}
+                -PullRequestUrl ""
+                -Status "Failed to generate SDK."
                 -SdkRepoName "$(SdkRepoName)"
 
       - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:

--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -120,6 +120,8 @@ stages:
           Write-Host "##vso[task.setvariable variable=SdkPrStatus]$prStatus"
           $releasePlanInfo = ''
           Write-Host "##vso[task.setvariable variable=ReleasePlanInfo]$releasePlanInfo"
+          $prUrl = ""
+          Write-Host "##vso[task.setvariable variable=PullRequestUrl]$prUrl"
         displayName: "Create Run Time Variables"
 
       - ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
@@ -325,23 +327,21 @@ stages:
 
         - ${{ if ne(parameters.ReleasePlanWorkItemId, 0) }}:
           - pwsh: |
-              if ('$(Submitted.PullRequest.Number)' -ne '') 
-              {
-                $prUrl = "https://github.com/Azure/$(SdkRepoName)/pull/$(Submitted.PullRequest.Number)"
-                Write-Host "Pull request created: $prUrl"
-                Write-Host "##vso[task.setvariable variable=PullRequestUrl]$prUrl"
-                $prStatus = "draft"
-                Write-Host "##vso[task.setvariable variable=SdkPrStatus]$prStatus"
-              }
-              else
-              {
-                $prUrl = ""
-                Write-Host "##vso[task.setvariable variable=PullRequestUrl]$prUrl"
-                $prStatus = "Failed to generate SDK."
-                Write-Host "##vso[task.setvariable variable=SdkPrStatus]$prStatus"
-              }
-            condition: not(endsWith(variables['SdkRepoName'], '-pr'))
-            displayName: "Set pull request URL variables"
+              $prUrl = "https://github.com/Azure/$(SdkRepoName)/pull/$(Submitted.PullRequest.Number)"
+              Write-Host "Pull request created: $prUrl"
+              Write-Host "##vso[task.setvariable variable=PullRequestUrl]$prUrl"
+              $prStatus = "draft"
+              Write-Host "##vso[task.setvariable variable=SdkPrStatus]$prStatus"
+            condition: and(succeeded(), eq(variables['HasChanges'], 'true'), ne(variables['Build.Reason'], 'PullRequest'), not(endsWith(variables['SdkRepoName'], '-pr')))
+            displayName: "Set pull request URL variable"
+
+          - pwsh: |
+              $prUrl = ""
+              Write-Host "##vso[task.setvariable variable=PullRequestUrl]$prUrl"
+              $prStatus = "Failed to generate SDK."
+              Write-Host "##vso[task.setvariable variable=SdkPrStatus]$prStatus"
+            condition: failed()
+            displayName: "Set pull request generation failed status variable"
 
           - task: AzureCLI@2
             displayName: Link pull request to release plan

--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -321,26 +321,31 @@ stages:
               -PRTitle "$(PrTitle)-generated-from-$(Build.DefinitionName)-$(Build.BuildId)"
               -PRBody "$(GeneratedSDKInformation)  $(ReleasePlanInfo)"
               -OpenAsDraft $true
+        
 
         - ${{ if ne(parameters.ReleasePlanWorkItemId, 0) }}:
-          - task: AzureCLI@2
-            displayName: Link pull request to release plan
-            condition: and(succeeded(), eq(variables['HasChanges'], 'true'), not(endsWith(variables['SdkRepoName'], '-pr')))
-            continueOnError: true
-            inputs:
-              azureSubscription: opensource-api-connection
-              scriptType: pscore
-              scriptLocation: scriptPath
-              scriptPath: $(SpecRepoDirectory)/eng/scripts/Update-PullRequest-In-ReleasePlan.ps1
-              arguments: >
-                -ReleasePlanWorkItemId ${{ parameters.ReleasePlanWorkItemId }}
-                -PullRequestUrl "https://github.com/Azure/$(SdkRepoName)/pull/$(Submitted.PullRequest.Number)"
-                -Status "draft"
-                -SdkRepoName "$(SdkRepoName)"
+          - pwsh: |
+              if ('$(Submitted.PullRequest.Number)' -ne '') 
+              {
+                $prUrl = "https://github.com/Azure/$(SdkRepoName)/pull/$(Submitted.PullRequest.Number)"
+                Write-Host "Pull request created: $prUrl"
+                Write-Host "##vso[task.setvariable variable=PullRequestUrl]$prUrl"
+                $prStatus = "draft"
+                Write-Host "##vso[task.setvariable variable=SdkPrStatus]$prStatus"
+              }
+              else
+              {
+                $prUrl = ""
+                Write-Host "##vso[task.setvariable variable=PullRequestUrl]$prUrl"
+                $prStatus = "Failed to generate SDK."
+                Write-Host "##vso[task.setvariable variable=SdkPrStatus]$prStatus"
+              }
+            condition: not(endsWith(variables['SdkRepoName'], '-pr')))
+            displayName: "Set pull request URL variables"
 
           - task: AzureCLI@2
-            displayName: Update SDK generation status as failed
-            condition: and(Failed(), not(endsWith(variables['SdkRepoName'], '-pr')))
+            displayName: Link pull request to release plan
+            condition: not(endsWith(variables['SdkRepoName'], '-pr'))
             continueOnError: true
             inputs:
               azureSubscription: opensource-api-connection
@@ -349,8 +354,8 @@ stages:
               scriptPath: $(SpecRepoDirectory)/eng/scripts/Update-PullRequest-In-ReleasePlan.ps1
               arguments: >
                 -ReleasePlanWorkItemId ${{ parameters.ReleasePlanWorkItemId }}
-                -PullRequestUrl ""
-                -Status "Failed to generate SDK."
+                -PullRequestUrl "$(PullRequestUrl)"
+                -Status "$(SdkPrStatus)"
                 -SdkRepoName "$(SdkRepoName)"
 
       - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:


### PR DESCRIPTION
Add a step to run when SDK generation fails which will mark generation status as failed in release plan.