### PR TITLE
Clean up TypeSpec emitter configurations (only for test)

### DIFF
--- a/specification/codesigning/CodeSigning.Management/client.tsp
+++ b/specification/codesigning/CodeSigning.Management/client.tsp
@@ -5,7 +5,7 @@ using Azure.ClientGenerator.Core;
 using Microsoft.CodeSigning;
 using Azure.Core;
 
-@@clientName(Microsoft.CodeSigning, "TrustedSigningMgmt", "python");
+@@clientName(Microsoft.CodeSigning, "TrustedSigningMgmtClient", "python");
 @@clientName(Microsoft.CodeSigning, "TrustedSigningManagementClient", "java");
 
 @@clientName(AccountSku, "TrustedSigningAccountSku", "csharp");

--- a/specification/codesigning/CodeSigning.Management/tspconfig.yaml
+++ b/specification/codesigning/CodeSigning.Management/tspconfig.yaml
@@ -12,36 +12,12 @@ options:
     # `arm-resource-flattening` is only used for back-compat for specs existed on July 2024. All new service spec should NOT use this flag
     arm-resource-flattening: true
     output-file: "{azure-resource-provider-folder}/{service-name}/{version-status}/{version}/codeSigningAccount.json"
-  "@azure-tools/typespec-java":
-    emitter-output-dir: "{output-dir}/{service-dir}/azure-resourcemanager-trustedsigning"
-    flavor: "azure"
-    namespace: "com.azure.resourcemanager.trustedsigning"
-    service-name: "Trusted Signing"
   "@azure-tools/typespec-python":
     emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-trustedsigning"
     namespace: "azure.mgmt.trustedsigning"
     flavor: "azure"
     generate-test: true
     generate-sample: true
-  "@azure-tools/typespec-ts":
-    experimental-extensible-enums: true
-    emitter-output-dir: "{output-dir}/{service-dir}/arm-trustedsigning"
-    flavor: azure
-    package-details:
-      name: "@azure/arm-trustedsigning"
-  "@azure-tools/typespec-go":
-    service-dir: "sdk/resourcemanager/trustedsigning"
-    emitter-output-dir: "{output-dir}/{service-dir}/armtrustedsigning"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armtrustedsigning"
-    fix-const-stuttering: true
-    flavor: "azure"
-    generate-samples: true
-    generate-fakes: true
-    head-as-boolean: true
-    inject-spans: true
-  "@azure-typespec/http-client-csharp-mgmt":
-    namespace: "Azure.ResourceManager.TrustedSigning"
-    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/resource-manager"


### PR DESCRIPTION
Removed configuration for TypeSpec emitters for Java, TypeScript, Go, and C#.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
