### PR TITLE
[CosmosDB] Vector Indexing - Addition of quantizationByteSize, shardedDiskANN, indexingSearchListSize to vector indexing policy

### DIFF
--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2025-11-01-preview/cosmos-db.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2025-11-01-preview/cosmos-db.json
@@ -10354,6 +10354,31 @@
             "name": "VectorIndexType",
             "modelAsString": true
           }
+        },
+        "quantizationByteSize": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The number of bytes used in product quantization of the vectors. A larger value may result in better recall for vector searches at the expense of latency. This is only applicable for the quantizedFlat and diskANN vector index types.",
+          "minimum": 4
+        },
+        "indexingSearchListSize": {
+          "type": "integer",
+          "format": "int64",
+          "description": "This is the size of the candidate list of approximate neighbors stored while building the DiskANN index as part of the optimization processes. Large values may improve recall at the expense of latency. This is only applicable for the diskANN vector index type.",
+          "default": 100,
+          "minimum": 25,
+          "maximum": 500
+        },
+        "vectorIndexShardKey": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "example": [
+            "/vectorShardKey1",
+            "/vectorShardKey2"
+          ],
+          "description": "Array of shard keys for the vector index. This is only applicable for the quantizedFlat and diskANN vector index types."
         }
       },
       "required": [

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2025-11-01-preview/examples/CosmosDBSqlContainerCreateUpdate.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2025-11-01-preview/examples/CosmosDBSqlContainerCreateUpdate.json
@@ -168,11 +168,21 @@
                 },
                 {
                   "path": "/vectorPath2",
-                  "type": "quantizedFlat"
+                  "type": "quantizedFlat",
+                  "quantizationByteSize": 100,
+                  "vectorIndexShardKey": [
+                    "/vectorShardKey1"
+                  ]
                 },
                 {
                   "path": "/vectorPath3",
-                  "type": "diskANN"
+                  "type": "diskANN",
+                  "quantizationByteSize": 100,
+                  "indexingSearchListSize": 25,
+                  "vectorIndexShardKey": [
+                    "/vectorShardKey1",
+                    "/vectorShardKey2"
+                  ]
                 }
               ]
             },

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2025-11-01-preview/examples/CosmosDBSqlContainerGet.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2025-11-01-preview/examples/CosmosDBSqlContainerGet.json
@@ -46,11 +46,21 @@
                 },
                 {
                   "path": "/vectorPath2",
-                  "type": "quantizedFlat"
+                  "type": "quantizedFlat",
+                  "quantizationByteSize": 100,
+                  "vectorIndexShardKey": [
+                    "/vectorShardKey1"
+                  ]
                 },
                 {
                   "path": "/vectorPath3",
-                  "type": "diskANN"
+                  "type": "diskANN",
+                  "quantizationByteSize": 100,
+                  "indexingSearchListSize": 25,
+                  "vectorIndexShardKey": [
+                    "/vectorShardKey1",
+                    "/vectorShardKey2"
+                  ]
                 }
               ]
             },

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2025-11-01-preview/examples/CosmosDBSqlContainerList.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2025-11-01-preview/examples/CosmosDBSqlContainerList.json
@@ -225,11 +225,21 @@
                     },
                     {
                       "path": "/vectorPath2",
-                      "type": "quantizedFlat"
+                      "type": "quantizedFlat",
+                      "quantizationByteSize": 100,
+                      "vectorIndexShardKey": [
+                        "/vectorShardKey1"
+                      ]
                     },
                     {
                       "path": "/vectorPath3",
-                      "type": "diskANN"
+                      "type": "diskANN",
+                      "quantizationByteSize": 100,
+                      "indexingSearchListSize": 25,
+                      "vectorIndexShardKey": [
+                        "/vectorShardKey1",
+                        "/vectorShardKey2"
+                      ]
                     }
                   ]
                 },


### PR DESCRIPTION
# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
