### PR TITLE
[Monitor Query Logs] .NET client updates

### DIFF
--- a/specification/monitor/Monitor.Query.Logs/client.tsp
+++ b/specification/monitor/Monitor.Query.Logs/client.tsp
@@ -117,6 +117,6 @@ interface LogsQueryClient {
 
 @@access(QueryBody, Access.internal, "csharp");
 @@access(BatchQueryRequest, Access.internal, "csharp");
-@@access(LogsQueryClient.QueryBatch, Access.internal, "csharp");
-@@access(LogsQueryClient.QueryWorkspace, Access.internal, "csharp");
-@@access(LogsQueryClient.QueryResource, Access.internal, "csharp");
+@@access(LogsQueryClient.queryBatch, Access.internal, "csharp");
+@@access(LogsQueryClient.queryWorkspace, Access.internal, "csharp");
+@@access(LogsQueryClient.queryResource, Access.internal, "csharp");

--- a/specification/monitor/Monitor.Query.Logs/client.tsp
+++ b/specification/monitor/Monitor.Query.Logs/client.tsp
@@ -100,13 +100,13 @@ interface Client {
 )
 interface LogsQueryClient {
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Doesn't fit standard ops"
-  QueryWorkspace is MonitorQueryLogs.Query.execute;
+  queryWorkspace is MonitorQueryLogs.Query.execute;
 
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Doesn't fit standard ops"
-  QueryResource is MonitorQueryLogs.Query.executeWithResourceId;
+  queryResource is MonitorQueryLogs.Query.executeWithResourceId;
 
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Doesn't fit standard ops"
-  QueryBatch is MonitorQueryLogs.Query.batch;
+  queryBatch is MonitorQueryLogs.Query.batch;
 }
 
 @@clientName(Column, "LogsTableColumn", "csharp");

--- a/specification/monitor/Monitor.Query.Logs/client.tsp
+++ b/specification/monitor/Monitor.Query.Logs/client.tsp
@@ -89,3 +89,34 @@ interface Client {
   Access.internal,
   "python"
 );
+
+// .NET configuration
+@client(
+  {
+    name: "LogsQueryClient",
+    service: MonitorQueryLogs,
+  },
+  "csharp"
+)
+interface LogsQueryClient {
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Doesn't fit standard ops"
+  QueryWorkspace is MonitorQueryLogs.Query.execute;
+
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Doesn't fit standard ops"
+  QueryResource is MonitorQueryLogs.Query.executeWithResourceId;
+
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Doesn't fit standard ops"
+  QueryBatch is MonitorQueryLogs.Query.batch;
+}
+
+@@clientName(Column, "LogsTableColumn", "csharp");
+@@clientName(ColumnDataType, "LogsColumnType", "csharp");
+@@clientName(Table, "LogsTable", "csharp");
+@@clientName(QueryResults, "LogsQueryResult", "csharp");
+@@clientName(BatchQueryResults, "LogsBatchQueryResult", "csharp");
+
+@@access(QueryBody, Access.internal, "csharp");
+@@access(BatchQueryRequest, Access.internal, "csharp");
+@@access(LogsQueryClient.QueryBatch, Access.internal, "csharp");
+@@access(LogsQueryClient.QueryWorkspace, Access.internal, "csharp");
+@@access(LogsQueryClient.QueryResource, Access.internal, "csharp");

--- a/specification/monitor/Monitor.Query.Logs/tspconfig.yaml
+++ b/specification/monitor/Monitor.Query.Logs/tspconfig.yaml
@@ -23,12 +23,12 @@ options:
     package-version: 2.0.0
     flavor: azure
     namespace: azure.monitor.query
-  "@azure-tools/typespec-csharp":
-    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
-    namespace: "Azure.Monitor.Query.Logs"
-    clear-output-folder: true
-    model-namespace: false
-    flavor: azure
+  "@azure-typespec/http-client-csharp":
+    package-name: "Azure.Monitor.Query.Logs"
+    namespace: "{package-name}"
+    generate-convenience-methods: true
+    generate-protocol-methods: false
+    model-namespace: true
   "@azure-tools/typespec-ts":
     package-dir: "monitor-query-logs"
     is-modular-library: true

--- a/specification/monitor/Monitor.Query.Logs/tspconfig.yaml
+++ b/specification/monitor/Monitor.Query.Logs/tspconfig.yaml
@@ -25,6 +25,7 @@ options:
     namespace: azure.monitor.query
   "@azure-typespec/http-client-csharp":
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
+    clear-output-folder: true
     package-name: "Azure.Monitor.Query.Logs"
     namespace: "{package-name}"
     generate-convenience-methods: true

--- a/specification/monitor/Monitor.Query.Logs/tspconfig.yaml
+++ b/specification/monitor/Monitor.Query.Logs/tspconfig.yaml
@@ -24,6 +24,7 @@ options:
     flavor: azure
     namespace: azure.monitor.query
   "@azure-typespec/http-client-csharp":
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     package-name: "Azure.Monitor.Query.Logs"
     namespace: "{package-name}"
     generate-convenience-methods: true

--- a/specification/monitor/Monitor.Query.Logs/tspconfig.yaml
+++ b/specification/monitor/Monitor.Query.Logs/tspconfig.yaml
@@ -25,7 +25,6 @@ options:
     namespace: azure.monitor.query
   "@azure-typespec/http-client-csharp":
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
-    clear-output-folder: true
     package-name: "Azure.Monitor.Query.Logs"
     namespace: "{package-name}"
     generate-convenience-methods: true


### PR DESCRIPTION
The focus of these changes is to add the .NET-specific client configuration for the Monitor Query Logs service.