### PR TITLE
add override

### DIFF
--- a/specification/keyvault/KeyVault.Management/back-compatible.tsp
+++ b/specification/keyvault/KeyVault.Management/back-compatible.tsp
@@ -252,7 +252,10 @@ op ManagedHsmsPurgeDeletedCustomized(
 ): void;
 
 @@override(DeletedVaults.getDeleted, VaultsGetDeletedCustomized, "python,go");
-@@override(DeletedVaults.purgeDeleted, VaultsPurgeDeletedCustomized, "python,go");
+@@override(DeletedVaults.purgeDeleted,
+  VaultsPurgeDeletedCustomized,
+  "python,go"
+);
 @@override(DeletedManagedHsms.getDeleted,
   ManagedHsmsGetDeletedCustomized,
   "python,go"

--- a/specification/keyvault/KeyVault.Management/back-compatible.tsp
+++ b/specification/keyvault/KeyVault.Management/back-compatible.tsp
@@ -251,23 +251,13 @@ op ManagedHsmsPurgeDeletedCustomized(
   body: void,
 ): void;
 
-@@override(DeletedVaults.getDeleted, VaultsGetDeletedCustomized, "python");
-@@override(DeletedVaults.purgeDeleted, VaultsPurgeDeletedCustomized, "python");
+@@override(DeletedVaults.getDeleted, VaultsGetDeletedCustomized, "python,go");
+@@override(DeletedVaults.purgeDeleted, VaultsPurgeDeletedCustomized, "python,go");
 @@override(DeletedManagedHsms.getDeleted,
   ManagedHsmsGetDeletedCustomized,
-  "python"
+  "python,go"
 );
 @@override(DeletedManagedHsms.purgeDeleted,
   ManagedHsmsPurgeDeletedCustomized,
-  "python"
-);
-@@override(DeletedVaults.getDeleted, VaultsGetDeletedCustomized, "go");
-@@override(DeletedVaults.purgeDeleted, VaultsPurgeDeletedCustomized, "go");
-@@override(DeletedManagedHsms.getDeleted,
-  ManagedHsmsGetDeletedCustomized,
-  "go"
-);
-@@override(DeletedManagedHsms.purgeDeleted,
-  ManagedHsmsPurgeDeletedCustomized,
-  "go"
+  "python,go"
 );

--- a/specification/keyvault/KeyVault.Management/back-compatible.tsp
+++ b/specification/keyvault/KeyVault.Management/back-compatible.tsp
@@ -261,7 +261,8 @@ op ManagedHsmsPurgeDeletedCustomized(
   ManagedHsmsPurgeDeletedCustomized,
   "python"
 );
-
+@@override(DeletedVaults.getDeleted, VaultsGetDeletedCustomized, "go");
+@@override(DeletedVaults.purgeDeleted, VaultsPurgeDeletedCustomized, "go");
 @@override(DeletedManagedHsms.getDeleted,
   ManagedHsmsGetDeletedCustomized,
   "go"

--- a/specification/keyvault/KeyVault.Management/back-compatible.tsp
+++ b/specification/keyvault/KeyVault.Management/back-compatible.tsp
@@ -261,3 +261,12 @@ op ManagedHsmsPurgeDeletedCustomized(
   ManagedHsmsPurgeDeletedCustomized,
   "python"
 );
+
+@@override(DeletedManagedHsms.getDeleted,
+  ManagedHsmsGetDeletedCustomized,
+  "go"
+);
+@@override(DeletedManagedHsms.purgeDeleted,
+  ManagedHsmsPurgeDeletedCustomized,
+  "go"
+);


### PR DESCRIPTION
# SDK configuration pull request

## Purpose of this PR

- [ ] Make changes to the SDK configuration only when there are no modifications to the API specification, eliminating the need for an ARM or Stewardship Board API review.

## Due diligence checklist

To merge this PR, you **must** go through the following checklist and confirm you understood
and followed the instructions by checking all the boxes:

- [ ] I confirm this PR is modifying only SDK configurations, and not API related specifications.
- [ ] I have reviewed and used the respective `tspconfig.yaml` templates:
  - [ARM tspconfig template](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/contosowidgetmanager/Contoso.Management/tspconfig.yaml)
  - [Data plane tspconfig template](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/contosowidgetmanager/Contoso.WidgetManager/tspconfig.yaml)

## Getting help

- First, carefully read through this PR description, from top to bottom. Fill out the `Purpose of this PR` and `Due diligence checklist`.
- If you don't have permissions to remove or add labels to the PR, request `write access` per [aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories](https://aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories)
- To understand what you must do next to merge this PR, see the `Next Steps to Merge` comment. It will appear within few minutes of submitting this PR and will continue to be up-to-date with current PR state.
- For guidance on fixing this PR CI check failures, see the hyperlinks provided in given failure and https://aka.ms/ci-fix.
- If the PR CI checks appear to be stuck in `queued` state, please add a comment with contents `/azp run`.
  This should result in a new comment denoting a `PR validation pipeline` has started and the checks should be updated after few minutes.
- If the help provided by the previous points is not enough, post to https://aka.ms/azsdk/support/specreview-channel and link to this PR.