### PR TITLE
Made dotnet SDK validation required

### DIFF
--- a/eng/tools/spec-gen-sdk-runner/src/types.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/types.ts
@@ -65,7 +65,7 @@ export const SpecGenSdkRequiredSettings: Record<SdkName, PlaneTypeSettings> = {
   },
   "azure-sdk-for-net": {
     dataPlane: false,
-    managementPlane: false,
+    managementPlane: true,
   },
   "azure-sdk-for-python": {
     dataPlane: true,

--- a/eng/tools/spec-gen-sdk-runner/test/command-helpers.test.ts
+++ b/eng/tools/spec-gen-sdk-runner/test/command-helpers.test.ts
@@ -608,8 +608,8 @@ describe("commands.ts", () => {
       expect(result).toBe(true);
 
       const result2 = getRequiredSettingValue(true, true, "azure-sdk-for-net");
-      // .NET SDK set (managementPlane: false)
-      expect(result2).toBe(false);
+      // .NET SDK set (managementPlane: true)
+      expect(result2).toBe(true);
     });
 
     test("should return dataPlane setting when hasManagementPlaneSpecs is false", () => {


### PR DESCRIPTION
Enabled the require setting for .NET management plane SDK only.
This check now applies exclusively to SDKs generated using the `@azure-typespec/http-client-csharp-mgmt` emitter.

See the script [here](https://github.com/Azure/azure-sdk-for-net/blob/a6e041d18a4af7659964fdbf799efebdd0d9da95/eng/scripts/Invoke-GenerateAndBuildV2.ps1#L267) for details.