### PR TITLE
[computelimit] add config for sdk

### DIFF
--- a/specification/computelimit/resource-manager/Microsoft.ComputeLimit/ComputeLimit/back-compat.tsp
+++ b/specification/computelimit/resource-manager/Microsoft.ComputeLimit/ComputeLimit/back-compat.tsp
@@ -2,7 +2,9 @@ import "@azure-tools/typespec-client-generator-core";
 import "./GuestSubscription.tsp";
 import "./SharedLimit.tsp";
 
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(Microsoft.ComputeLimit.GuestSubscription.properties
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(Microsoft.ComputeLimit.GuestSubscription.properties,
+  "autorest"
 );
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(Microsoft.ComputeLimit.SharedLimit.properties
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(Microsoft.ComputeLimit.SharedLimit.properties,
+  "autorest"
 );


### PR DESCRIPTION
Since this is new service, SDK doesn't need flatten decorator.