### PR TITLE
Application Gateway MTLS Passthrough Feature Support

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/stable/2025-03-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2025-03-01/applicationGateway.json
@@ -1397,6 +1397,18 @@
             "name": "ApplicationGatewayClientRevocationOptions",
             "modelAsString": true
           }
+        },
+        "verifyClientAuthMode": {
+          "type": "string",
+          "description": "Verify client Authentication mode.",
+          "enum": [
+            "Strict",
+            "Passthrough"
+          ],
+          "x-ms-enum": {
+            "name": "ApplicationGatewayClientAuthVerificationModes",
+            "modelAsString": true
+          }
         }
       },
       "description": "Application gateway client authentication configuration."

--- a/specification/network/resource-manager/Microsoft.Network/stable/2025-03-01/examples/ApplicationGatewayCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2025-03-01/examples/ApplicationGatewayCreate.json
@@ -390,7 +390,8 @@
                 },
                 "clientAuthConfiguration": {
                   "verifyClientCertIssuerDN": true,
-                  "verifyClientRevocation": "OCSP"
+                  "verifyClientRevocation": "OCSP",
+                  "verifyClientAuthMode": "Strict"
                 },
                 "trustedClientCertificates": [
                   {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2025-03-01/examples/ApplicationGatewayGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2025-03-01/examples/ApplicationGatewayGet.json
@@ -135,7 +135,8 @@
                 },
                 "clientAuthConfiguration": {
                   "verifyClientCertIssuerDN": true,
-                  "verifyClientRevocation": "OCSP"
+                  "verifyClientRevocation": "OCSP",
+                  "verifyClientAuthMode": "Strict"
                 },
                 "trustedClientCertificates": [
                   {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2025-03-01/examples/ApplicationGatewayList.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2025-03-01/examples/ApplicationGatewayList.json
@@ -136,7 +136,8 @@
                     },
                     "clientAuthConfiguration": {
                       "verifyClientCertIssuerDN": true,
-                      "verifyClientRevocation": "OCSP"
+                      "verifyClientRevocation": "OCSP",
+                      "verifyClientAuthMode": "Strict"
                     },
                     "trustedClientCertificates": [
                       {

--- a/specification/network/resource-manager/Microsoft.Network/stable/2025-03-01/examples/ApplicationGatewayListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/stable/2025-03-01/examples/ApplicationGatewayListAll.json
@@ -135,7 +135,8 @@
                     },
                     "clientAuthConfiguration": {
                       "verifyClientCertIssuerDN": true,
-                      "verifyClientRevocation": "OCSP"
+                      "verifyClientRevocation": "OCSP",
+                      "verifyClientAuthMode": "Strict"
                     },
                     "trustedClientCertificates": [
                       {


### PR DESCRIPTION
Application Gateway MTLS Passthrough Feature Support:
Added a new property, VerifyClientAuthMode, to ApplicationGatewayClientAuthConfiguration. This property lets users switch the client certificate verification mode between strict and passthrough. With VerifyClientAuthMode, users can choose the desired verification mode when configuring frontend MTLS. In passthrough mode, client certificate authentication is handled by the backend, and AppGw forwards the certificate without verifying it.

[Application Gateway MTLS-Passthrough Design Doc](https://microsoft.sharepoint.com/:w:/t/Aznet/EWrXR_E5J_JJlVTpz3idt6EBf0-v9lhGM-7Ub1I39jYIKQ?e=IWyqzY)

These changes are associated with the NRP 188 API version and have already been deployed, along with the 2025-03-01 ARM Manifest.

The properties were previously approved in a Private branch PR, which you can review here: https://github.com/Azure/azure-rest-api-specs-pr/pull/22268

