### PR TITLE
Remove package-name from C# HTTP client config

### DIFF
--- a/specification/storageactions/StorageAction.Management/tspconfig.yaml
+++ b/specification/storageactions/StorageAction.Management/tspconfig.yaml
@@ -13,7 +13,6 @@ options:
     examples-dir: "{project-root}/examples"
   "@azure-typespec/http-client-csharp-mgmt":
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
-    package-name: "Azure.ResourceManager.StorageActions"
     namespace: "{package-name}"
   "@azure-tools/typespec-python":
     emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-storageactions"


### PR DESCRIPTION
Removed package-name entry for C# HTTP client for testing