### PR TITLE
Update managed identity used by github  coding agent

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Azure Login with Workload Identity Federation
         uses: azure/login@v2
         with:
-          client-id: "936c56f0-298b-467f-b702-3ad5bf4b15c1"
+          client-id: "c277c2aa-5326-4d16-90de-98feeca69cbc"
           tenant-id: "72f988bf-86f1-41af-91ab-2d7cd011db47"
           allow-no-subscriptions: true
 


### PR DESCRIPTION
Update the identity used by coding agent to a managed identity instead of an entraa app.