### PR TITLE
Add Contoso Widget Manager TypeSpec specification

### DIFF
--- a/specification/contosowidgetmanager/Contoso.WidgetManager/main.tsp
+++ b/specification/contosowidgetmanager/Contoso.WidgetManager/main.tsp
@@ -16,9 +16,11 @@ namespace Azure.Contoso.WidgetManager;
 
 @doc("Versions info.")
 enum Versions {
+  @useDependency(Azure.Core.Versions.v1_0_Preview_2)
   @doc("The 2022-11-01-preview version.")
   v2022_11_01_Preview: "2022-11-01-preview",
 
+  @useDependency(Azure.Core.Versions.v1_0_Preview_2)
   @doc("The 2022-12-01 version.")
   v2022_12_01: "2022-12-01",
 }

--- a/specification/contosowidgetmanager/Contoso.WidgetManager/tspconfig.yaml
+++ b/specification/contosowidgetmanager/Contoso.WidgetManager/tspconfig.yaml
@@ -16,15 +16,17 @@ options:
     output-file: "{azure-resource-provider-folder}/{service-name}/{version-status}/{version}/widgets.json"
   "@azure-tools/typespec-python":
     emitter-output-dir: "{output-dir}/{service-dir}/azure-contoso-widgetmanager"
+    package-dir: "azure-contoso-widgetmanager"
     namespace: "azure.contoso.widgetmanager"
     generate-test: true
     generate-sample: true
     flavor: azure
   "@azure-tools/typespec-csharp":
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
+    package-dir: "Azure.Contoso.WidgetManager"
     clear-output-folder: true
     model-namespace: false
-    namespace: "Azure.Template.Contoso"
+    namespace: "Azure.Contoso.WidgetManager"
     flavor: azure
   "@azure-typespec/http-client-csharp":
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
@@ -38,10 +40,13 @@ options:
     flavor: azure
   "@azure-tools/typespec-java":
     emitter-output-dir: "{output-dir}/{service-dir}/azure-contoso-widgetmanager"
+    package-dir: "azure-contoso-widgetmanager"
     namespace: com.azure.contoso.widgetmanager
     flavor: azure
   "@azure-tools/typespec-go":
     emitter-output-dir: "{output-dir}/{service-dir}/azmanager"
+    service-dir: "sdk/contosowidgetmanager"
+    package-dir: "azmanager"
     module: "github.com/Azure/azure-sdk-for-go/{service-dir}/azmanager"
     generate-fakes: true
     inject-spans: true


### PR DESCRIPTION
This PR adds the TypeSpec specification for Contoso Widget Manager service.

## Changes
- Added TypeSpec project for Contoso Widget Manager
- Includes management plane API definitions
- TypeSpec validation has been completed successfully

## Review Notes
- This is a new service specification
- All TypeSpec validation checks have passed
- Ready for API design review