### PR TITLE
[lint-diff] Add missing "await" of async API

### DIFF
--- a/eng/tools/lint-diff/src/lint-diff.ts
+++ b/eng/tools/lint-diff/src/lint-diff.ts
@@ -157,7 +157,7 @@ async function runLintDiff(
     })
     .filter((result) => result.errors.length > 0);
   if (autoRestErrors.length > 0) {
-    generateAutoRestErrorReport(autoRestErrors, outFile);
+    await generateAutoRestErrorReport(autoRestErrors, outFile);
     console.log("AutoRest errors found. See workflow summary for details.");
 
     process.exitCode = 1;


### PR DESCRIPTION
- Fixes bug where callstacks can be lost after a crash
- Fixes #38498
- Should be detected by `eslint`, but we haven't yet enabled this on all tools (#35683)
