### PR TITLE
[dependabot.yml] Remove ignores for prettier, vitest, typescript

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,11 +24,6 @@ updates:
     ignore:
       # Updated manually to align with minimum supported Node version
       - dependency-name: "@types/node"
-      # Updated manually to align with repo microsoft/typespec
-      - dependency-name: "@vitest/coverage-v8"
-      - dependency-name: "prettier"
-      - dependency-name: "vitest"
-      - dependency-name: "typescript"
       # Updated manually by the Liftr team
       - dependency-name: "@azure-tools/typespec-liftr-base"
       # Only allow patch updates for spec-gen-sdk
@@ -61,11 +56,6 @@ updates:
     ignore:
       # Updated manually to align with minimum supported Node version
       - dependency-name: "@types/node"
-      # Updated manually to align with repo microsoft/typespec
-      - dependency-name: "@vitest/coverage-v8"
-      - dependency-name: "prettier"
-      - dependency-name: "vitest"
-      - dependency-name: "typescript"
       # Points to "github:actions/github-script" since package isn't published to npmjs
       - dependency-name: "@types/github-script"
     groups:


### PR DESCRIPTION
- Not necessary to align with typespec repo
- Sufficient for both repos to stay near latest
