### PR TITLE
Remove Python section from readme

### DIFF
--- a/specification/azurestackhci/resource-manager/readme.md
+++ b/specification/azurestackhci/resource-manager/readme.md
@@ -517,10 +517,6 @@ See configuration in [readme.go.md](./readme.go.md)
 
 See configuration in [readme.java.md](./readme.java.md)
 
-## Python
-
-See configuration in [readme.python.md](./readme.python.md)
-
 ## Ruby
 
 See configuration in [readme.ruby.md](./readme.ruby.md)

--- a/specification/azurestackhci/resource-manager/readme.md
+++ b/specification/azurestackhci/resource-manager/readme.md
@@ -497,7 +497,6 @@ This is not used by Autorest itself.
 
 ``` yaml $(swagger-to-sdk)
 swagger-to-sdk:
-  - repo: azure-sdk-for-python
   - repo: azure-sdk-for-java
   - repo: azure-sdk-for-js
   - repo: azure-sdk-for-ruby
@@ -516,6 +515,10 @@ See configuration in [readme.go.md](./readme.go.md)
 ## Java
 
 See configuration in [readme.java.md](./readme.java.md)
+
+## Python
+
+See configuration in [readme.python.md](./readme.python.md)
 
 ## Ruby
 


### PR DESCRIPTION
Fix python generation failure of https://github.com/Azure/azure-rest-api-specs/pull/38577

According to https://github.com/Azure/azure-sdk-for-python/blob/85a9b78304d04c51a53eb4ad295aa31345747aa8/sdk/azurestackhci/azure-mgmt-azurestackhci/_meta.json, `azure-mgmt-azurestackhci` is generated from `specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/readme.md` instead of `specification/azurestackhci/resource-manager/readme.md` so no need to keep python configuration.