### PR TITLE
mgmt, Add NetApp client.tsp and update tspconfig.yaml

### DIFF
--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/client.tsp
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/client.tsp
@@ -12,6 +12,9 @@ using Microsoft.NetApp;
 // Snapshot is not updatable
 @@scope(Microsoft.NetApp.Snapshots.update, "!java");
 
+// rename QuotaItem to SubscriptionQuotaItem, avoid break in SDK
+@@clientName(QuotaItem, "SubscriptionQuotaItem", "java");
+
 // Fix property name case changes
 @@clientName(Microsoft.NetApp.AccountProperties.nfsV4IDDomain,
   "nfsV4IdDomain",

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/tspconfig.yaml
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/tspconfig.yaml
@@ -33,6 +33,8 @@ options:
     namespace: "com.azure.resourcemanager.netapp"
     service-name: "NetAppFiles"
     flavor: azure
+    float32-as-double: false
+    client-side-validations: true
   "@azure-tools/typespec-ts":
     emitter-output-dir: "{output-dir}/{service-dir}/arm-netapp"
     flavor: azure


### PR DESCRIPTION
NO API CHANGE, for SDK only

This draft PR adds `client.tsp` with NetApp client customizations (naming scopes, property/model name adjustments) and updates `tspconfig.yaml` (ensuring client-side validations setting retained).

Changes:
- Added `specification/netapp/resource-manager/Microsoft.NetApp/NetApp/client.tsp`
- Recommitted `tspconfig.yaml` including explicit `client-side-validations` for Java emitter.

Next steps before ready for review:
- Confirm regenerated SDK artifacts across languages.
- Run TypeSpec emitters to validate no breaking changes.
- Collect any necessary example updates.

Keeping as draft pending validation.
