### PR TITLE
Remove credscan from guardian pipeline

### DIFF
--- a/eng/pipelines/guardian.yml
+++ b/eng/pipelines/guardian.yml
@@ -22,8 +22,5 @@ extends:
         name: $(WINDOWSPOOL)
         image: $(WINDOWSVMIMAGE)
         os: windows
-      credscan:
-        enabled: true
-        # This uses the Credscan Supression file from .config/CredScanSuppressions.json which is the default location for Credscan Suppression Files
       policheck:
         enabled: true


### PR DESCRIPTION
We no longer need to run credscan in our nightly guardian pipeline as we depend on other tools now.