### PR TITLE
Add support for empty results in getChangedFiles

### DIFF
--- a/.github/shared/src/changed-files.js
+++ b/.github/shared/src/changed-files.js
@@ -33,7 +33,10 @@ export async function getChangedFiles(options = {}) {
   // filter based on status with a single call to `git diff`.
   const result = await simpleGit(cwd).diff(["--name-only", baseCommitish, headCommitish, ...paths]);
 
-  const files = result.trim().split("\n");
+  const files = result
+    .trim()
+    .split("\n")
+    .filter((s) => s.length > 0);
   logger?.info("Changed Files:");
   for (const file of files) {
     logger?.info(`  ${file}`);

--- a/.github/shared/src/changed-files.js
+++ b/.github/shared/src/changed-files.js
@@ -36,6 +36,7 @@ export async function getChangedFiles(options = {}) {
   const files = result
     .trim()
     .split("\n")
+    // ignore empty lines (e.g. when no files are changed)
     .filter((s) => s.length > 0);
   logger?.info("Changed Files:");
   for (const file of files) {

--- a/.github/shared/test/changed-files.test.js
+++ b/.github/shared/test/changed-files.test.js
@@ -57,6 +57,12 @@ describe("changedFiles", () => {
     ]);
   });
 
+  it("getChangedFiles returns empty array when no files are changed", async () => {
+    vi.mocked(simpleGit.simpleGit().diff).mockResolvedValue("");
+    await expect(getChangedFiles()).resolves.toEqual([]);
+    expect(simpleGit.simpleGit().diff).toHaveBeenCalledWith(["--name-only", "HEAD^", "HEAD"]);
+  });
+
   const files = [
     "cspell.json",
     "cspell.yaml",


### PR DESCRIPTION
Currently `getChangedFiles` returns an array with an empty string in it `[""]` when `git diff ...` returns an empty string (no changed files). 