### PR TITLE
typespec-next: update specs for XML

### DIFF
--- a/specification/orbital/Microsoft.PlanetaryComputer/tspconfig.yaml
+++ b/specification/orbital/Microsoft.PlanetaryComputer/tspconfig.yaml
@@ -13,6 +13,7 @@ options:
     azure-resource-provider-folder: "data-plane"
     emitter-output-dir: "{project-root}/.."
     output-file: "{azure-resource-provider-folder}/{service-name}/{version-status}/{version}/openapi.json"
+    xml-strategy: none
   "@azure-tools/typespec-python":
     emitter-output-dir: "{output-dir}/{service-dir}/azure-planetarycomputer"
     namespace: "azure.planetarycomputer"

--- a/specification/orbital/data-plane/Microsoft.PlanetaryComputer/preview/2025-04-30-preview/openapi.json
+++ b/specification/orbital/data-plane/Microsoft.PlanetaryComputer/preview/2025-04-30-preview/openapi.json
@@ -14,7 +14,8 @@
   ],
   "host": "contoso-catalog.gwhqfdeddydpareu.uksouth.geocatalog.spatio.azure.com",
   "produces": [
-    "application/json"
+    "application/json",
+    "application/xml"
   ],
   "consumes": [
     "application/json"
@@ -216,10 +217,6 @@
         ],
         "summary": "Wmts Tilematrixsetid As Path",
         "description": "OGC WMTS endpoint.",
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -413,6 +410,9 @@
         ],
         "summary": "Tilejson Tilematrixsetid As Path",
         "description": "Return the Tilejson Tilematrixsetid As a path",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -605,10 +605,6 @@
         ],
         "summary": "Wmts",
         "description": "OGC WMTS endpoint.",
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -878,6 +874,9 @@
         ],
         "summary": "Asset Statistics",
         "description": "Per Asset statistics",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -975,6 +974,9 @@
         ],
         "summary": "Available Assets",
         "description": "Return a list of supported assets.",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -1039,6 +1041,9 @@
         ],
         "summary": "Bounds",
         "description": "Return all Bounds",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -2035,6 +2040,9 @@
         ],
         "summary": "Info",
         "description": "Return dataset's basic info.",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -2104,6 +2112,9 @@
         ],
         "summary": "Info Geojson",
         "description": "Return Info Geojson",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -2173,6 +2184,9 @@
         ],
         "summary": "Point",
         "description": "Get Point value for a dataset.",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -2827,6 +2841,9 @@
         ],
         "summary": "Statistics",
         "description": "Merged assets statistics.",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -2922,6 +2939,9 @@
         ],
         "summary": "Geojson Statistics",
         "description": "Get Statistics from a geojson feature or featureCollection.",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -3036,6 +3056,9 @@
         ],
         "summary": "Tilejson",
         "description": "Return Tilejson",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -3685,6 +3708,9 @@
         ],
         "summary": "Get Classmap Legend",
         "description": "Generate values and color swatches mapping for a given classmap.\n\nArgs:\ntrim_start (int, optional): Number of items to trim\nfrom the start of the cmap\ntrim_end (int, optional): Number of items to trim from the end of the cmap",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -3847,6 +3873,9 @@
         ],
         "summary": "Get Interval Legend",
         "description": "Generate values and color swatches mapping for a given interval classmap.\n\nArgs:\ntrim_start (int, optional): Number of items to trim from\nthe start of the cmap\ntrim_end (int, optional): Number of items to trim from the end of the cmap",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -3923,10 +3952,6 @@
         ],
         "summary": "Wmts Tilematrixsetid As Path",
         "description": "OGC WMTS endpoint.",
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -4069,6 +4094,9 @@
         ],
         "summary": "Assets For Point",
         "description": "Return a list of assets for a given point.",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -4163,6 +4191,9 @@
         ],
         "summary": "Tilejson Tilematrixsetid As Path",
         "description": "Return TileJSON document for a searchId.",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -4366,10 +4397,6 @@
         ],
         "summary": "Wmts",
         "description": "OGC WMTS endpoint.",
-        "produces": [
-          "application/xml",
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -4585,6 +4612,9 @@
         ],
         "summary": "Info Search",
         "description": "Get Search query metadata.",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -4634,6 +4664,9 @@
         ],
         "summary": "Tilejson",
         "description": "Return TileJSON document for a searchId.",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -6826,6 +6859,9 @@
         ],
         "summary": "Assets For Tile Tilematrixsetid As Path",
         "description": "Return a list of assets which overlap a given tile",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -6914,6 +6950,9 @@
         ],
         "summary": "Assets For Tile",
         "description": "Return a list of assets which overlap a given tile",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7075,6 +7114,9 @@
         ],
         "summary": "Register Search",
         "description": "Register a Search query",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7123,6 +7165,9 @@
         ],
         "summary": "Matrix List",
         "description": "Return Matrix List",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7169,6 +7214,9 @@
         ],
         "summary": "Matrix Definition",
         "description": "Return Matrix Definition",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7218,6 +7266,9 @@
         ],
         "summary": "Get Auth Config",
         "description": "Get the app id and tenant id information to make a MSAL request for this\nGeoCatalog instance.",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7258,6 +7309,9 @@
         ],
         "summary": "Get Azmaps Client Id",
         "description": "Fetch the client id for the Azure Maps API service based on the current\non the current identity. This client id is used for the Explorer to\nauthenticate with the Azure Maps API service.",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7298,6 +7352,9 @@
         ],
         "summary": "Get Azmaps Token",
         "description": "Fetch a token for the Azure Maps API service based on the current\nservice identity. This token is used for the Explorer to authenticate\nwith the Azure Maps API service.",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7337,6 +7394,9 @@
           "Ingestion Management"
         ],
         "description": "Get ingestions of a catalog",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7383,6 +7443,9 @@
           "Ingestion Management"
         ],
         "description": "Create a new ingestion",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7441,6 +7504,9 @@
           "Ingestion Management"
         ],
         "description": "Get the definition of an ingestion",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7484,6 +7550,9 @@
           "Ingestion Management"
         ],
         "description": "Update an existing ingestion",
+        "produces": [
+          "application/json"
+        ],
         "consumes": [
           "application/merge-patch+json"
         ],
@@ -7539,6 +7608,9 @@
           "Ingestion Management"
         ],
         "description": "Delete an ingestion from a catalog. All runs of the ingestion will be deleted. Ingestion must not have any runs in progress or queued.",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7600,6 +7672,9 @@
           "Ingestion Management"
         ],
         "description": "Get the runs of an ingestion",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7649,6 +7724,9 @@
           "Ingestion Management"
         ],
         "description": "Create a new run of an ingestion",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7701,6 +7779,9 @@
           "Ingestion Management"
         ],
         "description": "Get a run of an ingestion",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7749,6 +7830,9 @@
           "Ingestion Sources"
         ],
         "description": "Get ingestion sources in a geo-catalog",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7792,6 +7876,9 @@
           "Ingestion Sources"
         ],
         "description": "Create a new ingestion source in a geo-catalog",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7847,6 +7934,9 @@
           "Ingestion Sources"
         ],
         "description": "Get an ingestion source in a geo-catalog",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/IngestionSources.IngestionSourceParameters"
@@ -7887,6 +7977,9 @@
           "Ingestion Sources"
         ],
         "description": "Update an existing ingestion source in a geo-catalog",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7962,6 +8055,9 @@
           "Ingestion Sources"
         ],
         "description": "Delete an ingestion source from a geo-catalog",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -8007,6 +8103,9 @@
           "Ingestion Sources"
         ],
         "description": "Get all managed identities with access to storage accounts configured for a geo-catalog",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -8046,6 +8145,9 @@
           "Ingestion Management"
         ],
         "description": "Get operations of a geo-catalog collection",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -8147,6 +8249,9 @@
           "Ingestion Management"
         ],
         "description": "Cancel all running operations of a geo-catalog collection",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -8183,6 +8288,9 @@
           "Ingestion Management"
         ],
         "description": "Get an operation of a geo-catalog collection",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -8229,6 +8337,9 @@
           "Ingestion Management"
         ],
         "description": "Cancel a running operation of a geo-catalog collection",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -8275,6 +8386,9 @@
         ],
         "summary": "sign an HREF in the format of a URL and returns a SingedLink",
         "description": "Signs a HREF (a link URL) by appending a [SAS Token](https://docs.microsoft.com/en-us/azure/storage/common/storage-sas-overview#how-a-shared-access-signature-works).\nIf the HREF is not a Azure Blob Storage HREF, then pass back the HREF unsigned.",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -8330,6 +8444,9 @@
         ],
         "summary": "generate a SAS Token for the given Azure Blob storage account and container.",
         "description": "Generate a [SAS Token](https://docs.microsoft.com/en-us/azure/storage/common/storage-sas-overview#how-a-shared-access-signature-works)\nfor the given storage account and container. The storage account and container\nmust be associated with a Planetary Computer dataset indexed by the STAC API.",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -8385,6 +8502,9 @@
         ],
         "summary": "revoke a SAS Token for the given Azure Blob storage account",
         "description": "Revoke a [SAS Token](https://docs.microsoft.com/en-us/azure/storage/common/storage-sas-overview#how-a-shared-access-signature-works)\nfor managed storage account of this GeoCatalog.",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -8430,6 +8550,9 @@
         ],
         "summary": "Landing Page",
         "description": "Endpoint.",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -8470,6 +8593,9 @@
         ],
         "summary": "Get Collections",
         "description": "Endpoint.",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -8543,6 +8669,9 @@
         ],
         "summary": "Create Collection",
         "description": "Create a new collection in the GeoCatalog instance",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -8608,6 +8737,9 @@
         ],
         "summary": "Get Collection",
         "description": "Get a collection in the GeoCatalog instance",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -8691,6 +8823,9 @@
         ],
         "summary": "Create or update Collection",
         "description": "Create or replace a collection in the GeoCatalog instance",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -8757,6 +8892,9 @@
         ],
         "summary": "Delete Collection",
         "description": "Delete a collection in the GeoCatalog instance",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -8816,6 +8954,9 @@
         ],
         "summary": "Create Collection Asset",
         "description": "Create a new asset in the Collection metadata and write the associated\nfile to managed storage.\n\nArgs:\nrequest: The incoming request.\nasset: The Asset object to write, without a valid href to the asset.\nfile: The file to write.\ncollection_id: The ID of the collection to write the asset to.\ncontent_type: The content type of the request.\n\nReturns:\nA Response object containing the newly created asset.",
+        "produces": [
+          "application/json"
+        ],
         "consumes": [
           "multipart/form-data"
         ],
@@ -8888,6 +9029,9 @@
         ],
         "summary": "Update Collection Asset",
         "description": "Update an existing asset in a given collection.\n\nArgs:\nrequest: The incoming request.\nasset: The Asset object to update.\nfile: The file to update (optional).\ncollection_id: The ID of the collection to update the asset in.\nasset_id: The ID of the asset to update.\ncontent_type: The content type of the request.\n\nReturns:\nA Response object containing the updated asset.",
+        "produces": [
+          "application/json"
+        ],
         "consumes": [
           "multipart/form-data"
         ],
@@ -8967,6 +9111,9 @@
         ],
         "summary": "Delete Collection Asset",
         "description": "Delete an asset from a given collection.\n\nArgs:\nrequest: The incoming request.\ncollection_id: The ID of the collection to delete the asset from.\nasset_id: The ID of the asset to delete.\n\nReturns:\nA Response object indicating the success of the deletion.",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9025,6 +9172,9 @@
         ],
         "summary": "Get Config",
         "description": "Get the complete user configuration for a given collection",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9074,6 +9224,9 @@
         ],
         "summary": "Get Collection Mosaics",
         "description": "Get the mosaic definitions for a given collection",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9127,6 +9280,9 @@
         ],
         "summary": "Add Collection Mosaic",
         "description": "Add a mosaic definition to a given collection",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9191,6 +9347,9 @@
         ],
         "summary": "Get Collection Mosaic",
         "description": "Get a mosaic definition from a given collection",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9247,6 +9406,9 @@
         ],
         "summary": "Update Collection Mosaic",
         "description": "Update a mosaic definition from a given collection",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9318,6 +9480,9 @@
         ],
         "summary": "Delete Collection Mosaic",
         "description": "Delete a mosaic definition from a given collection",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9376,6 +9541,9 @@
         ],
         "summary": "Get Partitiontype",
         "description": "Get the partitiontype for a GeoCatalog Collection.\n\nArgs:\ncollection_id: the collection id to get the partitiontype for.\n\nReturns:\nThe partitiontype for the collection.",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9423,6 +9591,9 @@
         ],
         "summary": "Create Partitiontype",
         "description": "Updates partition type for a GeoCatalog Collection. This will\ndetermine the partitioning scheme for items within the database,\nand can only be set before any items are loaded.\n\nIdeal partitioning schemes result in partitions of roughly 100k items each.\n\nThe default partitioning scheme is \"none\" which does not partition items.\n\nArgs:\ncollection_id: the collection id to add the partitiontype to.\npartitiontype: the partitiontype to add.\n\nReturns:\nNone",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9484,6 +9655,9 @@
         ],
         "summary": "Get Collection Render Options",
         "description": "Get all render options for a given collection",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9537,6 +9711,9 @@
         ],
         "summary": "Add Collection Render Option",
         "description": "Add a render option for a given collection",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9601,6 +9778,9 @@
         ],
         "summary": "Get Collection Render Option",
         "description": "Get a render option for a given collection",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9660,6 +9840,9 @@
         ],
         "summary": "Update Collection Render Option",
         "description": "Update a render option for a given collection",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9731,6 +9914,9 @@
         ],
         "summary": "Delete Collection Render Option",
         "description": "Delete a render option for a given collection",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9789,6 +9975,9 @@
         ],
         "summary": "Get Collection Tile Settings",
         "description": "Get the tile settings for a given collection",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9836,6 +10025,9 @@
         ],
         "summary": "Update Collection Tile Settings",
         "description": "Update the tile settings for a given collection",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9893,6 +10085,9 @@
           "SpatioTemporal Asset Catalog (STAC) API"
         ],
         "description": "Fetch features of the feature collection with id `collectionId`.\n\nEvery feature in a dataset belongs to a collection. A dataset may\nconsist of multiple feature collections. A feature collection is often a\ncollection of features of a similar type, based on a common schema.\")",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9959,6 +10154,9 @@
           "SpatioTemporal Asset Catalog (STAC) API"
         ],
         "description": "Create a new STAC item or a set of items in a collection",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -10024,6 +10222,9 @@
           "SpatioTemporal Asset Catalog (STAC) API"
         ],
         "description": "Fetch a single STAC Item",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -10073,6 +10274,9 @@
           "SpatioTemporal Asset Catalog (STAC) API"
         ],
         "description": "Create or replace a STAC item in a collection",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -10147,6 +10351,9 @@
           "SpatioTemporal Asset Catalog (STAC) API"
         ],
         "description": "Update a STAC item in a collection",
+        "produces": [
+          "application/json"
+        ],
         "consumes": [
           "application/merge-patch+json"
         ],
@@ -10224,6 +10431,9 @@
           "SpatioTemporal Asset Catalog (STAC) API"
         ],
         "description": "Delete a STAC item from a collection",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -10292,6 +10502,9 @@
         ],
         "summary": "Collection Queryables",
         "description": "Endpoint.",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -10345,6 +10558,9 @@
         ],
         "summary": "Set Collection Queryables",
         "description": "Set queryables for a collection given a list of queryable definitions",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -10412,6 +10628,9 @@
         ],
         "summary": "Update Collection Queryables",
         "description": "Updates a queryable given a queryable definition and\ncorresponding collection id.",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -10483,6 +10702,9 @@
         ],
         "summary": "Delete Queryables",
         "description": "Delete queryables by name for specified collection.",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -10603,6 +10825,9 @@
         ],
         "summary": "Conformance Classes",
         "description": "Endpoint.",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -10643,6 +10868,9 @@
         ],
         "summary": "Queryables",
         "description": "Endpoint.",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -10689,6 +10917,9 @@
         ],
         "summary": "Search",
         "description": "Endpoint.",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -10848,6 +11079,9 @@
         ],
         "summary": "Search",
         "description": "Endpoint.",
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"

--- a/specification/orbital/data-plane/Microsoft.PlanetaryComputer/preview/2025-04-30-preview/openapi.json
+++ b/specification/orbital/data-plane/Microsoft.PlanetaryComputer/preview/2025-04-30-preview/openapi.json
@@ -14,8 +14,7 @@
   ],
   "host": "contoso-catalog.gwhqfdeddydpareu.uksouth.geocatalog.spatio.azure.com",
   "produces": [
-    "application/json",
-    "application/xml"
+    "application/json"
   ],
   "consumes": [
     "application/json"
@@ -217,6 +216,10 @@
         ],
         "summary": "Wmts Tilematrixsetid As Path",
         "description": "OGC WMTS endpoint.",
+        "produces": [
+          "application/xml",
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -410,9 +413,6 @@
         ],
         "summary": "Tilejson Tilematrixsetid As Path",
         "description": "Return the Tilejson Tilematrixsetid As a path",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -605,6 +605,10 @@
         ],
         "summary": "Wmts",
         "description": "OGC WMTS endpoint.",
+        "produces": [
+          "application/xml",
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -874,9 +878,6 @@
         ],
         "summary": "Asset Statistics",
         "description": "Per Asset statistics",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -974,9 +975,6 @@
         ],
         "summary": "Available Assets",
         "description": "Return a list of supported assets.",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -1041,9 +1039,6 @@
         ],
         "summary": "Bounds",
         "description": "Return all Bounds",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -2040,9 +2035,6 @@
         ],
         "summary": "Info",
         "description": "Return dataset's basic info.",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -2112,9 +2104,6 @@
         ],
         "summary": "Info Geojson",
         "description": "Return Info Geojson",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -2184,9 +2173,6 @@
         ],
         "summary": "Point",
         "description": "Get Point value for a dataset.",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -2841,9 +2827,6 @@
         ],
         "summary": "Statistics",
         "description": "Merged assets statistics.",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -2939,9 +2922,6 @@
         ],
         "summary": "Geojson Statistics",
         "description": "Get Statistics from a geojson feature or featureCollection.",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -3056,9 +3036,6 @@
         ],
         "summary": "Tilejson",
         "description": "Return Tilejson",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -3708,9 +3685,6 @@
         ],
         "summary": "Get Classmap Legend",
         "description": "Generate values and color swatches mapping for a given classmap.\n\nArgs:\ntrim_start (int, optional): Number of items to trim\nfrom the start of the cmap\ntrim_end (int, optional): Number of items to trim from the end of the cmap",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -3873,9 +3847,6 @@
         ],
         "summary": "Get Interval Legend",
         "description": "Generate values and color swatches mapping for a given interval classmap.\n\nArgs:\ntrim_start (int, optional): Number of items to trim from\nthe start of the cmap\ntrim_end (int, optional): Number of items to trim from the end of the cmap",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -3952,6 +3923,10 @@
         ],
         "summary": "Wmts Tilematrixsetid As Path",
         "description": "OGC WMTS endpoint.",
+        "produces": [
+          "application/xml",
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -4094,9 +4069,6 @@
         ],
         "summary": "Assets For Point",
         "description": "Return a list of assets for a given point.",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -4191,9 +4163,6 @@
         ],
         "summary": "Tilejson Tilematrixsetid As Path",
         "description": "Return TileJSON document for a searchId.",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -4397,6 +4366,10 @@
         ],
         "summary": "Wmts",
         "description": "OGC WMTS endpoint.",
+        "produces": [
+          "application/xml",
+          "application/json"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -4612,9 +4585,6 @@
         ],
         "summary": "Info Search",
         "description": "Get Search query metadata.",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -4664,9 +4634,6 @@
         ],
         "summary": "Tilejson",
         "description": "Return TileJSON document for a searchId.",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -6859,9 +6826,6 @@
         ],
         "summary": "Assets For Tile Tilematrixsetid As Path",
         "description": "Return a list of assets which overlap a given tile",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -6950,9 +6914,6 @@
         ],
         "summary": "Assets For Tile",
         "description": "Return a list of assets which overlap a given tile",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7114,9 +7075,6 @@
         ],
         "summary": "Register Search",
         "description": "Register a Search query",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7165,9 +7123,6 @@
         ],
         "summary": "Matrix List",
         "description": "Return Matrix List",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7214,9 +7169,6 @@
         ],
         "summary": "Matrix Definition",
         "description": "Return Matrix Definition",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7266,9 +7218,6 @@
         ],
         "summary": "Get Auth Config",
         "description": "Get the app id and tenant id information to make a MSAL request for this\nGeoCatalog instance.",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7309,9 +7258,6 @@
         ],
         "summary": "Get Azmaps Client Id",
         "description": "Fetch the client id for the Azure Maps API service based on the current\non the current identity. This client id is used for the Explorer to\nauthenticate with the Azure Maps API service.",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7352,9 +7298,6 @@
         ],
         "summary": "Get Azmaps Token",
         "description": "Fetch a token for the Azure Maps API service based on the current\nservice identity. This token is used for the Explorer to authenticate\nwith the Azure Maps API service.",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7394,9 +7337,6 @@
           "Ingestion Management"
         ],
         "description": "Get ingestions of a catalog",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7443,9 +7383,6 @@
           "Ingestion Management"
         ],
         "description": "Create a new ingestion",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7504,9 +7441,6 @@
           "Ingestion Management"
         ],
         "description": "Get the definition of an ingestion",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7550,9 +7484,6 @@
           "Ingestion Management"
         ],
         "description": "Update an existing ingestion",
-        "produces": [
-          "application/json"
-        ],
         "consumes": [
           "application/merge-patch+json"
         ],
@@ -7608,9 +7539,6 @@
           "Ingestion Management"
         ],
         "description": "Delete an ingestion from a catalog. All runs of the ingestion will be deleted. Ingestion must not have any runs in progress or queued.",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7672,9 +7600,6 @@
           "Ingestion Management"
         ],
         "description": "Get the runs of an ingestion",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7724,9 +7649,6 @@
           "Ingestion Management"
         ],
         "description": "Create a new run of an ingestion",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7779,9 +7701,6 @@
           "Ingestion Management"
         ],
         "description": "Get a run of an ingestion",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7830,9 +7749,6 @@
           "Ingestion Sources"
         ],
         "description": "Get ingestion sources in a geo-catalog",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7876,9 +7792,6 @@
           "Ingestion Sources"
         ],
         "description": "Create a new ingestion source in a geo-catalog",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7934,9 +7847,6 @@
           "Ingestion Sources"
         ],
         "description": "Get an ingestion source in a geo-catalog",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/IngestionSources.IngestionSourceParameters"
