### PR TITLE
Make MeshMembership PUT and DELETE long running operations

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2025-08-02-preview/examples/MeshMemberships_Delete.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2025-08-02-preview/examples/MeshMemberships_Delete.json
@@ -7,7 +7,11 @@
     "meshMembershipName": "meshmembership1"
   },
   "responses": {
-    "200": {},
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.ContainerService/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2025-08-02-preview"
+      }
+    },
     "204": {}
   }
 }

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2025-08-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2025-08-02-preview/managedClusters.json
@@ -12813,6 +12813,11 @@
       "type": "object",
       "description": "Mesh membership properties of a managed cluster.",
       "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/MeshMembershipProvisioningState",
+          "readOnly": true,
+          "description": "The current provisioning state of the Mesh Membership."
+        },
         "managedMeshID": {
           "type": "string",
           "format": "arm-id",
@@ -12829,6 +12834,55 @@
       "required": [
         "managedMeshID"
       ]
+    },
+    "MeshMembershipProvisioningState": {
+      "type": "string",
+      "description": "The provisioning state of the last accepted operation.",
+      "enum": [
+        "Canceled",
+        "Creating",
+        "Deleting",
+        "Failed",
+        "Succeeded",
+        "Updating"
+      ],
+      "x-ms-enum": {
+        "name": "MeshMembershipProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Resource creation was canceled."
+          },
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "The Mesh Membership is being created."
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "The Mesh Membership is being deleted."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Resource creation failed."
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Resource has been created."
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "The Mesh Membership is being updated."
+          }
+        ]
+      },
+      "readOnly": true
     },
     "MeshMembershipsListResult": {
       "type": "object",

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2025-08-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2025-08-02-preview/managedClusters.json
@@ -5161,6 +5161,7 @@
             }
           }
         },
+        "x-ms-long-running-operation": true,
         "x-ms-examples": {
           "Create or update Mesh Membership": {
             "$ref": "./examples/MeshMemberships_CreateOrUpdate.json"
@@ -5191,8 +5192,14 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "OK"
+          "202": {
+            "description": "Accepted",
+            "headers": {
+              "Location": {
+                "description": "URL to query for status of the operation.",
+                "type": "string"
+              }
+            }
           },
           "204": {
             "description": "NoContent"
@@ -5204,6 +5211,7 @@
             }
           }
         },
+        "x-ms-long-running-operation": true,
         "x-ms-examples": {
           "Delete Mesh Membership": {
             "$ref": "./examples/MeshMemberships_Delete.json"


### PR DESCRIPTION
Although today MeshMembership PUT and DELETE do not have async operations, in the future they will. Therefore, we still make MeshMembership PUT and DELETE long running operations.

[API design doc](https://msazure.visualstudio.com/CloudNativeCompute/_wiki/wikis/CloudNativeCompute.wiki/792627/MeshMembership-Subresource)