### PR TITLE
Security: use a new separated managed identity in the SDK validation check and the SDK breaking change label check 

### DIFF
--- a/.github/workflows/sdk-breaking-change-labels.yaml
+++ b/.github/workflows/sdk-breaking-change-labels.yaml
@@ -28,7 +28,7 @@ jobs:
         name: Azure Login with Workload Identity Federation
         uses: azure/login@v2
         with:
-          client-id: "936c56f0-298b-467f-b702-3ad5bf4b15c1"
+          client-id: "34bd541d-1803-437e-b663-da8114650466"
           tenant-id: "72f988bf-86f1-41af-91ab-2d7cd011db47"
           allow-no-subscriptions: true
 

--- a/.github/workflows/sdk-breaking-change-labels.yaml
+++ b/.github/workflows/sdk-breaking-change-labels.yaml
@@ -28,7 +28,7 @@ jobs:
         name: Azure Login with Workload Identity Federation
         uses: azure/login@v2
         with:
-          client-id: "34bd541d-1803-437e-b663-da8114650466"
+          client-id: "205398f1-715f-40a7-8d52-856097f28281"
           tenant-id: "72f988bf-86f1-41af-91ab-2d7cd011db47"
           allow-no-subscriptions: true
 

--- a/.github/workflows/spec-gen-sdk-status.yaml
+++ b/.github/workflows/spec-gen-sdk-status.yaml
@@ -28,7 +28,7 @@ jobs:
         name: Azure Login with Workload Identity Federation
         uses: azure/login@v2
         with:
-          client-id: "936c56f0-298b-467f-b702-3ad5bf4b15c1"
+          client-id: "34bd541d-1803-437e-b663-da8114650466"
           tenant-id: "72f988bf-86f1-41af-91ab-2d7cd011db47"
           allow-no-subscriptions: true
 

--- a/.github/workflows/spec-gen-sdk-status.yaml
+++ b/.github/workflows/spec-gen-sdk-status.yaml
@@ -28,7 +28,7 @@ jobs:
         name: Azure Login with Workload Identity Federation
         uses: azure/login@v2
         with:
-          client-id: "34bd541d-1803-437e-b663-da8114650466"
+          client-id: "205398f1-715f-40a7-8d52-856097f28281"
           tenant-id: "72f988bf-86f1-41af-91ab-2d7cd011db47"
           allow-no-subscriptions: true
 


### PR DESCRIPTION
Resolved https://github.com/Azure/azure-rest-api-specs/issues/38974

I've already granted read permission to this app registration for `azure-sdk/internal` project.