### PR TITLE
Add deployment pause/resume APIs and service tier management

### DIFF
--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2025-10-01-preview/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2025-10-01-preview/cognitiveservices.json
@@ -1691,7 +1691,7 @@
             "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/deploymentNameParameter"
+            "$ref": "#/parameters/deploymentNameForActionParameter"
           }
         ],
         "responses": {
@@ -1737,7 +1737,7 @@
             "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/deploymentNameParameter"
+            "$ref": "#/parameters/deploymentNameForActionParameter"
           }
         ],
         "responses": {
@@ -11810,8 +11810,16 @@
       "in": "path",
       "required": true,
       "type": "string",
-      "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$",
       "description": "The name of the deployment associated with the Cognitive Services Account",
+      "x-ms-parameter-location": "method"
+    },
+    "deploymentNameForActionParameter": {
+      "name": "deploymentName",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$",
+      "description": "The name of the deployment for pause/resume actions",
       "x-ms-parameter-location": "method"
     },
     "raiPolicyNameParameter": {

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2025-10-01-preview/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2025-10-01-preview/cognitiveservices.json
@@ -1664,6 +1664,98 @@
         }
       }
     },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/deployments/{deploymentName}/pause": {
+      "post": {
+        "tags": [
+          "Deployments"
+        ],
+        "operationId": "Deployments_Pause",
+        "summary": "Pause a deployment",
+        "description": "Pauses inferencing on a deployment by setting the deploymentState to 'Paused' (see #/definitions/DeploymentProperties/properties/deploymentState). Only Standard, DataZoneStandard, and GlobalStandard SKUs support this operation. Inference requests to the paused deployment endpoint will receive HTTP 423 (Locked). This operation is idempotent.",
+        "x-ms-examples": {
+          "PauseDeployment": {
+            "$ref": "./examples/PauseDeployment.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/accountNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/deploymentNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK -- Deployment paused successfully.",
+            "schema": {
+              "$ref": "#/definitions/Deployment"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/deployments/{deploymentName}/resume": {
+      "post": {
+        "tags": [
+          "Deployments"
+        ],
+        "operationId": "Deployments_Resume",
+        "summary": "Resume a deployment",
+        "description": "Resumes inferencing on a previously paused deployment by setting the deploymentState to 'Running' (see #/definitions/DeploymentProperties/properties/deploymentState). This operation is idempotent and can be safely called on already running deployments.",
+        "x-ms-examples": {
+          "ResumeDeployment": {
+            "$ref": "./examples/ResumeDeployment.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/accountNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/deploymentNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK -- Deployment resumed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Deployment"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/commitmentPlans": {
       "get": {
         "tags": [
@@ -8116,6 +8208,52 @@
         "spilloverDeploymentName": {
           "type": "string",
           "description": "Specifies the deployment name that should serve requests when the request would have otherwise been throttled due to reaching current deployment throughput limit."
+        },
+        "serviceTier": {
+          "type": "string",
+          "description": "The service tier for the deployment. Determines the pricing and performance level for request processing. Use 'Default' for standard pricing or 'Priority' for higher-priority processing with premium pricing. Note: Pause operations are only supported on Standard, DataZoneStandard, and GlobalStandard SKUs.",
+          "enum": [
+            "Default",
+            "Priority"
+          ],
+          "x-nullable": true,
+          "x-ms-enum": {
+            "name": "ServiceTier",
+            "modelAsString": true,
+            "values": [
+              {
+                "value": "Default",
+                "description": "Default service tier meaning the request will be processed with the standard pricing and performance for the selected model."
+              },
+              {
+                "value": "Priority",
+                "description": "Priority service tier meaning the request will be processed with higher pricing and performance for the selected model."
+              }
+            ]
+          }
+        },
+        "deploymentState": {
+          "type": "string",
+          "description": "The state of the deployment. Controls whether the deployment is accepting inference requests. Use 'Running' for active deployments that process requests, or 'Paused' to temporarily stop inference while preserving the deployment configuration.",
+          "enum": [
+            "Running",
+            "Paused"
+          ],
+          "x-nullable": true,
+          "x-ms-enum": {
+            "name": "DeploymentState",
+            "modelAsString": true,
+            "values": [
+              {
+                "value": "Running",
+                "description": "The deployment is running and accepting inference requests."
+              },
+              {
+                "value": "Paused",
+                "description": "The deployment is paused and not accepting inference requests."
+              }
+            ]
+          }
         }
       },
       "description": "Properties of Cognitive Services account deployment."

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2025-10-01-preview/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2025-10-01-preview/cognitiveservices.json
@@ -11810,6 +11810,7 @@
       "in": "path",
       "required": true,
       "type": "string",
+      "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$",
       "description": "The name of the deployment associated with the Cognitive Services Account",
       "x-ms-parameter-location": "method"
     },

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2025-10-01-preview/examples/ListDeployments.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2025-10-01-preview/examples/ListDeployments.json
@@ -23,6 +23,8 @@
                 "name": "ada",
                 "version": "1"
               },
+              "serviceTier": "Default",
+              "deploymentState": "Running",
               "provisioningState": "Succeeded"
             }
           }

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2025-10-01-preview/examples/PauseDeployment.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2025-10-01-preview/examples/PauseDeployment.json
@@ -19,11 +19,10 @@
         "properties": {
           "model": {
             "format": "OpenAI",
-            "name": "ada",
-            "version": "1"
+            "name": "gpt-4",
+            "version": "0613"
           },
-          "serviceTier": "Default",
-          "deploymentState": "Running",
+          "deploymentState": "Paused",
           "provisioningState": "Succeeded"
         }
       }

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2025-10-01-preview/examples/PutDeployment.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2025-10-01-preview/examples/PutDeployment.json
@@ -15,7 +15,9 @@
           "format": "OpenAI",
           "name": "ada",
           "version": "1"
-        }
+        },
+        "serviceTier": "Priority",
+        "deploymentState": "Running"
       }
     }
   },
