### PR TITLE
[dependabot.yml] Remove cooldown for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    cooldown:
-      default-days: 7
   - package-ecosystem: "npm"
     directories:
       - "/"


### PR DESCRIPTION
- We only pin actions major versions, so cooldown less useful
- Cooldown also prevents creating PRs to update major versions, if the latest patch release is within the cooldown period
