### PR TITLE
Fix text translation 3.0 folder path mismatch post folder restructure refactoring

### DIFF
--- a/specification/translation/data-plane/TextTranslation/readme.md
+++ b/specification/translation/data-plane/TextTranslation/readme.md
@@ -18,7 +18,7 @@ openapi-type: data-plane
 These settings apply only when `--tag=release_3_0` is specified on the command line.
 
 ``` yaml $(tag) == 'release_3_0'
-input-file: stable/v3.0/openapi.json
+input-file: stable/3.0/openapi.json
 ```
 
 ## Multi-API/Profile support for AutoRest v3 generators 
@@ -33,7 +33,7 @@ require: $(this-folder)/../../../../profiles/readme.md
 
 # all the input files across all versions
 input-file:
-  - $(this-folder)/stable/v3.0/openapi.json
+  - $(this-folder)/stable/3.0/openapi.json
 ```
 
 If there are files that should not be in the `all-api-versions` set, 


### PR DESCRIPTION
In previous translation folder restructure #36765 stable/v3.0 was renamed to stable/3.0, but references in readme were not updated accordingly, which is causing new changes fail on Breaking Change(Cross-Version) and Swagger LintDiff checks.

A separate PR addressing the mismatch of the version names used in translation folders.