### PR TITLE
[Storage] `set_legal_hold` for BlobClient TypeSpec Changes

### DIFF
--- a/specification/storage/Microsoft.BlobStorage/models.tsp
+++ b/specification/storage/Microsoft.BlobStorage/models.tsp
@@ -1830,6 +1830,14 @@ alias LegalHoldResponseHeader = {
   legalHold: boolean;
 };
 
+/** The legal hold response header. */
+alias LegalHoldResponseHeaderPrivate = {
+  /** Specifies the legal hold status to set on the blob. */
+  @access(Access.internal)
+  @header("x-ms-legal-hold")
+  legalHold: boolean;
+};
+
 /** The legal hold required parameter. */
 alias LegalHoldRequiredParameter = {
   /** Required.  Specifies the legal hold status to set on the blob. */

--- a/specification/storage/Microsoft.BlobStorage/routes.tsp
+++ b/specification/storage/Microsoft.BlobStorage/routes.tsp
@@ -1005,8 +1005,8 @@ interface Blob {
       ...VersionIdParameter;
     },
     {
-      ...DateResponseHeader;
-      ...LegalHoldResponseHeader;
+      ...DateResponseHeaderPrivate;
+      ...LegalHoldResponseHeaderPrivate;
     }
   >;
 


### PR DESCRIPTION
Privatizes `Date` and `LegalHoldResponse`