### PR TITLE
Foundry Classic (v1) Agents: widen mcp_list_tools to allow arbitrary schema items

### DIFF
--- a/specification/ai/Azure.AI.Agents/run_steps/models.tsp
+++ b/specification/ai/Azure.AI.Agents/run_steps/models.tsp
@@ -566,41 +566,5 @@ model RunStepDetailsActivity {
   serverLabel: string;
 
   @doc("The supported function list.")
-  tools: Record<ActivityFunctionDefinition>;
-}
-
-@doc("The activity definition information for a function.")
-@added(Versions.v2025_05_15_preview)
-model ActivityFunctionDefinition {
-  @doc("A description of what the function does, used by the model to choose when and how to call the function.")
-  description?: string;
-
-  @doc("The parameters the functions accepts, described as a JSON Schema object.")
-  parameters: ActivityFunctionParameters;
-}
-
-@doc("The parameters used for activity function definition.")
-@added(Versions.v2025_05_15_preview)
-model ActivityFunctionParameters {
-  @doc("The parameter type, it is always object.")
-  type: "object";
-
-  @doc("The dictionary of function arguments.")
-  properties: Record<FunctionArgument>;
-
-  @doc("The list of the required parameters.")
-  required: string[];
-
-  @doc("If true the function has additional parameters.")
-  additionalProperties?: boolean;
-}
-
-@doc("The function argument and description.")
-@added(Versions.v2025_05_15_preview)
-model FunctionArgument {
-  @doc("The type of an argument, for example 'string' or 'number'.")
-  type: string;
-
-  @doc("The argument description.")
-  description?: string;
+  tools: Record<unknown>;
 }

--- a/specification/ai/data-plane/Azure.AI.Agents/preview/2025-05-15-preview/azure-ai-agents.json
+++ b/specification/ai/data-plane/Azure.AI.Agents/preview/2025-05-15-preview/azure-ai-agents.json
@@ -2804,62 +2804,6 @@
         }
       }
     },
-    "ActivityFunctionDefinition": {
-      "type": "object",
-      "description": "The activity definition information for a function.",
-      "properties": {
-        "description": {
-          "type": "string",
-          "description": "A description of what the function does, used by the model to choose when and how to call the function."
-        },
-        "parameters": {
-          "$ref": "#/definitions/ActivityFunctionParameters",
-          "description": "The parameters the functions accepts, described as a JSON Schema object."
-        }
-      },
-      "required": [
-        "parameters"
-      ]
-    },
-    "ActivityFunctionParameters": {
-      "type": "object",
-      "description": "The parameters used for activity function definition.",
-      "properties": {
-        "type": {
-          "type": "string",
-          "description": "The parameter type, it is always object.",
-          "enum": [
-            "object"
-          ],
-          "x-ms-enum": {
-            "modelAsString": false
-          }
-        },
-        "properties": {
-          "type": "object",
-          "description": "The dictionary of function arguments.",
-          "additionalProperties": {
-            "$ref": "#/definitions/FunctionArgument"
-          }
-        },
-        "required": {
-          "type": "array",
-          "description": "The list of the required parameters.",
-          "items": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": {
-          "type": "boolean",
-          "description": "If true the function has additional parameters."
-        }
-      },
-      "required": [
-        "type",
-        "properties",
-        "required"
-      ]
-    },
     "Agent": {
       "type": "object",
       "description": "Represents an agent that can call the model and use tools.",
@@ -4898,23 +4842,6 @@
           }
         ]
       }
-    },
-    "FunctionArgument": {
-      "type": "object",
-      "description": "The function argument and description.",
-      "properties": {
-        "type": {
-          "type": "string",
-          "description": "The type of an argument, for example 'string' or 'number'."
-        },
-        "description": {
-          "type": "string",
-          "description": "The argument description."
-        }
-      },
-      "required": [
-        "type"
-      ]
     },
     "FunctionDefinition": {
       "type": "object",
@@ -7834,9 +7761,7 @@
         "tools": {
           "type": "object",
           "description": "The supported function list.",
-          "additionalProperties": {
-            "$ref": "#/definitions/ActivityFunctionDefinition"
-          }
+          "additionalProperties": {}
         }
       },
       "required": [


### PR DESCRIPTION
The `mcp_list_tools` schema component used in run step details has inappropriately specified a narrowly defined item schema for its `tools` property array elements. These property values are ultimately at the discretion of the MCP tools being used and this has resulted in validation errors when non-conforming tool representations didn't parse in the restricted schema.

This change replaces the `Record<ActivityFunctionDefinition>` previously used with an open-ended `Record<unknown>`, also removing the otherwise unused schema components.