### PR TITLE
Add cspell to root package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "azure-rest-api-specs",
       "devDependencies": {
         "@autorest/openapi-to-typespec": "0.11.12",
+        "@azure-tools/cspell": "file:eng/common/spelling",
         "@azure-tools/spec-gen-sdk": "~0.9.1",
         "@azure-tools/specs-shared": "file:.github/shared",
         "@azure-tools/typespec-apiview": "0.7.2",
@@ -35,7 +36,6 @@
         "@typespec/versioning": "0.75.0",
         "@typespec/xml": "0.75.0",
         "azure-rest-api-specs-eng-tools": "file:eng/tools",
-        "cspell-version-pin": "file:eng/common/spelling",
         "oav": "4.0.2",
         "prettier": "~3.6.2",
         "typescript": "~5.9.2"
@@ -838,6 +838,10 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/@azure-tools/cspell": {
+      "resolved": "eng/common/spelling",
+      "link": true
     },
     "node_modules/@azure-tools/json": {
       "version": "1.3.1",
@@ -7357,10 +7361,6 @@
       "engines": {
         "node": ">=20"
       }
-    },
-    "node_modules/cspell-version-pin": {
-      "resolved": "eng/common/spelling",
-      "link": true
     },
     "node_modules/cspell/node_modules/commander": {
       "version": "14.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "@typespec/versioning": "0.75.0",
         "@typespec/xml": "0.75.0",
         "azure-rest-api-specs-eng-tools": "file:eng/tools",
+        "cspell-version-pin": "file:eng/common/spelling",
         "oav": "4.0.2",
         "prettier": "~3.6.2",
         "typescript": "~5.9.2"
@@ -88,6 +89,14 @@
       },
       "engines": {
         "node": ">= 20"
+      }
+    },
+    "eng/common/spelling": {
+      "name": "cspell-version-pin",
+      "version": "1.0.0",
+      "dev": true,
+      "dependencies": {
+        "cspell": "^9.2.1"
       }
     },
     "eng/tools": {
@@ -684,7 +693,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1039,7 +1047,6 @@
       "integrity": "sha512-sqOYBUghAtVMBiAWwT3fMRVSDNwR7IU3AQ96n/ErhAthwWjTe7PFVfK/MPjpI1mO3cdyLeS2DGyI3gt/waWP4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -1066,7 +1073,6 @@
       "integrity": "sha512-+BVZf1OfSZfEaXsOp1ZUCyjjZjC465ieIAr1zEz4yD7KaWGW+yE/w+HXbsRNNw0B52FhgVcWX6iVuvBtMZpNMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "change-case": "~5.4.4",
         "pluralize": "^8.0.0"
@@ -1135,7 +1141,6 @@
       "integrity": "sha512-CUhw8vkMzDTYlRfddQERT0ZEJAtwjKteRNuhs1S3IrDceJlHEiXTK+FpPwen/F5DBbj1w2SgnSFfaJ3fL171/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "change-case": "~5.4.4",
         "pluralize": "^8.0.0",
@@ -1970,6 +1975,594 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@cspell/cspell-bundled-dicts": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-9.2.2.tgz",
+      "integrity": "sha512-W3FKgb89DwMuQEVWz0dPH9uZqC8w+ylpbtmXuevflw3SLtGPyllMvf/1T6tcqIkg3KEWoRYFxjpJWyoOjJkZGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/dict-ada": "^4.1.1",
+        "@cspell/dict-al": "^1.1.1",
+        "@cspell/dict-aws": "^4.0.15",
+        "@cspell/dict-bash": "^4.2.1",
+        "@cspell/dict-companies": "^3.2.6",
+        "@cspell/dict-cpp": "^6.0.12",
+        "@cspell/dict-cryptocurrencies": "^5.0.5",
+        "@cspell/dict-csharp": "^4.0.7",
+        "@cspell/dict-css": "^4.0.18",
+        "@cspell/dict-dart": "^2.3.1",
+        "@cspell/dict-data-science": "^2.0.10",
+        "@cspell/dict-django": "^4.1.5",
+        "@cspell/dict-docker": "^1.1.16",
+        "@cspell/dict-dotnet": "^5.0.10",
+        "@cspell/dict-elixir": "^4.0.8",
+        "@cspell/dict-en_us": "^4.4.20",
+        "@cspell/dict-en-common-misspellings": "^2.1.6",
+        "@cspell/dict-en-gb-mit": "^3.1.10",
+        "@cspell/dict-filetypes": "^3.0.14",
+        "@cspell/dict-flutter": "^1.1.1",
+        "@cspell/dict-fonts": "^4.0.5",
+        "@cspell/dict-fsharp": "^1.1.1",
+        "@cspell/dict-fullstack": "^3.2.7",
+        "@cspell/dict-gaming-terms": "^1.1.2",
+        "@cspell/dict-git": "^3.0.7",
+        "@cspell/dict-golang": "^6.0.23",
+        "@cspell/dict-google": "^1.0.9",
+        "@cspell/dict-haskell": "^4.0.6",
+        "@cspell/dict-html": "^4.0.12",
+        "@cspell/dict-html-symbol-entities": "^4.0.4",
+        "@cspell/dict-java": "^5.0.12",
+        "@cspell/dict-julia": "^1.1.1",
+        "@cspell/dict-k8s": "^1.0.12",
+        "@cspell/dict-kotlin": "^1.1.1",
+        "@cspell/dict-latex": "^4.0.4",
+        "@cspell/dict-lorem-ipsum": "^4.0.5",
+        "@cspell/dict-lua": "^4.0.8",
+        "@cspell/dict-makefile": "^1.0.5",
+        "@cspell/dict-markdown": "^2.0.12",
+        "@cspell/dict-monkeyc": "^1.0.11",
+        "@cspell/dict-node": "^5.0.8",
+        "@cspell/dict-npm": "^5.2.18",
+        "@cspell/dict-php": "^4.0.15",
+        "@cspell/dict-powershell": "^5.0.15",
+        "@cspell/dict-public-licenses": "^2.0.15",
+        "@cspell/dict-python": "^4.2.20",
+        "@cspell/dict-r": "^2.1.1",
+        "@cspell/dict-ruby": "^5.0.9",
+        "@cspell/dict-rust": "^4.0.12",
+        "@cspell/dict-scala": "^5.0.8",
+        "@cspell/dict-shell": "^1.1.1",
+        "@cspell/dict-software-terms": "^5.1.9",
+        "@cspell/dict-sql": "^2.2.1",
+        "@cspell/dict-svelte": "^1.0.7",
+        "@cspell/dict-swift": "^2.0.6",
+        "@cspell/dict-terraform": "^1.1.3",
+        "@cspell/dict-typescript": "^3.2.3",
+        "@cspell/dict-vue": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@cspell/cspell-json-reporter": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-9.2.2.tgz",
+      "integrity": "sha512-7nTqnnRCyQB+bTmIuBR4aRwV5JHymckmz1snCF+ItjDSvlc3qzjxldG8ao5zm34h+b/8YCvdMU9B92eHBt803w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/cspell-types": "9.2.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@cspell/cspell-pipe": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-9.2.2.tgz",
+      "integrity": "sha512-YOdbp1uoKMkYy92qxMjoOxcqcR6LEVDus+72C4X9L8eJ2b+CBO3VaVqU16Y7OQGjYMnukYgB6eyTh8YFo9uBRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@cspell/cspell-resolver": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-9.2.2.tgz",
+      "integrity": "sha512-5tST2xoU8xbXihr1bdQ6pfcScQ3PkFpKKhFGClVfqS0yf/CKYURqzJlRDVjrFZsl+PT6tw/Jdt0E9Wwp1X1Qgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-directory": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@cspell/cspell-service-bus": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-9.2.2.tgz",
+      "integrity": "sha512-AxJuw/YPJkz1Ali5mA+OW9y4JiJzb2U7H4pGYq0nRB/mWwI/xtFjuWVkI+BhwrA2P6hHdifu0JdxSLqW4IYpPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@cspell/cspell-types": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-9.2.2.tgz",
+      "integrity": "sha512-/1dRFQ3sEY9Yo+f3w0A8MFJ0BOapQc1uFjlMF19c3uoD/e4PpNLpL1qXY4FeLWKDk1D9VT8SL93J+lIwEi5bvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@cspell/dict-ada": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-ada/-/dict-ada-4.1.1.tgz",
+      "integrity": "sha512-E+0YW9RhZod/9Qy2gxfNZiHJjCYFlCdI69br1eviQQWB8yOTJX0JHXLs79kOYhSW0kINPVUdvddEBe6Lu6CjGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-al": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-al/-/dict-al-1.1.1.tgz",
+      "integrity": "sha512-sD8GCaZetgQL4+MaJLXqbzWcRjfKVp8x+px3HuCaaiATAAtvjwUQ5/Iubiqwfd1boIh2Y1/3EgM3TLQ7Q8e0wQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-aws": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-aws/-/dict-aws-4.0.15.tgz",
+      "integrity": "sha512-aPY7VVR5Os4rz36EaqXBAEy14wR4Rqv+leCJ2Ug/Gd0IglJpM30LalF3e2eJChnjje3vWoEC0Rz3+e5gpZG+Kg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-bash": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-bash/-/dict-bash-4.2.2.tgz",
+      "integrity": "sha512-kyWbwtX3TsCf5l49gGQIZkRLaB/P8g73GDRm41Zu8Mv51kjl2H7Au0TsEvHv7jzcsRLS6aUYaZv6Zsvk1fOz+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/dict-shell": "1.1.2"
+      }
+    },
+    "node_modules/@cspell/dict-companies": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.2.7.tgz",
+      "integrity": "sha512-fEyr3LmpFKTaD0LcRhB4lfW1AmULYBqzg4gWAV0dQCv06l+TsA+JQ+3pZJbUcoaZirtgsgT3dL3RUjmGPhUH0A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-cpp": {
+      "version": "6.0.14",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-6.0.14.tgz",
+      "integrity": "sha512-dkmpSwvVfVdtoZ4mW/CK2Ep1v8mJlp6uiKpMNbSMOdJl4kq28nQS4vKNIX3B2bJa0Ha5iHHu+1mNjiLeO3g7Xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-cryptocurrencies": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-cryptocurrencies/-/dict-cryptocurrencies-5.0.5.tgz",
+      "integrity": "sha512-R68hYYF/rtlE6T/dsObStzN5QZw+0aQBinAXuWCVqwdS7YZo0X33vGMfChkHaiCo3Z2+bkegqHlqxZF4TD3rUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-csharp": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-csharp/-/dict-csharp-4.0.7.tgz",
+      "integrity": "sha512-H16Hpu8O/1/lgijFt2lOk4/nnldFtQ4t8QHbyqphqZZVE5aS4J/zD/WvduqnLY21aKhZS6jo/xF5PX9jyqPKUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-css": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-4.0.18.tgz",
+      "integrity": "sha512-EF77RqROHL+4LhMGW5NTeKqfUd/e4OOv6EDFQ/UQQiFyWuqkEKyEz0NDILxOFxWUEVdjT2GQ2cC7t12B6pESwg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-dart": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-dart/-/dict-dart-2.3.1.tgz",
+      "integrity": "sha512-xoiGnULEcWdodXI6EwVyqpZmpOoh8RA2Xk9BNdR7DLamV/QMvEYn8KJ7NlRiTSauJKPNkHHQ5EVHRM6sTS7jdg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-data-science": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-data-science/-/dict-data-science-2.0.11.tgz",
+      "integrity": "sha512-Dt+83nVCcF+dQyvFSaZjCKt1H5KbsVJFtH2X7VUfmIzQu8xCnV1fUmkhBzGJ+NiFs99Oy9JA6I9EjeqExzXk7g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-django": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-django/-/dict-django-4.1.5.tgz",
+      "integrity": "sha512-AvTWu99doU3T8ifoMYOMLW2CXKvyKLukPh1auOPwFGHzueWYvBBN+OxF8wF7XwjTBMMeRleVdLh3aWCDEX/ZWg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-docker": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-docker/-/dict-docker-1.1.16.tgz",
+      "integrity": "sha512-UiVQ5RmCg6j0qGIxrBnai3pIB+aYKL3zaJGvXk1O/ertTKJif9RZikKXCEgqhaCYMweM4fuLqWSVmw3hU164Iw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-dotnet": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-dotnet/-/dict-dotnet-5.0.10.tgz",
+      "integrity": "sha512-ooar8BP/RBNP1gzYfJPStKEmpWy4uv/7JCq6FOnJLeD1yyfG3d/LFMVMwiJo+XWz025cxtkM3wuaikBWzCqkmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-elixir": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-elixir/-/dict-elixir-4.0.8.tgz",
+      "integrity": "sha512-CyfphrbMyl4Ms55Vzuj+mNmd693HjBFr9hvU+B2YbFEZprE5AG+EXLYTMRWrXbpds4AuZcvN3deM2XVB80BN/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-en_us": {
+      "version": "4.4.23",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.4.23.tgz",
+      "integrity": "sha512-9GsWPl651GNfZyfIQgrb29XRDlSiwvvwrbdi8WFPI5HoxqCKfi0sQ1YAAyOSHDWG/3As6nmkRU1ZEyrjJJ7KFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-en-common-misspellings": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en-common-misspellings/-/dict-en-common-misspellings-2.1.7.tgz",
+      "integrity": "sha512-HAWSOoQ+lxdzLaTALhPofKNJdxZ7HAcTZWQNwb7cvGBiKEy182cb96U35602yBPrBsKY/vLxVs6f0E1JTeQjRQ==",
+      "dev": true,
+      "license": "CC BY-SA 4.0"
+    },
+    "node_modules/@cspell/dict-en-gb-mit": {
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb-mit/-/dict-en-gb-mit-3.1.13.tgz",
+      "integrity": "sha512-qcJrBbWh59+P0K4ZypGfNoQbkyZlj2ZTeJG+d8oy2GGj1OZAgW7Hu/X9p3KfbSI8MenOes/cbahVMstlDtzZPg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-filetypes": {
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-filetypes/-/dict-filetypes-3.0.14.tgz",
+      "integrity": "sha512-KSXaSMYYNMLLdHEnju1DyRRH3eQWPRYRnOXpuHUdOh2jC44VgQoxyMU7oB3NAhDhZKBPCihabzECsAGFbdKfEA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-flutter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-flutter/-/dict-flutter-1.1.1.tgz",
+      "integrity": "sha512-UlOzRcH2tNbFhZmHJN48Za/2/MEdRHl2BMkCWZBYs+30b91mWvBfzaN4IJQU7dUZtowKayVIF9FzvLZtZokc5A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-fonts": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-fonts/-/dict-fonts-4.0.5.tgz",
+      "integrity": "sha512-BbpkX10DUX/xzHs6lb7yzDf/LPjwYIBJHJlUXSBXDtK/1HaeS+Wqol4Mlm2+NAgZ7ikIE5DQMViTgBUY3ezNoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-fsharp": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-fsharp/-/dict-fsharp-1.1.1.tgz",
+      "integrity": "sha512-imhs0u87wEA4/cYjgzS0tAyaJpwG7vwtC8UyMFbwpmtw+/bgss+osNfyqhYRyS/ehVCWL17Ewx2UPkexjKyaBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-fullstack": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-fullstack/-/dict-fullstack-3.2.7.tgz",
+      "integrity": "sha512-IxEk2YAwAJKYCUEgEeOg3QvTL4XLlyArJElFuMQevU1dPgHgzWElFevN5lsTFnvMFA1riYsVinqJJX0BanCFEg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-gaming-terms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-gaming-terms/-/dict-gaming-terms-1.1.2.tgz",
+      "integrity": "sha512-9XnOvaoTBscq0xuD6KTEIkk9hhdfBkkvJAIsvw3JMcnp1214OCGW8+kako5RqQ2vTZR3Tnf3pc57o7VgkM0q1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-git": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-git/-/dict-git-3.0.7.tgz",
+      "integrity": "sha512-odOwVKgfxCQfiSb+nblQZc4ErXmnWEnv8XwkaI4sNJ7cNmojnvogYVeMqkXPjvfrgEcizEEA4URRD2Ms5PDk1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-golang": {
+      "version": "6.0.24",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-6.0.24.tgz",
+      "integrity": "sha512-rY7PlC3MsHozmjrZWi0HQPUl0BVCV0+mwK0rnMT7pOIXqOe4tWCYMULDIsEk4F0gbIxb5badd2dkCPDYjLnDgA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-google": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-google/-/dict-google-1.0.9.tgz",
+      "integrity": "sha512-biL65POqialY0i4g6crj7pR6JnBkbsPovB2WDYkj3H4TuC/QXv7Pu5pdPxeUJA6TSCHI7T5twsO4VSVyRxD9CA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-haskell": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-haskell/-/dict-haskell-4.0.6.tgz",
+      "integrity": "sha512-ib8SA5qgftExpYNjWhpYIgvDsZ/0wvKKxSP+kuSkkak520iPvTJumEpIE+qPcmJQo4NzdKMN8nEfaeci4OcFAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-html": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-4.0.12.tgz",
+      "integrity": "sha512-JFffQ1dDVEyJq6tCDWv0r/RqkdSnV43P2F/3jJ9rwLgdsOIXwQbXrz6QDlvQLVvNSnORH9KjDtenFTGDyzfCaA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-html-symbol-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-html-symbol-entities/-/dict-html-symbol-entities-4.0.4.tgz",
+      "integrity": "sha512-afea+0rGPDeOV9gdO06UW183Qg6wRhWVkgCFwiO3bDupAoyXRuvupbb5nUyqSTsLXIKL8u8uXQlJ9pkz07oVXw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-java": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-java/-/dict-java-5.0.12.tgz",
+      "integrity": "sha512-qPSNhTcl7LGJ5Qp6VN71H8zqvRQK04S08T67knMq9hTA8U7G1sTKzLmBaDOFhq17vNX/+rT+rbRYp+B5Nwza1A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-julia": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-julia/-/dict-julia-1.1.1.tgz",
+      "integrity": "sha512-WylJR9TQ2cgwd5BWEOfdO3zvDB+L7kYFm0I9u0s9jKHWQ6yKmfKeMjU9oXxTBxIufhCXm92SKwwVNAC7gjv+yA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-k8s": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-k8s/-/dict-k8s-1.0.12.tgz",
+      "integrity": "sha512-2LcllTWgaTfYC7DmkMPOn9GsBWsA4DZdlun4po8s2ysTP7CPEnZc1ZfK6pZ2eI4TsZemlUQQ+NZxMe9/QutQxg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-kotlin": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-kotlin/-/dict-kotlin-1.1.1.tgz",
+      "integrity": "sha512-J3NzzfgmxRvEeOe3qUXnSJQCd38i/dpF9/t3quuWh6gXM+krsAXP75dY1CzDmS8mrJAlBdVBeAW5eAZTD8g86Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-latex": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-latex/-/dict-latex-4.0.4.tgz",
+      "integrity": "sha512-YdTQhnTINEEm/LZgTzr9Voz4mzdOXH7YX+bSFs3hnkUHCUUtX/mhKgf1CFvZ0YNM2afjhQcmLaR9bDQVyYBvpA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-lorem-ipsum": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-lorem-ipsum/-/dict-lorem-ipsum-4.0.5.tgz",
+      "integrity": "sha512-9a4TJYRcPWPBKkQAJ/whCu4uCAEgv/O2xAaZEI0n4y1/l18Yyx8pBKoIX5QuVXjjmKEkK7hi5SxyIsH7pFEK9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-lua": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-lua/-/dict-lua-4.0.8.tgz",
+      "integrity": "sha512-N4PkgNDMu9JVsRu7JBS/3E/dvfItRgk9w5ga2dKq+JupP2Y3lojNaAVFhXISh4Y0a6qXDn2clA6nvnavQ/jjLA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-makefile": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-makefile/-/dict-makefile-1.0.5.tgz",
+      "integrity": "sha512-4vrVt7bGiK8Rx98tfRbYo42Xo2IstJkAF4tLLDMNQLkQ86msDlYSKG1ZCk8Abg+EdNcFAjNhXIiNO+w4KflGAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-markdown": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-markdown/-/dict-markdown-2.0.12.tgz",
+      "integrity": "sha512-ufwoliPijAgWkD/ivAMC+A9QD895xKiJRF/fwwknQb7kt7NozTLKFAOBtXGPJAB4UjhGBpYEJVo2elQ0FCAH9A==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@cspell/dict-css": "^4.0.18",
+        "@cspell/dict-html": "^4.0.12",
+        "@cspell/dict-html-symbol-entities": "^4.0.4",
+        "@cspell/dict-typescript": "^3.2.3"
+      }
+    },
+    "node_modules/@cspell/dict-monkeyc": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-monkeyc/-/dict-monkeyc-1.0.11.tgz",
+      "integrity": "sha512-7Q1Ncu0urALI6dPTrEbSTd//UK0qjRBeaxhnm8uY5fgYNFYAG+u4gtnTIo59S6Bw5P++4H3DiIDYoQdY/lha8w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-node": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-node/-/dict-node-5.0.8.tgz",
+      "integrity": "sha512-AirZcN2i84ynev3p2/1NCPEhnNsHKMz9zciTngGoqpdItUb2bDt1nJBjwlsrFI78GZRph/VaqTVFwYikmncpXg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-npm": {
+      "version": "5.2.20",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.2.20.tgz",
+      "integrity": "sha512-tJRv1qEdW3f8fxK/D2huoqkSvM6ogz55hAt9RTdB7tZy57wio9Tkj+xfi2DIeOlmf6e94c6pNPZIC/o5rclMhw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-php": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-php/-/dict-php-4.1.0.tgz",
+      "integrity": "sha512-dTDeabyOj7eFvn2Q4Za3uVXM2+SzeFMqX8ly2P0XTo4AzbCmI2hulFD/QIADwWmwiRrInbbf8cxwFHNIYrXl4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-powershell": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-powershell/-/dict-powershell-5.0.15.tgz",
+      "integrity": "sha512-l4S5PAcvCFcVDMJShrYD0X6Huv9dcsQPlsVsBGbH38wvuN7gS7+GxZFAjTNxDmTY1wrNi1cCatSg6Pu2BW4rgg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-public-licenses": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-public-licenses/-/dict-public-licenses-2.0.15.tgz",
+      "integrity": "sha512-cJEOs901H13Pfy0fl4dCD1U+xpWIMaEPq8MeYU83FfDZvellAuSo4GqWCripfIqlhns/L6+UZEIJSOZnjgy7Wg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-python": {
+      "version": "4.2.21",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.21.tgz",
+      "integrity": "sha512-M9OgwXWhpZqEZqKU2psB2DFsT8q5SwEahkQeIpNIRWIErjwG7I9yYhhfvPz6s5gMCMhhb3hqcPJTnmdgqGrQyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/dict-data-science": "^2.0.11"
+      }
+    },
+    "node_modules/@cspell/dict-r": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-r/-/dict-r-2.1.1.tgz",
+      "integrity": "sha512-71Ka+yKfG4ZHEMEmDxc6+blFkeTTvgKbKAbwiwQAuKl3zpqs1Y0vUtwW2N4b3LgmSPhV3ODVY0y4m5ofqDuKMw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-ruby": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-ruby/-/dict-ruby-5.0.9.tgz",
+      "integrity": "sha512-H2vMcERMcANvQshAdrVx0XoWaNX8zmmiQN11dZZTQAZaNJ0xatdJoSqY8C8uhEMW89bfgpN+NQgGuDXW2vmXEw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-rust": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-rust/-/dict-rust-4.0.12.tgz",
+      "integrity": "sha512-z2QiH+q9UlNhobBJArvILRxV8Jz0pKIK7gqu4TgmEYyjiu1TvnGZ1tbYHeu9w3I/wOP6UMDoCBTty5AlYfW0mw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-scala": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-scala/-/dict-scala-5.0.8.tgz",
+      "integrity": "sha512-YdftVmumv8IZq9zu1gn2U7A4bfM2yj9Vaupydotyjuc+EEZZSqAafTpvW/jKLWji2TgybM1L2IhmV0s/Iv9BTw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-shell": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-shell/-/dict-shell-1.1.2.tgz",
+      "integrity": "sha512-WqOUvnwcHK1X61wAfwyXq04cn7KYyskg90j4lLg3sGGKMW9Sq13hs91pqrjC44Q+lQLgCobrTkMDw9Wyl9nRFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-software-terms": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-5.1.11.tgz",
+      "integrity": "sha512-xwARdlp6o81BK7uNl4qR5CmLBXuc9xWyEeEwzeAw/8SkBdYheVQO6F1Fey2iqMRDT9LAb5Znbg83pJVpLjgBjg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-sql": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-sql/-/dict-sql-2.2.1.tgz",
+      "integrity": "sha512-qDHF8MpAYCf4pWU8NKbnVGzkoxMNrFqBHyG/dgrlic5EQiKANCLELYtGlX5auIMDLmTf1inA0eNtv74tyRJ/vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-svelte": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-svelte/-/dict-svelte-1.0.7.tgz",
+      "integrity": "sha512-hGZsGqP0WdzKkdpeVLBivRuSNzOTvN036EBmpOwxH+FTY2DuUH7ecW+cSaMwOgmq5JFSdTcbTNFlNC8HN8lhaQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-swift": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-swift/-/dict-swift-2.0.6.tgz",
+      "integrity": "sha512-PnpNbrIbex2aqU1kMgwEKvCzgbkHtj3dlFLPMqW1vSniop7YxaDTtvTUO4zA++ugYAEL+UK8vYrBwDPTjjvSnA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-terraform": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-terraform/-/dict-terraform-1.1.3.tgz",
+      "integrity": "sha512-gr6wxCydwSFyyBKhBA2xkENXtVFToheqYYGFvlMZXWjviynXmh+NK/JTvTCk/VHk3+lzbO9EEQKee6VjrAUSbA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-typescript": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.2.3.tgz",
+      "integrity": "sha512-zXh1wYsNljQZfWWdSPYwQhpwiuW0KPW1dSd8idjMRvSD0aSvWWHoWlrMsmZeRl4qM4QCEAjua8+cjflm41cQBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-vue": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-vue/-/dict-vue-3.0.5.tgz",
+      "integrity": "sha512-Mqutb8jbM+kIcywuPQCCaK5qQHTdaByoEO2J9LKFy3sqAdiBogNkrplqUK0HyyRFgCfbJUgjz3N85iCMcWH0JA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dynamic-import": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-9.2.2.tgz",
+      "integrity": "sha512-RHQLp0iYcWuK0MGiUBA6dgEOCdI29kZTiBRVcJM/Pzvhvs8j9pzBTkMesZAJ7XOSFz2kU+skRMBsFd774dmYTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/url": "9.2.2",
+        "import-meta-resolve": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@cspell/filetypes": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-9.2.2.tgz",
+      "integrity": "sha512-oM+cqipbZ4PNxQcKP9sKOeRKBG+oM3NKO3To1FyxYxvnUG7DukW2yH6BS0/GUY7qK+oSftuq5d6DXEAl9wzbEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@cspell/strong-weak-map": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-9.2.2.tgz",
+      "integrity": "sha512-Z7rd7NwHaoH/d/Ds97Rv042WS9PgpVdqgO2X0ehYZmgj2E0LIq2MTkIJMheUrSn37D0PW/suroKh6hN15pJtpQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@cspell/url": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-9.2.2.tgz",
+      "integrity": "sha512-gvLprhrArvLP/rnC8b766dA80EXwBbzXqb9tNDRk1esQV7d3uS1Ftk1970MRlAfLg1pG6V+3C4UrB6WOB/rMCQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@dabh/diagnostics": {
@@ -3526,7 +4119,6 @@
       "integrity": "sha512-t54CUOsFMappY1Jbzb7fetWeO0n6K0k/4+/ZpkS+3Joz8I4VcvY9OiEBFRYISqaI2fq5sCiPtAjRDOzVYG8m+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.2",
@@ -4233,7 +4825,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -4324,7 +4915,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -4665,8 +5255,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true,
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/@ts-common/property-set": {
       "version": "0.1.0",
@@ -4876,8 +5465,7 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/lodash": {
       "version": "4.17.20",
@@ -5005,7 +5593,6 @@
       "integrity": "sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.2",
         "@typescript-eslint/types": "8.46.2",
@@ -5237,7 +5824,6 @@
       "integrity": "sha512-REJgZOEZ9g9CC72GGT0+nLbjW+5WVlCfm1d6w18N5RsUo7vLXs8IPXwq7xZJzoqU99Q9B4keqzPuTU4OrDUTrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "~7.27.1",
         "@inquirer/prompts": "^7.4.0",
@@ -5394,7 +5980,6 @@
       "integrity": "sha512-V7unXnj+sZoa/1wQG8G6x2TiQqotx18S/qFbDzdfJRPCVpH/Z3xIpppce4jTZALXT97tKZK5GDHijn2zWuWWxg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -5408,7 +5993,6 @@
       "integrity": "sha512-52XLXwqSY2SY6nSvfkiTsNiJzlMeIAZ6MFIVJ5YkoibA21TNAP4DtjTZgC2GieZLY2NNN/rqDCqBX+DyWqTrfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -5428,7 +6012,6 @@
       "integrity": "sha512-27sXkSK2r1sAmVMLv+pwlN/Cm+yg9nEK8iuGyJRuEkBk7hcsJDbTnBlsEvlRTI8DqljtzA7YECDHBLK88zZHeg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -5490,7 +6073,6 @@
       "integrity": "sha512-rQ+RP0kcrKWjbpCIkBd8hpxYSNc3CfQxl0MLP1+MYGRHlHL8ss4xbwdANIYZXZZ2i2Hqt19B7cEUGD4MLoCHvw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -5505,7 +6087,6 @@
       "integrity": "sha512-8iODUY3C/0hR9sTzyHeTgYfZkKeqZM+/P0OmN1ZWlLUokXQ67yydGXIqnjl+yaeuntwN8H2DDwLguU15c+j+UQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -5522,7 +6103,6 @@
       "integrity": "sha512-ubvxCN+SZwN9aEarz8CPtMJgnopeu8dXyut47q0FAPp9nykmXy7s+dmsopR+7OX0Fhcnh8ZFYTQcJzJ3QftOiQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -5551,7 +6131,6 @@
       "integrity": "sha512-wdLcVx5UW4WRks/OXfqLiaDTtWfAWgv/nj69u99gRJU6iY9ExEvK5x9NQszZQKYnu6tM7nkoYMg4zu+7YBUBaw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -5565,7 +6144,6 @@
       "integrity": "sha512-JVafN1nZE3BcQrKbaAFVWw/IleTRdsJpwT3oZ2m7EfWnG30sKtoR9inF9dRoW+XXIjNzCfeYqjkwzEkEnIrCww==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -5741,7 +6319,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5900,6 +6477,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/array-timsort": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
+      "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/arraybuffer.prototype.slice": {
       "version": "1.0.4",
@@ -6199,6 +6783,22 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chalk-template": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-1.1.2.tgz",
+      "integrity": "sha512-2bxTP2yUH7AJj/VAXfcA+4IcWGdQ87HwBANLt5XxGTeomo8yG0y95N1um9i5StvhT/Bl0/2cARA5v1PpPXUxUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
     "node_modules/change-case": {
       "version": "5.4.4",
       "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
@@ -6244,6 +6844,46 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/clear-module": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/clear-module/-/clear-module-4.1.2.tgz",
+      "integrity": "sha512-LWAxzHqdHsAZlPlEyJ2Poz6AIs384mPeqLVCru2p0BrP9G/kVGuhNyZYClLO6cXlnuJjzC8xtsJIuMjKqLXoAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^2.0.0",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clear-module/node_modules/parent-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-2.0.0.tgz",
+      "integrity": "sha512-uo0Z9JJeWzv8BG+tRcapBKNJ0dro9cLyczGzulS6EfeyAdeC9sbojtW6XwvYxJkEne9En+J2XEl4zyglVeIwFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/clear-module/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/cli-width": {
@@ -6417,6 +7057,21 @@
         "node": ">= 6"
       }
     },
+    "node_modules/comment-json": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.4.1.tgz",
+      "integrity": "sha512-r1To31BQD5060QdkC+Iheai7gHwoSZobzunqkf2/kQ6xIAfJyrKNAFUwdKvkK7Qgu7pVTKQEa7ok7Ed3ycAJgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-timsort": "^1.0.3",
+        "core-util-is": "^1.0.3",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/commonmark": {
       "version": "0.31.2",
       "resolved": "https://registry.npmjs.org/commonmark/-/commonmark-0.31.2.tgz",
@@ -6497,6 +7152,224 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/cspell": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-9.2.2.tgz",
+      "integrity": "sha512-D9jxXlYWIxUw4IjicxrmK83n5BzuQVZaIhsDsfRiH7iP4F71gDtKR9b+UgmXevvseN7OH4LkdyaPKzjNliGAbg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/cspell-json-reporter": "9.2.2",
+        "@cspell/cspell-pipe": "9.2.2",
+        "@cspell/cspell-types": "9.2.2",
+        "@cspell/dynamic-import": "9.2.2",
+        "@cspell/url": "9.2.2",
+        "chalk": "^5.6.2",
+        "chalk-template": "^1.1.2",
+        "commander": "^14.0.1",
+        "cspell-config-lib": "9.2.2",
+        "cspell-dictionary": "9.2.2",
+        "cspell-gitignore": "9.2.2",
+        "cspell-glob": "9.2.2",
+        "cspell-io": "9.2.2",
+        "cspell-lib": "9.2.2",
+        "fast-json-stable-stringify": "^2.1.0",
+        "flatted": "^3.3.3",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "cspell": "bin.mjs",
+        "cspell-esm": "bin.mjs"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/streetsidesoftware/cspell?sponsor=1"
+      }
+    },
+    "node_modules/cspell-config-lib": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-9.2.2.tgz",
+      "integrity": "sha512-Fp3jdFxb5gxcQP146TfNVmDqXKfm3xmcEUr1K829DmAFwhc7s+/pCRjhBPoGfQt6U7ugpxjkSx2gGKSbLhp7Mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/cspell-types": "9.2.2",
+        "comment-json": "^4.4.1",
+        "smol-toml": "^1.4.2",
+        "yaml": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cspell-dictionary": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-9.2.2.tgz",
+      "integrity": "sha512-lnoCFoCAaiFJi+Hz22t+tdTj76jyTA76EYFKhmf/dbj5UO6kVy8by08uFfUbbMaC9Oi09YHnI62P/e+LBx1v8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/cspell-pipe": "9.2.2",
+        "@cspell/cspell-types": "9.2.2",
+        "cspell-trie-lib": "9.2.2",
+        "fast-equals": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cspell-gitignore": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-9.2.2.tgz",
+      "integrity": "sha512-Idx3IVKTpnGoyRlkj8F/lSWtWiJpqLhXmZglTzfGWxzbik8E0aQmSyT3blbNWhZL/K1JqlTjbSiAICVMoWTkhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/url": "9.2.2",
+        "cspell-glob": "9.2.2",
+        "cspell-io": "9.2.2"
+      },
+      "bin": {
+        "cspell-gitignore": "bin.mjs"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cspell-glob": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-9.2.2.tgz",
+      "integrity": "sha512-6mhUk4iLu5YzY9PE86ZyAjNFjM7TD8Oh4btJ7ZV+edzJjdVjFugXWyefPXCGNfuvpaJqpuoLDwMvNHJxUmLwbg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/url": "9.2.2",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cspell-glob/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/cspell-grammar": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-9.2.2.tgz",
+      "integrity": "sha512-m0aozo5gjZYL5Vm3/9D0/yLZJTsVJAP8VeRVljN4u5T7w+WY+LsnvKSZhnkOvsT3kCJDhcKEkMVkCo8d/7EcAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/cspell-pipe": "9.2.2",
+        "@cspell/cspell-types": "9.2.2"
+      },
+      "bin": {
+        "cspell-grammar": "bin.mjs"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cspell-io": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-9.2.2.tgz",
+      "integrity": "sha512-Rpky4woeB6/1VUCk7DtRm94A6c5XRbhcj5dUZh851EpZ0ItEz3S9+MhkX8g1sTVkDg6Hln1pu+Nbm9dFIpGkGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/cspell-service-bus": "9.2.2",
+        "@cspell/url": "9.2.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cspell-lib": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-9.2.2.tgz",
+      "integrity": "sha512-ksy+5vCSZz7ECUDlLA8ZGNEcWmnzl5bMe4IEPHAMaPFY3iWNsG7dXBrae1dj/b/3HqVqOdXPdwjnGAyZciissg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/cspell-bundled-dicts": "9.2.2",
+        "@cspell/cspell-pipe": "9.2.2",
+        "@cspell/cspell-resolver": "9.2.2",
+        "@cspell/cspell-types": "9.2.2",
+        "@cspell/dynamic-import": "9.2.2",
+        "@cspell/filetypes": "9.2.2",
+        "@cspell/strong-weak-map": "9.2.2",
+        "@cspell/url": "9.2.2",
+        "clear-module": "^4.1.2",
+        "cspell-config-lib": "9.2.2",
+        "cspell-dictionary": "9.2.2",
+        "cspell-glob": "9.2.2",
+        "cspell-grammar": "9.2.2",
+        "cspell-io": "9.2.2",
+        "cspell-trie-lib": "9.2.2",
+        "env-paths": "^3.0.0",
+        "gensequence": "^7.0.0",
+        "import-fresh": "^3.3.1",
+        "resolve-from": "^5.0.0",
+        "vscode-languageserver-textdocument": "^1.0.12",
+        "vscode-uri": "^3.1.0",
+        "xdg-basedir": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cspell-lib/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cspell-trie-lib": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-9.2.2.tgz",
+      "integrity": "sha512-84L0Or6xkfnDMmxx2BtuaqsM4LOVCgnG4ZzMMgwQJU+9nSOAHs0ULNWQTHLbsCF+FFG/siILpUkIc3z+UxjGFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/cspell-pipe": "9.2.2",
+        "@cspell/cspell-types": "9.2.2",
+        "gensequence": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cspell-version-pin": {
+      "resolved": "eng/common/spelling",
+      "link": true
+    },
+    "node_modules/cspell/node_modules/commander": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz",
+      "integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/data-uri-to-buffer": {
@@ -7029,7 +7902,6 @@
       "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7322,6 +8194,16 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.3.2.tgz",
+      "integrity": "sha512-6rxyATwPCkaFIL3JLqw8qXqMpIZ942pTX/tbQFkRsDGblS8tNGtlUauA/+mt6RUfqn/4MoEr+WDkYoIQbibWuQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -7798,6 +8680,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/gensequence": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/gensequence/-/gensequence-7.0.0.tgz",
+      "integrity": "sha512-47Frx13aZh01afHJTB3zTtKIlFI6vWY+MYCN9Qpew6i52rfKjnhCF/l1YlC8UmEMvvntZZ6z4PiCcmyuedR2aQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -7994,6 +8886,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/global-directory": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
+      "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "4.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globals": {
@@ -8337,6 +9245,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -8353,6 +9272,16 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
+      "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -8916,7 +9845,6 @@
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -9843,8 +10771,7 @@
       "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
       "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -10137,7 +11064,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -10303,8 +11229,7 @@
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
       "dev": true,
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -10813,6 +11738,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.4.2.tgz",
+      "integrity": "sha512-rInDH6lCNiEyn3+hH8KVGFdbjc099j47+OSgbMrfDYX1CmXLfdKd7qi6IfcWj2wFxvSVkuI46M+wPGYfEOEj6g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
       }
     },
     "node_modules/source-map": {
@@ -11397,7 +12335,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11517,8 +12454,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
@@ -11627,7 +12563,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11790,7 +12725,6 @@
       "integrity": "sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -11907,7 +12841,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11921,7 +12854,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -12057,6 +12989,13 @@
       "version": "3.17.5",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
       "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -12459,6 +13398,19 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/xdg-basedir": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-5.1.0.tgz",
+      "integrity": "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/xml2js": {
       "version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@typespec/versioning": "0.75.0",
     "@typespec/xml": "0.75.0",
     "azure-rest-api-specs-eng-tools": "file:eng/tools",
+    "cspell-version-pin": "file:eng/common/spelling",
     "oav": "4.0.2",
     "prettier": "~3.6.2",
     "typescript": "~5.9.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "azure-rest-api-specs",
   "devDependencies": {
+    "@azure-tools/cspell": "file:eng/common/spelling",
     "@azure-tools/spec-gen-sdk": "~0.9.1",
     "@azure-tools/specs-shared": "file:.github/shared",
     "@azure-tools/typespec-apiview": "0.7.2",
@@ -30,7 +31,6 @@
     "@typespec/versioning": "0.75.0",
     "@typespec/xml": "0.75.0",
     "azure-rest-api-specs-eng-tools": "file:eng/tools",
-    "cspell-version-pin": "file:eng/common/spelling",
     "oav": "4.0.2",
     "prettier": "~3.6.2",
     "typescript": "~5.9.2"


### PR DESCRIPTION
This is intended for dev convenience. It doesn't use the exact set of packages in `eng/common/spelling/package-lock.json` but it's close enough for now. 

Now one can run `npm ci` at the root of the specs repo and `npx cspell` to run an approximation of the spell check in CI. 

Upgrades to `eng/common/spelling`'s cspell in the future can be coordinated closely with the root package.json file to make the versions align better, if needed. Since this is a dev convenience, it's not required. 