### PR TITLE
Application Gateway L4 Client IP Preservation Support

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2025-01-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2025-01-01/applicationGateway.json
@@ -1176,6 +1176,10 @@
           "type": "boolean",
           "description": "Whether the host header should be picked from the backend http settings. Default value is false."
         },
+        "enableProbeProxyProtocolHeader": {
+          "type": "boolean",
+          "description": "Whether to send Proxy Protocol header along with the Health Probe over TCP or TLS protocol. Default value is false."
+        },
         "match": {
           "$ref": "#/definitions/ApplicationGatewayProbeHealthResponseMatch",
           "description": "Criterion for classifying a healthy probe response."
@@ -1970,6 +1974,10 @@
           "type": "boolean",
           "description": "Whether to pick server name indication from the host name of the backend server for Tls protocol. Default value is false."
         },
+        "enableL4ClientIpPreservation": {
+          "type": "boolean",
+          "description": "Whether to send Proxy Protocol header to backend servers over TCP or TLS protocols. Default value is false."
+        },
         "provisioningState": {
           "readOnly": true,
           "$ref": "./network.json#/definitions/ProvisioningState",
@@ -2330,6 +2338,10 @@
         "match": {
           "$ref": "#/definitions/ApplicationGatewayProbeHealthResponseMatch",
           "description": "Criterion for classifying a healthy probe response."
+        },
+        "enableProbeProxyProtocolHeader": {
+          "type": "boolean",
+          "description": "Whether to send Proxy Protocol header along with the Health Probe over TCP or TLS protocol. Default value is false."
         },
         "provisioningState": {
           "readOnly": true,


### PR DESCRIPTION
## Purpose of this PR

Added Client IP Preservation options in template for application Gateway.
Following are the 2 properties that will be added in Backend Settings, Probe and OnDemandHealthProbe for Application Gateway Resource.

enableL4ClientIpPreservation
enableProbeProxyProtocolHeader

Changes will be tied to NRP 187 API version, the changes have been rolled out already

**Previous PR where the Properties were already approved in Private branch: -
https://github.com/Azure/azure-rest-api-specs-pr/pull/20948**

