### PR TITLE
[github-test] bump actionlint from 1.7.8 to 1.7.9

### DIFF
--- a/.github/workflows/github-test.yaml
+++ b/.github/workflows/github-test.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - if: ${{ matrix.folder == '.github' && matrix.os == 'ubuntu'}}
         name: Lint workflows
-        uses: docker://rhysd/actionlint:1.7.8
+        uses: docker://rhysd/actionlint:1.7.9
         with:
           args: -color -verbose
 


### PR DESCRIPTION
- adds support for ubuntu-slim
