### PR TITLE
[Key Vault] omit generated constructors for Go

### DIFF
--- a/specification/keyvault/Security.KeyVault.BackupRestore/tspconfig.yaml
+++ b/specification/keyvault/Security.KeyVault.BackupRestore/tspconfig.yaml
@@ -32,6 +32,7 @@ options:
     inject-spans: true
     single-client: true
     generate-fakes: true
+    omit-constructors: true
   "@azure-tools/typespec-client-generator-cli":
     additionalDirectories:
       - "specification/keyvault/Security.KeyVault.Common/"

--- a/specification/keyvault/Security.KeyVault.Certificates/tspconfig.yaml
+++ b/specification/keyvault/Security.KeyVault.Certificates/tspconfig.yaml
@@ -58,6 +58,7 @@ options:
     single-client: true
     inject-spans: true
     generate-fakes: true
+    omit-constructors: true
   "@azure-tools/typespec-rust":
     crate-name: "azure_security_keyvault_certificates"
     crate-version: "0.0.1"

--- a/specification/keyvault/Security.KeyVault.Keys/tspconfig.yaml
+++ b/specification/keyvault/Security.KeyVault.Keys/tspconfig.yaml
@@ -57,6 +57,7 @@ options:
     single-client: true
     inject-spans: true
     generate-fakes: true
+    omit-constructors: true
   "@azure-tools/typespec-rust":
     crate-name: "azure_security_keyvault_keys"
     crate-version: "0.0.1"

--- a/specification/keyvault/Security.KeyVault.RBAC/tspconfig.yaml
+++ b/specification/keyvault/Security.KeyVault.RBAC/tspconfig.yaml
@@ -32,6 +32,7 @@ options:
     inject-spans: true
     single-client: true
     generate-fakes: true
+    omit-constructors: true
   "@azure-tools/typespec-client-generator-cli":
     additionalDirectories:
       - "specification/keyvault/Security.KeyVault.Common/"

--- a/specification/keyvault/Security.KeyVault.Secrets/tspconfig.yaml
+++ b/specification/keyvault/Security.KeyVault.Secrets/tspconfig.yaml
@@ -56,6 +56,7 @@ options:
     single-client: true
     inject-spans: true
     generate-fakes: true
+    omit-constructors: true
   "@azure-tools/typespec-rust":
     crate-name: "azure_security_keyvault_secrets"
     crate-version: "0.0.1"

--- a/specification/keyvault/Security.KeyVault.Settings/tspconfig.yaml
+++ b/specification/keyvault/Security.KeyVault.Settings/tspconfig.yaml
@@ -31,6 +31,7 @@ options:
     inject-spans: true
     single-client: true
     generate-fakes: true
+    omit-constructors: true
   "@azure-tools/typespec-client-generator-cli":
     additionalDirectories:
       - "specification/keyvault/Security.KeyVault.Common/"


### PR DESCRIPTION
The Go generator now automatically generates client constructors. Opting out for Go as the Key Vault libraries need custom constructors.