### PR TITLE
Enable dataPlane required for Java and JS

### DIFF
--- a/eng/tools/spec-gen-sdk-runner/src/types.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/types.ts
@@ -85,11 +85,11 @@ export const SpecGenSdkRequiredSettings: Record<SdkName, PlaneTypeSettings> = {
     managementPlane: true,
   },
   "azure-sdk-for-java": {
-    dataPlane: false,
+    dataPlane: true,
     managementPlane: true,
   },
   "azure-sdk-for-js": {
-    dataPlane: false,
+    dataPlane: true,
     managementPlane: true,
   },
   "azure-sdk-for-net": {

--- a/eng/tools/spec-gen-sdk-runner/test/command-helpers.test.ts
+++ b/eng/tools/spec-gen-sdk-runner/test/command-helpers.test.ts
@@ -461,7 +461,7 @@ describe("commands.ts", () => {
             headSha: "abc123",
             prNumber: "123",
             labelAction: false,
-            isSpecGenSdkCheckRequired: false,
+            isSpecGenSdkCheckRequired: true,
             apiViewRequestData: [],
           },
           undefined,

--- a/eng/tools/spec-gen-sdk-runner/test/command-helpers.test.ts
+++ b/eng/tools/spec-gen-sdk-runner/test/command-helpers.test.ts
@@ -619,7 +619,7 @@ describe("commands.ts", () => {
 
       const result2 = getRequiredSettingValue(false, true, "azure-sdk-for-js");
       // Based on the constants in types.ts, JS SDK does not require check for data plane
-      expect(result2).toBe(false);
+      expect(result2).toBe(true);
 
       const result3 = getRequiredSettingValue(false, true, "azure-sdk-for-net");
       // .NET SDK set (dataplane: false)


### PR DESCRIPTION
Making the SDK Validation check required for them since it's confirmed by the language contacts.