@@ -35,6 +37,8 @@
             "name": "ada",
             "version": "1"
           },
+          "serviceTier": "Priority",
+          "deploymentState": "Running",
           "provisioningState": "Succeeded"
         }
       }
@@ -54,6 +58,8 @@
             "name": "ada",
             "version": "1"
           },
+          "serviceTier": "Priority",
+          "deploymentState": "Running",
           "provisioningState": "Accepted"
         }
       }

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2025-10-01-preview/examples/ResumeDeployment.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2025-10-01-preview/examples/ResumeDeployment.json
@@ -19,10 +19,9 @@
         "properties": {
           "model": {
             "format": "OpenAI",
-            "name": "ada",
-            "version": "1"
+            "name": "gpt-4",
+            "version": "0613"
           },
-          "serviceTier": "Default",
           "deploymentState": "Running",
           "provisioningState": "Succeeded"
         }

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2025-10-01-preview/examples/UpdateDeployment.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2025-10-01-preview/examples/UpdateDeployment.json
@@ -28,6 +28,8 @@
             "name": "ada",
             "version": "1"
           },
+          "serviceTier": "Priority",
+          "deploymentState": "Paused",
           "provisioningState": "Succeeded"
         }
       }


### PR DESCRIPTION
Add deployment pause/resume APIs and service tier management

- Add serviceTier enum property to DeploymentProperties (Default, Priority)
- Add deploymentState enum property to DeploymentProperties (Running, Paused)
- Add POST /deployments/{deploymentName}/pause endpoint for pausing deployments
- Add POST /deployments/{deploymentName}/resume endpoint for resuming deployments
- Create API examples for pause and resume operations
- Update existing deployment examples to include new properties
- Add comprehensive descriptions with usage guidance and SKU restrictions
- Document HTTP 423 behavior for paused deployments
- Mark both operations as idempotent

This enables customers to control deployment processing priority through service tiers and pause/resume deployment inferencing for cost optimization and resource management.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
