### PR TITLE
LintDiff: Ensure that default tag is scanned when there is a new tag in the 'after' state

### DIFF
--- a/eng/tools/lint-diff/src/correlateResults.ts
+++ b/eng/tools/lint-diff/src/correlateResults.ts
@@ -43,7 +43,9 @@ export async function correlateRuns(
         throw new Error(`No default tag found for readme ${readme} in before state`);
       }
       const beforeDefaultTagCandidates = beforeChecks.filter(
-        (r) => relative(beforePath, r.readme.path) === readmePathRelative && r.tag === defaultTag,
+        (r) =>
+          relative(beforePath, r.readme.path) === readmePathRelative &&
+          (r.tag === defaultTag || r.tag == ""),
       );
 
       if (beforeDefaultTagCandidates.length === 1) {

--- a/eng/tools/lint-diff/src/processChanges.ts
+++ b/eng/tools/lint-diff/src/processChanges.ts
@@ -148,7 +148,7 @@ export async function buildState(
     if (!changedFileAndTagsMap.has(changedReadme)) {
       changedFileAndTagsMap.set(changedReadme, {
         readme: readmeObject,
-        changedTags: new Set<string>(),
+        changedTags: new Set<string>([""]),
       });
     }
   }
@@ -216,6 +216,7 @@ export function reconcileChangedFilesAndTags(
     for (const tag of afterTags.changedTags) {
       if (!beforeTags.has(tag)) {
         beforeTags.add("");
+        break;
       }
     }
   }

--- a/eng/tools/lint-diff/src/processChanges.ts
+++ b/eng/tools/lint-diff/src/processChanges.ts
@@ -205,6 +205,21 @@ export function reconcileChangedFilesAndTags(
     });
   }
 
+  // If a tag exists in after but not in before, make sure that the the default
+  // tag from before is included in scans
+  for (const [readme, afterTags] of afterFinal.entries()) {
+    if (!beforeFinal.has(readme)) {
+      continue;
+    }
+
+    const beforeTags = beforeFinal.get(readme)!.changedTags;
+    for (const tag of afterTags.changedTags) {
+      if (!beforeTags.has(tag)) {
+        beforeTags.add("");
+      }
+    }
+  }
+
   return [beforeFinal, afterFinal];
 }
 

