### PR TITLE
[spec-model] Add option `includeOperations` to `toJSONAsync()`

### DIFF
--- a/.github/shared/cmd/spec-model.js
+++ b/.github/shared/cmd/spec-model.js
@@ -4,7 +4,7 @@ import { debugLogger } from "../src/logger.js";
 import { SpecModel } from "../src/spec-model.js";
 
 const USAGE =
-  "Usage: npx spec-model path/to/spec [--debug] [--include-refs] [--relative-paths] [--no-embed-errors]\n" +
+  "Usage: npx spec-model path/to/spec [--debug] [--include-operations] [--include-refs] [--relative-paths] [--no-embed-errors]\n" +
   "Example: npx spec-model specification/widget";
 
 // Exclude first two args (node, script file)
@@ -12,6 +12,9 @@ let args = process.argv.slice(2);
 
 const debug = args.includes("--debug");
 args = args.filter((a) => a != "--debug");
+
+const includeOperations = args.includes("--include-operations");
+args = args.filter((a) => a != "--include-operations");
 
 const includeRefs = args.includes("--include-refs");
 args = args.filter((a) => a != "--include-refs");
@@ -42,7 +45,12 @@ const specModel = new SpecModel(specPath, { logger });
 
 console.log(
   JSON.stringify(
-    await specModel.toJSONAsync({ embedErrors: !noEmbedErrors, includeRefs, relativePaths }),
+    await specModel.toJSONAsync({
+      embedErrors: !noEmbedErrors,
+      includeOperations,
+      includeRefs,
+      relativePaths,
+    }),
     null,
     2,
   ),

--- a/.github/shared/cmd/spec-model.js
+++ b/.github/shared/cmd/spec-model.js
@@ -5,7 +5,9 @@ import { SpecModel } from "../src/spec-model.js";
 
 const USAGE =
   "Usage: npx spec-model path/to/spec [--debug] [--include-operations] [--include-refs] [--relative-paths] [--no-embed-errors]\n" +
-  "Example: npx spec-model specification/widget";
+  "Examples:\n" +
+  "  npx spec-model specification/widget\n" +
+  "  npx spec-model specification --include-operations --include-refs > out.txt; grep out.txt '\"error\":'";
 
 // Exclude first two args (node, script file)
 let args = process.argv.slice(2);

--- a/.github/shared/src/spec-model.js
+++ b/.github/shared/src/spec-model.js
@@ -26,6 +26,7 @@ import { SpecModelError } from "./spec-model-error.js";
 /**
  * @typedef {Object} ToJSONOptions
  * @prop {boolean} [embedErrors]
+ * @prop {boolean} [includeOperations] Whether to include the operations in each swagger. Increases runtime about 20x, from 6s to 120s for whole specs repo.
  * @prop {boolean} [includeRefs]
  * @prop {boolean} [relativePaths]
  */

--- a/.github/shared/src/swagger.js
+++ b/.github/shared/src/swagger.js
@@ -303,6 +303,7 @@ export class Swagger {
             : this.#path,
         operations: includeOperations
           ? [...(await this.getOperations()).values()].map((o) => {
+              // Create new object with properties in preferred output order
               return { path: o.path, httpMethod: o.httpMethod, id: o.id };
             })
           : undefined,

--- a/.github/shared/src/swagger.js
+++ b/.github/shared/src/swagger.js
@@ -24,6 +24,7 @@ import { embedError } from "./spec-model.js";
 /**
  * @typedef {Object} SwaggerJSON
  * @property {string} path
+ * @property {Operation[]} operations
  * @property {Object[]} [refs]
  */
 
@@ -300,6 +301,10 @@ export class Swagger {
           relativePaths && this.#tag?.readme?.specModel
             ? relative(this.#tag?.readme?.specModel.folder, this.#path)
             : this.#path,
+        // TODO: Measure perf of including this, say on the whole specs repo.  Probably needs to be optional.
+        operations: [...(await this.getOperations()).values()].map((o) => {
+          return { path: o.path, httpMethod: o.httpMethod, id: o.id };
+        }),
         refs: includeRefs
           ? await mapAsync(
               [...(await this.getRefs()).values()].sort((a, b) => a.path.localeCompare(b.path)),

--- a/.github/shared/src/swagger.js
+++ b/.github/shared/src/swagger.js
@@ -24,7 +24,7 @@ import { embedError } from "./spec-model.js";
 /**
  * @typedef {Object} SwaggerJSON
  * @property {string} path
- * @property {Operation[]} operations
+ * @property {Operation[]} [operations]
  * @property {Object[]} [refs]
  */
 
@@ -293,7 +293,7 @@ export class Swagger {
    * @returns {Promise<SwaggerJSON|ErrorJSON>}
    */
   async toJSONAsync(options = {}) {
-    const { includeRefs, relativePaths } = options;
+    const { includeOperations, includeRefs, relativePaths } = options;
 
     return await embedError(
       async () => ({
@@ -301,10 +301,11 @@ export class Swagger {
           relativePaths && this.#tag?.readme?.specModel
             ? relative(this.#tag?.readme?.specModel.folder, this.#path)
             : this.#path,
-        // TODO: Measure perf of including this, say on the whole specs repo.  Probably needs to be optional.
-        operations: [...(await this.getOperations()).values()].map((o) => {
-          return { path: o.path, httpMethod: o.httpMethod, id: o.id };
-        }),
+        operations: includeOperations
+          ? [...(await this.getOperations()).values()].map((o) => {
+              return { path: o.path, httpMethod: o.httpMethod, id: o.id };
+            })
+          : undefined,
         refs: includeRefs
           ? await mapAsync(
               [...(await this.getRefs()).values()].sort((a, b) => a.path.localeCompare(b.path)),

--- a/.github/shared/test/spec-model.test.js
+++ b/.github/shared/test/spec-model.test.js
@@ -109,6 +109,7 @@ describe("SpecModel", () => {
 
     const jsonRefsRelative = /** @type {SpecModelJSON} */ (
       await specModel.toJSONAsync({
+        includeOperations: true,
         includeRefs: true,
         relativePaths: true,
       })
@@ -116,6 +117,10 @@ describe("SpecModel", () => {
     const readmeJSONRelative = /** @type {ReadmeJSON} */ (jsonRefsRelative.readmes[0]);
     const readmePathRelative = readmeJSONRelative.path;
     expect(isAbsolute(readmePathRelative)).toBe(false);
+    expect(
+      /** @type {SwaggerJSON}*/ (/** @type {TagJSON} */ (readmeJSONRelative.tags[0]).inputFiles[0])
+        .operations,
+    ).toBeDefined();
     expect(
       /** @type {SwaggerJSON}*/ (/** @type {TagJSON} */ (readmeJSONRelative.tags[0]).inputFiles[0])
         .refs,


### PR DESCRIPTION
- Useful for testing "get operations" on all specs in repo