### PR TITLE
Upgrade liftr-base to 0.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@azure-tools/typespec-azure-rulesets": "0.60.0",
         "@azure-tools/typespec-client-generator-cli": "0.28.3",
         "@azure-tools/typespec-client-generator-core": "0.60.2",
-        "@azure-tools/typespec-liftr-base": "0.8.0",
+        "@azure-tools/typespec-liftr-base": "0.10.0",
         "@azure/avocado": "0.10.2",
         "@azure/oad": "0.12.1",
         "@microsoft.azure/openapi-validator": "2.2.4",
@@ -1243,9 +1243,9 @@
       }
     },
     "node_modules/@azure-tools/typespec-liftr-base": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-liftr-base/-/typespec-liftr-base-0.8.0.tgz",
-      "integrity": "sha512-xftTTtVjDuxIzugQ9nL/abmttdDM3HAf5HhqKzs9DO0Kl0ZhXQlB2DYlT1hBs/N+IWerMF9k2eKs2RncngA03g==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-liftr-base/-/typespec-liftr-base-0.10.0.tgz",
+      "integrity": "sha512-FcF8IusZcS2vvm1J+CzaeZkv15FgcFOSR+YoFdIusnnm+mlcLudM92NupdxZnuobPYcfZzq+rRvylxzzgWky7A==",
       "dev": true
     },
     "node_modules/@azure-tools/typespec-migration-validation": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@azure-tools/typespec-azure-rulesets": "0.60.0",
     "@azure-tools/typespec-client-generator-cli": "0.28.3",
     "@azure-tools/typespec-client-generator-core": "0.60.2",
-    "@azure-tools/typespec-liftr-base": "0.8.0",
+    "@azure-tools/typespec-liftr-base": "0.10.0",
     "@autorest/openapi-to-typespec": "0.11.11",
     "@azure/avocado": "0.10.2",
     "@azure/oad": "0.12.1",


### PR DESCRIPTION
This contains the removal of `@useDependency` on azure specs