@@ -7977,9 +7887,6 @@
           "Ingestion Sources"
         ],
         "description": "Update an existing ingestion source in a geo-catalog",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -8055,9 +7962,6 @@
           "Ingestion Sources"
         ],
         "description": "Delete an ingestion source from a geo-catalog",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -8103,9 +8007,6 @@
           "Ingestion Sources"
         ],
         "description": "Get all managed identities with access to storage accounts configured for a geo-catalog",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -8145,9 +8046,6 @@
           "Ingestion Management"
         ],
         "description": "Get operations of a geo-catalog collection",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -8249,9 +8147,6 @@
           "Ingestion Management"
         ],
         "description": "Cancel all running operations of a geo-catalog collection",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -8288,9 +8183,6 @@
           "Ingestion Management"
         ],
         "description": "Get an operation of a geo-catalog collection",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -8337,9 +8229,6 @@
           "Ingestion Management"
         ],
         "description": "Cancel a running operation of a geo-catalog collection",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -8386,9 +8275,6 @@
         ],
         "summary": "sign an HREF in the format of a URL and returns a SingedLink",
         "description": "Signs a HREF (a link URL) by appending a [SAS Token](https://docs.microsoft.com/en-us/azure/storage/common/storage-sas-overview#how-a-shared-access-signature-works).\nIf the HREF is not a Azure Blob Storage HREF, then pass back the HREF unsigned.",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -8444,9 +8330,6 @@
         ],
         "summary": "generate a SAS Token for the given Azure Blob storage account and container.",
         "description": "Generate a [SAS Token](https://docs.microsoft.com/en-us/azure/storage/common/storage-sas-overview#how-a-shared-access-signature-works)\nfor the given storage account and container. The storage account and container\nmust be associated with a Planetary Computer dataset indexed by the STAC API.",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -8502,9 +8385,6 @@
         ],
         "summary": "revoke a SAS Token for the given Azure Blob storage account",
         "description": "Revoke a [SAS Token](https://docs.microsoft.com/en-us/azure/storage/common/storage-sas-overview#how-a-shared-access-signature-works)\nfor managed storage account of this GeoCatalog.",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -8550,9 +8430,6 @@
         ],
         "summary": "Landing Page",
         "description": "Endpoint.",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -8593,9 +8470,6 @@
         ],
         "summary": "Get Collections",
         "description": "Endpoint.",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -8669,9 +8543,6 @@
         ],
         "summary": "Create Collection",
         "description": "Create a new collection in the GeoCatalog instance",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -8737,9 +8608,6 @@
         ],
         "summary": "Get Collection",
         "description": "Get a collection in the GeoCatalog instance",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -8823,9 +8691,6 @@
         ],
         "summary": "Create or update Collection",
         "description": "Create or replace a collection in the GeoCatalog instance",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -8892,9 +8757,6 @@
         ],
         "summary": "Delete Collection",
         "description": "Delete a collection in the GeoCatalog instance",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -8954,9 +8816,6 @@
         ],
         "summary": "Create Collection Asset",
         "description": "Create a new asset in the Collection metadata and write the associated\nfile to managed storage.\n\nArgs:\nrequest: The incoming request.\nasset: The Asset object to write, without a valid href to the asset.\nfile: The file to write.\ncollection_id: The ID of the collection to write the asset to.\ncontent_type: The content type of the request.\n\nReturns:\nA Response object containing the newly created asset.",
-        "produces": [
-          "application/json"
-        ],
         "consumes": [
           "multipart/form-data"
         ],
@@ -9029,9 +8888,6 @@
         ],
         "summary": "Update Collection Asset",
         "description": "Update an existing asset in a given collection.\n\nArgs:\nrequest: The incoming request.\nasset: The Asset object to update.\nfile: The file to update (optional).\ncollection_id: The ID of the collection to update the asset in.\nasset_id: The ID of the asset to update.\ncontent_type: The content type of the request.\n\nReturns:\nA Response object containing the updated asset.",
-        "produces": [
-          "application/json"
-        ],
         "consumes": [
           "multipart/form-data"
         ],
@@ -9111,9 +8967,6 @@
         ],
         "summary": "Delete Collection Asset",
         "description": "Delete an asset from a given collection.\n\nArgs:\nrequest: The incoming request.\ncollection_id: The ID of the collection to delete the asset from.\nasset_id: The ID of the asset to delete.\n\nReturns:\nA Response object indicating the success of the deletion.",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9172,9 +9025,6 @@
         ],
         "summary": "Get Config",
         "description": "Get the complete user configuration for a given collection",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9224,9 +9074,6 @@
         ],
         "summary": "Get Collection Mosaics",
         "description": "Get the mosaic definitions for a given collection",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9280,9 +9127,6 @@
         ],
         "summary": "Add Collection Mosaic",
         "description": "Add a mosaic definition to a given collection",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9347,9 +9191,6 @@
         ],
         "summary": "Get Collection Mosaic",
         "description": "Get a mosaic definition from a given collection",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9406,9 +9247,6 @@
         ],
         "summary": "Update Collection Mosaic",
         "description": "Update a mosaic definition from a given collection",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9480,9 +9318,6 @@
         ],
         "summary": "Delete Collection Mosaic",
         "description": "Delete a mosaic definition from a given collection",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9541,9 +9376,6 @@
         ],
         "summary": "Get Partitiontype",
         "description": "Get the partitiontype for a GeoCatalog Collection.\n\nArgs:\ncollection_id: the collection id to get the partitiontype for.\n\nReturns:\nThe partitiontype for the collection.",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9591,9 +9423,6 @@
         ],
         "summary": "Create Partitiontype",
         "description": "Updates partition type for a GeoCatalog Collection. This will\ndetermine the partitioning scheme for items within the database,\nand can only be set before any items are loaded.\n\nIdeal partitioning schemes result in partitions of roughly 100k items each.\n\nThe default partitioning scheme is \"none\" which does not partition items.\n\nArgs:\ncollection_id: the collection id to add the partitiontype to.\npartitiontype: the partitiontype to add.\n\nReturns:\nNone",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9655,9 +9484,6 @@
         ],
         "summary": "Get Collection Render Options",
         "description": "Get all render options for a given collection",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9711,9 +9537,6 @@
         ],
         "summary": "Add Collection Render Option",
         "description": "Add a render option for a given collection",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9778,9 +9601,6 @@
         ],
         "summary": "Get Collection Render Option",
         "description": "Get a render option for a given collection",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9840,9 +9660,6 @@
         ],
         "summary": "Update Collection Render Option",
         "description": "Update a render option for a given collection",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9914,9 +9731,6 @@
         ],
         "summary": "Delete Collection Render Option",
         "description": "Delete a render option for a given collection",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9975,9 +9789,6 @@
         ],
         "summary": "Get Collection Tile Settings",
         "description": "Get the tile settings for a given collection",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -10025,9 +9836,6 @@
         ],
         "summary": "Update Collection Tile Settings",
         "description": "Update the tile settings for a given collection",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -10085,9 +9893,6 @@
           "SpatioTemporal Asset Catalog (STAC) API"
         ],
         "description": "Fetch features of the feature collection with id `collectionId`.\n\nEvery feature in a dataset belongs to a collection. A dataset may\nconsist of multiple feature collections. A feature collection is often a\ncollection of features of a similar type, based on a common schema.\")",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -10154,9 +9959,6 @@
           "SpatioTemporal Asset Catalog (STAC) API"
         ],
         "description": "Create a new STAC item or a set of items in a collection",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -10222,9 +10024,6 @@
           "SpatioTemporal Asset Catalog (STAC) API"
         ],
         "description": "Fetch a single STAC Item",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -10274,9 +10073,6 @@
           "SpatioTemporal Asset Catalog (STAC) API"
         ],
         "description": "Create or replace a STAC item in a collection",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -10351,9 +10147,6 @@
           "SpatioTemporal Asset Catalog (STAC) API"
         ],
         "description": "Update a STAC item in a collection",
-        "produces": [
-          "application/json"
-        ],
         "consumes": [
           "application/merge-patch+json"
         ],
@@ -10431,9 +10224,6 @@
           "SpatioTemporal Asset Catalog (STAC) API"
         ],
         "description": "Delete a STAC item from a collection",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -10502,9 +10292,6 @@
         ],
         "summary": "Collection Queryables",
         "description": "Endpoint.",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -10558,9 +10345,6 @@
         ],
         "summary": "Set Collection Queryables",
         "description": "Set queryables for a collection given a list of queryable definitions",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -10628,9 +10412,6 @@
         ],
         "summary": "Update Collection Queryables",
         "description": "Updates a queryable given a queryable definition and\ncorresponding collection id.",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -10702,9 +10483,6 @@
         ],
         "summary": "Delete Queryables",
         "description": "Delete queryables by name for specified collection.",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -10825,9 +10603,6 @@
         ],
         "summary": "Conformance Classes",
         "description": "Endpoint.",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -10868,9 +10643,6 @@
         ],
         "summary": "Queryables",
         "description": "Endpoint.",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -10917,9 +10689,6 @@
         ],
         "summary": "Search",
         "description": "Endpoint.",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -11079,9 +10848,6 @@
         ],
         "summary": "Search",
         "description": "Endpoint.",
-        "produces": [
-          "application/json"
-        ],
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"

