### PR TITLE
[lint-diff] Increase max-old-space-size from 8GB to 16GB

### DIFF
--- a/.github/workflows/lintdiff-code.yaml
+++ b/.github/workflows/lintdiff-code.yaml
@@ -75,7 +75,7 @@ jobs:
         env:
           # Some LintDiff runs are memory intensive and require more than the
           # default.
-          NODE_OPTIONS: "--max-old-space-size=8192"
+          NODE_OPTIONS: "--max-old-space-size=16384"
 
       # Used by other workflows like set-status
       - name: Set job-summary artifact


### PR DESCRIPTION
- Fixes crash running on large PR #37995
- Should be OK even if agent has < 16GB, machine will just swap and run slowly
