### PR TITLE
add SDK generation client.tsp customizations reference

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -359,6 +359,10 @@ Follow the steps in [typespec to sdk](..\eng\common\instructions\azsdk-tools\typ
 
 Run [check package readiness](..\eng\common\instructions\azsdk-tools\check-package-readiness.instructions.md) to check the release readiness of an SDK package. This prompt will collect the required information from the user, execute the readiness check, and present the results.
 
+## SDK customizations in TypeSpec projects
+
+TypeSpec supports making client-specific customizations to a TypeSpec project to change how an SDK is generated. When making client-specific changes, read the [typespec client customizations reference](../eng/common/knowledge/customizing-client-tsp.md) to understand the types of customizations supported and how to apply them.
+
 # Instructions for GitHub coding agent to generate SDKs using GitHub.com
 
 Run only SDK generation step and Update SDK details back in issue description and release plan. Do not run TypeSpec validation, or service label check. This is applicable only when GitHub copilot coding agent is used to generate SDK and if a Release Plan is available in the context. Run SDK generation tool even if release plan already has SDK generation pipeline URL to support regenerating SDK.


### PR DESCRIPTION
Follow up to https://github.com/Azure/azure-sdk-tools/pull/12758

Copying over description of testing:
#### SDK build failures
I primarily tested the .NET local sdk generation and local sdk build MCP flows with copilot from the azure-rest-api-specs repo. .NET has code analysis tools that give feedback such as model names being too generic, names that don't follow conventions, etc.

(Thank you @radhgupta for help identifying examples to test!) 

Prior to these changes, I saw a mix of unwanted behavior when copilot encountered these errors:
- changing model names in `main.tsp` directly, which impacts all languages and swaggers
- changing the generated SDK code directly
- making up tspconfig.yaml rules to create model name mappings
- Applied .NET-specific customization to all languages

After these changes, I reliably saw copilot correctly identify that a client customization should be used. It created a `client.tsp` file if it didn't already exist, and applied the correct scoping to the customizations. It also automatically reran the sdk generate and build commands to verify the errors were fixed.

#### Conversational feedback
I also tested various prompts to rename models and split clients based on our documentation, as well as some real API view feedback seen in the wild. (Thank you @swathipil for help identifying API view feedback!)

For example, copilot was able to take this feedback and apply the correct customization:
> Azure.AI.Projects.AIProjectConnectionEntraIDCredential: "ID is cased "Id" in .NET"

Without these changes, copilot updated the client customizations, but also updated the original model in `main.tsp` file for good measure 😓 

---

__Here's an example of copilot's recommendations from the .NET build failures without this change:__

<img width="435" height="238" alt="no-reference" src="https://github.com/user-attachments/assets/f99fdba5-49b3-4bcd-824c-fd1b388c15de" />

---

__Here's an example of the same prompt with this change:__

<img width="440" height="281" alt="reference-1" src="https://github.com/user-attachments/assets/052be25a-f2e5-4b1a-9b4d-7fee112b9f27" />
<img width="1057" height="688" alt="reference-2" src="https://github.com/user-attachments/assets/c669b185-6d79-4faf-82c3-65638198f857" />
