### PR TITLE
[JS] Exclude JS flatten for services that have already been released

### DIFF
--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/client.tsp
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/client.tsp
@@ -52,23 +52,33 @@ using Microsoft.Chaos;
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "property flatten for SDK backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(Experiment.properties);
-#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "property flatten for SDK backward compatibility"
-#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(ExperimentExecution.properties
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(Experiment.properties,
+  "!javascript"
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "property flatten for SDK backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(TargetType.properties);
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(ExperimentExecution.properties,
+  "!javascript"
+);
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "property flatten for SDK backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(Capability.properties);
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(TargetType.properties,
+  "!javascript"
+);
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "property flatten for SDK backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(CapabilityType.properties);
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(Capability.properties,
+  "!javascript"
+);
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "property flatten for SDK backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(ExperimentExecutionDetails.properties
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(CapabilityType.properties,
+  "!javascript"
+);
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "property flatten for SDK backward compatibility"
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(ExperimentExecutionDetails.properties,
+  "!javascript"
 );
 
 @@clientName(Microsoft.Chaos.Operations.list, "listAll", "javascript,python");

--- a/specification/codesigning/CodeSigning.Management/back-compatible.tsp
+++ b/specification/codesigning/CodeSigning.Management/back-compatible.tsp
@@ -5,19 +5,24 @@ using Microsoft.CodeSigning;
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(CertificateProfile.properties
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(CertificateProfile.properties,
+  "!javascript"
 );
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(CodeSigningAccount.properties
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(CodeSigningAccount.properties,
+  "!javascript"
 );
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(CodeSigningAccountPatch.properties
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(CodeSigningAccountPatch.properties,
+  "!javascript"
 );
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(Certificate.revocation);
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(Certificate.revocation,
+  "!javascript"
+);

--- a/specification/dashboard/Dashboard.Management/back-compatible.tsp
+++ b/specification/dashboard/Dashboard.Management/back-compatible.tsp
@@ -13,12 +13,14 @@ using Azure.Core;
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(PrivateEndpointConnection.properties
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(PrivateEndpointConnection.properties,
+  "!javascript"
 );
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(PrivateLinkResource.properties
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(PrivateLinkResource.properties,
+  "!javascript"
 );
 
 @@clientName(ManagedPrivateEndpointModels.create::parameters.resource,
@@ -29,7 +31,8 @@ using Azure.Core;
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(ManagedPrivateEndpointModel.properties
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(ManagedPrivateEndpointModel.properties,
+  "!javascript"
 );
 
 @@clientName(IntegrationFabrics.create::parameters.resource,
@@ -48,7 +51,8 @@ using Azure.Core;
 @@clientName(PrivateEndpointConnections.approve::parameters.resource, "body");
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(ManagedDashboard.properties
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(ManagedDashboard.properties,
+  "!javascript"
 );
 @@alternateType(ManagedPrivateEndpointModelProperties.privateLinkResourceId,
   armResourceIdentifier

--- a/specification/hardwaresecuritymodules/resource-manager/Microsoft.HardwareSecurityModules/HardwareSecurityModules/back-compatible.tsp
+++ b/specification/hardwaresecuritymodules/resource-manager/Microsoft.HardwareSecurityModules/HardwareSecurityModules/back-compatible.tsp
@@ -6,7 +6,7 @@ using Microsoft.HardwareSecurityModules;
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(BackupResult.properties,
-  "!python,!java,!csharp"
+  "!python,!java,!csharp,!javascript"
 );
 @@clientName(Error.innererror, "innerError");
 @@clientName(CloudHsmClusters.createOrUpdate::parameters.resource, "body");
@@ -17,7 +17,7 @@ using Microsoft.HardwareSecurityModules;
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(CloudHsmCluster.properties,
-  "!python,!java,!csharp"
+  "!python,!java,!csharp,!javascript"
 );
 @@clientName(PrivateEndpointConnections.create::parameters.resource,
   "properties"
@@ -25,14 +25,14 @@ using Microsoft.HardwareSecurityModules;
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(PrivateEndpointConnection.properties,
-  "!python,!java,!csharp"
+  "!python,!java,!csharp,!javascript"
 );
 @@clientName(DedicatedHsms.createOrUpdate::parameters.resource, "parameters");
 @@clientName(DedicatedHsms.update::parameters.properties, "parameters");
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(DedicatedHsm.properties,
-  "!python,!java,!csharp"
+  "!python,!java,!csharp,!javascript"
 );
 @@clientName(CloudHsmClusters.validateBackupProperties::parameters.body,
   "backupRequestProperties",

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/back-compatible.tsp
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/back-compatible.tsp
@@ -5,19 +5,19 @@ using Azure.ClientGenerator.Core.Legacy;
 using Microsoft.NetApp;
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For backward compatibility"
-@@flattenProperty(Operation.properties);
+@@flattenProperty(Operation.properties, "!javascript");
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For backward compatibility"
-@@flattenProperty(UsageResult.properties);
+@@flattenProperty(UsageResult.properties, "!javascript");
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For backward compatibility"
-@@flattenProperty(NetAppAccountPatch.properties);
+@@flattenProperty(NetAppAccountPatch.properties, "!javascript");
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For backward compatibility"
-@@flattenProperty(GetKeyVaultStatusResponse.properties);
+@@flattenProperty(GetKeyVaultStatusResponse.properties, "!javascript");
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For backward compatibility"
-@@flattenProperty(CapacityPoolPatch.properties);
+@@flattenProperty(CapacityPoolPatch.properties, "!javascript");
 
 @@clientName(ExportPolicyRule.kerberos5iReadOnly, "kerberos5IReadOnly");
 @@clientName(ExportPolicyRule.kerberos5iReadWrite, "kerberos5IReadWrite");
@@ -25,41 +25,41 @@ using Microsoft.NetApp;
 @@clientName(ExportPolicyRule.kerberos5pReadWrite, "kerberos5PReadWrite");
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For backward compatibility"
-@@flattenProperty(VolumePatch.properties);
+@@flattenProperty(VolumePatch.properties, "!javascript");
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For backward compatibility"
-@@flattenProperty(SnapshotPolicyPatch.properties);
+@@flattenProperty(SnapshotPolicyPatch.properties, "!javascript");
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For backward compatibility"
-@@flattenProperty(BackupPolicyPatch.properties);
+@@flattenProperty(BackupPolicyPatch.properties, "!javascript");
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For backward compatibility"
-@@flattenProperty(VolumeQuotaRulePatch.properties);
+@@flattenProperty(VolumeQuotaRulePatch.properties, "!javascript");
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For backward compatibility"
-@@flattenProperty(VolumeGroup.properties);
+@@flattenProperty(VolumeGroup.properties, "!javascript");
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For backward compatibility"
-@@flattenProperty(VolumeGroupVolumeProperties.properties);
+@@flattenProperty(VolumeGroupVolumeProperties.properties, "!javascript");
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For backward compatibility"
-@@flattenProperty(SubvolumePatchRequest.properties);
+@@flattenProperty(SubvolumePatchRequest.properties, "!javascript");
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For backward compatibility"
-@@flattenProperty(SubvolumeModel.properties);
+@@flattenProperty(SubvolumeModel.properties, "!javascript");
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For backward compatibility"
-@@flattenProperty(BackupPatch.properties);
+@@flattenProperty(BackupPatch.properties, "!javascript");
 
 @@clientLocation(SubscriptionQuotaItems.get, "NetAppResourceQuotaLimits");
 @@clientLocation(SubscriptionQuotaItems.list, "NetAppResourceQuotaLimits");
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For backward compatibility"
-@@flattenProperty(QuotaItem.properties);
+@@flattenProperty(QuotaItem.properties, "!javascript");
 
 @@clientLocation(RegionInfoResources.get, "NetAppResourceRegionInfos");
 @@clientLocation(RegionInfoResources.list, "NetAppResourceRegionInfos");
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For backward compatibility"
-@@flattenProperty(RegionInfoResource.properties);
+@@flattenProperty(RegionInfoResource.properties, "!javascript");
 
 @@clientLocation(NetAppAccounts.get, "Accounts");
 @@clientLocation(NetAppAccounts.createOrUpdate, "Accounts");
@@ -76,7 +76,7 @@ using Microsoft.NetApp;
 @@clientLocation(NetAppAccounts.listByNetAppAccount, VolumeGroups);
 @@clientLocation(NetAppAccounts.migrateBackups, "BackupsUnderAccount");
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For backward compatibility"
-@@flattenProperty(NetAppAccount.properties);
+@@flattenProperty(NetAppAccount.properties, "!javascript");
 
 @@clientLocation(CapacityPools.get, "Pools");
 @@clientLocation(CapacityPools.createOrUpdate, "Pools");
@@ -86,7 +86,7 @@ using Microsoft.NetApp;
 @@clientLocation(CapacityPools.delete, "Pools");
 @@clientLocation(CapacityPools.list, "Pools");
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For backward compatibility"
-@@flattenProperty(CapacityPool.properties);
+@@flattenProperty(CapacityPool.properties, "!javascript");
 
 @@clientName(Volumes.createOrUpdate::parameters.resource, "body");
 @@clientName(Volumes.update::parameters.properties, "body");
@@ -94,31 +94,31 @@ using Microsoft.NetApp;
 @@clientLocation(Volumes.getVolumeLatestRestoreStatus, Backups);
 @@clientLocation(Volumes.migrateBackups, "BackupsUnderVolume");
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For backward compatibility"
-@@flattenProperty(Volume.properties);
+@@flattenProperty(Volume.properties, "!javascript");
 
 @@clientName(Snapshots.create::parameters.resource, "body");
 @@clientName(Snapshots.update::parameters.properties, "body");
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For backward compatibility"
-@@flattenProperty(Snapshot.properties);
+@@flattenProperty(Snapshot.properties, "!javascript");
 
 @@clientName(SnapshotPolicies.create::parameters.resource, "body");
 @@clientName(SnapshotPolicies.update::parameters.properties, "body");
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For backward compatibility"
-@@flattenProperty(SnapshotPolicy.properties);
+@@flattenProperty(SnapshotPolicy.properties, "!javascript");
 
 @@clientName(BackupPolicies.create::parameters.resource, "body");
 @@clientName(BackupPolicies.update::parameters.properties, "body");
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For backward compatibility"
-@@flattenProperty(BackupPolicy.properties);
+@@flattenProperty(BackupPolicy.properties, "!javascript");
 
 @@clientName(VolumeQuotaRules.create::parameters.resource, "body");
 @@clientName(VolumeQuotaRules.update::parameters.properties, "body");
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For backward compatibility"
-@@flattenProperty(VolumeQuotaRule.properties);
+@@flattenProperty(VolumeQuotaRule.properties, "!javascript");
 
 @@clientName(VolumeGroups.create::parameters.resource, "body");
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For backward compatibility"
-@@flattenProperty(VolumeGroupDetails.properties);
+@@flattenProperty(VolumeGroupDetails.properties, "!javascript");
 
 @@clientLocation(SubvolumeInfos.get, "Subvolumes");
 @@clientLocation(SubvolumeInfos.create, "Subvolumes");
@@ -129,25 +129,25 @@ using Microsoft.NetApp;
 @@clientLocation(SubvolumeInfos.listByVolume, "Subvolumes");
 @@clientLocation(SubvolumeInfos.getMetadata, "Subvolumes");
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For backward compatibility"
-@@flattenProperty(SubvolumeInfo.properties);
+@@flattenProperty(SubvolumeInfo.properties, "!javascript");
 
 @@clientName(Backups.create::parameters.resource, "body");
 @@clientName(Backups.update::parameters.properties, "body");
 @@clientLocation(Backups.restoreFiles, "BackupsUnderBackupVault");
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For backward compatibility"
-@@flattenProperty(Backup.properties);
+@@flattenProperty(Backup.properties, "!javascript");
 
 @@clientName(BackupVaults.createOrUpdate::parameters.resource, "body");
 @@clientName(BackupVaults.update::parameters.properties, "body");
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For backward compatibility"
-@@flattenProperty(BackupVault.properties);
+@@flattenProperty(BackupVault.properties, "!javascript");
 
 @@clientName(Buckets.createOrUpdate::parameters.resource, "body");
 @@clientName(Buckets.update::parameters.properties, "body");
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For backward compatibility"
-@@flattenProperty(Bucket.properties);
+@@flattenProperty(Bucket.properties, "!javascript");
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For backward compatibility"
-@@flattenProperty(BucketPatch.properties);
+@@flattenProperty(BucketPatch.properties, "!javascript");
 
 @@clientLocation(NetAppResourceOperationGroup.checkNameAvailability,
   "NetAppResource"

--- a/specification/quota/resource-manager/Microsoft.Quota/Quota/back-compatible.tsp
+++ b/specification/quota/resource-manager/Microsoft.Quota/Quota/back-compatible.tsp
@@ -5,45 +5,56 @@ using Microsoft.Quota;
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(GroupQuotaDetails.name);
-
-#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(GroupQuotaRequestBase.properties
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(GroupQuotaDetails.name,
+  "!javascript"
 );
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(GroupQuotaRequestBaseProperties.name
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(GroupQuotaRequestBase.properties,
+  "!javascript"
 );
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(SubscriptionQuotaDetails.name
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(GroupQuotaRequestBaseProperties.name,
+  "!javascript"
 );
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(QuotaAllocationRequestBase.properties
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(SubscriptionQuotaDetails.name,
+  "!javascript"
 );
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(QuotaAllocationRequestBaseProperties.name
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(QuotaAllocationRequestBase.properties,
+  "!javascript"
 );
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(GroupQuotaUsagesBase.name);
-
-#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(QuotaRequestOneResourceSubmitResponse.properties
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(QuotaAllocationRequestBaseProperties.name,
+  "!javascript"
 );
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(QuotaRequestSubmitResponse202.properties
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(GroupQuotaUsagesBase.name,
+  "!javascript"
+);
+
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(QuotaRequestOneResourceSubmitResponse.properties,
+  "!javascript"
+);
+
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(QuotaRequestSubmitResponse202.properties,
+  "!javascript"
 );
 
 @@clientLocation(CurrentUsagesBases.get, "Usages", "!csharp");
@@ -90,7 +101,8 @@ using Microsoft.Quota;
 );
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(QuotaAllocationRequestStatus.properties
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(QuotaAllocationRequestStatus.properties,
+  "!javascript"
 );
 
 @@clientLocation(GroupQuotasEnforcementStatuses.get,
@@ -169,7 +181,8 @@ using Microsoft.Quota;
 );
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(QuotaRequestDetails.properties
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(QuotaRequestDetails.properties,
+  "!javascript"
 );
 
 @@maxLength(Azure.ResourceManager.Extension.ManagementGroup.name, 63);

--- a/specification/recoveryservices/resource-manager/Microsoft.RecoveryServices/RecoveryServices/back-compatible.tsp
+++ b/specification/recoveryservices/resource-manager/Microsoft.RecoveryServices/RecoveryServices/back-compatible.tsp
@@ -7,7 +7,8 @@ using Microsoft.RecoveryServices;
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(PrivateLinkResource.properties
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(PrivateLinkResource.properties,
+  "!javascript"
 );
 
 @@clientName(Vaults.createOrUpdate::parameters.resource, "vault");
@@ -32,7 +33,8 @@ using Microsoft.RecoveryServices;
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(VaultExtendedInfoResource.properties
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(VaultExtendedInfoResource.properties,
+  "!javascript"
 );
 @@clientName(RecoveryServicesOperationGroup.capabilities::parameters.body,
   "input"

--- a/specification/storageactions/StorageAction.Management/back-compatible.tsp
+++ b/specification/storageactions/StorageAction.Management/back-compatible.tsp
@@ -6,13 +6,13 @@ using Microsoft.StorageActions;
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(StorageTaskPreviewAction.properties,
-  "!csharp,!java,!python"
+  "!csharp,!java,!python,!javascript"
 );
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(StorageTaskUpdateParameters.properties,
-  "!csharp,!java,!python"
+  "!csharp,!java,!python,!javascript"
 );
 
 @@clientName(StorageTasks.create::parameters.resource, "parameters");
@@ -24,7 +24,7 @@ using Microsoft.StorageActions;
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(StorageTask.properties,
-  "!csharp,!java,!python"
+  "!csharp,!java,!python,!javascript"
 );
 
 // @@clientLocation decorators for operations with custom @operationId

--- a/specification/storagemover/StorageMover.Management/back-compatible.tsp
+++ b/specification/storagemover/StorageMover.Management/back-compatible.tsp
@@ -5,35 +5,43 @@ using Microsoft.StorageMover;
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(StorageMoverUpdateParameters.properties
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(StorageMoverUpdateParameters.properties,
+  "!javascript"
 );
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(AgentUpdateParameters.properties
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(AgentUpdateParameters.properties,
+  "!javascript"
 );
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(ProjectUpdateParameters.properties
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(ProjectUpdateParameters.properties,
+  "!javascript"
 );
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(JobDefinitionUpdateParameters.properties
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(JobDefinitionUpdateParameters.properties,
+  "!javascript"
 );
 
 @@clientName(StorageMovers.createOrUpdate::parameters.resource, "storageMover");
 @@clientName(StorageMovers.update::parameters.properties, "storageMover");
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(StorageMover.properties);
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(StorageMover.properties, "
+  "!javascript"
+);
 
 @@clientName(Agents.createOrUpdate::parameters.resource, "agent");
 @@clientName(Agents.update::parameters.properties, "agent");
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(Agent.properties);
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(Agent.properties,
+  "!javascript"
+);
 
 @@clientName(Endpoints.createOrUpdate::parameters.resource,
   "endpoint",
@@ -45,7 +53,9 @@ using Microsoft.StorageMover;
 @@clientName(Projects.update::parameters.properties, "project");
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(Project.properties);
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(Project.properties,
+  "!javascript"
+);
 
 @@clientName(JobDefinitions.createOrUpdate::parameters.resource,
   "jobDefinition"
@@ -53,11 +63,15 @@ using Microsoft.StorageMover;
 @@clientName(JobDefinitions.update::parameters.properties, "jobDefinition");
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(JobDefinition.properties);
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(JobDefinition.properties,
+  "!javascript"
+);
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(JobRun.properties);
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(JobRun.properties,
+  "!javascript"
+);
 
 @@clientName(Connections.createOrUpdate::parameters.resource,
   "connection",

--- a/specification/storagemover/StorageMover.Management/back-compatible.tsp
+++ b/specification/storagemover/StorageMover.Management/back-compatible.tsp
@@ -31,7 +31,7 @@ using Microsoft.StorageMover;
 @@clientName(StorageMovers.update::parameters.properties, "storageMover");
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(StorageMover.properties, "
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(StorageMover.properties,
   "!javascript"
 );
 


### PR DESCRIPTION
related issue: https://github.com/Azure/autorest.typescript/issues/3644
In order to prevent introducing breaking changes, exclude JS flatten for services that have already been released.