--- a/specification/storage/data-plane/Microsoft.BlobStorage/stable/2025-11-05/generated_blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/stable/2025-11-05/generated_blob.json
@@ -28,10 +28,10 @@
     ]
   },
   "produces": [
-    "application/json"
+    "application/xml"
   ],
   "consumes": [
-    "application/json"
+    "application/xml"
   ],
   "security": [
     {
@@ -972,9 +972,6 @@
       "put": {
         "operationId": "Blob_StartCopyFromUrl",
         "description": "The Start Copy From URL operation copies a blob or an internet resource to a new blob.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -1444,9 +1441,6 @@
       "delete": {
         "operationId": "Blob_Delete",
         "description": "If the storage account's soft delete feature is disabled then, when a blob is deleted, it is permanently removed from the storage account. If the storage account's soft delete feature is enabled, then, when a blob is deleted, it is marked for deletion and becomes inaccessible immediately. However, the blob service retains the blob or snapshot for the number of days specified by the DeleteRetentionPolicy section of [Storage service properties] (Set-Blob-Service-Properties.md). After the specified number of days has passed, the blob's data is permanently removed from the storage account. Note that you continue to be charged for the soft-deleted blob's storage until it is permanently removed. Use the List Blobs API and specify the \\\"include=deleted\\\" query parameter to discover which blobs and snapshots have been soft deleted. You can then use the Undelete Blob API to restore a soft-deleted blob. All other operations on a soft-deleted blob or snapshot causes the service to return an HTTP status code of 404 (ResourceNotFound).",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -1658,9 +1652,6 @@
       "head": {
         "operationId": "Blob_GetProperties",
         "description": "The Get Properties operation returns all user-defined metadata, standard HTTP properties, and system properties for the blob. It does not return the content of the blob.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -2260,9 +2251,6 @@
       "put": {
         "operationId": "Container_Create",
         "description": "Creates a new container under the specified account. If the container with the same name already exists, the operation fails.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -2412,9 +2400,6 @@
       "get": {
         "operationId": "Container_GetProperties",
         "description": "returns all user-defined metadata and system properties for the specified container. The data returned does not include the container's list of blobs",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -2658,9 +2643,6 @@
       "delete": {
         "operationId": "Container_Delete",
         "description": "operation marks the specified container for deletion. The container and any blobs contained within it are later deleted during garbage collection",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -2770,9 +2752,6 @@
       "put": {
         "operationId": "Container_SetMetadata",
         "description": "operation sets one or more user-defined name-value pairs for the specified container.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -2895,9 +2874,6 @@
       "get": {
         "operationId": "Container_GetAccessPolicy",
         "description": "gets the permissions for the specified container. The permissions indicate whether container data may be accessed publicly.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -3030,12 +3006,6 @@
       "put": {
         "operationId": "Container_SetAccessPolicy",
         "description": "sets the permissions for the specified container. The permissions indicate whether blobs in a container may be accessed publicly.",
-        "produces": [
-          "application/xml"
-        ],
-        "consumes": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -3196,9 +3166,6 @@
       "put": {
         "operationId": "Container_Restore",
         "description": "Restores a previously-deleted container.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -3303,9 +3270,6 @@
       "put": {
         "operationId": "Container_Rename",
         "description": "Renames an existing container.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -3519,9 +3483,6 @@
       "get": {
         "operationId": "Container_FilterBlobs",
         "description": "The Filter Blobs operation enables callers to list blobs in a container whose tags match a given search expression.  Filter blobs searches within the given container.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -3667,9 +3628,6 @@
       "put": {
         "operationId": "Container_AcquireLease",
         "description": "The Acquire Lease operation requests a new lease on a container. The lease lock duration can be 15 to 60 seconds, or can be infinite.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -3820,9 +3778,6 @@
       "put": {
         "operationId": "Container_ReleaseLease",
         "description": "The Release Lease operation frees the lease if it's no longer needed, so that another client can immediately acquire a lease against the container.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -3960,9 +3915,6 @@
       "put": {
         "operationId": "Container_RenewLease",
         "description": "The Renew Lease operation renews an existing lease.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -4104,9 +4056,6 @@
       "put": {
         "operationId": "Container_BreakLease",
         "description": "The Break Lease operation ends a lease and ensures that another client can't acquire a new lease until the current lease period has expired.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -4250,9 +4199,6 @@
       "put": {
         "operationId": "Container_ChangeLease",
         "description": "The Change Lease operation is used to change the ID of an existing lease.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -4402,9 +4348,6 @@
       "get": {
         "operationId": "Container_ListBlobFlatSegment",
         "description": "The List Blobs operation returns a list of the blobs under the specified container.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -4598,9 +4541,6 @@
       "get": {
         "operationId": "Container_ListBlobHierarchySegment",
         "description": "The List Blobs operation returns a list of the blobs under the specified container. A delimiter can be used to traverse a virtual hierarchy of blobs as though it were a file system.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -4801,9 +4741,6 @@
       "get": {
         "operationId": "Container_GetAccountInfo",
         "description": "Returns the sku name and account kind",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -4980,9 +4917,6 @@
       "put": {
         "operationId": "Blob_Undelete",
         "description": "Undelete a blob that was previously soft deleted",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -5081,9 +5015,6 @@
       "put": {
         "operationId": "Blob_SetExpiry",
         "description": "Set the expiration time of a blob",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -5240,9 +5171,6 @@
       "put": {
         "operationId": "Blob_SetProperties",
         "description": "The Set HTTP Headers operation sets system properties on the blob.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -5454,9 +5382,6 @@
       "put": {
         "operationId": "Blob_SetImmutabilityPolicy",
         "description": "Set the immutability policy of a blob",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -5651,9 +5576,6 @@
       "delete": {
         "operationId": "Blob_DeleteImmutabilityPolicy",
         "description": "The Delete Immutability Policy operation deletes the immutability policy on the blob.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -5767,9 +5689,6 @@
       "put": {
         "operationId": "Blob_SetLegalHold",
         "description": "The Set Legal Hold operation sets a legal hold on the blob.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -5895,9 +5814,6 @@
       "put": {
         "operationId": "Blob_SetMetadata",
         "description": "The Set Metadata operation sets user-defined metadata for the specified blob as one or more name-value pairs.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -6125,9 +6041,6 @@
       "put": {
         "operationId": "Blob_AcquireLease",
         "description": "The Acquire Lease operation requests a new lease on a blob. The lease lock duration can be 15 to 60 seconds, or can be infinite.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -6312,9 +6225,6 @@
       "put": {
         "operationId": "Blob_ReleaseLease",
         "description": "The Release Lease operation frees the lease if it's no longer needed, so that another client can immediately acquire a lease against the blob.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -6486,9 +6396,6 @@
       "put": {
         "operationId": "Blob_RenewLease",
         "description": "The Renew Lease operation renews an existing lease.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -6664,9 +6571,6 @@
       "put": {
         "operationId": "Blob_ChangeLease",
         "description": "The Change Lease operation is used to change the ID of an existing lease.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -6850,9 +6754,6 @@
       "put": {
         "operationId": "Blob_BreakLease",
         "description": "The Break Lease operation ends a lease and ensures that another client can't acquire a new lease until the current lease period has expired.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -7030,9 +6931,6 @@
       "put": {
         "operationId": "Blob_CreateSnapshot",
         "description": "The Create Snapshot operation creates a read-only snapshot of a blob",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -7256,9 +7154,6 @@
       "put": {
         "operationId": "Blob_CopyFromUrl",
         "description": "The Copy From URL operation copies a blob or an internet resource to a new blob. It will not return a response until the copy is complete.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -7752,9 +7647,6 @@
       "put": {
         "operationId": "Blob_AbortCopyFromUrl",
         "description": "The Abort Copy From URL operation aborts a pending Copy From URL operation, and leaves a destination blob with zero length and full metadata.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -7883,9 +7775,6 @@
       "put": {
         "operationId": "Blob_SetTier",
         "description": "The Set Tier operation sets the tier on a block blob. The operation is allowed on a page blob or block blob, but not on an append blob. A block blob's tier determines Hot/Cool/Archive storage type. This operation does not update the blob's ETag.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -8169,9 +8058,6 @@
       "get": {
         "operationId": "Blob_GetAccountInfo",
         "description": "Returns the sku name and account kind",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -8358,9 +8244,6 @@
       "get": {
         "operationId": "Blob_GetTags",
         "description": "The Get Blob Tags operation enables users to get tags on a blob.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -8493,12 +8376,6 @@
       "put": {
         "operationId": "Blob_SetTags",
         "description": "The Set Tags operation enables users to set tags on a blob.",
-        "produces": [
-          "application/xml"
-        ],
-        "consumes": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -8648,9 +8525,6 @@
       "put": {
         "operationId": "AppendBlob_Create",
         "description": "The Create operation creates a new append blob.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -9010,9 +8884,6 @@
       "put": {
         "operationId": "PageBlob_UploadPages",
         "description": "The Upload Pages operation writes a range of pages to a page blob",
-        "produces": [
-          "application/xml"
-        ],
         "consumes": [
           "application/octet-stream"
         ],
@@ -9353,9 +9224,6 @@
       "put": {
         "operationId": "PageBlob_ClearPages",
         "description": "The Clear Pages operation clears a range of pages from a page blob",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -9634,9 +9502,6 @@
       "put": {
         "operationId": "PageBlob_UploadPagesFromUrl",
         "description": "The Upload Pages operation writes a range of pages to a page blob where the contents are read from a URL.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -10023,9 +9888,6 @@
       "get": {
         "operationId": "PageBlob_GetPageRanges",
         "description": "The Get Page Ranges operation returns the list of valid page ranges for a page blob or snapshot of a page blob.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -10222,9 +10084,6 @@
       "get": {
         "operationId": "PageBlob_GetPageRangesDiff",
         "description": "The Get Page Ranges Diff operation returns the list of valid page ranges for a page blob or snapshot of a page blob.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -10436,9 +10295,6 @@
       "put": {
         "operationId": "PageBlob_Resize",
         "description": "The Resize operation increases the size of the page blob to the specified size.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -10656,9 +10512,6 @@
       "put": {
         "operationId": "PageBlob_SetSequenceNumber",
         "description": "The Update Sequence Number operation sets the blob's sequence number. The operation will fail if the specified sequence number is less than the current sequence number of the blob.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -10865,9 +10718,6 @@
       "put": {
         "operationId": "PageBlob_CopyIncremental",
         "description": "The Copy Incremental operation copies a snapshot of the source page blob to a destination page blob. The snapshot is copied such that only the differential changes between the previously copied snapshot are transferred to the destination. The copied snapshots are complete copies of the original snapshot and can be read or copied from as usual. This API is supported since REST version 2016-05-31.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -11065,9 +10915,6 @@
       "put": {
         "operationId": "AppendBlob_AppendBlock",
         "description": "The Append Block operation commits a new block of data to the end of an append blob.",
-        "produces": [
-          "application/xml"
-        ],
         "consumes": [
           "application/octet-stream"
         ],
@@ -11381,9 +11228,6 @@
       "put": {
         "operationId": "AppendBlob_AppendBlockFromUrl",
         "description": "The Append Block From URL operation creates a new block to be committed as part of an append blob where the contents are read from a URL.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -11752,9 +11596,6 @@
       "put": {
         "operationId": "AppendBlob_Seal",
         "description": "The Seal operation seals the Append Blob to make it read-only. Seal is supported only on version 2019-12-12 version or later.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -11917,9 +11758,6 @@
       "put": {
         "operationId": "BlockBlob_Upload",
         "description": "The Upload Block Blob operation updates the content of an existing block blob. Updating an existing block blob overwrites any existing metadata on the blob. Partial updates are not supported with Put Blob; the content of the existing blob is overwritten with the content of the new blob. To perform a partial update of the content of a block blob, use the Put Block List operation.",
-        "produces": [
-          "application/xml"
-        ],
         "consumes": [
           "application/octet-stream"
         ],
@@ -12441,9 +12279,6 @@
       "put": {
         "operationId": "BlockBlob_PutBlobFromUrl",
         "description": "The Put Blob from URL operation creates a new Block Blob where the contents of the blob are read from a given URL.  This API is supported beginning with the 2020-04-08 version. Partial updates are not supported with Put Blob from URL; the content of an existing blob is overwritten with the content of the new blob.  To perform partial updates to a block blob’s contents using a source URL, use the Put Block from URL API in conjunction with Put Block List.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -13002,9 +12837,6 @@
       "put": {
         "operationId": "BlockBlob_StageBlock",
         "description": "The Stage Block operation creates a new block to be committed as part of a blob",
-        "produces": [
-          "application/xml"
-        ],
         "consumes": [
           "application/octet-stream"
         ],
@@ -13249,9 +13081,6 @@
       "put": {
         "operationId": "BlockBlob_StageBlockFromUrl",
         "description": "The Stage Block From URL operation creates a new block to be committed as part of a blob where the contents are read from a URL.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -13542,12 +13371,6 @@
       "put": {
         "operationId": "BlockBlob_CommitBlockList",
         "description": "The Commit Block List operation writes a blob by specifying the list of block IDs that make up the blob. In order to be written as part of a blob, a block must have been successfully written to the server in a prior Put Block operation. You can call Put Block List to update a blob by uploading only those blocks that have changed, then committing the new and existing blocks together. You can do this by specifying whether to commit a block from the committed block list or from the uncommitted block list, or to commit the most recently uploaded version of the block, whichever list it may belong to.",
-        "produces": [
-          "application/xml"
-        ],
-        "consumes": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -14026,9 +13849,6 @@
       "get": {
         "operationId": "BlockBlob_GetBlockList",
         "description": "The Get Block List operation retrieves the list of blocks that have been uploaded as part of a block blob.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -14203,9 +14023,6 @@
         "description": "The Query operation enables users to select/project on blob data by providing simple query expressions.",
         "produces": [
           "application/octet-stream",
-          "application/xml"
-        ],
-        "consumes": [
           "application/xml"
         ],
         "parameters": [
@@ -15059,9 +14876,6 @@
       "get": {
         "operationId": "FilterBlobs",
         "description": "The Filter Blobs operation enables callers to list blobs across all containers whose tags match a given search expression.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -15200,9 +15014,6 @@
       "get": {
         "operationId": "ListContainersSegment",
         "description": "The List Containers Segment operation returns a list of the containers under the specified account",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -15342,9 +15153,6 @@
       "get": {
         "operationId": "GetAccountInfo",
         "description": "Returns the sku name and account kind.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -15514,12 +15322,6 @@
       "put": {
         "operationId": "SetProperties",
         "description": "Sets properties for a storage account's Blob service endpoint, including properties for Storage Analytics and CORS (Cross-Origin Resource Sharing) rules",
-        "produces": [
-          "application/xml"
-        ],
-        "consumes": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -15605,9 +15407,6 @@
       "get": {
         "operationId": "GetProperties",
         "description": "Retrieves properties of a storage account's Blob service, including properties for Storage Analytics and CORS (Cross-Origin Resource Sharing) rules.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -15687,9 +15486,6 @@
       "get": {
         "operationId": "GetStatistics",
         "description": "Retrieves statistics related to replication for the Blob service. It is only available on the secondary location endpoint when read-access geo-redundant replication is enabled for the storage account.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -15774,12 +15570,6 @@
       "post": {
         "operationId": "GetUserDelegationKey",
         "description": "Retrieves a user delegation key for the Blob service. This is only a valid operation when using bearer token authentication.",
-        "produces": [
-          "application/xml"
-        ],
-        "consumes": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -15875,25 +15665,28 @@
       "type": "object",
       "description": "Represents an access policy.",
       "properties": {
-        "start": {
+        "Start": {
           "type": "string",
           "format": "date-time-rfc7231",
-          "description": "The date-time the policy is active."
+          "description": "The date-time the policy is active.",
+          "x-ms-client-name": "start"
         },
-        "expiry": {
+        "Expiry": {
           "type": "string",
           "format": "date-time-rfc7231",
-          "description": "The date-time the policy expires."
+          "description": "The date-time the policy expires.",
+          "x-ms-client-name": "expiry"
         },
-        "permission": {
+        "Permission": {
           "type": "string",
-          "description": "The permissions for acl the policy."
+          "description": "The permissions for acl the policy.",
+          "x-ms-client-name": "permission"
         }
       },
       "required": [
-        "start",
-        "expiry",
-        "permission"
+        "Start",
+        "Expiry",
+        "Permission"
       ]
     },
     "AccessTier": {
@@ -16080,49 +15873,63 @@
       "type": "object",
       "description": "Represents the Apache Arrow configuration.",
       "properties": {
-        "schema": {
+        "Schema": {
           "type": "array",
           "description": "The Apache Arrow schema",
           "items": {
             "$ref": "#/definitions/ArrowField"
-          }
+          },
+          "xml": {
+            "wrapped": true
+          },
+          "x-ms-client-name": "schema"
         }
       },
       "required": [
-        "schema"
+        "Schema"
       ]
     },
     "ArrowField": {
       "type": "object",
       "description": "Represents an Apache Arrow field.",
       "properties": {
-        "type": {
+        "Type": {
           "type": "string",
-          "description": "The arrow field type."
+          "description": "The arrow field type.",
+          "x-ms-client-name": "type"
         },
-        "name": {
+        "Name": {
           "type": "string",
-          "description": "The arrow field name."
+          "description": "The arrow field name.",
+          "x-ms-client-name": "name"
         },
-        "precision": {
+        "Precision": {
           "type": "integer",
           "format": "int32",
-          "description": "The arrow field precision."
+          "description": "The arrow field precision.",
+          "x-ms-client-name": "precision"
         },
-        "scale": {
+        "Scale": {
           "type": "integer",
           "format": "int32",
-          "description": "The arrow field scale."
+          "description": "The arrow field scale.",
+          "x-ms-client-name": "scale"
         }
       },
       "required": [
-        "type"
-      ]
+        "Type"
+      ],
+      "xml": {
+        "name": "Field"
+      }
     },
     "Azure.Core.uuid": {
       "type": "string",
       "format": "uuid",
-      "description": "Universally Unique Identifier"
+      "description": "Universally Unique Identifier",
+      "xml": {
+        "name": "uuid"
+      }
     },
     "BlobCopySourceTags": {
       "type": "string",
@@ -16206,39 +16013,51 @@
       "type": "object",
       "description": "The blob flat list segment.",
       "properties": {
-        "blobItems": {
+        "Blob": {
           "type": "array",
           "description": "The blob items.",
           "items": {
             "$ref": "#/definitions/BlobItemInternal"
-          }
+          },
+          "xml": {
+            "wrapped": false
+          },
+          "x-ms-client-name": "blobItems"
         }
       },
       "required": [
-        "blobItems"
+        "Blob"
       ]
     },
     "BlobHierarchyListSegment": {
       "type": "object",
       "description": "Represents an array of blobs.",
       "properties": {
-        "blobItems": {
+        "Blob": {
           "type": "array",
           "description": "The blob items",
           "items": {
             "$ref": "#/definitions/BlobItemInternal"
-          }
+          },
+          "xml": {
+            "wrapped": false
+          },
+          "x-ms-client-name": "blobItems"
         },
-        "blobPrefixes": {
+        "BlobPrefix": {
           "type": "array",
           "description": "The blob prefixes.",
           "items": {
             "$ref": "#/definitions/BlobPrefix"
-          }
+          },
+          "xml": {
+            "wrapped": false
+          },
+          "x-ms-client-name": "blobPrefixes"
         }
       },
       "required": [
-        "blobItems"
+        "Blob"
       ]
     },
     "BlobImmutabilityPolicyMode": {
@@ -16275,61 +16094,78 @@
       "type": "object",
       "description": "An Azure Storage Blob",
       "properties": {
-        "name": {
+        "Name": {
           "$ref": "#/definitions/BlobName",
-          "description": "The name of the blob."
+          "description": "The name of the blob.",
+          "x-ms-client-name": "name"
         },
-        "deleted": {
+        "Deleted": {
           "type": "boolean",
-          "description": "Whether the blob is deleted."
+          "description": "Whether the blob is deleted.",
+          "x-ms-client-name": "deleted"
         },
-        "snapshot": {
+        "Snapshot": {
           "type": "string",
-          "description": "The snapshot of the blob."
+          "description": "The snapshot of the blob.",
+          "x-ms-client-name": "snapshot"
         },
-        "versionId": {
+        "VersionId": {
           "type": "string",
-          "description": "The version id of the blob."
+          "description": "The version id of the blob.",
+          "x-ms-client-name": "versionId"
         },
-        "isCurrentVersion": {
+        "IsCurrentVersion": {
           "type": "boolean",
-          "description": "Whether the blob is the current version."
+          "description": "Whether the blob is the current version.",
+          "x-ms-client-name": "isCurrentVersion"
         },
-        "properties": {
+        "Properties": {
           "$ref": "#/definitions/BlobPropertiesInternal",
-          "description": "The properties of the blob."
+          "description": "The properties of the blob.",
+          "x-ms-client-name": "properties"
         },
-        "metadata": {
+        "Metadata": {
           "$ref": "#/definitions/BlobMetadata",
-          "description": "The metadata of the blob."
+          "description": "The metadata of the blob.",
+          "x-ms-client-name": "metadata"
         },
-        "blobTags": {
+        "BlobTags": {
           "$ref": "#/definitions/BlobTags",
-          "description": "The tags of the blob."
+          "description": "The tags of the blob.",
+          "x-ms-client-name": "blobTags"
         },
-        "objectReplicationMetadata": {
+        "ObjectReplicationMetadata": {
           "$ref": "#/definitions/ObjectReplicationMetadata",
-          "description": "The object replication metadata of the blob."
+          "description": "The object replication metadata of the blob.",
+          "x-ms-client-name": "objectReplicationMetadata"
         },
-        "hasVersionsOnly": {
+        "HasVersionsOnly": {
           "type": "boolean",
-          "description": "Whether the blog has versions only."
+          "description": "Whether the blog has versions only.",
+          "x-ms-client-name": "hasVersionsOnly"
         }
       },
       "required": [
-        "name",
-        "deleted",
-        "snapshot",
-        "properties"
-      ]
+        "Name",
+        "Deleted",
+        "Snapshot",
+        "Properties"
+      ],
+      "xml": {
+        "name": "Blob"
+      }
     },
     "BlobMetadata": {
       "type": "object",
       "description": "The blob metadata.",
       "properties": {
-        "encrypted": {
+        "Encrypted": {
           "type": "string",
-          "description": "Whether the blob metadata is encrypted."
+          "description": "Whether the blob metadata is encrypted.",
+          "xml": {
+            "attribute": true
+          },
+          "x-ms-client-name": "encrypted"
         }
       },
       "additionalProperties": {
@@ -16340,13 +16176,20 @@
       "type": "object",
       "description": "Represents a blob name.",
       "properties": {
-        "encoded": {
+        "Encoded": {
           "type": "boolean",
-          "description": "Whether the blob name is encoded."
+          "description": "Whether the blob name is encoded.",
+          "xml": {
+            "attribute": true
+          },
+          "x-ms-client-name": "encoded"
         },
         "content": {
           "type": "string",
-          "description": "The blob name."
+          "description": "The blob name.",
+          "xml": {
+            "x-ms-text": true
+          }
         }
       }
     },
@@ -16354,231 +16197,287 @@
       "type": "object",
       "description": "Represents a blob prefix.",
       "properties": {
-        "name": {
+        "Name": {
           "$ref": "#/definitions/BlobName",
-          "description": "The blob name."
+          "description": "The blob name.",
+          "x-ms-client-name": "name"
         }
       },
       "required": [
-        "name"
+        "Name"
       ]
     },
     "BlobPropertiesInternal": {
       "type": "object",
       "description": "The properties of a blob.",
       "properties": {
-        "creationTime": {
+        "Creation-Time": {
           "type": "string",
           "format": "date-time-rfc7231",
-          "description": "The date-time the blob was created in RFC1123 format."
+          "description": "The date-time the blob was created in RFC1123 format.",
+          "x-ms-client-name": "creationTime"
         },
-        "lastModified": {
+        "Last-Modified": {
           "type": "string",
           "format": "date-time-rfc7231",
-          "description": "The date-time the blob was last modified in RFC1123 format."
+          "description": "The date-time the blob was last modified in RFC1123 format.",
+          "x-ms-client-name": "lastModified"
         },
-        "eTag": {
+        "Etag": {
           "type": "string",
-          "description": "The blog ETag."
+          "description": "The blog ETag.",
+          "x-ms-client-name": "eTag"
         },
-        "contentLength": {
+        "Content-Length": {
           "type": "integer",
           "format": "int64",
-          "description": "The content length of the blob."
+          "description": "The content length of the blob.",
+          "x-ms-client-name": "contentLength"
         },
-        "contentType": {
+        "Content-Type": {
           "type": "string",
-          "description": "The content type of the blob."
+          "description": "The content type of the blob.",
+          "x-ms-client-name": "contentType"
         },
-        "contentEncoding": {
+        "Content-Encoding": {
           "type": "string",
-          "description": "The content encoding of the blob."
+          "description": "The content encoding of the blob.",
+          "x-ms-client-name": "contentEncoding"
         },
-        "contentLanguage": {
+        "Content-Language": {
           "type": "string",
-          "description": "The content language of the blob."
+          "description": "The content language of the blob.",
+          "x-ms-client-name": "contentLanguage"
         },
-        "contentMd5": {
+        "Content-MD5": {
           "type": "string",
           "format": "byte",
-          "description": "The content MD5 of the blob."
+          "description": "The content MD5 of the blob.",
+          "x-ms-client-name": "contentMd5"
         },
-        "contentDisposition": {
+        "Content-Disposition": {
           "type": "string",
-          "description": "The content disposition of the blob."
+          "description": "The content disposition of the blob.",
+          "x-ms-client-name": "contentDisposition"
         },
-        "cacheControl": {
+        "Cache-Control": {
           "type": "string",
-          "description": "The cache control of the blob."
+          "description": "The cache control of the blob.",
+          "x-ms-client-name": "cacheControl"
         },
-        "blobSequenceNumber": {
+        "x-ms-blob-sequence-number": {
           "type": "integer",
           "format": "int64",
-          "description": "The sequence number of the blob."
+          "description": "The sequence number of the blob.",
+          "x-ms-client-name": "blobSequenceNumber"
         },
-        "blobType": {
+        "BlobType": {
           "$ref": "#/definitions/BlobType",
-          "description": "The blob type."
+          "description": "The blob type.",
+          "x-ms-client-name": "blobType"
         },
-        "leaseStatus": {
+        "LeaseStatus": {
           "$ref": "#/definitions/LeaseStatus",
-          "description": "The lease status of the blob."
+          "description": "The lease status of the blob.",
+          "x-ms-client-name": "leaseStatus"
         },
-        "leaseState": {
+        "LeaseState": {
           "$ref": "#/definitions/LeaseState",
-          "description": "The lease state of the blob."
+          "description": "The lease state of the blob.",
+          "x-ms-client-name": "leaseState"
         },
-        "leaseDuration": {
+        "LeaseDuration": {
           "$ref": "#/definitions/LeaseDuration",
-          "description": "The lease duration of the blob."
+          "description": "The lease duration of the blob.",
+          "x-ms-client-name": "leaseDuration"
         },
-        "copyId": {
+        "CopyId": {
           "type": "string",
-          "description": "The copy ID of the blob."
+          "description": "The copy ID of the blob.",
+          "x-ms-client-name": "copyId"
         },
-        "copyStatus": {
+        "CopyStatus": {
           "$ref": "#/definitions/CopyStatus",
-          "description": "The copy status of the blob."
+          "description": "The copy status of the blob.",
+          "x-ms-client-name": "copyStatus"
         },
-        "copySource": {
+        "CopySource": {
           "type": "string",
-          "description": "The copy source of the blob."
+          "description": "The copy source of the blob.",
+          "x-ms-client-name": "copySource"
         },
-        "copyProgress": {
+        "CopyProgress": {
           "type": "string",
-          "description": "The copy progress of the blob."
+          "description": "The copy progress of the blob.",
+          "x-ms-client-name": "copyProgress"
         },
-        "copyCompletionTime": {
-          "type": "string",
-          "format": "date-time-rfc7231",
-          "description": "The copy completion time of the blob."
-        },
-        "copyStatusDescription": {
-          "type": "string",
-          "description": "The copy status description of the blob."
-        },
-        "serverEncrypted": {
-          "type": "boolean",
-          "description": "Whether the blog is encrypted on the server."
-        },
-        "incrementalCopy": {
-          "type": "boolean",
-          "description": "Whether the blog is incremental copy."
-        },
-        "destinationSnapshot": {
-          "type": "string",
-          "description": "The name of the destination snapshot."
-        },
-        "deletedTime": {
+        "CopyCompletionTime": {
           "type": "string",
           "format": "date-time-rfc7231",
-          "description": "The time the blob was deleted."
+          "description": "The copy completion time of the blob.",
+          "x-ms-client-name": "copyCompletionTime"
         },
-        "remainingRetentionDays": {
+        "CopyStatusDescription": {
+          "type": "string",
+          "description": "The copy status description of the blob.",
+          "x-ms-client-name": "copyStatusDescription"
+        },
+        "ServerEncrypted": {
+          "type": "boolean",
+          "description": "Whether the blog is encrypted on the server.",
+          "x-ms-client-name": "serverEncrypted"
+        },
+        "IncrementalCopy": {
+          "type": "boolean",
+          "description": "Whether the blog is incremental copy.",
+          "x-ms-client-name": "incrementalCopy"
+        },
+        "DestinationSnapshot": {
+          "type": "string",
+          "description": "The name of the destination snapshot.",
+          "x-ms-client-name": "destinationSnapshot"
+        },
+        "DeletedTime": {
+          "type": "string",
+          "format": "date-time-rfc7231",
+          "description": "The time the blob was deleted.",
+          "x-ms-client-name": "deletedTime"
+        },
+        "RemainingRetentionDays": {
           "type": "integer",
           "format": "int32",
-          "description": "The remaining retention days of the blob."
+          "description": "The remaining retention days of the blob.",
+          "x-ms-client-name": "remainingRetentionDays"
         },
-        "accessTier": {
+        "AccessTier": {
           "$ref": "#/definitions/AccessTier",
-          "description": "The access tier of the blob."
+          "description": "The access tier of the blob.",
+          "x-ms-client-name": "accessTier"
         },
-        "accessTierInferred": {
+        "AccessTierInferred": {
           "type": "boolean",
-          "description": "Whether the access tier is inferred."
+          "description": "Whether the access tier is inferred.",
+          "x-ms-client-name": "accessTierInferred"
         },
-        "archiveStatus": {
+        "ArchiveStatus": {
           "$ref": "#/definitions/ArchiveStatus",
-          "description": "The archive status of the blob."
+          "description": "The archive status of the blob.",
+          "x-ms-client-name": "archiveStatus"
         },
-        "customerProvidedKeySha256": {
+        "CustomerProvidedKeySha256": {
           "type": "string",
-          "description": "Customer provided key sha256"
+          "description": "Customer provided key sha256",
+          "x-ms-client-name": "customerProvidedKeySha256"
         },
-        "encryptionScope": {
+        "EncryptionScope": {
           "type": "string",
-          "description": "The encryption scope of the blob."
+          "description": "The encryption scope of the blob.",
+          "x-ms-client-name": "encryptionScope"
         },
-        "accessTierChangeTime": {
+        "AccessTierChangeTime": {
           "type": "string",
           "format": "date-time-rfc7231",
-          "description": "The access tier change time of the blob."
+          "description": "The access tier change time of the blob.",
+          "x-ms-client-name": "accessTierChangeTime"
         },
-        "tagCount": {
+        "TagCount": {
           "type": "integer",
           "format": "int32",
-          "description": "The number of tags for the blob."
+          "description": "The number of tags for the blob.",
+          "x-ms-client-name": "tagCount"
         },
-        "expiryTime": {
+        "Expiry-Time": {
           "type": "string",
           "format": "date-time-rfc7231",
-          "description": "The expire time of the blob."
+          "description": "The expire time of the blob.",
+          "x-ms-client-name": "expiryTime"
         },
-        "sealed": {
+        "Sealed": {
           "type": "boolean",
-          "description": "Whether the blob is sealed."
+          "description": "Whether the blob is sealed.",
+          "x-ms-client-name": "sealed"
         },
-        "rehydratePriority": {
+        "RehydratePriority": {
           "$ref": "#/definitions/RehydratePriority",
-          "description": "The rehydrate priority of the blob."
+          "description": "The rehydrate priority of the blob.",
+          "x-ms-client-name": "rehydratePriority"
         },
-        "lastAccessTime": {
+        "LastAccessTime": {
           "type": "string",
           "format": "date-time-rfc7231",
-          "description": "The last access time of the blob."
+          "description": "The last access time of the blob.",
+          "x-ms-client-name": "lastAccessTime"
         },
-        "immutabilityPolicyUntilDate": {
+        "ImmutabilityPolicyUntilDate": {
           "type": "string",
           "format": "date-time-rfc7231",
-          "description": "The immutability policy until time of the blob."
+          "description": "The immutability policy until time of the blob.",
+          "x-ms-client-name": "immutabilityPolicyUntilDate"
         },
-        "immutabilityPolicyMode": {
+        "ImmutabilityPolicyMode": {
           "$ref": "#/definitions/BlobImmutabilityPolicyMode",
-          "description": "The immutability policy mode of the blob."
+          "description": "The immutability policy mode of the blob.",
+          "x-ms-client-name": "immutabilityPolicyMode"
         },
-        "legalHold": {
+        "LegalHold": {
           "type": "boolean",
-          "description": "Whether the blob is under legal hold."
+          "description": "Whether the blob is under legal hold.",
+          "x-ms-client-name": "legalHold"
         }
       },
       "required": [
-        "lastModified",
-        "eTag"
-      ]
+        "Last-Modified",
+        "Etag"
+      ],
+      "xml": {
+        "name": "Properties"
+      }
     },
     "BlobTag": {
       "type": "object",
       "description": "The blob tags.",
       "properties": {
-        "key": {
+        "Key": {
           "type": "string",
-          "description": "The key of the tag."
+          "description": "The key of the tag.",
+          "x-ms-client-name": "key"
         },
-        "value": {
+        "Value": {
           "type": "string",
-          "description": "The value of the tag."
+          "description": "The value of the tag.",
+          "x-ms-client-name": "value"
         }
       },
       "required": [
-        "key",
-        "value"
-      ]
+        "Key",
+        "Value"
+      ],
+      "xml": {
+        "name": "Tag"
+      }
     },
     "BlobTags": {
       "type": "object",
       "description": "Represents blob tags.",
       "properties": {
-        "blobTagSet": {
+        "TagSet": {
           "type": "array",
           "description": "Represents the blob tags.",
           "items": {
             "$ref": "#/definitions/BlobTag"
-          }
+          },
+          "xml": {
+            "wrapped": true
+          },
+          "x-ms-client-name": "blobTagSet"
         }
       },
       "required": [
-        "blobTagSet"
-      ]
+        "TagSet"
+      ],
+      "xml": {
+        "name": "Tags"
+      }
     },
     "BlobType": {
       "type": "string",
@@ -16614,38 +16513,48 @@
       "type": "object",
       "description": "Represents a single block in a block blob. It describes the block's ID and size.",
       "properties": {
-        "name": {
+        "Name": {
           "$ref": "#/definitions/base64Bytes",
-          "description": "The base64 encoded block ID."
+          "description": "The base64 encoded block ID.",
+          "x-ms-client-name": "name"
         },
-        "size": {
+        "Size": {
           "type": "integer",
           "format": "int64",
-          "description": "The block size in bytes."
+          "description": "The block size in bytes.",
+          "x-ms-client-name": "size"
         }
       },
       "required": [
-        "name",
-        "size"
+        "Name",
+        "Size"
       ]
     },
     "BlockList": {
       "type": "object",
       "description": "Contains the committed and uncommitted blocks in a block blob.",
       "properties": {
-        "committedBlocks": {
+        "CommittedBlocks": {
           "type": "array",
           "description": "The list of committed blocks.",
           "items": {
             "$ref": "#/definitions/Block"
-          }
+          },
+          "xml": {
+            "wrapped": true
+          },
+          "x-ms-client-name": "committedBlocks"
         },
-        "uncommittedBlocks": {
+        "UncommittedBlocks": {
           "type": "array",
           "description": "The list of uncommitted blocks.",
           "items": {
             "$ref": "#/definitions/Block"
-          }
+          },
+          "xml": {
+            "wrapped": true
+          },
+          "x-ms-client-name": "uncommittedBlocks"
         }
       }
     },
@@ -16683,145 +16592,183 @@
       "type": "object",
       "description": "The Block lookup list.",
       "properties": {
-        "committed": {
+        "Committed": {
           "type": "array",
           "description": "The committed blocks",
           "items": {
             "$ref": "#/definitions/base64Bytes"
-          }
+          },
+          "xml": {
+            "wrapped": false
+          },
+          "x-ms-client-name": "committed"
         },
-        "uncommitted": {
+        "Uncommitted": {
           "type": "array",
           "description": "The uncommitted blocks",
           "items": {
             "$ref": "#/definitions/base64Bytes"
-          }
+          },
+          "xml": {
+            "wrapped": false
+          },
+          "x-ms-client-name": "uncommitted"
         },
-        "latest": {
+        "Latest": {
           "type": "array",
           "description": "The latest blocks",
           "items": {
             "$ref": "#/definitions/base64Bytes"
-          }
+          },
+          "xml": {
+            "wrapped": false
+          },
+          "x-ms-client-name": "latest"
         }
+      },
+      "xml": {
+        "name": "BlockList"
       }
     },
     "ClearRange": {
       "type": "object",
       "description": "The clear range.",
       "properties": {
-        "start": {
+        "Start": {
           "type": "integer",
           "format": "int64",
-          "description": "The start of the byte range."
+          "description": "The start of the byte range.",
+          "x-ms-client-name": "start"
         },
-        "end": {
+        "End": {
           "type": "integer",
           "format": "int64",
-          "description": "The end of the byte range."
+          "description": "The end of the byte range.",
+          "x-ms-client-name": "end"
         }
       },
       "required": [
-        "start",
-        "end"
+        "Start",
+        "End"
       ]
     },
     "ContainerItem": {
       "type": "object",
       "description": "An Azure Storage container.",
       "properties": {
-        "name": {
+        "Name": {
           "type": "string",
-          "description": "The name of the container."
+          "description": "The name of the container.",
+          "x-ms-client-name": "name"
         },
-        "delete": {
+        "Deleted": {
           "type": "boolean",
-          "description": "Whether the container is deleted."
+          "description": "Whether the container is deleted.",
+          "x-ms-client-name": "delete"
         },
-        "version": {
+        "Version": {
           "type": "string",
-          "description": "The version of the container."
+          "description": "The version of the container.",
+          "x-ms-client-name": "version"
         },
-        "properties": {
+        "Properties": {
           "$ref": "#/definitions/ContainerProperties",
-          "description": "The properties of the container."
+          "description": "The properties of the container.",
+          "x-ms-client-name": "properties"
         },
-        "metadata": {
+        "Metadata": {
           "type": "object",
           "description": "The metadata of the container.",
           "additionalProperties": {
             "type": "string"
-          }
+          },
+          "x-ms-client-name": "metadata"
         }
       },
       "required": [
-        "name",
-        "properties"
-      ]
+        "Name",
+        "Properties"
+      ],
+      "xml": {
+        "name": "Container"
+      }
     },
     "ContainerProperties": {
       "type": "object",
       "description": "The properties of a container.",
       "properties": {
-        "lastModified": {
+        "Last-Modified": {
           "type": "string",
           "format": "date-time-rfc7231",
-          "description": "The date-time the container was last modified in RFC1123 format."
+          "description": "The date-time the container was last modified in RFC1123 format.",
+          "x-ms-client-name": "lastModified"
         },
-        "eTag": {
+        "ETag": {
           "type": "string",
-          "description": "The ETag of the container."
+          "description": "The ETag of the container.",
+          "x-ms-client-name": "eTag"
         },
-        "leaseStatus": {
+        "LeaseStatus": {
           "$ref": "#/definitions/LeaseStatus",
-          "description": "The lease status of the container."
+          "description": "The lease status of the container.",
+          "x-ms-client-name": "leaseStatus"
         },
-        "leaseState": {
+        "LeaseState": {
           "$ref": "#/definitions/LeaseState",
-          "description": "The lease state of the container."
+          "description": "The lease state of the container.",
+          "x-ms-client-name": "leaseState"
         },
-        "leaseDuration": {
+        "LeaseDuration": {
           "$ref": "#/definitions/LeaseDuration",
-          "description": "The lease duration of the container."
+          "description": "The lease duration of the container.",
+          "x-ms-client-name": "leaseDuration"
         },
-        "publicAccess": {
+        "PublicAccess": {
           "$ref": "#/definitions/PublicAccessType",
-          "description": "The public access type of the container."
+          "description": "The public access type of the container.",
+          "x-ms-client-name": "publicAccess"
         },
-        "hasImmutabilityPolicy": {
+        "HasImmutabilityPolicy": {
           "type": "boolean",
-          "description": "Whether it has an immutability policy."
+          "description": "Whether it has an immutability policy.",
+          "x-ms-client-name": "hasImmutabilityPolicy"
         },
-        "hasLegalHold": {
+        "HasLegalHold": {
           "type": "boolean",
-          "description": "The has legal hold status of the container."
+          "description": "The has legal hold status of the container.",
+          "x-ms-client-name": "hasLegalHold"
         },
-        "defaultEncryptionScope": {
+        "DefaultEncryptionScope": {
           "type": "string",
-          "description": "The default encryption scope of the container."
+          "description": "The default encryption scope of the container.",
+          "x-ms-client-name": "defaultEncryptionScope"
         },
-        "denyEncryptionScopeOverride": {
+        "DenyEncryptionScopeOverride": {
           "type": "boolean",
-          "description": "Whether to prevent encryption scope override."
+          "description": "Whether to prevent encryption scope override.",
+          "x-ms-client-name": "denyEncryptionScopeOverride"
         },
-        "deletedTime": {
+        "DeletedTime": {
           "type": "string",
           "format": "date-time-rfc7231",
-          "description": "The deleted time of the container."
+          "description": "The deleted time of the container.",
+          "x-ms-client-name": "deletedTime"
         },
-        "remainingRetentionDays": {
+        "RemainingRetentionDays": {
           "type": "integer",
           "format": "int32",
-          "description": "The remaining retention days of the container."
+          "description": "The remaining retention days of the container.",
+          "x-ms-client-name": "remainingRetentionDays"
         },
-        "immutableStorageWithVersioningEnabled": {
+        "ImmutableStorageWithVersioningEnabled": {
           "type": "boolean",
-          "description": "Whether immutable storage with versioning is enabled."
+          "description": "Whether immutable storage with versioning is enabled.",
+          "x-ms-client-name": "immutableStorageWithVersioningEnabled"
         }
       },
       "required": [
-        "lastModified",
-        "eTag"
+        "Last-Modified",
+        "ETag"
       ]
     },
     "CopyStatus": {
@@ -16864,35 +16811,40 @@
       "type": "object",
       "description": "CORS is an HTTP feature that enables a web application running under one domain to access resources in another domain. Web browsers implement a security restriction known as same-origin policy that prevents a web page from calling APIs in a different domain; CORS provides a secure way to allow one domain (the origin domain) to call APIs in another domain",
       "properties": {
-        "allowedOrigins": {
+        "AllowedOrigins": {
           "type": "string",
-          "description": "The allowed origins."
+          "description": "The allowed origins.",
+          "x-ms-client-name": "allowedOrigins"
         },
-        "allowedMethods": {
+        "AllowedMethods": {
           "type": "string",
-          "description": "The allowed methods."
+          "description": "The allowed methods.",
+          "x-ms-client-name": "allowedMethods"
         },
-        "allowedHeaders": {
+        "AllowedHeaders": {
           "type": "string",
-          "description": "The allowed headers."
+          "description": "The allowed headers.",
+          "x-ms-client-name": "allowedHeaders"
         },
-        "exposedHeaders": {
+        "ExposedHeaders": {
           "type": "string",
-          "description": "The exposed headers."
+          "description": "The exposed headers.",
+          "x-ms-client-name": "exposedHeaders"
         },
-        "maxAgeInSeconds": {
+        "MaxAgeInSeconds": {
           "type": "integer",
           "format": "int32",
           "description": "The maximum age in seconds.",
-          "minimum": 0
+          "minimum": 0,
+          "x-ms-client-name": "maxAgeInSeconds"
         }
       },
       "required": [
-        "allowedOrigins",
-        "allowedMethods",
-        "allowedHeaders",
-        "exposedHeaders",
-        "maxAgeInSeconds"
+        "AllowedOrigins",
+        "AllowedMethods",
+        "AllowedHeaders",
+        "ExposedHeaders",
+        "MaxAgeInSeconds"
       ]
     },
     "DeleteSnapshotsOptionType": {
@@ -16923,25 +16875,30 @@
       "type": "object",
       "description": "Represents the delimited text configuration.",
       "properties": {
-        "columnSeparator": {
+        "ColumnSeparator": {
           "type": "string",
-          "description": "The string used to separate columns."
+          "description": "The string used to separate columns.",
+          "x-ms-client-name": "columnSeparator"
         },
-        "fieldQuote": {
+        "FieldQuote": {
           "type": "string",
-          "description": "The string used to quote a specific field."
+          "description": "The string used to quote a specific field.",
+          "x-ms-client-name": "fieldQuote"
         },
-        "recordSeparator": {
+        "RecordSeparator": {
           "type": "string",
-          "description": "The string used to separate records."
+          "description": "The string used to separate records.",
+          "x-ms-client-name": "recordSeparator"
         },
-        "escapeChar": {
+        "EscapeChar": {
           "type": "string",
-          "description": "The string used to escape a quote character in a field."
+          "description": "The string used to escape a quote character in a field.",
+          "x-ms-client-name": "escapeChar"
         },
-        "headersPresent": {
+        "HasHeaders": {
           "type": "boolean",
-          "description": "Represents whether the data has headers."
+          "description": "Represents whether the data has headers.",
+          "x-ms-client-name": "headersPresent"
         }
       }
     },
@@ -16985,61 +16942,81 @@
       "type": "object",
       "description": "The filter blob item.",
       "properties": {
-        "name": {
+        "Name": {
           "type": "string",
-          "description": "The name of the blob."
+          "description": "The name of the blob.",
+          "x-ms-client-name": "name"
         },
-        "containerName": {
+        "ContainerName": {
           "type": "string",
-          "description": "The properties of the blob."
+          "description": "The properties of the blob.",
+          "x-ms-client-name": "containerName"
         },
         "tags": {
           "$ref": "#/definitions/BlobTags",
           "description": "The metadata of the blob."
         },
-        "versionId": {
+        "VersionId": {
           "type": "string",
-          "description": "The version ID of the blob."
+          "description": "The version ID of the blob.",
+          "x-ms-client-name": "versionId"
         },
-        "isCurrentVersion": {
+        "IsCurrentVersion": {
           "type": "boolean",
-          "description": "Whether it is the current version of the blob"
+          "description": "Whether it is the current version of the blob",
+          "x-ms-client-name": "isCurrentVersion"
         }
       },
       "required": [
-        "name",
-        "containerName"
-      ]
+        "Name",
+        "ContainerName"
+      ],
+      "xml": {
+        "name": "Blob"
+      }
     },
     "FilterBlobSegment": {
       "type": "object",
       "description": "The result of a Filter Blobs API call",
       "properties": {
-        "serviceEndpoint": {
+        "ServiceEndpoint": {
           "type": "string",
-          "description": "The service endpoint."
+          "description": "The service endpoint.",
+          "xml": {
+            "attribute": true
+          },
+          "x-ms-client-name": "serviceEndpoint"
         },
-        "where": {
+        "Where": {
           "type": "string",
-          "description": "The filter for the blobs."
+          "description": "The filter for the blobs.",
+          "x-ms-client-name": "where"
         },
-        "blobs": {
+        "Blobs": {
           "type": "array",
           "description": "The blob segment.",
           "items": {
             "$ref": "#/definitions/FilterBlobItem"
-          }
+          },
+          "xml": {
+            "wrapped": true
+          },
+          "x-ms-client-name": "blobs"
         },
-        "nextMarker": {
+        "NextMarker": {
           "type": "string",
-          "description": "The next marker of the blobs."
+          "description": "The next marker of the blobs.",
+          "x-ms-client-name": "nextMarker"
         }
       },
       "required": [
-        "serviceEndpoint",
-        "where",
-        "blobs"
-      ]
+        "ServiceEndpoint",
+        "Where",
+        "Blobs"
+      ],
+      "xml": {
+        "name": "EnumerationResults"
+      }
     },
     "FilterBlobsIncludeItem": {
       "type": "string",
@@ -17069,19 +17046,21 @@
       "type": "object",
       "description": "Geo-Replication information for the Secondary Storage Service",
       "properties": {
-        "status": {
+        "Status": {
           "$ref": "#/definitions/GeoReplicationStatusType",
-          "description": "The status of the secondary location"
+          "description": "The status of the secondary location",
+          "x-ms-client-name": "status"
         },
-        "lastSyncTime": {
+        "LastSyncTime": {
           "type": "string",
           "format": "date-time-rfc7231",
-          "description": "A GMT date/time value, to the second. All primary writes preceding this value are guaranteed to be available for read operations at the secondary. Primary writes after this point in time may or may not be available for reads."
+          "description": "A GMT date/time value, to the second. All primary writes preceding this value are guaranteed to be available for read operations at the secondary. Primary writes after this point in time may or may not be available for reads.",
+          "x-ms-client-name": "lastSyncTime"
         }
       },
       "required": [
-        "status",
-        "lastSyncTime"
+        "Status",
+        "LastSyncTime"
       ]
     },
     "GeoReplicationStatusType": {
@@ -17142,9 +17121,10 @@
       "type": "object",
       "description": "Represents the JSON text configuration.",
       "properties": {
-        "recordSeparator": {
+        "RecordSeparator": {
           "type": "string",
-          "description": "The string used to separate records."
+          "description": "The string used to separate records.",
+          "x-ms-client-name": "recordSeparator"
         }
       }
     },
@@ -17152,18 +17132,20 @@
       "type": "object",
       "description": "Key information",
       "properties": {
-        "start": {
+        "Start": {
           "type": "string",
-          "description": "The date-time the key is active."
+          "description": "The date-time the key is active.",
+          "x-ms-client-name": "start"
         },
-        "expiry": {
+        "Expiry": {
           "type": "string",
-          "description": "The date-time the key expires."
+          "description": "The date-time the key expires.",
+          "x-ms-client-name": "expiry"
         }
       },
       "required": [
-        "start",
-        "expiry"
+        "Start",
+        "Expiry"
       ]
     },
     "LeaseDuration": {
@@ -17260,85 +17242,118 @@
       "type": "object",
       "description": "An enumeration of blobs.",
       "properties": {
-        "serviceEndpoint": {
+        "ServiceEndpoint": {
           "type": "string",
-          "description": "The service endpoint."
+          "description": "The service endpoint.",
+          "xml": {
+            "attribute": true
+          },
+          "x-ms-client-name": "serviceEndpoint"
         },
-        "containerName": {
+        "ContainerName": {
           "type": "string",
-          "description": "The container name."
+          "description": "The container name.",
+          "xml": {
+            "attribute": true
+          },
+          "x-ms-client-name": "containerName"
         },
-        "prefix": {
+        "Prefix": {
           "type": "string",
-          "description": "The prefix of the blobs."
+          "description": "The prefix of the blobs.",
+          "x-ms-client-name": "prefix"
         },
-        "marker": {
+        "Marker": {
           "type": "string",
-          "description": "The marker of the blobs."
+          "description": "The marker of the blobs.",
+          "x-ms-client-name": "marker"
         },
-        "maxResults": {
+        "MaxResults": {
           "type": "integer",
           "format": "int32",
-          "description": "The max results of the blobs."
+          "description": "The max results of the blobs.",
+          "x-ms-client-name": "maxResults"
         },
-        "segment": {
+        "Blobs": {
           "$ref": "#/definitions/BlobFlatListSegment",
-          "description": "The blob segment."
+          "description": "The blob segment.",
+          "x-ms-client-name": "segment"
         },
-        "nextMarker": {
+        "NextMarker": {
           "type": "string",
-          "description": "The next marker of the blobs."
+          "description": "The next marker of the blobs.",
+          "x-ms-client-name": "nextMarker"
         }
       },
       "required": [
-        "serviceEndpoint",
-        "containerName",
-        "segment"
-      ]
+        "ServiceEndpoint",
+        "ContainerName",
+        "Blobs"
+      ],
+      "xml": {
+        "name": "EnumerationResults"
+      }
     },
     "ListBlobsHierarchySegmentResponse": {
       "type": "object",
       "description": "An enumeration of blobs",
       "properties": {
-        "serviceEndpoint": {
+        "ServiceEndpoint": {
           "type": "string",
-          "description": "The service endpoint."
+          "description": "The service endpoint.",
+          "xml": {
+            "attribute": true
+          },
+          "x-ms-client-name": "serviceEndpoint"
         },
-        "containerName": {
+        "ContainerName": {
           "type": "string",
-          "description": "The container name."
+          "description": "The container name.",
+          "xml": {
+            "attribute": true
+          },
+          "x-ms-client-name": "containerName"
         },
-        "delimiter": {
+        "Delimiter": {
           "type": "string",
-          "description": "The delimiter of the blobs."
+          "description": "The delimiter of the blobs.",
+          "x-ms-client-name": "delimiter"
         },
-        "prefix": {
+        "Prefix": {
           "type": "string",
-          "description": "The prefix of the blobs."
+          "description": "The prefix of the blobs.",
+          "x-ms-client-name": "prefix"
         },
-        "marker": {
+        "Marker": {
           "type": "string",
-          "description": "The marker of the blobs."
+          "description": "The marker of the blobs.",
+          "x-ms-client-name": "marker"
         },
-        "maxResults": {
+        "MaxResults": {
           "type": "integer",
           "format": "int32",
-          "description": "The max results of the blobs."
+          "description": "The max results of the blobs.",
+          "x-ms-client-name": "maxResults"
         },
-        "segment": {
+        "Blobs": {
           "$ref": "#/definitions/BlobHierarchyListSegment",
-          "description": "The blob segment."
+          "description": "The blob segment.",
+          "x-ms-client-name": "segment"
         },
-        "nextMarker": {
+        "NextMarker": {
           "type": "string",
-          "description": "The next marker of the blobs."
+          "description": "The next marker of the blobs.",
+          "x-ms-client-name": "nextMarker"
         }
       },
       "required": [
-        "serviceEndpoint",
-        "containerName",
-        "segment"
-      ]
+        "ServiceEndpoint",
+        "ContainerName",
+        "Blobs"
+      ],
+      "xml": {
+        "name": "EnumerationResults"
+      }
     },
     "ListBlobsIncludeItem": {
       "type": "string",
@@ -17446,29 +17461,40 @@
       "type": "object",
       "description": "The list container segment response",
       "properties": {
-        "serviceEndpoint": {
+        "ServiceEndpoint": {
           "type": "string",
-          "description": "The service endpoint."
+          "description": "The service endpoint.",
+          "xml": {
+            "attribute": true
+          },
+          "x-ms-client-name": "serviceEndpoint"
         },
-        "prefix": {
+        "Prefix": {
           "type": "string",
-          "description": "The prefix of the containers."
+          "description": "The prefix of the containers.",
+          "x-ms-client-name": "prefix"
         },
-        "marker": {
+        "Marker": {
           "type": "string",
-          "description": "The marker of the containers."
+          "description": "The marker of the containers.",
+          "x-ms-client-name": "marker"
         },
-        "maxResults": {
+        "MaxResults": {
           "type": "integer",
           "format": "int32",
-          "description": "The max results of the containers."
+          "description": "The max results of the containers.",
+          "x-ms-client-name": "maxResults"
         },
-        "containerItems": {
+        "Containers": {
           "type": "array",
           "description": "The container segment.",
           "items": {
             "$ref": "#/definitions/ContainerItem"
-          }
+          },
+          "xml": {
+            "wrapped": true
+          },
+          "x-ms-client-name": "containerItems"
         },
         "NextMarker": {
           "type": "string",
@@ -17476,66 +17502,78 @@
         }
       },
       "required": [
-        "serviceEndpoint",
-        "containerItems"
-      ]
+        "ServiceEndpoint",
+        "Containers"
+      ],
+      "xml": {
+        "name": "EnumerationResults"
+      }
     },
     "Logging": {
       "type": "object",
       "description": "Azure Analytics Logging settings.",
       "properties": {
-        "version": {
+        "Version": {
           "type": "string",
-          "description": "The version of the logging properties."
+          "description": "The version of the logging properties.",
+          "x-ms-client-name": "version"
         },
-        "delete": {
+        "Delete": {
           "type": "boolean",
-          "description": "Whether delete operation is logged."
+          "description": "Whether delete operation is logged.",
+          "x-ms-client-name": "delete"
         },
-        "read": {
+        "Read": {
           "type": "boolean",
-          "description": "Whether read operation is logged."
+          "description": "Whether read operation is logged.",
+          "x-ms-client-name": "read"
         },
-        "write": {
+        "Write": {
           "type": "boolean",
-          "description": "Whether write operation is logged."
+          "description": "Whether write operation is logged.",
+          "x-ms-client-name": "write"
         },
-        "retentionPolicy": {
+        "RetentionPolicy": {
           "$ref": "#/definitions/RetentionPolicy",
-          "description": "The retention policy of the logs."
+          "description": "The retention policy of the logs.",
+          "x-ms-client-name": "retentionPolicy"
         }
       },
       "required": [
-        "version",
-        "delete",
-        "read",
-        "write",
-        "retentionPolicy"
+        "Version",
+        "Delete",
+        "Read",
+        "Write",
+        "RetentionPolicy"
       ]
     },
     "Metrics": {
       "type": "object",
       "description": "The metrics properties.",
       "properties": {
-        "version": {
+        "Version": {
           "type": "string",
-          "description": "The version of the metrics properties."
+          "description": "The version of the metrics properties.",
+          "x-ms-client-name": "version"
         },
-        "enabled": {
+        "Enabled": {
           "type": "boolean",
-          "description": "Whether it is enabled."
+          "description": "Whether it is enabled.",
+          "x-ms-client-name": "enabled"
         },
-        "includeApis": {
+        "IncludeAPIs": {
           "type": "boolean",
-          "description": "Whether to include API in the metrics."
+          "description": "Whether to include API in the metrics.",
+          "x-ms-client-name": "includeApis"
         },
-        "retentionPolicy": {
+        "RetentionPolicy": {
           "$ref": "#/definitions/RetentionPolicy",
-          "description": "The retention policy of the metrics."
+          "description": "The retention policy of the metrics.",
+          "x-ms-client-name": "retentionPolicy"
         }
       },
       "required": [
-        "enabled"
+        "Enabled"
       ]
     },
     "ObjectReplicationMetadata": {
@@ -17543,29 +17581,41 @@
       "description": "The object replication metadata.",
       "additionalProperties": {
         "type": "string"
+      },
+      "xml": {
+        "name": "OrMetadata"
       }
     },
     "PageList": {
       "type": "object",
       "description": "Represents a page list.",
       "properties": {
-        "pageRange": {
+        "PageRange": {
           "type": "array",
           "description": "The page ranges.",
           "items": {
             "$ref": "#/definitions/PageRange"
-          }
+          },
+          "xml": {
+            "wrapped": false
+          },
+          "x-ms-client-name": "pageRange"
         },
-        "clearRange": {
+        "ClearRange": {
           "type": "array",
           "description": "The clear ranges.",
           "items": {
             "$ref": "#/definitions/ClearRange"
-          }
+          },
+          "xml": {
+            "wrapped": false
+          },
+          "x-ms-client-name": "clearRange"
         },
-        "nextMarker": {
+        "NextMarker": {
           "type": "string",
-          "description": "The next marker."
+          "description": "The next marker.",
+          "x-ms-client-name": "nextMarker"
         }
       }
     },
@@ -17573,20 +17623,22 @@
       "type": "object",
       "description": "The page range.",
       "properties": {
-        "start": {
+        "Start": {
           "type": "integer",
           "format": "int64",
-          "description": "The start of the byte range."
+          "description": "The start of the byte range.",
+          "x-ms-client-name": "start"
         },
-        "end": {
+        "End": {
           "type": "integer",
           "format": "int64",
-          "description": "The end of the byte range."
+          "description": "The end of the byte range.",
+          "x-ms-client-name": "end"
         }
       },
       "required": [
-        "start",
-        "end"
+        "Start",
+        "End"
       ]
     },
     "ParquetConfiguration": {
@@ -17700,55 +17752,64 @@
       "type": "object",
       "description": "The query format settings.",
       "properties": {
-        "type": {
+        "Type": {
           "$ref": "#/definitions/QueryType",
-          "description": "The query type."
+          "description": "The query type.",
+          "x-ms-client-name": "type"
         },
-        "delimitedTextConfiguration": {
+        "DelimitedTextConfiguration": {
           "$ref": "#/definitions/DelimitedTextConfiguration",
-          "description": "The delimited text configuration."
+          "description": "The delimited text configuration.",
+          "x-ms-client-name": "delimitedTextConfiguration"
         },
-        "jsonTextConfiguration": {
+        "JsonTextConfiguration": {
           "$ref": "#/definitions/JsonTextConfiguration",
-          "description": "The JSON text configuration."
+          "description": "The JSON text configuration.",
+          "x-ms-client-name": "jsonTextConfiguration"
         },
-        "arrowConfiguration": {
+        "ArrowConfiguration": {
           "$ref": "#/definitions/ArrowConfiguration",
-          "description": "The Apache Arrow configuration."
+          "description": "The Apache Arrow configuration.",
+          "x-ms-client-name": "arrowConfiguration"
         },
-        "parquetTextConfiguration": {
+        "ParquetConfiguration": {
           "$ref": "#/definitions/ParquetConfiguration",
-          "description": "The Parquet configuration."
+          "description": "The Parquet configuration.",
+          "x-ms-client-name": "parquetTextConfiguration"
         }
       },
       "required": [
-        "type"
+        "Type"
       ]
     },
     "QueryRequest": {
       "type": "object",
       "description": "Groups the set of query request settings.",
       "properties": {
-        "queryType": {
+        "QueryType": {
           "$ref": "#/definitions/QueryRequestType",
-          "description": "Required. The type of the provided query expression."
+          "description": "Required. The type of the provided query expression.",
+          "x-ms-client-name": "queryType"
         },
-        "expression": {
+        "Expression": {
           "type": "string",
-          "description": "The query expression in SQL. The maximum size of the query expression is 256KiB."
+          "description": "The query expression in SQL. The maximum size of the query expression is 256KiB.",
+          "x-ms-client-name": "expression"
         },
-        "inputSerialization": {
+        "InputSerialization": {
           "$ref": "#/definitions/QuerySerialization",
-          "description": "The input serialization settings."
+          "description": "The input serialization settings.",
+          "x-ms-client-name": "inputSerialization"
         },
-        "outputSerialization": {
+        "OutputSerialization": {
           "$ref": "#/definitions/QuerySerialization",
-          "description": "The output serialization settings."
+          "description": "The output serialization settings.",
+          "x-ms-client-name": "outputSerialization"
         }
       },
       "required": [
-        "queryType",
-        "expression"
+        "QueryType",
+        "Expression"
       ]
     },
     "QueryRequestType": {
@@ -17773,13 +17834,14 @@
       "type": "object",
       "description": "The query serialization settings.",
       "properties": {
-        "format": {
+        "Format": {
           "$ref": "#/definitions/QueryFormat",
-          "description": "The query format."
+          "description": "The query format.",
+          "x-ms-client-name": "format"
         }
       },
       "required": [
-        "format"
+        "Format"
       ]
     },
     "QueryType": {
@@ -17816,6 +17878,9 @@
             "description": "The query format type is Parquet."
           }
         ]
+      },
+      "xml": {
+        "name": "Type"
       }
     },
     "RehydratePriority": {
@@ -17846,23 +17911,26 @@
       "type": "object",
       "description": "The retention policy.",
       "properties": {
-        "enabled": {
+        "Enabled": {
           "type": "boolean",
-          "description": "Whether to enable the retention policy."
+          "description": "Whether to enable the retention policy.",
+          "x-ms-client-name": "enabled"
         },
-        "days": {
+        "Days": {
           "type": "integer",
           "format": "int32",
           "description": "The number of days to retain the logs.",
-          "minimum": 1
+          "minimum": 1,
+          "x-ms-client-name": "days"
         },
-        "allowPermanentDelete": {
+        "AllowPermanentDelete": {
           "type": "boolean",
-          "description": "Whether to allow permanent delete."
+          "description": "Whether to allow permanent delete.",
+          "x-ms-client-name": "allowPermanentDelete"
         }
       },
       "required": [
-        "enabled"
+        "Enabled"
       ]
     },
     "SequenceNumberActionType": {
@@ -17899,18 +17967,20 @@
       "type": "object",
       "description": "The signed identifier.",
       "properties": {
-        "id": {
+        "Id": {
           "type": "string",
-          "description": "The unique ID for the signed identifier."
+          "description": "The unique ID for the signed identifier.",
+          "x-ms-client-name": "id"
         },
-        "accessPolicy": {
+        "AccessPolicy": {
           "$ref": "#/definitions/AccessPolicy",
-          "description": "The access policy for the signed identifier."
+          "description": "The access policy for the signed identifier.",
+          "x-ms-client-name": "accessPolicy"
         }
       },
       "required": [
-        "id",
-        "accessPolicy"
+        "Id",
+        "AccessPolicy"
       ]
     },
     "SignedIdentifiers": {
@@ -17966,51 +18036,60 @@
       "type": "object",
       "description": "The properties that enable an account to host a static website",
       "properties": {
-        "enabled": {
+        "Enabled": {
           "type": "boolean",
-          "description": "Indicates whether this account is hosting a static website"
+          "description": "Indicates whether this account is hosting a static website",
+          "x-ms-client-name": "enabled"
         },
-        "indexDocument": {
+        "IndexDocument": {
           "type": "string",
-          "description": "The index document."
+          "description": "The index document.",
+          "x-ms-client-name": "indexDocument"
         },
-        "errorDocument404Path": {
+        "ErrorDocument404Path": {
           "type": "string",
-          "description": "The error document."
+          "description": "The error document.",
+          "x-ms-client-name": "errorDocument404Path"
         },
-        "defaultIndexDocumentPath": {
+        "DefaultIndexDocumentPath": {
           "type": "string",
-          "description": "Absolute path of the default index page"
+          "description": "Absolute path of the default index page",
+          "x-ms-client-name": "defaultIndexDocumentPath"
         }
       },
       "required": [
-        "enabled"
+        "Enabled"
       ]
     },
     "StorageError": {
       "type": "object",
       "description": "The error response.",
       "properties": {
-        "code": {
+        "Code": {
           "type": "string",
-          "description": "The error code."
+          "description": "The error code.",
+          "x-ms-client-name": "code"
         },
-        "message": {
+        "Message": {
           "type": "string",
-          "description": "The error message."
+          "description": "The error message.",
+          "x-ms-client-name": "message"
         },
-        "copySourceStatusCode": {
+        "CopySourceStatusCode": {
           "type": "integer",
           "format": "int32",
-          "description": "Copy source status code"
+          "description": "Copy source status code",
+          "x-ms-client-name": "copySourceStatusCode"
         },
-        "copySourceErrorCode": {
+        "CopySourceErrorCode": {
           "type": "string",
-          "description": "Copy source error code"
+          "description": "Copy source error code",
+          "x-ms-client-name": "copySourceErrorCode"
         },
-        "copySourceErrorMessage": {
+        "CopySourceErrorMessage": {
           "type": "string",
-          "description": "Copy source error message"
+          "description": "Copy source error message",
+          "x-ms-client-name": "copySourceErrorMessage"
         }
       }
     },
@@ -18018,36 +18097,46 @@
       "type": "object",
       "description": "The service properties.",
       "properties": {
-        "logging": {
+        "Logging": {
           "$ref": "#/definitions/Logging",
-          "description": "The logging properties."
+          "description": "The logging properties.",
+          "x-ms-client-name": "logging"
         },
-        "hourMetrics": {
+        "HourMetrics": {
           "$ref": "#/definitions/Metrics",
-          "description": "The hour metrics properties."
+          "description": "The hour metrics properties.",
+          "x-ms-client-name": "hourMetrics"
         },
-        "minuteMetrics": {
+        "MinuteMetrics": {
           "$ref": "#/definitions/Metrics",
-          "description": "The minute metrics properties."
+          "description": "The minute metrics properties.",
+          "x-ms-client-name": "minuteMetrics"
         },
-        "cors": {
+        "Cors": {
           "type": "array",
           "description": "The CORS properties.",
           "items": {
             "$ref": "#/definitions/CorsRule"
-          }
+          },
+          "xml": {
+            "wrapped": true
+          },
+          "x-ms-client-name": "cors"
         },
-        "defaultServiceVersion": {
+        "DefaultServiceVersion": {
           "type": "string",
-          "description": "The default service version."
+          "description": "The default service version.",
+          "x-ms-client-name": "defaultServiceVersion"
         },
-        "deleteRetentionPolicy": {
+        "DeleteRetentionPolicy": {
           "$ref": "#/definitions/RetentionPolicy",
-          "description": "The delete retention policy."
+          "description": "The delete retention policy.",
+          "x-ms-client-name": "deleteRetentionPolicy"
         },
-        "staticWebsite": {
+        "StaticWebsite": {
           "$ref": "#/definitions/StaticWebsite",
-          "description": "The static website properties."
+          "description": "The static website properties.",
+          "x-ms-client-name": "staticWebsite"
         }
       }
     },
@@ -18055,9 +18144,10 @@
       "type": "object",
       "description": "Stats for the storage service.",
       "properties": {
-        "geoReplication": {
+        "GeoReplication": {
           "$ref": "#/definitions/GeoReplication",
-          "description": "The geo replication stats."
+          "description": "The geo replication stats.",
+          "x-ms-client-name": "geoReplication"
         }
       }
     },
@@ -18065,43 +18155,50 @@
       "type": "object",
       "description": "A user delegation key.",
       "properties": {
-        "signedOid": {
+        "SignedOid": {
           "$ref": "#/definitions/Azure.Core.uuid",
-          "description": "The Azure Active Directory object ID in GUID format."
+          "description": "The Azure Active Directory object ID in GUID format.",
+          "x-ms-client-name": "signedOid"
         },
-        "signedTid": {
+        "SignedTid": {
           "$ref": "#/definitions/Azure.Core.uuid",
-          "description": "The Azure Active Directory tenant ID in GUID format."
+          "description": "The Azure Active Directory tenant ID in GUID format.",
+          "x-ms-client-name": "signedTid"
         },
-        "signedStart": {
+        "SignedStart": {
           "type": "string",
-          "description": "The date-time the key is active."
+          "description": "The date-time the key is active.",
+          "x-ms-client-name": "signedStart"
         },
-        "signedExpiry": {
+        "SignedExpiry": {
           "type": "string",
-          "description": "The date-time the key expires."
+          "description": "The date-time the key expires.",
+          "x-ms-client-name": "signedExpiry"
         },
-        "signedService": {
+        "SignedService": {
           "type": "string",
-          "description": "Abbreviation of the Azure Storage service that accepts the key."
+          "description": "Abbreviation of the Azure Storage service that accepts the key.",
+          "x-ms-client-name": "signedService"
         },
-        "signedVersion": {
+        "SignedVersion": {
           "type": "string",
-          "description": "The service version that created the key."
+          "description": "The service version that created the key.",
+          "x-ms-client-name": "signedVersion"
         },
-        "value": {
+        "Value": {
           "$ref": "#/definitions/base64Bytes",
-          "description": "The key as a base64 string."
+          "description": "The key as a base64 string.",
+          "x-ms-client-name": "value"
         }
       },
       "required": [
-        "signedOid",
-        "signedTid",
-        "signedStart",
-        "signedExpiry",
-        "signedService",
-        "signedVersion",
-        "value"
+        "SignedOid",
+        "SignedTid",
+        "SignedStart",
+        "SignedExpiry",
+        "SignedService",
+        "SignedVersion",
+        "Value"
       ]
     },
     "base64Bytes": {

--- a/specification/storage/data-plane/Microsoft.BlobStorage/stable/2026-02-06/generated_blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/stable/2026-02-06/generated_blob.json
@@ -28,10 +28,10 @@
     ]
   },
   "produces": [
-    "application/json"
+    "application/xml"
   ],
   "consumes": [
-    "application/json"
+    "application/xml"
   ],
   "security": [
     {
@@ -972,9 +972,6 @@
       "put": {
         "operationId": "Blob_StartCopyFromUrl",
         "description": "The Start Copy From URL operation copies a blob or an internet resource to a new blob.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -1444,9 +1441,6 @@
       "delete": {
         "operationId": "Blob_Delete",
         "description": "If the storage account's soft delete feature is disabled then, when a blob is deleted, it is permanently removed from the storage account. If the storage account's soft delete feature is enabled, then, when a blob is deleted, it is marked for deletion and becomes inaccessible immediately. However, the blob service retains the blob or snapshot for the number of days specified by the DeleteRetentionPolicy section of [Storage service properties] (Set-Blob-Service-Properties.md). After the specified number of days has passed, the blob's data is permanently removed from the storage account. Note that you continue to be charged for the soft-deleted blob's storage until it is permanently removed. Use the List Blobs API and specify the \\\"include=deleted\\\" query parameter to discover which blobs and snapshots have been soft deleted. You can then use the Undelete Blob API to restore a soft-deleted blob. All other operations on a soft-deleted blob or snapshot causes the service to return an HTTP status code of 404 (ResourceNotFound).",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -1658,9 +1652,6 @@
       "head": {
         "operationId": "Blob_GetProperties",
         "description": "The Get Properties operation returns all user-defined metadata, standard HTTP properties, and system properties for the blob. It does not return the content of the blob.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -2260,9 +2251,6 @@
       "put": {
         "operationId": "Container_Create",
         "description": "Creates a new container under the specified account. If the container with the same name already exists, the operation fails.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -2412,9 +2400,6 @@
       "get": {
         "operationId": "Container_GetProperties",
         "description": "returns all user-defined metadata and system properties for the specified container. The data returned does not include the container's list of blobs",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -2658,9 +2643,6 @@
       "delete": {
         "operationId": "Container_Delete",
         "description": "operation marks the specified container for deletion. The container and any blobs contained within it are later deleted during garbage collection",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -2770,9 +2752,6 @@
       "put": {
         "operationId": "Container_SetMetadata",
         "description": "operation sets one or more user-defined name-value pairs for the specified container.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -2895,9 +2874,6 @@
       "get": {
         "operationId": "Container_GetAccessPolicy",
         "description": "gets the permissions for the specified container. The permissions indicate whether container data may be accessed publicly.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -3030,12 +3006,6 @@
       "put": {
         "operationId": "Container_SetAccessPolicy",
         "description": "sets the permissions for the specified container. The permissions indicate whether blobs in a container may be accessed publicly.",
-        "produces": [
-          "application/xml"
-        ],
-        "consumes": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -3196,9 +3166,6 @@
       "put": {
         "operationId": "Container_Restore",
         "description": "Restores a previously-deleted container.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -3303,9 +3270,6 @@
       "put": {
         "operationId": "Container_Rename",
         "description": "Renames an existing container.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -3519,9 +3483,6 @@
       "get": {
         "operationId": "Container_FilterBlobs",
         "description": "The Filter Blobs operation enables callers to list blobs in a container whose tags match a given search expression.  Filter blobs searches within the given container.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -3667,9 +3628,6 @@
       "put": {
         "operationId": "Container_AcquireLease",
         "description": "The Acquire Lease operation requests a new lease on a container. The lease lock duration can be 15 to 60 seconds, or can be infinite.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -3820,9 +3778,6 @@
       "put": {
         "operationId": "Container_ReleaseLease",
         "description": "The Release Lease operation frees the lease if it's no longer needed, so that another client can immediately acquire a lease against the container.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -3960,9 +3915,6 @@
       "put": {
         "operationId": "Container_RenewLease",
         "description": "The Renew Lease operation renews an existing lease.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -4104,9 +4056,6 @@
       "put": {
         "operationId": "Container_BreakLease",
         "description": "The Break Lease operation ends a lease and ensures that another client can't acquire a new lease until the current lease period has expired.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -4250,9 +4199,6 @@
       "put": {
         "operationId": "Container_ChangeLease",
         "description": "The Change Lease operation is used to change the ID of an existing lease.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -4402,9 +4348,6 @@
       "get": {
         "operationId": "Container_ListBlobFlatSegment",
         "description": "The List Blobs operation returns a list of the blobs under the specified container.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -4605,9 +4548,6 @@
       "get": {
         "operationId": "Container_ListBlobHierarchySegment",
         "description": "The List Blobs operation returns a list of the blobs under the specified container. A delimiter can be used to traverse a virtual hierarchy of blobs as though it were a file system.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -4815,9 +4755,6 @@
       "get": {
         "operationId": "Container_GetAccountInfo",
         "description": "Returns the sku name and account kind",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -4994,9 +4931,6 @@
       "put": {
         "operationId": "Blob_Undelete",
         "description": "Undelete a blob that was previously soft deleted",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -5095,9 +5029,6 @@
       "put": {
         "operationId": "Blob_SetExpiry",
         "description": "Set the expiration time of a blob",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -5254,9 +5185,6 @@
       "put": {
         "operationId": "Blob_SetProperties",
         "description": "The Set HTTP Headers operation sets system properties on the blob.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -5468,9 +5396,6 @@
       "put": {
         "operationId": "Blob_SetImmutabilityPolicy",
         "description": "Set the immutability policy of a blob",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -5665,9 +5590,6 @@
       "delete": {
         "operationId": "Blob_DeleteImmutabilityPolicy",
         "description": "The Delete Immutability Policy operation deletes the immutability policy on the blob.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -5781,9 +5703,6 @@
       "put": {
         "operationId": "Blob_SetLegalHold",
         "description": "The Set Legal Hold operation sets a legal hold on the blob.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -5909,9 +5828,6 @@
       "put": {
         "operationId": "Blob_SetMetadata",
         "description": "The Set Metadata operation sets user-defined metadata for the specified blob as one or more name-value pairs.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -6139,9 +6055,6 @@
       "put": {
         "operationId": "Blob_AcquireLease",
         "description": "The Acquire Lease operation requests a new lease on a blob. The lease lock duration can be 15 to 60 seconds, or can be infinite.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -6326,9 +6239,6 @@
       "put": {
         "operationId": "Blob_ReleaseLease",
         "description": "The Release Lease operation frees the lease if it's no longer needed, so that another client can immediately acquire a lease against the blob.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -6500,9 +6410,6 @@
       "put": {
         "operationId": "Blob_RenewLease",
         "description": "The Renew Lease operation renews an existing lease.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -6678,9 +6585,6 @@
       "put": {
         "operationId": "Blob_ChangeLease",
         "description": "The Change Lease operation is used to change the ID of an existing lease.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -6864,9 +6768,6 @@
       "put": {
         "operationId": "Blob_BreakLease",
         "description": "The Break Lease operation ends a lease and ensures that another client can't acquire a new lease until the current lease period has expired.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -7044,9 +6945,6 @@
       "put": {
         "operationId": "Blob_CreateSnapshot",
         "description": "The Create Snapshot operation creates a read-only snapshot of a blob",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -7270,9 +7168,6 @@
       "put": {
         "operationId": "Blob_CopyFromUrl",
         "description": "The Copy From URL operation copies a blob or an internet resource to a new blob. It will not return a response until the copy is complete.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -7766,9 +7661,6 @@
       "put": {
         "operationId": "Blob_AbortCopyFromUrl",
         "description": "The Abort Copy From URL operation aborts a pending Copy From URL operation, and leaves a destination blob with zero length and full metadata.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -7897,9 +7789,6 @@
       "put": {
         "operationId": "Blob_SetTier",
         "description": "The Set Tier operation sets the tier on a block blob. The operation is allowed on a page blob or block blob, but not on an append blob. A block blob's tier determines Hot/Cool/Archive storage type. This operation does not update the blob's ETag.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -8183,9 +8072,6 @@
       "get": {
         "operationId": "Blob_GetAccountInfo",
         "description": "Returns the sku name and account kind",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -8372,9 +8258,6 @@
       "get": {
         "operationId": "Blob_GetTags",
         "description": "The Get Blob Tags operation enables users to get tags on a blob.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -8541,12 +8424,6 @@
       "put": {
         "operationId": "Blob_SetTags",
         "description": "The Set Tags operation enables users to set tags on a blob.",
-        "produces": [
-          "application/xml"
-        ],
-        "consumes": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -8730,9 +8607,6 @@
       "put": {
         "operationId": "AppendBlob_Create",
         "description": "The Create operation creates a new append blob.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -9092,9 +8966,6 @@
       "put": {
         "operationId": "PageBlob_UploadPages",
         "description": "The Upload Pages operation writes a range of pages to a page blob",
-        "produces": [
-          "application/xml"
-        ],
         "consumes": [
           "application/octet-stream"
         ],
@@ -9435,9 +9306,6 @@
       "put": {
         "operationId": "PageBlob_ClearPages",
         "description": "The Clear Pages operation clears a range of pages from a page blob",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -9716,9 +9584,6 @@
       "put": {
         "operationId": "PageBlob_UploadPagesFromUrl",
         "description": "The Upload Pages operation writes a range of pages to a page blob where the contents are read from a URL.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -10105,9 +9970,6 @@
       "get": {
         "operationId": "PageBlob_GetPageRanges",
         "description": "The Get Page Ranges operation returns the list of valid page ranges for a page blob or snapshot of a page blob.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -10304,9 +10166,6 @@
       "get": {
         "operationId": "PageBlob_GetPageRangesDiff",
         "description": "The Get Page Ranges Diff operation returns the list of valid page ranges for a page blob or snapshot of a page blob.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -10518,9 +10377,6 @@
       "put": {
         "operationId": "PageBlob_Resize",
         "description": "The Resize operation increases the size of the page blob to the specified size.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -10738,9 +10594,6 @@
       "put": {
         "operationId": "PageBlob_SetSequenceNumber",
         "description": "The Update Sequence Number operation sets the blob's sequence number. The operation will fail if the specified sequence number is less than the current sequence number of the blob.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -10947,9 +10800,6 @@
       "put": {
         "operationId": "PageBlob_CopyIncremental",
         "description": "The Copy Incremental operation copies a snapshot of the source page blob to a destination page blob. The snapshot is copied such that only the differential changes between the previously copied snapshot are transferred to the destination. The copied snapshots are complete copies of the original snapshot and can be read or copied from as usual. This API is supported since REST version 2016-05-31.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -11147,9 +10997,6 @@
       "put": {
         "operationId": "AppendBlob_AppendBlock",
         "description": "The Append Block operation commits a new block of data to the end of an append blob.",
-        "produces": [
-          "application/xml"
-        ],
         "consumes": [
           "application/octet-stream"
         ],
@@ -11463,9 +11310,6 @@
       "put": {
         "operationId": "AppendBlob_AppendBlockFromUrl",
         "description": "The Append Block From URL operation creates a new block to be committed as part of an append blob where the contents are read from a URL.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -11834,9 +11678,6 @@
       "put": {
         "operationId": "AppendBlob_Seal",
         "description": "The Seal operation seals the Append Blob to make it read-only. Seal is supported only on version 2019-12-12 version or later.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -11999,9 +11840,6 @@
       "put": {
         "operationId": "BlockBlob_Upload",
         "description": "The Upload Block Blob operation updates the content of an existing block blob. Updating an existing block blob overwrites any existing metadata on the blob. Partial updates are not supported with Put Blob; the content of the existing blob is overwritten with the content of the new blob. To perform a partial update of the content of a block blob, use the Put Block List operation.",
-        "produces": [
-          "application/xml"
-        ],
         "consumes": [
           "application/octet-stream"
         ],
@@ -12523,9 +12361,6 @@
       "put": {
         "operationId": "BlockBlob_PutBlobFromUrl",
         "description": "The Put Blob from URL operation creates a new Block Blob where the contents of the blob are read from a given URL.  This API is supported beginning with the 2020-04-08 version. Partial updates are not supported with Put Blob from URL; the content of an existing blob is overwritten with the content of the new blob.  To perform partial updates to a block blob’s contents using a source URL, use the Put Block from URL API in conjunction with Put Block List.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -13084,9 +12919,6 @@
       "put": {
         "operationId": "BlockBlob_StageBlock",
         "description": "The Stage Block operation creates a new block to be committed as part of a blob",
-        "produces": [
-          "application/xml"
-        ],
         "consumes": [
           "application/octet-stream"
         ],
@@ -13331,9 +13163,6 @@
       "put": {
         "operationId": "BlockBlob_StageBlockFromUrl",
         "description": "The Stage Block From URL operation creates a new block to be committed as part of a blob where the contents are read from a URL.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -13624,12 +13453,6 @@
       "put": {
         "operationId": "BlockBlob_CommitBlockList",
         "description": "The Commit Block List operation writes a blob by specifying the list of block IDs that make up the blob. In order to be written as part of a blob, a block must have been successfully written to the server in a prior Put Block operation. You can call Put Block List to update a blob by uploading only those blocks that have changed, then committing the new and existing blocks together. You can do this by specifying whether to commit a block from the committed block list or from the uncommitted block list, or to commit the most recently uploaded version of the block, whichever list it may belong to.",
-        "produces": [
-          "application/xml"
-        ],
-        "consumes": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -14108,9 +13931,6 @@
       "get": {
         "operationId": "BlockBlob_GetBlockList",
         "description": "The Get Block List operation retrieves the list of blocks that have been uploaded as part of a block blob.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -14285,9 +14105,6 @@
         "description": "The Query operation enables users to select/project on blob data by providing simple query expressions.",
         "produces": [
           "application/octet-stream",
-          "application/xml"
-        ],
-        "consumes": [
           "application/xml"
         ],
         "parameters": [
@@ -15141,9 +14958,6 @@
       "get": {
         "operationId": "FilterBlobs",
         "description": "The Filter Blobs operation enables callers to list blobs across all containers whose tags match a given search expression.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -15282,9 +15096,6 @@
       "get": {
         "operationId": "ListContainersSegment",
         "description": "The List Containers Segment operation returns a list of the containers under the specified account",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -15424,9 +15235,6 @@
       "get": {
         "operationId": "GetAccountInfo",
         "description": "Returns the sku name and account kind.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -15596,12 +15404,6 @@
       "put": {
         "operationId": "SetProperties",
         "description": "Sets properties for a storage account's Blob service endpoint, including properties for Storage Analytics and CORS (Cross-Origin Resource Sharing) rules",
-        "produces": [
-          "application/xml"
-        ],
-        "consumes": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -15687,9 +15489,6 @@
       "get": {
         "operationId": "GetProperties",
         "description": "Retrieves properties of a storage account's Blob service, including properties for Storage Analytics and CORS (Cross-Origin Resource Sharing) rules.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -15769,9 +15568,6 @@
       "get": {
         "operationId": "GetStatistics",
         "description": "Retrieves statistics related to replication for the Blob service. It is only available on the secondary location endpoint when read-access geo-redundant replication is enabled for the storage account.",
-        "produces": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -15856,12 +15652,6 @@
       "post": {
         "operationId": "GetUserDelegationKey",
         "description": "Retrieves a user delegation key for the Blob service. This is only a valid operation when using bearer token authentication.",
-        "produces": [
-          "application/xml"
-        ],
-        "consumes": [
-          "application/xml"
-        ],
         "parameters": [
           {
             "name": "x-ms-version",
@@ -15957,25 +15747,28 @@
       "type": "object",
       "description": "Represents an access policy.",
       "properties": {
-        "start": {
+        "Start": {
           "type": "string",
           "format": "date-time-rfc7231",
-          "description": "The date-time the policy is active."
+          "description": "The date-time the policy is active.",
+          "x-ms-client-name": "start"
         },
-        "expiry": {
+        "Expiry": {
           "type": "string",
           "format": "date-time-rfc7231",
-          "description": "The date-time the policy expires."
+          "description": "The date-time the policy expires.",
+          "x-ms-client-name": "expiry"
         },
-        "permission": {
+        "Permission": {
           "type": "string",
-          "description": "The permissions for acl the policy."
+          "description": "The permissions for acl the policy.",
+          "x-ms-client-name": "permission"
         }
       },
       "required": [
-        "start",
-        "expiry",
-        "permission"
+        "Start",
+        "Expiry",
+        "Permission"
       ]
     },
     "AccessTier": {
@@ -16162,49 +15955,63 @@
       "type": "object",
       "description": "Represents the Apache Arrow configuration.",
       "properties": {
-        "schema": {
+        "Schema": {
           "type": "array",
           "description": "The Apache Arrow schema",
           "items": {
             "$ref": "#/definitions/ArrowField"
-          }
+          },
+          "xml": {
+            "wrapped": true
+          },
+          "x-ms-client-name": "schema"
         }
       },
       "required": [
-        "schema"
+        "Schema"
       ]
     },
     "ArrowField": {
       "type": "object",
       "description": "Represents an Apache Arrow field.",
       "properties": {
-        "type": {
+        "Type": {
           "type": "string",
-          "description": "The arrow field type."
+          "description": "The arrow field type.",
+          "x-ms-client-name": "type"
         },
-        "name": {
+        "Name": {
           "type": "string",
-          "description": "The arrow field name."
+          "description": "The arrow field name.",
+          "x-ms-client-name": "name"
         },
-        "precision": {
+        "Precision": {
           "type": "integer",
           "format": "int32",
-          "description": "The arrow field precision."
+          "description": "The arrow field precision.",
+          "x-ms-client-name": "precision"
         },
-        "scale": {
+        "Scale": {
           "type": "integer",
           "format": "int32",
-          "description": "The arrow field scale."
+          "description": "The arrow field scale.",
+          "x-ms-client-name": "scale"
         }
       },
       "required": [
-        "type"
-      ]
+        "Type"
+      ],
+      "xml": {
+        "name": "Field"
+      }
     },
     "Azure.Core.uuid": {
       "type": "string",
       "format": "uuid",
-      "description": "Universally Unique Identifier"
+      "description": "Universally Unique Identifier",
+      "xml": {
+        "name": "uuid"
+      }
     },
     "BlobCopySourceTags": {
       "type": "string",
@@ -16288,39 +16095,51 @@
       "type": "object",
       "description": "The blob flat list segment.",
       "properties": {
-        "blobItems": {
+        "Blob": {
           "type": "array",
           "description": "The blob items.",
           "items": {
             "$ref": "#/definitions/BlobItemInternal"
-          }
+          },
+          "xml": {
+            "wrapped": false
+          },
+          "x-ms-client-name": "blobItems"
         }
       },
       "required": [
-        "blobItems"
+        "Blob"
       ]
     },
     "BlobHierarchyListSegment": {
       "type": "object",
       "description": "Represents an array of blobs.",
       "properties": {
-        "blobItems": {
+        "Blob": {
           "type": "array",
           "description": "The blob items",
           "items": {
             "$ref": "#/definitions/BlobItemInternal"
-          }
+          },
+          "xml": {
+            "wrapped": false
+          },
+          "x-ms-client-name": "blobItems"
         },
-        "blobPrefixes": {
+        "BlobPrefix": {
           "type": "array",
           "description": "The blob prefixes.",
           "items": {
             "$ref": "#/definitions/BlobPrefix"
-          }
+          },
+          "xml": {
+            "wrapped": false
+          },
+          "x-ms-client-name": "blobPrefixes"
         }
       },
       "required": [
-        "blobItems"
+        "Blob"
       ]
     },
     "BlobImmutabilityPolicyMode": {
@@ -16357,61 +16176,78 @@
       "type": "object",
       "description": "An Azure Storage Blob",
       "properties": {
-        "name": {
+        "Name": {
           "$ref": "#/definitions/BlobName",
-          "description": "The name of the blob."
+          "description": "The name of the blob.",
+          "x-ms-client-name": "name"
         },
-        "deleted": {
+        "Deleted": {
           "type": "boolean",
-          "description": "Whether the blob is deleted."
+          "description": "Whether the blob is deleted.",
+          "x-ms-client-name": "deleted"
         },
-        "snapshot": {
+        "Snapshot": {
           "type": "string",
-          "description": "The snapshot of the blob."
+          "description": "The snapshot of the blob.",
+          "x-ms-client-name": "snapshot"
         },
-        "versionId": {
+        "VersionId": {
           "type": "string",
-          "description": "The version id of the blob."
+          "description": "The version id of the blob.",
+          "x-ms-client-name": "versionId"
         },
-        "isCurrentVersion": {
+        "IsCurrentVersion": {
           "type": "boolean",
-          "description": "Whether the blob is the current version."
+          "description": "Whether the blob is the current version.",
+          "x-ms-client-name": "isCurrentVersion"
         },
-        "properties": {
+        "Properties": {
           "$ref": "#/definitions/BlobPropertiesInternal",
-          "description": "The properties of the blob."
+          "description": "The properties of the blob.",
+          "x-ms-client-name": "properties"
         },
-        "metadata": {
+        "Metadata": {
           "$ref": "#/definitions/BlobMetadata",
-          "description": "The metadata of the blob."
+          "description": "The metadata of the blob.",
+          "x-ms-client-name": "metadata"
         },
-        "blobTags": {
+        "BlobTags": {
           "$ref": "#/definitions/BlobTags",
-          "description": "The tags of the blob."
+          "description": "The tags of the blob.",
+          "x-ms-client-name": "blobTags"
         },
-        "objectReplicationMetadata": {
+        "ObjectReplicationMetadata": {
           "$ref": "#/definitions/ObjectReplicationMetadata",
-          "description": "The object replication metadata of the blob."
+          "description": "The object replication metadata of the blob.",
+          "x-ms-client-name": "objectReplicationMetadata"
         },
-        "hasVersionsOnly": {
+        "HasVersionsOnly": {
           "type": "boolean",
-          "description": "Whether the blog has versions only."
+          "description": "Whether the blog has versions only.",
+          "x-ms-client-name": "hasVersionsOnly"
         }
       },
       "required": [
-        "name",
-        "deleted",
-        "snapshot",
-        "properties"
-      ]
+        "Name",
+        "Deleted",
+        "Snapshot",
+        "Properties"
+      ],
+      "xml": {
+        "name": "Blob"
+      }
     },
     "BlobMetadata": {
       "type": "object",
       "description": "The blob metadata.",
       "properties": {
-        "encrypted": {
+        "Encrypted": {
           "type": "string",
-          "description": "Whether the blob metadata is encrypted."
+          "description": "Whether the blob metadata is encrypted.",
+          "xml": {
+            "attribute": true
+          },
+          "x-ms-client-name": "encrypted"
         }
       },
       "additionalProperties": {
@@ -16422,13 +16258,20 @@
       "type": "object",
       "description": "Represents a blob name.",
       "properties": {
-        "encoded": {
+        "Encoded": {
           "type": "boolean",
-          "description": "Whether the blob name is encoded."
+          "description": "Whether the blob name is encoded.",
+          "xml": {
+            "attribute": true
+          },
+          "x-ms-client-name": "encoded"
         },
         "content": {
           "type": "string",
-          "description": "The blob name."
+          "description": "The blob name.",
+          "xml": {
+            "x-ms-text": true
+          }
         }
       }
     },
@@ -16436,231 +16279,287 @@
       "type": "object",
       "description": "Represents a blob prefix.",
       "properties": {
-        "name": {
+        "Name": {
           "$ref": "#/definitions/BlobName",
-          "description": "The blob name."
+          "description": "The blob name.",
+          "x-ms-client-name": "name"
         }
       },
       "required": [
-        "name"
+        "Name"
       ]
     },
     "BlobPropertiesInternal": {
       "type": "object",
       "description": "The properties of a blob.",
       "properties": {
-        "creationTime": {
+        "Creation-Time": {
           "type": "string",
           "format": "date-time-rfc7231",
-          "description": "The date-time the blob was created in RFC1123 format."
+          "description": "The date-time the blob was created in RFC1123 format.",
+          "x-ms-client-name": "creationTime"
         },
-        "lastModified": {
+        "Last-Modified": {
           "type": "string",
           "format": "date-time-rfc7231",
-          "description": "The date-time the blob was last modified in RFC1123 format."
+          "description": "The date-time the blob was last modified in RFC1123 format.",
+          "x-ms-client-name": "lastModified"
         },
-        "eTag": {
+        "Etag": {
           "type": "string",
-          "description": "The blog ETag."
+          "description": "The blog ETag.",
+          "x-ms-client-name": "eTag"
         },
-        "contentLength": {
+        "Content-Length": {
           "type": "integer",
           "format": "int64",
-          "description": "The content length of the blob."
+          "description": "The content length of the blob.",
+          "x-ms-client-name": "contentLength"
         },
-        "contentType": {
+        "Content-Type": {
           "type": "string",
-          "description": "The content type of the blob."
+          "description": "The content type of the blob.",
+          "x-ms-client-name": "contentType"
         },
-        "contentEncoding": {
+        "Content-Encoding": {
           "type": "string",
-          "description": "The content encoding of the blob."
+          "description": "The content encoding of the blob.",
+          "x-ms-client-name": "contentEncoding"
         },
-        "contentLanguage": {
+        "Content-Language": {
           "type": "string",
-          "description": "The content language of the blob."
+          "description": "The content language of the blob.",
+          "x-ms-client-name": "contentLanguage"
         },
-        "contentMd5": {
+        "Content-MD5": {
           "type": "string",
           "format": "byte",
-          "description": "The content MD5 of the blob."
+          "description": "The content MD5 of the blob.",
+          "x-ms-client-name": "contentMd5"
         },
-        "contentDisposition": {
+        "Content-Disposition": {
           "type": "string",
-          "description": "The content disposition of the blob."
+          "description": "The content disposition of the blob.",
+          "x-ms-client-name": "contentDisposition"
         },
-        "cacheControl": {
+        "Cache-Control": {
           "type": "string",
-          "description": "The cache control of the blob."
+          "description": "The cache control of the blob.",
+          "x-ms-client-name": "cacheControl"
         },
-        "blobSequenceNumber": {
+        "x-ms-blob-sequence-number": {
           "type": "integer",
           "format": "int64",
-          "description": "The sequence number of the blob."
+          "description": "The sequence number of the blob.",
+          "x-ms-client-name": "blobSequenceNumber"
         },
-        "blobType": {
+        "BlobType": {
           "$ref": "#/definitions/BlobType",
-          "description": "The blob type."
+          "description": "The blob type.",
+          "x-ms-client-name": "blobType"
         },
-        "leaseStatus": {
+        "LeaseStatus": {
           "$ref": "#/definitions/LeaseStatus",
-          "description": "The lease status of the blob."
+          "description": "The lease status of the blob.",
+          "x-ms-client-name": "leaseStatus"
         },
-        "leaseState": {
+        "LeaseState": {
           "$ref": "#/definitions/LeaseState",
-          "description": "The lease state of the blob."
+          "description": "The lease state of the blob.",
+          "x-ms-client-name": "leaseState"
         },
-        "leaseDuration": {
+        "LeaseDuration": {
           "$ref": "#/definitions/LeaseDuration",
-          "description": "The lease duration of the blob."
+          "description": "The lease duration of the blob.",
+          "x-ms-client-name": "leaseDuration"
         },
-        "copyId": {
+        "CopyId": {
           "type": "string",
-          "description": "The copy ID of the blob."
+          "description": "The copy ID of the blob.",
+          "x-ms-client-name": "copyId"
         },
-        "copyStatus": {
+        "CopyStatus": {
           "$ref": "#/definitions/CopyStatus",
-          "description": "The copy status of the blob."
+          "description": "The copy status of the blob.",
+          "x-ms-client-name": "copyStatus"
         },
-        "copySource": {
+        "CopySource": {
           "type": "string",
-          "description": "The copy source of the blob."
+          "description": "The copy source of the blob.",
+          "x-ms-client-name": "copySource"
         },
-        "copyProgress": {
+        "CopyProgress": {
           "type": "string",
-          "description": "The copy progress of the blob."
+          "description": "The copy progress of the blob.",
+          "x-ms-client-name": "copyProgress"
         },
-        "copyCompletionTime": {
-          "type": "string",
-          "format": "date-time-rfc7231",
-          "description": "The copy completion time of the blob."
-        },
-        "copyStatusDescription": {
-          "type": "string",
-          "description": "The copy status description of the blob."
-        },
-        "serverEncrypted": {
-          "type": "boolean",
-          "description": "Whether the blog is encrypted on the server."
-        },
-        "incrementalCopy": {
-          "type": "boolean",
-          "description": "Whether the blog is incremental copy."
-        },
-        "destinationSnapshot": {
-          "type": "string",
-          "description": "The name of the destination snapshot."
-        },
-        "deletedTime": {
+        "CopyCompletionTime": {
           "type": "string",
           "format": "date-time-rfc7231",
-          "description": "The time the blob was deleted."
+          "description": "The copy completion time of the blob.",
+          "x-ms-client-name": "copyCompletionTime"
         },
-        "remainingRetentionDays": {
+        "CopyStatusDescription": {
+          "type": "string",
+          "description": "The copy status description of the blob.",
+          "x-ms-client-name": "copyStatusDescription"
+        },
+        "ServerEncrypted": {
+          "type": "boolean",
+          "description": "Whether the blog is encrypted on the server.",
+          "x-ms-client-name": "serverEncrypted"
+        },
+        "IncrementalCopy": {
+          "type": "boolean",
+          "description": "Whether the blog is incremental copy.",
+          "x-ms-client-name": "incrementalCopy"
+        },
+        "DestinationSnapshot": {
+          "type": "string",
+          "description": "The name of the destination snapshot.",
+          "x-ms-client-name": "destinationSnapshot"
+        },
+        "DeletedTime": {
+          "type": "string",
+          "format": "date-time-rfc7231",
+          "description": "The time the blob was deleted.",
+          "x-ms-client-name": "deletedTime"
+        },
+        "RemainingRetentionDays": {
           "type": "integer",
           "format": "int32",
-          "description": "The remaining retention days of the blob."
+          "description": "The remaining retention days of the blob.",
+          "x-ms-client-name": "remainingRetentionDays"
         },
-        "accessTier": {
+        "AccessTier": {
           "$ref": "#/definitions/AccessTier",
-          "description": "The access tier of the blob."
+          "description": "The access tier of the blob.",
+          "x-ms-client-name": "accessTier"
         },
-        "accessTierInferred": {
+        "AccessTierInferred": {
           "type": "boolean",
-          "description": "Whether the access tier is inferred."
+          "description": "Whether the access tier is inferred.",
+          "x-ms-client-name": "accessTierInferred"
         },
-        "archiveStatus": {
+        "ArchiveStatus": {
           "$ref": "#/definitions/ArchiveStatus",
-          "description": "The archive status of the blob."
+          "description": "The archive status of the blob.",
+          "x-ms-client-name": "archiveStatus"
         },
-        "customerProvidedKeySha256": {
+        "CustomerProvidedKeySha256": {
           "type": "string",
-          "description": "Customer provided key sha256"
+          "description": "Customer provided key sha256",
+          "x-ms-client-name": "customerProvidedKeySha256"
         },
-        "encryptionScope": {
+        "EncryptionScope": {
           "type": "string",
-          "description": "The encryption scope of the blob."
+          "description": "The encryption scope of the blob.",
+          "x-ms-client-name": "encryptionScope"
         },
-        "accessTierChangeTime": {
+        "AccessTierChangeTime": {
           "type": "string",
           "format": "date-time-rfc7231",
-          "description": "The access tier change time of the blob."
+          "description": "The access tier change time of the blob.",
+          "x-ms-client-name": "accessTierChangeTime"
         },
-        "tagCount": {
+        "TagCount": {
           "type": "integer",
           "format": "int32",
-          "description": "The number of tags for the blob."
+          "description": "The number of tags for the blob.",
+          "x-ms-client-name": "tagCount"
         },
-        "expiryTime": {
+        "Expiry-Time": {
           "type": "string",
           "format": "date-time-rfc7231",
-          "description": "The expire time of the blob."
+          "description": "The expire time of the blob.",
+          "x-ms-client-name": "expiryTime"
         },
-        "sealed": {
+        "Sealed": {
           "type": "boolean",
-          "description": "Whether the blob is sealed."
+          "description": "Whether the blob is sealed.",
+          "x-ms-client-name": "sealed"
         },
-        "rehydratePriority": {
+        "RehydratePriority": {
           "$ref": "#/definitions/RehydratePriority",
-          "description": "The rehydrate priority of the blob."
+          "description": "The rehydrate priority of the blob.",
+          "x-ms-client-name": "rehydratePriority"
         },
-        "lastAccessTime": {
+        "LastAccessTime": {
           "type": "string",
           "format": "date-time-rfc7231",
-          "description": "The last access time of the blob."
+          "description": "The last access time of the blob.",
+          "x-ms-client-name": "lastAccessTime"
         },
-        "immutabilityPolicyUntilDate": {
+        "ImmutabilityPolicyUntilDate": {
           "type": "string",
           "format": "date-time-rfc7231",
-          "description": "The immutability policy until time of the blob."
+          "description": "The immutability policy until time of the blob.",
+          "x-ms-client-name": "immutabilityPolicyUntilDate"
         },
-        "immutabilityPolicyMode": {
+        "ImmutabilityPolicyMode": {
           "$ref": "#/definitions/BlobImmutabilityPolicyMode",
-          "description": "The immutability policy mode of the blob."
+          "description": "The immutability policy mode of the blob.",
+          "x-ms-client-name": "immutabilityPolicyMode"
         },
-        "legalHold": {
+        "LegalHold": {
           "type": "boolean",
-          "description": "Whether the blob is under legal hold."
+          "description": "Whether the blob is under legal hold.",
+          "x-ms-client-name": "legalHold"
         }
       },
       "required": [
-        "lastModified",
-        "eTag"
-      ]
+        "Last-Modified",
+        "Etag"
+      ],
+      "xml": {
+        "name": "Properties"
+      }
     },
     "BlobTag": {
       "type": "object",
       "description": "The blob tags.",
       "properties": {
-        "key": {
+        "Key": {
           "type": "string",
-          "description": "The key of the tag."
+          "description": "The key of the tag.",
+          "x-ms-client-name": "key"
         },
-        "value": {
+        "Value": {
           "type": "string",
-          "description": "The value of the tag."
+          "description": "The value of the tag.",
+          "x-ms-client-name": "value"
         }
       },
       "required": [
-        "key",
-        "value"
-      ]
+        "Key",
+        "Value"
+      ],
+      "xml": {
+        "name": "Tag"
+      }
     },
     "BlobTags": {
       "type": "object",
       "description": "Represents blob tags.",
       "properties": {
-        "blobTagSet": {
+        "TagSet": {
           "type": "array",
           "description": "Represents the blob tags.",
           "items": {
             "$ref": "#/definitions/BlobTag"
-          }
+          },
+          "xml": {
+            "wrapped": true
+          },
+          "x-ms-client-name": "blobTagSet"
         }
       },
       "required": [
-        "blobTagSet"
-      ]
+        "TagSet"
+      ],
+      "xml": {
+        "name": "Tags"
+      }
     },
     "BlobType": {
       "type": "string",
@@ -16696,38 +16595,48 @@
       "type": "object",
       "description": "Represents a single block in a block blob. It describes the block's ID and size.",
       "properties": {
-        "name": {
+        "Name": {
           "$ref": "#/definitions/base64Bytes",
-          "description": "The base64 encoded block ID."
+          "description": "The base64 encoded block ID.",
+          "x-ms-client-name": "name"
         },
-        "size": {
+        "Size": {
           "type": "integer",
           "format": "int64",
-          "description": "The block size in bytes."
+          "description": "The block size in bytes.",
+          "x-ms-client-name": "size"
         }
       },
       "required": [
-        "name",
-        "size"
+        "Name",
+        "Size"
       ]
     },
     "BlockList": {
       "type": "object",
       "description": "Contains the committed and uncommitted blocks in a block blob.",
       "properties": {
-        "committedBlocks": {
+        "CommittedBlocks": {
           "type": "array",
           "description": "The list of committed blocks.",
           "items": {
             "$ref": "#/definitions/Block"
-          }
+          },
+          "xml": {
+            "wrapped": true
+          },
+          "x-ms-client-name": "committedBlocks"
         },
-        "uncommittedBlocks": {
+        "UncommittedBlocks": {
           "type": "array",
           "description": "The list of uncommitted blocks.",
           "items": {
             "$ref": "#/definitions/Block"
-          }
+          },
+          "xml": {
+            "wrapped": true
+          },
+          "x-ms-client-name": "uncommittedBlocks"
         }
       }
     },
@@ -16765,145 +16674,183 @@
       "type": "object",
       "description": "The Block lookup list.",
       "properties": {
-        "committed": {
+        "Committed": {
           "type": "array",
           "description": "The committed blocks",
           "items": {
             "$ref": "#/definitions/base64Bytes"
-          }
+          },
+          "xml": {
+            "wrapped": false
+          },
+          "x-ms-client-name": "committed"
         },
-        "uncommitted": {
+        "Uncommitted": {
           "type": "array",
           "description": "The uncommitted blocks",
           "items": {
             "$ref": "#/definitions/base64Bytes"
-          }
+          },
+          "xml": {
+            "wrapped": false
+          },
+          "x-ms-client-name": "uncommitted"
         },
-        "latest": {
+        "Latest": {
           "type": "array",
           "description": "The latest blocks",
           "items": {
             "$ref": "#/definitions/base64Bytes"
-          }
+          },
+          "xml": {
+            "wrapped": false
+          },
+          "x-ms-client-name": "latest"
         }
+      },
+      "xml": {
+        "name": "BlockList"
       }
     },
     "ClearRange": {
       "type": "object",
       "description": "The clear range.",
       "properties": {
-        "start": {
+        "Start": {
           "type": "integer",
           "format": "int64",
-          "description": "The start of the byte range."
+          "description": "The start of the byte range.",
+          "x-ms-client-name": "start"
         },
-        "end": {
+        "End": {
           "type": "integer",
           "format": "int64",
-          "description": "The end of the byte range."
+          "description": "The end of the byte range.",
+          "x-ms-client-name": "end"
         }
       },
       "required": [
-        "start",
-        "end"
+        "Start",
+        "End"
       ]
     },
     "ContainerItem": {
       "type": "object",
       "description": "An Azure Storage container.",
       "properties": {
-        "name": {
+        "Name": {
           "type": "string",
-          "description": "The name of the container."
+          "description": "The name of the container.",
+          "x-ms-client-name": "name"
         },
-        "delete": {
+        "Deleted": {
           "type": "boolean",
-          "description": "Whether the container is deleted."
+          "description": "Whether the container is deleted.",
+          "x-ms-client-name": "delete"
         },
-        "version": {
+        "Version": {
           "type": "string",
-          "description": "The version of the container."
+          "description": "The version of the container.",
+          "x-ms-client-name": "version"
         },
-        "properties": {
+        "Properties": {
           "$ref": "#/definitions/ContainerProperties",
-          "description": "The properties of the container."
+          "description": "The properties of the container.",
+          "x-ms-client-name": "properties"
         },
-        "metadata": {
+        "Metadata": {
           "type": "object",
           "description": "The metadata of the container.",
           "additionalProperties": {
             "type": "string"
-          }
+          },
+          "x-ms-client-name": "metadata"
         }
       },
       "required": [
-        "name",
-        "properties"
-      ]
+        "Name",
+        "Properties"
+      ],
+      "xml": {
+        "name": "Container"
+      }
     },
     "ContainerProperties": {
       "type": "object",
       "description": "The properties of a container.",
       "properties": {
-        "lastModified": {
+        "Last-Modified": {
           "type": "string",
           "format": "date-time-rfc7231",
-          "description": "The date-time the container was last modified in RFC1123 format."
+          "description": "The date-time the container was last modified in RFC1123 format.",
+          "x-ms-client-name": "lastModified"
         },
-        "eTag": {
+        "ETag": {
           "type": "string",
-          "description": "The ETag of the container."
+          "description": "The ETag of the container.",
+          "x-ms-client-name": "eTag"
         },
-        "leaseStatus": {
+        "LeaseStatus": {
           "$ref": "#/definitions/LeaseStatus",
-          "description": "The lease status of the container."
+          "description": "The lease status of the container.",
+          "x-ms-client-name": "leaseStatus"
         },
-        "leaseState": {
+        "LeaseState": {
           "$ref": "#/definitions/LeaseState",
-          "description": "The lease state of the container."
+          "description": "The lease state of the container.",
+          "x-ms-client-name": "leaseState"
         },
-        "leaseDuration": {
+        "LeaseDuration": {
           "$ref": "#/definitions/LeaseDuration",
-          "description": "The lease duration of the container."
+          "description": "The lease duration of the container.",
+          "x-ms-client-name": "leaseDuration"
         },
-        "publicAccess": {
+        "PublicAccess": {
           "$ref": "#/definitions/PublicAccessType",
-          "description": "The public access type of the container."
+          "description": "The public access type of the container.",
+          "x-ms-client-name": "publicAccess"
         },
-        "hasImmutabilityPolicy": {
+        "HasImmutabilityPolicy": {
           "type": "boolean",
-          "description": "Whether it has an immutability policy."
+          "description": "Whether it has an immutability policy.",
+          "x-ms-client-name": "hasImmutabilityPolicy"
         },
-        "hasLegalHold": {
+        "HasLegalHold": {
           "type": "boolean",
-          "description": "The has legal hold status of the container."
+          "description": "The has legal hold status of the container.",
+          "x-ms-client-name": "hasLegalHold"
         },
-        "defaultEncryptionScope": {
+        "DefaultEncryptionScope": {
           "type": "string",
-          "description": "The default encryption scope of the container."
+          "description": "The default encryption scope of the container.",
+          "x-ms-client-name": "defaultEncryptionScope"
         },
-        "denyEncryptionScopeOverride": {
+        "DenyEncryptionScopeOverride": {
           "type": "boolean",
-          "description": "Whether to prevent encryption scope override."
+          "description": "Whether to prevent encryption scope override.",
+          "x-ms-client-name": "denyEncryptionScopeOverride"
         },
-        "deletedTime": {
+        "DeletedTime": {
           "type": "string",
           "format": "date-time-rfc7231",
-          "description": "The deleted time of the container."
+          "description": "The deleted time of the container.",
+          "x-ms-client-name": "deletedTime"
         },
-        "remainingRetentionDays": {
+        "RemainingRetentionDays": {
           "type": "integer",
           "format": "int32",
-          "description": "The remaining retention days of the container."
+          "description": "The remaining retention days of the container.",
+          "x-ms-client-name": "remainingRetentionDays"
         },
-        "immutableStorageWithVersioningEnabled": {
+        "ImmutableStorageWithVersioningEnabled": {
           "type": "boolean",
-          "description": "Whether immutable storage with versioning is enabled."
+          "description": "Whether immutable storage with versioning is enabled.",
+          "x-ms-client-name": "immutableStorageWithVersioningEnabled"
         }
       },
       "required": [
-        "lastModified",
-        "eTag"
+        "Last-Modified",
+        "ETag"
       ]
     },
     "CopyStatus": {
@@ -16946,35 +16893,40 @@
       "type": "object",
       "description": "CORS is an HTTP feature that enables a web application running under one domain to access resources in another domain. Web browsers implement a security restriction known as same-origin policy that prevents a web page from calling APIs in a different domain; CORS provides a secure way to allow one domain (the origin domain) to call APIs in another domain",
       "properties": {
-        "allowedOrigins": {
+        "AllowedOrigins": {
           "type": "string",
-          "description": "The allowed origins."
+          "description": "The allowed origins.",
+          "x-ms-client-name": "allowedOrigins"
         },
-        "allowedMethods": {
+        "AllowedMethods": {
           "type": "string",
-          "description": "The allowed methods."
+          "description": "The allowed methods.",
+          "x-ms-client-name": "allowedMethods"
         },
-        "allowedHeaders": {
+        "AllowedHeaders": {
           "type": "string",
-          "description": "The allowed headers."
+          "description": "The allowed headers.",
+          "x-ms-client-name": "allowedHeaders"
         },
-        "exposedHeaders": {
+        "ExposedHeaders": {
           "type": "string",
-          "description": "The exposed headers."
+          "description": "The exposed headers.",
+          "x-ms-client-name": "exposedHeaders"
         },
-        "maxAgeInSeconds": {
+        "MaxAgeInSeconds": {
           "type": "integer",
           "format": "int32",
           "description": "The maximum age in seconds.",
-          "minimum": 0
+          "minimum": 0,
+          "x-ms-client-name": "maxAgeInSeconds"
         }
       },
       "required": [
-        "allowedOrigins",
-        "allowedMethods",
-        "allowedHeaders",
-        "exposedHeaders",
-        "maxAgeInSeconds"
+        "AllowedOrigins",
+        "AllowedMethods",
+        "AllowedHeaders",
+        "ExposedHeaders",
+        "MaxAgeInSeconds"
       ]
     },
     "DeleteSnapshotsOptionType": {
@@ -17005,25 +16957,30 @@
       "type": "object",
       "description": "Represents the delimited text configuration.",
       "properties": {
-        "columnSeparator": {
+        "ColumnSeparator": {
           "type": "string",
-          "description": "The string used to separate columns."
+          "description": "The string used to separate columns.",
+          "x-ms-client-name": "columnSeparator"
         },
-        "fieldQuote": {
+        "FieldQuote": {
           "type": "string",
-          "description": "The string used to quote a specific field."
+          "description": "The string used to quote a specific field.",
+          "x-ms-client-name": "fieldQuote"
         },
-        "recordSeparator": {
+        "RecordSeparator": {
           "type": "string",
-          "description": "The string used to separate records."
+          "description": "The string used to separate records.",
+          "x-ms-client-name": "recordSeparator"
         },
-        "escapeChar": {
+        "EscapeChar": {
           "type": "string",
-          "description": "The string used to escape a quote character in a field."
+          "description": "The string used to escape a quote character in a field.",
+          "x-ms-client-name": "escapeChar"
         },
-        "headersPresent": {
+        "HasHeaders": {
           "type": "boolean",
-          "description": "Represents whether the data has headers."
+          "description": "Represents whether the data has headers.",
+          "x-ms-client-name": "headersPresent"
         }
       }
     },
@@ -17067,61 +17024,81 @@
       "type": "object",
       "description": "The filter blob item.",
       "properties": {
-        "name": {
+        "Name": {
           "type": "string",
-          "description": "The name of the blob."
+          "description": "The name of the blob.",
+          "x-ms-client-name": "name"
         },
-        "containerName": {
+        "ContainerName": {
           "type": "string",
-          "description": "The properties of the blob."
+          "description": "The properties of the blob.",
+          "x-ms-client-name": "containerName"
         },
         "tags": {
           "$ref": "#/definitions/BlobTags",
           "description": "The metadata of the blob."
         },
-        "versionId": {
+        "VersionId": {
           "type": "string",
-          "description": "The version ID of the blob."
+          "description": "The version ID of the blob.",
+          "x-ms-client-name": "versionId"
         },
-        "isCurrentVersion": {
+        "IsCurrentVersion": {
           "type": "boolean",
-          "description": "Whether it is the current version of the blob"
+          "description": "Whether it is the current version of the blob",
+          "x-ms-client-name": "isCurrentVersion"
         }
       },
       "required": [
-        "name",
-        "containerName"
-      ]
+        "Name",
+        "ContainerName"
+      ],
+      "xml": {
+        "name": "Blob"
+      }
     },
     "FilterBlobSegment": {
       "type": "object",
       "description": "The result of a Filter Blobs API call",
       "properties": {
-        "serviceEndpoint": {
+        "ServiceEndpoint": {
           "type": "string",
-          "description": "The service endpoint."
+          "description": "The service endpoint.",
+          "xml": {
+            "attribute": true
+          },
+          "x-ms-client-name": "serviceEndpoint"
         },
-        "where": {
+        "Where": {
           "type": "string",
-          "description": "The filter for the blobs."
+          "description": "The filter for the blobs.",
+          "x-ms-client-name": "where"
         },
-        "blobs": {
+        "Blobs": {
           "type": "array",
           "description": "The blob segment.",
           "items": {
             "$ref": "#/definitions/FilterBlobItem"
-          }
+          },
+          "xml": {
+            "wrapped": true
+          },
+          "x-ms-client-name": "blobs"
         },
-        "nextMarker": {
+        "NextMarker": {
           "type": "string",
-          "description": "The next marker of the blobs."
+          "description": "The next marker of the blobs.",
+          "x-ms-client-name": "nextMarker"
         }
       },
       "required": [
-        "serviceEndpoint",
-        "where",
-        "blobs"
-      ]
+        "ServiceEndpoint",
+        "Where",
+        "Blobs"
+      ],
+      "xml": {
+        "name": "EnumerationResults"
+      }
     },
     "FilterBlobsIncludeItem": {
       "type": "string",
@@ -17151,19 +17128,21 @@
       "type": "object",
       "description": "Geo-Replication information for the Secondary Storage Service",
       "properties": {
-        "status": {
+        "Status": {
           "$ref": "#/definitions/GeoReplicationStatusType",
-          "description": "The status of the secondary location"
+          "description": "The status of the secondary location",
+          "x-ms-client-name": "status"
         },
-        "lastSyncTime": {
+        "LastSyncTime": {
           "type": "string",
           "format": "date-time-rfc7231",
-          "description": "A GMT date/time value, to the second. All primary writes preceding this value are guaranteed to be available for read operations at the secondary. Primary writes after this point in time may or may not be available for reads."
+          "description": "A GMT date/time value, to the second. All primary writes preceding this value are guaranteed to be available for read operations at the secondary. Primary writes after this point in time may or may not be available for reads.",
+          "x-ms-client-name": "lastSyncTime"
         }
       },
       "required": [
-        "status",
-        "lastSyncTime"
+        "Status",
+        "LastSyncTime"
       ]
     },
     "GeoReplicationStatusType": {
@@ -17224,9 +17203,10 @@
       "type": "object",
       "description": "Represents the JSON text configuration.",
       "properties": {
-        "recordSeparator": {
+        "RecordSeparator": {
           "type": "string",
-          "description": "The string used to separate records."
+          "description": "The string used to separate records.",
+          "x-ms-client-name": "recordSeparator"
         }
       }
     },
@@ -17234,18 +17214,20 @@
       "type": "object",
       "description": "Key information",
       "properties": {
-        "start": {
+        "Start": {
           "type": "string",
-          "description": "The date-time the key is active."
+          "description": "The date-time the key is active.",
+          "x-ms-client-name": "start"
         },
-        "expiry": {
+        "Expiry": {
           "type": "string",
-          "description": "The date-time the key expires."
+          "description": "The date-time the key expires.",
+          "x-ms-client-name": "expiry"
         }
       },
       "required": [
-        "start",
-        "expiry"
+        "Start",
+        "Expiry"
       ]
     },
     "LeaseDuration": {
@@ -17342,85 +17324,118 @@
       "type": "object",
       "description": "An enumeration of blobs.",
       "properties": {
-        "serviceEndpoint": {
+        "ServiceEndpoint": {
           "type": "string",
-          "description": "The service endpoint."
+          "description": "The service endpoint.",
+          "xml": {
+            "attribute": true
+          },
+          "x-ms-client-name": "serviceEndpoint"
         },
-        "containerName": {
+        "ContainerName": {
           "type": "string",
-          "description": "The container name."
+          "description": "The container name.",
+          "xml": {
+            "attribute": true
+          },
+          "x-ms-client-name": "containerName"
         },
-        "prefix": {
+        "Prefix": {
           "type": "string",
-          "description": "The prefix of the blobs."
+          "description": "The prefix of the blobs.",
+          "x-ms-client-name": "prefix"
         },
-        "marker": {
+        "Marker": {
           "type": "string",
-          "description": "The marker of the blobs."
+          "description": "The marker of the blobs.",
+          "x-ms-client-name": "marker"
         },
-        "maxResults": {
+        "MaxResults": {
           "type": "integer",
           "format": "int32",
-          "description": "The max results of the blobs."
+          "description": "The max results of the blobs.",
+          "x-ms-client-name": "maxResults"
         },
-        "segment": {
+        "Blobs": {
           "$ref": "#/definitions/BlobFlatListSegment",
-          "description": "The blob segment."
+          "description": "The blob segment.",
+          "x-ms-client-name": "segment"
         },
-        "nextMarker": {
+        "NextMarker": {
           "type": "string",
-          "description": "The next marker of the blobs."
+          "description": "The next marker of the blobs.",
+          "x-ms-client-name": "nextMarker"
         }
       },
       "required": [
-        "serviceEndpoint",
-        "containerName",
-        "segment"
-      ]
+        "ServiceEndpoint",
+        "ContainerName",
+        "Blobs"
+      ],
+      "xml": {
+        "name": "EnumerationResults"
+      }
     },
     "ListBlobsHierarchySegmentResponse": {
       "type": "object",
       "description": "An enumeration of blobs",
       "properties": {
-        "serviceEndpoint": {
+        "ServiceEndpoint": {
           "type": "string",
-          "description": "The service endpoint."
+          "description": "The service endpoint.",
+          "xml": {
+            "attribute": true
+          },
+          "x-ms-client-name": "serviceEndpoint"
         },
-        "containerName": {
+        "ContainerName": {
           "type": "string",
-          "description": "The container name."
+          "description": "The container name.",
+          "xml": {
+            "attribute": true
+          },
+          "x-ms-client-name": "containerName"
         },
-        "delimiter": {
+        "Delimiter": {
           "type": "string",
-          "description": "The delimiter of the blobs."
+          "description": "The delimiter of the blobs.",
+          "x-ms-client-name": "delimiter"
         },
-        "prefix": {
+        "Prefix": {
           "type": "string",
-          "description": "The prefix of the blobs."
+          "description": "The prefix of the blobs.",
+          "x-ms-client-name": "prefix"
         },
-        "marker": {
+        "Marker": {
           "type": "string",
-          "description": "The marker of the blobs."
+          "description": "The marker of the blobs.",
+          "x-ms-client-name": "marker"
         },
-        "maxResults": {
+        "MaxResults": {
           "type": "integer",
           "format": "int32",
-          "description": "The max results of the blobs."
+          "description": "The max results of the blobs.",
+          "x-ms-client-name": "maxResults"
         },
-        "segment": {
+        "Blobs": {
           "$ref": "#/definitions/BlobHierarchyListSegment",
-          "description": "The blob segment."
+          "description": "The blob segment.",
+          "x-ms-client-name": "segment"
         },
-        "nextMarker": {
+        "NextMarker": {
           "type": "string",
-          "description": "The next marker of the blobs."
+          "description": "The next marker of the blobs.",
+          "x-ms-client-name": "nextMarker"
         }
       },
       "required": [
-        "serviceEndpoint",
-        "containerName",
-        "segment"
-      ]
+        "ServiceEndpoint",
+        "ContainerName",
+        "Blobs"
+      ],
+      "xml": {
+        "name": "EnumerationResults"
+      }
     },
     "ListBlobsIncludeItem": {
       "type": "string",
@@ -17528,29 +17543,40 @@
       "type": "object",
       "description": "The list container segment response",
       "properties": {
-        "serviceEndpoint": {
+        "ServiceEndpoint": {
           "type": "string",
-          "description": "The service endpoint."
+          "description": "The service endpoint.",
+          "xml": {
+            "attribute": true
+          },
+          "x-ms-client-name": "serviceEndpoint"
         },
-        "prefix": {
+        "Prefix": {
           "type": "string",
-          "description": "The prefix of the containers."
+          "description": "The prefix of the containers.",
+          "x-ms-client-name": "prefix"
         },
-        "marker": {
+        "Marker": {
           "type": "string",
-          "description": "The marker of the containers."
+          "description": "The marker of the containers.",
+          "x-ms-client-name": "marker"
         },
-        "maxResults": {
+        "MaxResults": {
           "type": "integer",
           "format": "int32",
-          "description": "The max results of the containers."
+          "description": "The max results of the containers.",
+          "x-ms-client-name": "maxResults"
         },
-        "containerItems": {
+        "Containers": {
           "type": "array",
           "description": "The container segment.",
           "items": {
             "$ref": "#/definitions/ContainerItem"
-          }
+          },
+          "xml": {
+            "wrapped": true
+          },
+          "x-ms-client-name": "containerItems"
         },
         "NextMarker": {
           "type": "string",
@@ -17558,66 +17584,78 @@
         }
       },
       "required": [
-        "serviceEndpoint",
-        "containerItems"
-      ]
+        "ServiceEndpoint",
+        "Containers"
+      ],
+      "xml": {
+        "name": "EnumerationResults"
+      }
     },
     "Logging": {
       "type": "object",
       "description": "Azure Analytics Logging settings.",
       "properties": {
-        "version": {
+        "Version": {
           "type": "string",
-          "description": "The version of the logging properties."
+          "description": "The version of the logging properties.",
+          "x-ms-client-name": "version"
         },
-        "delete": {
+        "Delete": {
           "type": "boolean",
-          "description": "Whether delete operation is logged."
+          "description": "Whether delete operation is logged.",
+          "x-ms-client-name": "delete"
         },
-        "read": {
+        "Read": {
           "type": "boolean",
-          "description": "Whether read operation is logged."
+          "description": "Whether read operation is logged.",
+          "x-ms-client-name": "read"
         },
-        "write": {
+        "Write": {
           "type": "boolean",
-          "description": "Whether write operation is logged."
+          "description": "Whether write operation is logged.",
+          "x-ms-client-name": "write"
         },
-        "retentionPolicy": {
+        "RetentionPolicy": {
           "$ref": "#/definitions/RetentionPolicy",
-          "description": "The retention policy of the logs."
+          "description": "The retention policy of the logs.",
+          "x-ms-client-name": "retentionPolicy"
         }
       },
       "required": [
-        "version",
-        "delete",
-        "read",
-        "write",
-        "retentionPolicy"
+        "Version",
+        "Delete",
+        "Read",
+        "Write",
+        "RetentionPolicy"
       ]
     },
     "Metrics": {
       "type": "object",
       "description": "The metrics properties.",
       "properties": {
-        "version": {
+        "Version": {
           "type": "string",
-          "description": "The version of the metrics properties."
+          "description": "The version of the metrics properties.",
+          "x-ms-client-name": "version"
         },
-        "enabled": {
+        "Enabled": {
           "type": "boolean",
-          "description": "Whether it is enabled."
+          "description": "Whether it is enabled.",
+          "x-ms-client-name": "enabled"
         },
-        "includeApis": {
+        "IncludeAPIs": {
           "type": "boolean",
-          "description": "Whether to include API in the metrics."
+          "description": "Whether to include API in the metrics.",
+          "x-ms-client-name": "includeApis"
         },
-        "retentionPolicy": {
+        "RetentionPolicy": {
           "$ref": "#/definitions/RetentionPolicy",
-          "description": "The retention policy of the metrics."
+          "description": "The retention policy of the metrics.",
+          "x-ms-client-name": "retentionPolicy"
         }
       },
       "required": [
-        "enabled"
+        "Enabled"
       ]
     },
     "ObjectReplicationMetadata": {
@@ -17625,29 +17663,41 @@
       "description": "The object replication metadata.",
       "additionalProperties": {
         "type": "string"
+      },
+      "xml": {
+        "name": "OrMetadata"
       }
     },
     "PageList": {
       "type": "object",
       "description": "Represents a page list.",
       "properties": {
-        "pageRange": {
+        "PageRange": {
           "type": "array",
           "description": "The page ranges.",
           "items": {
             "$ref": "#/definitions/PageRange"
-          }
+          },
+          "xml": {
+            "wrapped": false
+          },
+          "x-ms-client-name": "pageRange"
         },
-        "clearRange": {
+        "ClearRange": {
           "type": "array",
           "description": "The clear ranges.",
           "items": {
             "$ref": "#/definitions/ClearRange"
-          }
+          },
+          "xml": {
+            "wrapped": false
+          },
+          "x-ms-client-name": "clearRange"
         },
-        "nextMarker": {
+        "NextMarker": {
           "type": "string",
-          "description": "The next marker."
+          "description": "The next marker.",
+          "x-ms-client-name": "nextMarker"
         }
       }
     },
@@ -17655,20 +17705,22 @@
       "type": "object",
       "description": "The page range.",
       "properties": {
-        "start": {
+        "Start": {
           "type": "integer",
           "format": "int64",
-          "description": "The start of the byte range."
+          "description": "The start of the byte range.",
+          "x-ms-client-name": "start"
         },
-        "end": {
+        "End": {
           "type": "integer",
           "format": "int64",
-          "description": "The end of the byte range."
+          "description": "The end of the byte range.",
+          "x-ms-client-name": "end"
         }
       },
       "required": [
-        "start",
-        "end"
+        "Start",
+        "End"
       ]
     },
     "ParquetConfiguration": {
@@ -17782,55 +17834,64 @@
       "type": "object",
       "description": "The query format settings.",
       "properties": {
-        "type": {
+        "Type": {
           "$ref": "#/definitions/QueryType",
-          "description": "The query type."
+          "description": "The query type.",
+          "x-ms-client-name": "type"
         },
-        "delimitedTextConfiguration": {
+        "DelimitedTextConfiguration": {
           "$ref": "#/definitions/DelimitedTextConfiguration",
-          "description": "The delimited text configuration."
+          "description": "The delimited text configuration.",
+          "x-ms-client-name": "delimitedTextConfiguration"
         },
-        "jsonTextConfiguration": {
+        "JsonTextConfiguration": {
           "$ref": "#/definitions/JsonTextConfiguration",
-          "description": "The JSON text configuration."
+          "description": "The JSON text configuration.",
+          "x-ms-client-name": "jsonTextConfiguration"
         },
-        "arrowConfiguration": {
+        "ArrowConfiguration": {
           "$ref": "#/definitions/ArrowConfiguration",
-          "description": "The Apache Arrow configuration."
+          "description": "The Apache Arrow configuration.",
+          "x-ms-client-name": "arrowConfiguration"
         },
-        "parquetTextConfiguration": {
+        "ParquetConfiguration": {
           "$ref": "#/definitions/ParquetConfiguration",
-          "description": "The Parquet configuration."
+          "description": "The Parquet configuration.",
+          "x-ms-client-name": "parquetTextConfiguration"
         }
       },
       "required": [
-        "type"
+        "Type"
       ]
     },
     "QueryRequest": {
       "type": "object",
       "description": "Groups the set of query request settings.",
       "properties": {
-        "queryType": {
+        "QueryType": {
           "$ref": "#/definitions/QueryRequestType",
-          "description": "Required. The type of the provided query expression."
+          "description": "Required. The type of the provided query expression.",
+          "x-ms-client-name": "queryType"
         },
-        "expression": {
+        "Expression": {
           "type": "string",
-          "description": "The query expression in SQL. The maximum size of the query expression is 256KiB."
+          "description": "The query expression in SQL. The maximum size of the query expression is 256KiB.",
+          "x-ms-client-name": "expression"
         },
-        "inputSerialization": {
+        "InputSerialization": {
           "$ref": "#/definitions/QuerySerialization",
-          "description": "The input serialization settings."
+          "description": "The input serialization settings.",
+          "x-ms-client-name": "inputSerialization"
         },
-        "outputSerialization": {
+        "OutputSerialization": {
           "$ref": "#/definitions/QuerySerialization",
-          "description": "The output serialization settings."
+          "description": "The output serialization settings.",
+          "x-ms-client-name": "outputSerialization"
         }
       },
       "required": [
-        "queryType",
-        "expression"
+        "QueryType",
+        "Expression"
       ]
     },
     "QueryRequestType": {
@@ -17855,13 +17916,14 @@
       "type": "object",
       "description": "The query serialization settings.",
       "properties": {
-        "format": {
+        "Format": {
           "$ref": "#/definitions/QueryFormat",
-          "description": "The query format."
+          "description": "The query format.",
+          "x-ms-client-name": "format"
         }
       },
       "required": [
-        "format"
+        "Format"
       ]
     },
     "QueryType": {
@@ -17898,6 +17960,9 @@
             "description": "The query format type is Parquet."
           }
         ]
+      },
+      "xml": {
+        "name": "Type"
       }
     },
     "RehydratePriority": {
@@ -17928,23 +17993,26 @@
       "type": "object",
       "description": "The retention policy.",
       "properties": {
-        "enabled": {
+        "Enabled": {
           "type": "boolean",
-          "description": "Whether to enable the retention policy."
+          "description": "Whether to enable the retention policy.",
+          "x-ms-client-name": "enabled"
         },
-        "days": {
+        "Days": {
           "type": "integer",
           "format": "int32",
           "description": "The number of days to retain the logs.",
-          "minimum": 1
+          "minimum": 1,
+          "x-ms-client-name": "days"
         },
-        "allowPermanentDelete": {
+        "AllowPermanentDelete": {
           "type": "boolean",
-          "description": "Whether to allow permanent delete."
+          "description": "Whether to allow permanent delete.",
+          "x-ms-client-name": "allowPermanentDelete"
         }
       },
       "required": [
-        "enabled"
+        "Enabled"
       ]
     },
     "SequenceNumberActionType": {
@@ -17981,18 +18049,20 @@
       "type": "object",
       "description": "The signed identifier.",
       "properties": {
-        "id": {
+        "Id": {
           "type": "string",
-          "description": "The unique ID for the signed identifier."
+          "description": "The unique ID for the signed identifier.",
+          "x-ms-client-name": "id"
         },
-        "accessPolicy": {
+        "AccessPolicy": {
           "$ref": "#/definitions/AccessPolicy",
-          "description": "The access policy for the signed identifier."
+          "description": "The access policy for the signed identifier.",
+          "x-ms-client-name": "accessPolicy"
         }
       },
       "required": [
-        "id",
-        "accessPolicy"
+        "Id",
+        "AccessPolicy"
       ]
     },
     "SignedIdentifiers": {
@@ -18048,51 +18118,60 @@
       "type": "object",
       "description": "The properties that enable an account to host a static website",
       "properties": {
-        "enabled": {
+        "Enabled": {
           "type": "boolean",
-          "description": "Indicates whether this account is hosting a static website"
+          "description": "Indicates whether this account is hosting a static website",
+          "x-ms-client-name": "enabled"
         },
-        "indexDocument": {
+        "IndexDocument": {
           "type": "string",
-          "description": "The index document."
+          "description": "The index document.",
+          "x-ms-client-name": "indexDocument"
         },
-        "errorDocument404Path": {
+        "ErrorDocument404Path": {
           "type": "string",
-          "description": "The error document."
+          "description": "The error document.",
+          "x-ms-client-name": "errorDocument404Path"
         },
-        "defaultIndexDocumentPath": {
+        "DefaultIndexDocumentPath": {
           "type": "string",
-          "description": "Absolute path of the default index page"
+          "description": "Absolute path of the default index page",
+          "x-ms-client-name": "defaultIndexDocumentPath"
         }
       },
       "required": [
-        "enabled"
+        "Enabled"
       ]
     },
     "StorageError": {
       "type": "object",
       "description": "The error response.",
       "properties": {
-        "code": {
+        "Code": {
           "type": "string",
-          "description": "The error code."
+          "description": "The error code.",
+          "x-ms-client-name": "code"
         },
-        "message": {
+        "Message": {
           "type": "string",
-          "description": "The error message."
+          "description": "The error message.",
+          "x-ms-client-name": "message"
         },
-        "copySourceStatusCode": {
+        "CopySourceStatusCode": {
           "type": "integer",
           "format": "int32",
-          "description": "Copy source status code"
+          "description": "Copy source status code",
+          "x-ms-client-name": "copySourceStatusCode"
         },
-        "copySourceErrorCode": {
+        "CopySourceErrorCode": {
           "type": "string",
-          "description": "Copy source error code"
+          "description": "Copy source error code",
+          "x-ms-client-name": "copySourceErrorCode"
         },
-        "copySourceErrorMessage": {
+        "CopySourceErrorMessage": {
           "type": "string",
-          "description": "Copy source error message"
+          "description": "Copy source error message",
+          "x-ms-client-name": "copySourceErrorMessage"
         }
       }
     },
@@ -18100,36 +18179,46 @@
       "type": "object",
       "description": "The service properties.",
       "properties": {
-        "logging": {
+        "Logging": {
           "$ref": "#/definitions/Logging",
-          "description": "The logging properties."
+          "description": "The logging properties.",
+          "x-ms-client-name": "logging"
         },
-        "hourMetrics": {
+        "HourMetrics": {
           "$ref": "#/definitions/Metrics",
-          "description": "The hour metrics properties."
+          "description": "The hour metrics properties.",
+          "x-ms-client-name": "hourMetrics"
         },
-        "minuteMetrics": {
+        "MinuteMetrics": {
           "$ref": "#/definitions/Metrics",
-          "description": "The minute metrics properties."
+          "description": "The minute metrics properties.",
+          "x-ms-client-name": "minuteMetrics"
         },
-        "cors": {
+        "Cors": {
           "type": "array",
           "description": "The CORS properties.",
           "items": {
             "$ref": "#/definitions/CorsRule"
-          }
+          },
+          "xml": {
+            "wrapped": true
+          },
+          "x-ms-client-name": "cors"
         },
-        "defaultServiceVersion": {
+        "DefaultServiceVersion": {
           "type": "string",
-          "description": "The default service version."
+          "description": "The default service version.",
+          "x-ms-client-name": "defaultServiceVersion"
         },
-        "deleteRetentionPolicy": {
+        "DeleteRetentionPolicy": {
           "$ref": "#/definitions/RetentionPolicy",
-          "description": "The delete retention policy."
+          "description": "The delete retention policy.",
+          "x-ms-client-name": "deleteRetentionPolicy"
         },
-        "staticWebsite": {
+        "StaticWebsite": {
           "$ref": "#/definitions/StaticWebsite",
-          "description": "The static website properties."
+          "description": "The static website properties.",
+          "x-ms-client-name": "staticWebsite"
         }
       }
     },
@@ -18137,9 +18226,10 @@
       "type": "object",
       "description": "Stats for the storage service.",
       "properties": {
-        "geoReplication": {
+        "GeoReplication": {
           "$ref": "#/definitions/GeoReplication",
-          "description": "The geo replication stats."
+          "description": "The geo replication stats.",
+          "x-ms-client-name": "geoReplication"
         }
       }
     },
@@ -18147,43 +18237,50 @@
       "type": "object",
       "description": "A user delegation key.",
       "properties": {
-        "signedOid": {
+        "SignedOid": {
           "$ref": "#/definitions/Azure.Core.uuid",
-          "description": "The Azure Active Directory object ID in GUID format."
+          "description": "The Azure Active Directory object ID in GUID format.",
+          "x-ms-client-name": "signedOid"
         },
-        "signedTid": {
+        "SignedTid": {
           "$ref": "#/definitions/Azure.Core.uuid",
-          "description": "The Azure Active Directory tenant ID in GUID format."
+          "description": "The Azure Active Directory tenant ID in GUID format.",
+          "x-ms-client-name": "signedTid"
         },
-        "signedStart": {
+        "SignedStart": {
           "type": "string",
-          "description": "The date-time the key is active."
+          "description": "The date-time the key is active.",
+          "x-ms-client-name": "signedStart"
         },
-        "signedExpiry": {
+        "SignedExpiry": {
           "type": "string",
-          "description": "The date-time the key expires."
+          "description": "The date-time the key expires.",
+          "x-ms-client-name": "signedExpiry"
         },
-        "signedService": {
+        "SignedService": {
           "type": "string",
-          "description": "Abbreviation of the Azure Storage service that accepts the key."
+          "description": "Abbreviation of the Azure Storage service that accepts the key.",
+          "x-ms-client-name": "signedService"
         },
-        "signedVersion": {
+        "SignedVersion": {
           "type": "string",
-          "description": "The service version that created the key."
+          "description": "The service version that created the key.",
+          "x-ms-client-name": "signedVersion"
         },
-        "value": {
+        "Value": {
           "$ref": "#/definitions/base64Bytes",
-          "description": "The key as a base64 string."
+          "description": "The key as a base64 string.",
+          "x-ms-client-name": "value"
         }
       },
       "required": [
-        "signedOid",
-        "signedTid",
-        "signedStart",
-        "signedExpiry",
-        "signedService",
-        "signedVersion",
-        "value"
+        "SignedOid",
+        "SignedTid",
+        "SignedStart",
+        "SignedExpiry",
+        "SignedService",
+        "SignedVersion",
+        "Value"
       ]
     },
     "base64Bytes": {


### PR DESCRIPTION
- Regenerates generated_blob.json for Microsoft.BlobStorage using the new Autorest XML implementation.
- Updates Microsoft.PlanetaryComputer tspconfig.yaml to use the `xml-strategy: none` option.
- Updates Microsoft.PlanetaryComputer spec with new produces/consumes logic for specs that use XML.
