### PR TITLE
[Storage] `get/set_access_policy` TypeSpec Changes

### DIFF
--- a/specification/storage/Microsoft.BlobStorage/client.tsp
+++ b/specification/storage/Microsoft.BlobStorage/client.tsp
@@ -40,6 +40,8 @@ namespace Customizations;
   "rust"
 );
 
+@@alternateType(AccessPolicy.expiry, string, "rust");
+@@alternateType(AccessPolicy.start, string, "rust");
 @@alternateType(BlobPropertiesInternal.contentLength, uint64, "rust");
 @@alternateType(BlobContentLengthRequired.blobContentLength, uint64, "rust");
 @@alternateType(ContentLengthResponseHeader.contentLength, uint64, "rust");

--- a/specification/storage/Microsoft.BlobStorage/models.tsp
+++ b/specification/storage/Microsoft.BlobStorage/models.tsp
@@ -436,7 +436,7 @@ model BlockLookupList {
 
 /** Represents an array of signed identifiers */
 model SignedIdentifiers {
-  /** The array of signed  identifiers. */
+  /** The array of signed identifiers. */
   @Xml.unwrapped
   @Xml.name("SignedIdentifier")
   items: Array<SignedIdentifier>;

--- a/specification/storage/Microsoft.BlobStorage/models.tsp
+++ b/specification/storage/Microsoft.BlobStorage/models.tsp
@@ -435,8 +435,12 @@ model BlockLookupList {
 }
 
 /** Represents an array of signed identifiers */
-@Xml.name("SignedIdentifiers")
-model SignedIdentifiers is Array<SignedIdentifier>;
+model SignedIdentifiers {
+  /** The array of signed  identifiers. */
+  @Xml.unwrapped
+  @Xml.name("SignedIdentifier")
+  items: Array<SignedIdentifier>;
+}
 
 /** The signed identifier. */
 @Xml.name("SignedIdentifier")

--- a/specification/storage/Microsoft.BlobStorage/routes.tsp
+++ b/specification/storage/Microsoft.BlobStorage/routes.tsp
@@ -327,7 +327,7 @@ interface Container {
       ...BlobPublicAccess;
       ...EtagResponseHeader;
       ...LastModifiedResponseHeader;
-      ...DateResponseHeader;
+      ...DateResponseHeaderPrivate;
     }
   >;
 
@@ -351,9 +351,9 @@ interface Container {
       ...IfUnmodifiedSinceParameter;
     },
     {
-      ...EtagResponseHeader;
-      ...LastModifiedResponseHeader;
-      ...DateResponseHeader;
+      ...EtagResponseHeaderPrivate;
+      ...LastModifiedResponseHeaderPrivate;
+      ...DateResponseHeaderPrivate;
     }
   >;
 

--- a/specification/storage/Microsoft.BlobStorage/routes.tsp
+++ b/specification/storage/Microsoft.BlobStorage/routes.tsp
@@ -341,8 +341,8 @@ interface Container {
     {
       /** The access control list for the container. */
       #suppress "@azure-tools/typespec-azure-core/request-body-problem" "Existing API"
-      @bodyRoot
-      containerAcl?: SignedIdentifiers;
+      @body
+      containerAcl: SignedIdentifiers;
 
       ...TimeoutParameter;
       ...LeaseIdOptionalParameter;

--- a/specification/storage/Microsoft.BlobStorage/routes.tsp
+++ b/specification/storage/Microsoft.BlobStorage/routes.tsp
@@ -342,7 +342,7 @@ interface Container {
       /** The access control list for the container. */
       #suppress "@azure-tools/typespec-azure-core/request-body-problem" "Existing API"
       @body
-      containerAcl: SignedIdentifiers;
+      containerAcl?: SignedIdentifiers;
 
       ...TimeoutParameter;
       ...LeaseIdOptionalParameter;

--- a/specification/storage/Microsoft.BlobStorage/routes.tsp
+++ b/specification/storage/Microsoft.BlobStorage/routes.tsp
@@ -341,7 +341,7 @@ interface Container {
     {
       /** The access control list for the container. */
       #suppress "@azure-tools/typespec-azure-core/request-body-problem" "Existing API"
-      @body
+      @bodyRoot
       containerAcl?: SignedIdentifiers;
 
       ...TimeoutParameter;


### PR DESCRIPTION
- Fixes `SignedIdentifiers` model to accurately represent the XML body and deserialize properly
- Adds `@@alternateType` for `expiry` and `start` fields of `AccessPolicy` to allow us to manipulate the string to be the desired fixed-width (7) instead of being at the mercy of the datetime deserializations