### PR TITLE
Adding Back Legacy Fields to Avoid Breaking Changes in DataMaskingRules.json

### DIFF
--- a/specification/sql/resource-manager/Microsoft.Sql/preview/2025-02-01-preview/DataMaskingRules.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/preview/2025-02-01-preview/DataMaskingRules.json
@@ -187,6 +187,16 @@
         }
       ],
       "properties": {
+        "location": {
+          "description": "The location of the data masking rule.",
+          "type": "string",
+          "readOnly": true
+        },
+        "kind": {
+          "description": "The kind of Data Masking Rule. Metadata, used for Azure portal.",
+          "type": "string",
+          "readOnly": true
+        },
         "properties": {
           "$ref": "#/definitions/DataMaskingRuleProperties",
           "description": "Resource properties.",
@@ -250,6 +260,10 @@
         },
         "columnName": {
           "description": "The column name on which the data masking rule is applied.",
+          "type": "string"
+        },
+        "aliasName": {
+          "description": "The alias name. This is a legacy parameter and is no longer used.",
           "type": "string"
         },
         "maskingFunction": {


### PR DESCRIPTION
Some legacy fields were removed from the response objects for the new (2025-02-01) version of the Data Masking Rules API as they had not been in use. This leads to breaking changes in the 2025-02-01 version of the API.

Original PR introducing the 2025-02-01 version of the Data Masking Rules API: https://github.com/Azure/azure-rest-api-specs/pull/36819

In this PR, we are adding back those legacy fields to avoid the breaking changes. Although these fields would not be used, but still be retained to avoid breaking changes.