### PR TITLE
chore: add ossku Ubuntu2404 enum value to 2025-10-01

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2025-10-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2025-10-01/managedClusters.json
@@ -6562,6 +6562,7 @@
         "CBLMariner",
         "Ubuntu",
         "Ubuntu2204",
+        "Ubuntu2404",
         "Windows2019",
         "Windows2022"
       ],
@@ -6596,6 +6597,10 @@
           {
             "value": "Ubuntu2204",
             "description": "Use Ubuntu2204 as the OS for node images, however, Ubuntu 22.04 may not be supported for all nodepools. For limitations and supported kubernetes versions, see https://aka.ms/aks/supported-ubuntu-versions"
+          },
+          {
+            "value": "Ubuntu2404",
+            "description": "Use Ubuntu2404 as the OS for node images, however, Ubuntu 24.04 may not be supported for all nodepools. For limitations and supported kubernetes versions, see https://aka.ms/aks/supported-ubuntu-versions"
           }
         ]
       },


### PR DESCRIPTION
This PR adds the new OSSKU Ubuntu2404 to the 2025-10-01 API spec.

Approved API doc: https://msazure.visualstudio.com/CloudNativeCompute/_wiki/wikis/CloudNativeCompute.wiki/748089/Add-Ubuntu2204-and-Ubuntu2404-to-ossku
