### PR TITLE
Consolidate definition of `NetworkIsolationSettings`

### DIFF
--- a/specification/sql/resource-manager/Microsoft.Sql/preview/2024-11-01-preview/Servers.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/preview/2024-11-01-preview/Servers.json
@@ -753,6 +753,11 @@
           "description": "The resource id for the storage account used to store BACPAC file. If set, private endpoint connection will be created for the storage account. Must match storage account used for StorageUri parameter.",
           "type": "string",
           "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {}
+            ]
+          },
           "x-ms-mutability": [
             "create"
           ]
@@ -761,6 +766,11 @@
           "description": "The resource id for the SQL server which is the target of this request. If set, private endpoint connection will be created for the SQL server. Must match server which is target of the operation.",
           "type": "string",
           "format": "arm-id",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {}
+            ]
+          },
           "x-ms-mutability": [
             "create"
           ]


### PR DESCRIPTION
Prevent duplicate schema issue in m4 for the two definitions: [#1](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/sql/resource-manager/Microsoft.Sql/preview/2023-02-01-preview/Databases.json#L2109), [#2](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/sql/resource-manager/Microsoft.Sql/preview/2024-11-01-preview/Servers.json#L748)