### PR TITLE
Added deprecation notices for typeahead, queryType, and Score.

### DIFF
--- a/specification/maps/data-plane/Search/stable/1.0/search.json
+++ b/specification/maps/data-plane/Search/stable/1.0/search.json
@@ -287,7 +287,7 @@
       "name": "typeahead",
       "x-ms-client-name": "isTypeAhead",
       "in": "query",
-      "description": "Boolean. If the typeahead flag is set, the query will be interpreted as a partial input and the search will enter predictive mode",
+      "description": "Boolean. If the typeahead flag is set, the query will be interpreted as a partial input and the search will enter predictive mode.",
       "type": "boolean",
       "x-ms-parameter-location": "method"
     },
@@ -924,7 +924,8 @@
             "type": "string"
           },
           {
-            "$ref": "#/parameters/Typeahead"
+            "$ref": "#/parameters/Typeahead",
+            "description": "Boolean. If the typeahead flag is set, the query will be interpreted as a partial input and the search will enter predictive mode.\n\n**Important**: This property is deprecated and may be omitted from the response."
           },
           {
             "$ref": "#/parameters/LimitSearch"
@@ -1909,7 +1910,7 @@
           "readOnly": true
         },
         "queryType": {
-          "description": "The type of query being returned: NEARBY or NON_NEAR.",
+          "description": "The type of query being returned: NEARBY or NON_NEAR.\n\n**Important**: This property is deprecated and may be omitted from the response.",
           "type": "string",
           "readOnly": true,
           "enum": [
@@ -1923,7 +1924,7 @@
               {
                 "value": "NEARBY",
                 "name": "NEARBY",
-                "description": "Search was performed around a certain latitude and longitude with a defined radius"
+                "description": "Search was performed around a certain latitude and longitude with a defined radius.\n\n**Important**: This property is deprecated and may be omitted from the response."
               },
               {
                 "value": "NON_NEAR",
@@ -2603,7 +2604,7 @@
       }
     },
     "Score": {
-      "description": "The value within a result set to indicate the relative matching score between results.  You can use this to  determine that result x is twice as likely to be as relevant as result y if the value of x is 2x the value of y.   The values vary between queries and is only meant as a relative value for one result set.",
+      "description": "The value within a result set to indicate the relative matching score between results.  You can use this to  determine that result x is twice as likely to be as relevant as result y if the value of x is 2x the value of y.   The values vary between queries and is only meant as a relative value for one result set.\n\n**Important**: This property is deprecated and may be omitted from the response.",
       "type": "number",
       "format": "double",
       "readOnly": true

--- a/specification/maps/data-plane/Search/stable/1.0/search.json
+++ b/specification/maps/data-plane/Search/stable/1.0/search.json
@@ -924,8 +924,12 @@
             "type": "string"
           },
           {
-            "$ref": "#/parameters/Typeahead",
-            "description": "If the typeahead flag is set, the query will be interpreted as a partial input and the search will enter predictive mode.\n\n**Important**: This property is deprecated and may be omitted from the response."
+            "name": "typeahead",
+            "x-ms-client-name": "isTypeAhead",
+            "in": "query",
+            "description": "If the typeahead flag is set, the query will be interpreted as a partial input and the search will enter predictive mode.\n\n**Important**: This property is deprecated and may be omitted from the response.",
+            "type": "boolean",
+            "x-ms-parameter-location": "method"
           },
           {
             "$ref": "#/parameters/LimitSearch"

--- a/specification/maps/data-plane/Search/stable/1.0/search.json
+++ b/specification/maps/data-plane/Search/stable/1.0/search.json
@@ -287,7 +287,7 @@
       "name": "typeahead",
       "x-ms-client-name": "isTypeAhead",
       "in": "query",
-      "description": "Boolean. If the typeahead flag is set, the query will be interpreted as a partial input and the search will enter predictive mode.",
+      "description": "If the typeahead flag is set, the query will be interpreted as a partial input and the search will enter predictive mode.",
       "type": "boolean",
       "x-ms-parameter-location": "method"
     },
@@ -925,7 +925,7 @@
           },
           {
             "$ref": "#/parameters/Typeahead",
-            "description": "Boolean. If the typeahead flag is set, the query will be interpreted as a partial input and the search will enter predictive mode.\n\n**Important**: This property is deprecated and may be omitted from the response."
+            "description": "If the typeahead flag is set, the query will be interpreted as a partial input and the search will enter predictive mode.\n\n**Important**: This property is deprecated and may be omitted from the response."
           },
           {
             "$ref": "#/parameters/LimitSearch"
@@ -1924,7 +1924,7 @@
               {
                 "value": "NEARBY",
                 "name": "NEARBY",
-                "description": "Search was performed around a certain latitude and longitude with a defined radius.\n\n**Important**: This property is deprecated and may be omitted from the response."
+                "description": "Search was performed around a certain latitude and longitude with a defined radius."
               },
               {
                 "value": "NON_NEAR",


### PR DESCRIPTION
For **typeahead**, the deprecation only applies to search (geocode) See (Search request parameters in TomTom)[https://developer.tomtom.com/geocoding-api/documentation/geocode#request-parameters]:

<img width="392" height="203" alt="image" src="https://github.com/user-attachments/assets/f0f1fc93-35bb-45c4-be1f-cf1549f92f32" />

and (Fuzzy Search request parameters)[https://developer.tomtom.com/search-api/documentation/search-service/fuzzy-search#request-parameters] and (POI)[https://developer.tomtom.com/search-api/documentation/search-service/points-of-interest-search#request-parameters]

<img width="385" height="54" alt="image" src="https://github.com/user-attachments/assets/3de9cbbc-8eb8-4fa0-9632-62cc9f8b22e2" />
