### PR TITLE
Update rust specs to be compatible with tsp-client generation

### DIFF
--- a/specification/keyvault/Security.KeyVault.Certificates/tspconfig.yaml
+++ b/specification/keyvault/Security.KeyVault.Certificates/tspconfig.yaml
@@ -61,7 +61,7 @@ options:
     api-version: "7.6"
     crate-name: "azure_security_keyvault_certificates"
     crate-version: "0.0.1"
-    emitter-output-dir: "{project-root}/generated"
+    emitter-output-dir: "{output-dir}/{service-dir}/generated"
   "@azure-tools/typespec-client-generator-cli":
     additionalDirectories:
       - "specification/keyvault/Security.KeyVault.Common/"

--- a/specification/keyvault/Security.KeyVault.Certificates/tspconfig.yaml
+++ b/specification/keyvault/Security.KeyVault.Certificates/tspconfig.yaml
@@ -61,7 +61,7 @@ options:
     api-version: "7.6"
     crate-name: "azure_security_keyvault_certificates"
     crate-version: "0.0.1"
-    emitter-output-dir: "{output-dir}/{service-dir}/generated"
+    emitter-output-dir: "{output-dir}/{service-dir}/{crate-name}"
   "@azure-tools/typespec-client-generator-cli":
     additionalDirectories:
       - "specification/keyvault/Security.KeyVault.Common/"

--- a/specification/keyvault/Security.KeyVault.Keys/tspconfig.yaml
+++ b/specification/keyvault/Security.KeyVault.Keys/tspconfig.yaml
@@ -61,7 +61,7 @@ options:
     api-version: "7.6"
     crate-name: "azure_security_keyvault_keys"
     crate-version: "0.0.1"
-    emitter-output-dir: "{output-dir}/{service-dir}/generated"
+    emitter-output-dir: "{output-dir}/{service-dir}/{crate-name}"
   "@azure-tools/typespec-client-generator-cli":
     additionalDirectories:
       - "specification/keyvault/Security.KeyVault.Common/"

--- a/specification/keyvault/Security.KeyVault.Keys/tspconfig.yaml
+++ b/specification/keyvault/Security.KeyVault.Keys/tspconfig.yaml
@@ -61,7 +61,7 @@ options:
     api-version: "7.6"
     crate-name: "azure_security_keyvault_keys"
     crate-version: "0.0.1"
-    emitter-output-dir: "{project-root}/generated"
+    emitter-output-dir: "{output-dir}/{service-dir}/generated"
   "@azure-tools/typespec-client-generator-cli":
     additionalDirectories:
       - "specification/keyvault/Security.KeyVault.Common/"

--- a/specification/keyvault/Security.KeyVault.Secrets/tspconfig.yaml
+++ b/specification/keyvault/Security.KeyVault.Secrets/tspconfig.yaml
@@ -59,7 +59,7 @@ options:
     api-version: "7.6"
     crate-name: "azure_security_keyvault_secrets"
     crate-version: "0.0.1"
-    emitter-output-dir: "{project-root}/generated"
+    emitter-output-dir: "{output-dir}/{service-dir}/generated"
   "@azure-tools/typespec-client-generator-cli":
     additionalDirectories:
       - "specification/keyvault/Security.KeyVault.Common/"

--- a/specification/keyvault/Security.KeyVault.Secrets/tspconfig.yaml
+++ b/specification/keyvault/Security.KeyVault.Secrets/tspconfig.yaml
@@ -59,7 +59,7 @@ options:
     api-version: "7.6"
     crate-name: "azure_security_keyvault_secrets"
     crate-version: "0.0.1"
-    emitter-output-dir: "{output-dir}/{service-dir}/generated"
+    emitter-output-dir: "{output-dir}/{service-dir}/{crate-name}"
   "@azure-tools/typespec-client-generator-cli":
     additionalDirectories:
       - "specification/keyvault/Security.KeyVault.Common/"

--- a/specification/storage/Microsoft.BlobStorage/tspconfig.yaml
+++ b/specification/storage/Microsoft.BlobStorage/tspconfig.yaml
@@ -35,7 +35,7 @@ options:
     namespace: com.azure.storage.blob
     flavor: azure
   "@azure-tools/typespec-rust":
-    emitter-output-dir: "{output-dir}/{service-dir}/azure_storage_blob"
+    emitter-output-dir: "{output-dir}/{service-dir}/{crate-name}"
     crate-name: "azure_storage_blob"
     crate-version: "0.1.0"
     flavor: azure

--- a/specification/storage/Microsoft.BlobStorage/tspconfig.yaml
+++ b/specification/storage/Microsoft.BlobStorage/tspconfig.yaml
@@ -35,7 +35,7 @@ options:
     namespace: com.azure.storage.blob
     flavor: azure
   "@azure-tools/typespec-rust":
-    package-dir: "azure_storage_blob"
+    emitter-output-dir: "{output-dir}/{service-dir}/azure_storage_blob"
     crate-name: "azure_storage_blob"
     crate-version: "0.1.0"
     flavor: azure


### PR DESCRIPTION
Update emitter-output-dir entries to the appropriate format to work with the latest tsp-client 0.28.1 updates.