### PR TITLE
Remove basic-setup-py configuration from tspconfig

### DIFF
--- a/specification/keyvault/Security.KeyVault.Keys/tspconfig.yaml
+++ b/specification/keyvault/Security.KeyVault.Keys/tspconfig.yaml
@@ -19,7 +19,6 @@ options:
   # Uncomment this line and add "@azure-tools/typespec-python" to your package.json to generate Python code
   "@azure-tools/typespec-python":
     flavor: azure
-    "basic-setup-py": true
     "package-name": "azure-keyvault-keys"
     "package-pprint-name": "Key Vault Keys"
     "package-version": "4.10.0"


### PR DESCRIPTION
There is no `setup.py` in https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/keyvault/azure-keyvault-keys so configuration about `setup.py` shall be removed.