--- a/eng/tools/lint-diff/src/runChecks.ts
+++ b/eng/tools/lint-diff/src/runChecks.ts
@@ -31,9 +31,11 @@ export async function runChecks(
     // and overriding openapi-type with it.
     let openApiSubType = openApiType;
 
-    // If the tags array is empty run the loop once but with a null tag
-    const coalescedTags = tags.changedTags?.size ? [...tags.changedTags] : [null];
-    for (const tag of coalescedTags) {
+    if (tags.changedTags.size === 0) {
+      throw new Error(`No changed tags found for readme ${readme}`);
+    }
+
+    for (const tag of tags.changedTags) {
       console.log(`::group::Autorest for type: ${openApiType} readme: ${readme} tag: ${tag}`);
 
       const autorestArgs = [
@@ -67,7 +69,7 @@ export async function runChecks(
           autorestCommand,
           rootPath: path,
           readme: tags.readme,
-          tag: tag ? tag : "",
+          tag: tag,
           openApiType,
           error: null,
           ...executionResult,
@@ -82,7 +84,7 @@ export async function runChecks(
           autorestCommand,
           rootPath: path,
           readme: tags.readme,
-          tag: tag ? tag : "",
+          tag: tag,
           openApiType,
           error: execError,
           stdout: execError.stdout || "",

--- a/eng/tools/lint-diff/test/correlateResults.test.ts
+++ b/eng/tools/lint-diff/test/correlateResults.test.ts
@@ -120,6 +120,92 @@ describe.skipIf(isWindows())("correlateRuns", () => {
     });
   });
 
+  test("correlates before and after runs with matching readme and empty string tag", async () => {
+    const fixtureRoot = resolve(__dirname, "fixtures/correlateRuns");
+    const beforePath = resolve(fixtureRoot, "before");
+    const afterPath = resolve(fixtureRoot, "after");
+
+    const beforeChecks: AutorestRunResult[] = [
+      {
+        rootPath: beforePath,
+        readme: new Readme(
+          resolve(beforePath, "specification/service1/resource-manager/readme.md"),
+        ),
+        tag: "",
+        stdout: "stdout",
+        stderr: "stderr",
+        error: null,
+      },
+    ];
+
+    const afterChecks: AutorestRunResult[] = [
+      {
+        rootPath: afterPath,
+        readme: new Readme(resolve(afterPath, "specification/service1/resource-manager/readme.md")),
+        tag: "tag2",
+        stdout: "stdout",
+        stderr: "stderr",
+        error: null,
+      },
+    ];
+
+    const result = await correlateRuns(beforePath, beforeChecks, afterChecks);
+    expect(result.size).toEqual(1);
+    expect(result.get("specification/service1/resource-manager/readme.md#tag2")).toMatchObject({
+      before: beforeChecks[0],
+      after: afterChecks[0],
+    });
+  });
+
+  test("correlates before and multiple after runs with matching readme and empty string tag", async () => {
+    const fixtureRoot = resolve(__dirname, "fixtures/correlateRuns");
+    const beforePath = resolve(fixtureRoot, "before");
+    const afterPath = resolve(fixtureRoot, "after");
+
+    const beforeChecks: AutorestRunResult[] = [
+      {
+        rootPath: beforePath,
+        readme: new Readme(
+          resolve(beforePath, "specification/service1/resource-manager/readme.md"),
+        ),
+        tag: "",
+        stdout: "stdout",
+        stderr: "stderr",
+        error: null,
+      },
+    ];
+
+    const afterChecks: AutorestRunResult[] = [
+      {
+        rootPath: afterPath,
+        readme: new Readme(resolve(afterPath, "specification/service1/resource-manager/readme.md")),
+        tag: "tag2",
+        stdout: "stdout",
+        stderr: "stderr",
+        error: null,
+      },
+      {
+        rootPath: afterPath,
+        readme: new Readme(resolve(afterPath, "specification/service1/resource-manager/readme.md")),
+        tag: "tag3",
+        stdout: "stdout",
+        stderr: "stderr",
+        error: null,
+      },
+    ];
+
+    const result = await correlateRuns(beforePath, beforeChecks, afterChecks);
+    expect(result.size).toEqual(2);
+    expect(result.get("specification/service1/resource-manager/readme.md#tag2")).toMatchObject({
+      before: beforeChecks[0],
+      after: afterChecks[0],
+    });
+    expect(result.get("specification/service1/resource-manager/readme.md#tag3")).toMatchObject({
+      before: beforeChecks[0],
+      after: afterChecks[1],
+    });
+  });
+
   test("uses no baseline if there are no matching before checks", async () => {
     const fixtureRoot = resolve(__dirname, "fixtures/correlateRuns");
     const beforePath = resolve(fixtureRoot, "before");

--- a/eng/tools/lint-diff/test/processChanges.test.ts
+++ b/eng/tools/lint-diff/test/processChanges.test.ts
@@ -319,7 +319,7 @@ describe("buildState", () => {
         [
           "specification/edit-in-place/readme.md",
           {
-            changedTags: new Set<string>(),
+            changedTags: new Set<string>([""]),
             readme: expect.any(Readme),
           },
         ],
@@ -333,7 +333,7 @@ describe("buildState", () => {
   });
 
   test("does not throw if a file is missing", async () => {
-    expect(() =>
+    await expect(() =>
       buildState(
         ["specification/edit-in-place/data-plane/does-not-exist.json"],
         "test/fixtures/buildState/",

--- a/eng/tools/lint-diff/test/processChanges.test.ts
+++ b/eng/tools/lint-diff/test/processChanges.test.ts
@@ -82,12 +82,13 @@ describe("reconcileChangedFilesAndTags", () => {
 
     const [beforeFinal, afterFinal] = reconcileChangedFilesAndTags(before, after);
     expect(beforeFinal).toEqual(
-      new Map<string, string[]>([
+      new Map<string, ReadmeAffectedTags>([
         [
           "specification/1/readme.md",
-          expect.objectContaining({
+          {
+            readme: expect.any(Readme),
             changedTags: new Set<string>(["tag1"]),
-          }),
+          },
         ],
       ]),
     );
@@ -133,6 +134,96 @@ describe("reconcileChangedFilesAndTags", () => {
 
     const [beforeFinal, afterFinal] = reconcileChangedFilesAndTags(before, after);
     expect(beforeFinal).toEqual(before);
+    expect(afterFinal).toEqual(after);
+  });
+
+  test("adds an empty tag to beforeFinal if after has a new tag", () => {
+    const before = new Map<string, ReadmeAffectedTags>([
+      [
+        "specification/1/readme.md",
+        {
+          readme: new Readme("specification/1/readme.md"),
+          changedTags: new Set<string>(["tag2"]),
+        },
+      ],
+    ]);
+    const after = new Map<string, ReadmeAffectedTags>([
+      [
+        "specification/1/readme.md",
+        {
+          readme: new Readme("specification/1/readme.md"),
+          changedTags: new Set<string>(["tag2", "tag3"]),
+        },
+      ],
+    ]);
+
+    const [beforeFinal, afterFinal] = reconcileChangedFilesAndTags(before, after);
+
+    expect(beforeFinal).toEqual(
+      new Map<string, ReadmeAffectedTags>([
+        [
+          "specification/1/readme.md",
+          {
+            readme: expect.any(Readme),
+            changedTags: new Set<string>(["tag2", ""]),
+          },
+        ],
+      ]),
+    );
+    expect(afterFinal).toEqual(after);
+  });
+
+  test("adds an empty tag to beforeFinal if after has multiple new tags", () => {
+    const before = new Map<string, ReadmeAffectedTags>([
+      [
+        "specification/1/readme.md",
+        {
+          readme: new Readme("specification/1/readme.md"),
+          changedTags: new Set<string>(["tag2"]),
+        },
+      ],
+    ]);
+    const after = new Map<string, ReadmeAffectedTags>([
+      [
+        "specification/1/readme.md",
+        {
+          readme: new Readme("specification/1/readme.md"),
+          changedTags: new Set<string>(["tag2", "tag3", "tag4"]),
+        },
+      ],
+    ]);
+
+    const [beforeFinal, afterFinal] = reconcileChangedFilesAndTags(before, after);
+
+    expect(beforeFinal).toEqual(
+      new Map<string, ReadmeAffectedTags>([
+        [
+          "specification/1/readme.md",
+          {
+            readme: expect.any(Readme),
+            changedTags: new Set<string>(["tag2", ""]),
+          },
+        ],
+      ]),
+    );
+    expect(afterFinal).toEqual(after);
+  });
+
+  test("handles a new specification in after", () => {
+    const before = new Map<string, ReadmeAffectedTags>();
+    const after = new Map<string, ReadmeAffectedTags>([
+      [
+        "specification/1/readme.md",
+        {
+          readme: new Readme("specification/1/readme.md"),
+          changedTags: new Set<string>(["tag1"]),
+        },
+      ],
+    ]);
+
+    const [beforeFinal, afterFinal] = reconcileChangedFilesAndTags(before, after);
+
+    expect(beforeFinal).toEqual(new Map<string, ReadmeAffectedTags>());
     expect(afterFinal).toEqual(after);
   });
 });

--- a/eng/tools/lint-diff/test/runChecks.test.ts
+++ b/eng/tools/lint-diff/test/runChecks.test.ts
@@ -52,18 +52,14 @@ describe("runChecks", () => {
     );
   });
 
-  test("coalesces null tag when no tags specified", async () => {
+  test("throws when no tags specified", async () => {
     (execNpmExec as Mock).mockResolvedValue({ stdout: "", stderr: "" });
     const runList = new Map<string, ReadmeAffectedTags>([
       ["readme.md", { readme: new Readme(""), changedTags: new Set<string>() }],
     ]);
 
-    const actual = await runChecks("root", runList);
-    expect(actual).toHaveLength(1);
-    expect(execNpmExec).toHaveBeenCalledWith(
-      expect.not.arrayContaining([expect.stringContaining("--tag")]),
-      expect.anything(),
-    );
+    const actual = runChecks("root", runList);
+    await expect(actual).rejects.toThrowError("No changed tags found for readme");
   });
 
   test("error path populates error, stdout, stderr", async () => {


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-rest-api-specs/issues/38492 -- LintDiff should compare new tags to the previous default tag. 

The basic case covered by both old and new LintDiff: 

Before: 
  * tag-a -- default (already exists)
  * tag-b (already exists)
  * tag-c (already exists)

After:
  * tag-d (add a new tag) 

In this case, tag-c is compared with tag-a, the default tag

Both old and new LintDiff have gaps in coverage for the addition of a new tag in the presence of edited non-default tags: 

Before: 
  * tag-a -- default (already exists)
  * tag-b (already exists)
  * tag-c (already exists)

After:
  * tag-d (new tag) 
  * tag-b (edit tag-b)
  * tag-c (edit tag-c) 

In this case, we'll see error because the newly added tag-d has multiple possible correlation candidates (tag-b, tag-c) none of which are the default tag. Old LintDiff, by contrast, should have compared tag-d with tag-a (the way it would in the prior scenario) but it too can have undefined behavior in this case.
