### PR TITLE
Add hostedSystemProfile support for AKS clusters

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2025-08-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2025-08-02-preview/managedClusters.json
@@ -8010,6 +8010,10 @@
           "$ref": "#/definitions/SchedulerProfile",
           "description": "Profile of the pod scheduler configuration."
         },
+        "hostedSystemProfile": {
+          "$ref": "#/definitions/ManagedClusterHostedSystemProfile",
+          "description": "Settings for hosted system addons. For more information, see https://aka.ms/aks/automatic/systemcomponents."
+        },
         "status": {
           "$ref": "#/definitions/ManagedClusterStatus",
           "description": "Contains read-only information about the Managed Cluster."
@@ -12091,6 +12095,16 @@
         }
       },
       "type": "object"
+    },
+    "ManagedClusterHostedSystemProfile": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether to enable hosted system addons for the cluster."
+        }
+      },
+      "description": "Settings for hosted system addons."
     },
     "AgentPoolDeleteMachinesParameter": {
       "type": "object",


### PR DESCRIPTION
This PR adds support for hosted system addons in AKS clusters by introducing a new hostedSystemProfile property.

## Changes
- Added `hostedSystemProfile` property to `ManagedClusterProperties`
- Added `ManagedClusterHostedSystemProfile` definition with `enabled` boolean field
- Added appropriate description and documentation link
- Follows existing AKS API patterns for consistency

## Description
This feature enables configuration of hosted system addons for AKS clusters as part of the 2025-08-02-preview API version. The hostedSystemProfile allows users to enable or disable hosted system components for improved cluster management.

## Testing
- Changes follow the established OpenAPI 2.0 schema structure
- Property names and types are consistent with existing AKS API patterns
- Documentation includes appropriate reference links