### PR TITLE
Fix the definition of `CustomCredential` to match actual service response

### DIFF
--- a/specification/ai/Azure.AI.Projects/client.tsp
+++ b/specification/ai/Azure.AI.Projects/client.tsp
@@ -29,13 +29,6 @@ using Azure.ClientGenerator.Core;
 // More accurate naming
 @@clientName(Azure.AI.Projects.AssetCredentialResponse, "DatasetCredential");
 
-// In Python, the emitter changes "keys" to "keys_property", since there is already
-// a "keys" method in the generated code due to usage of MutableMapping. Call it credential_keys instead.
-@@clientName(Azure.AI.Projects.CustomCredential.keys,
-  "credential_keys",
-  "python"
-);
-
 // Less generic names for C# SDK (avoid one-word class names)
 @@clientName(Azure.AI.Projects.Connection, "ConnectionProperties", "csharp");
 @@clientName(Azure.AI.Projects.Deployment, "AssetDeployment", "csharp");

--- a/specification/ai/Azure.AI.Projects/connections/models.tsp
+++ b/specification/ai/Azure.AI.Projects/connections/models.tsp
@@ -78,9 +78,8 @@ model CustomCredential extends BaseCredentials {
   @visibility(Lifecycle.Read)
   type: CredentialType.custom;
 
-  @doc("The credential type")
-  @visibility(Lifecycle.Read)
-  keys: Record<string>;
+  // Secret custom keys
+  ...Record<string>;
 }
 
 #suppress "@azure-tools/typespec-azure-core/casing-style"

--- a/specification/ai/data-plane/Azure.AI.Projects/preview/2025-05-15-preview/azure-ai-projects.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/preview/2025-05-15-preview/azure-ai-projects.json
@@ -2242,19 +2242,9 @@
     "CustomCredential": {
       "type": "object",
       "description": "Custom credential definition",
-      "properties": {
-        "keys": {
-          "type": "object",
-          "description": "The credential type",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "readOnly": true
-        }
+      "additionalProperties": {
+        "type": "string"
       },
-      "required": [
-        "keys"
-      ],
       "allOf": [
         {
           "$ref": "#/definitions/BaseCredentials"

--- a/specification/ai/data-plane/Azure.AI.Projects/stable/2025-05-01/azure-ai-projects.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/stable/2025-05-01/azure-ai-projects.json
@@ -1443,19 +1443,9 @@
     "CustomCredential": {
       "type": "object",
       "description": "Custom credential definition",
-      "properties": {
-        "keys": {
-          "type": "object",
-          "description": "The credential type",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "readOnly": true
-        }
+      "additionalProperties": {
+        "type": "string"
       },
-      "required": [
-        "keys"
-      ],
       "allOf": [
         {
           "$ref": "#/definitions/BaseCredentials"

--- a/specification/ai/data-plane/Azure.AI.Projects/stable/v1/azure-ai-projects.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/stable/v1/azure-ai-projects.json
@@ -1443,19 +1443,9 @@
     "CustomCredential": {
       "type": "object",
       "description": "Custom credential definition",
-      "properties": {
-        "keys": {
-          "type": "object",
-          "description": "The credential type",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "readOnly": true
-        }
+      "additionalProperties": {
+        "type": "string"
       },
-      "required": [
-        "keys"
-      ],
       "allOf": [
         {
           "$ref": "#/definitions/BaseCredentials"


### PR DESCRIPTION
This PR does not introduce a breaking change in REST APIs. I fixes the TypeSpec to match the current behavior of the REST APIs, so ref-docs are accurate.

Details:

In my Foundry project I created a  connection of type "Custom Keys", and provide a couple of public keys and a couple of secret keys, as shown here:

<img width="1884" height="1087" alt="image" src="https://github.com/user-attachments/assets/861b9fbe-9f0d-4d14-9e14-2cff830dfa73" />


When I do a GET REST API to the /connections route to get the connection properties of this Foundry connection, this is the JSON response (as an example):

```
                      {
                            "name": "test_custom_connection",
                            "id": "/subscriptions/.../connections/test_custom_connection",
                            "type": "CustomKeys",
                            "target": "_",
                            "isDefault": true,
                            "credentials": {
                                "nameofprivatekey1": "PrivateKey1",
                                "nameofprivatekey2": "PrivateKey2",
                                "type": "CustomKeys"
                            },
                            "metadata": {
                                "NameOfPublicKey1": "PublicKey1",
                                "NameOfPublicKey2": "PublicKey2"
                            }
                        }
```

As you see the private (secret) keys are exposed directly in the "credentials" JSON element. Not under a new element "credentials.keys" as the TypeSpec says. A better design would have been to expose all secret keys under "credentials.keys" however since the REST API are already GA, we can't change that. So this PR updates the TypeSpec to match the service
behavior.

See also companion Python SDK PR: https://github.com/Azure/azure-sdk-for-python/pull/42937