### PR TITLE
Use "Tool" or "PreviewTool" as a suffix for Azure Tools

### DIFF
--- a/specification/ai/Foundry/client.tsp
+++ b/specification/ai/Foundry/client.tsp
@@ -266,3 +266,8 @@ using Azure.AI.Projects;
 // input parameter that calls either on these two.
 @@access(Connections.get, Access.internal);
 @@access(Connections.getWithCredentials, Access.internal);
+
+@@alternateType(OpenAI.ResponseFormatJsonSchemaSchema,
+  Record<unknown>,
+  "python"
+);

--- a/specification/ai/Foundry/responses/models.tsp
+++ b/specification/ai/Foundry/responses/models.tsp
@@ -121,6 +121,26 @@ union _AgentItemType {
   }
 );
 
+#suppress "@azure-tools/typespec-autorest/union-unsupported" "Temporary union change"
+#suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Union is intentional here"
+@@changePropertyType(OpenAI.ApplyPatchToolCall.created_by, CreatedBy | string);
+
+#suppress "@azure-tools/typespec-autorest/union-unsupported" "Temporary union change"
+#suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Union is intentional here"
+@@changePropertyType(OpenAI.ApplyPatchToolCallOutput.created_by,
+  CreatedBy | string
+);
+
+#suppress "@azure-tools/typespec-autorest/union-unsupported" "Temporary union change"
+#suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Union is intentional here"
+@@changePropertyType(OpenAI.FunctionShellCall.created_by, CreatedBy | string);
+
+#suppress "@azure-tools/typespec-autorest/union-unsupported" "Temporary union change"
+#suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Union is intentional here"
+@@changePropertyType(OpenAI.FunctionShellCallOutput.created_by,
+  CreatedBy | string
+);
+
 model CreatedBy {
   @doc("The agent that created the item.")
   agent?: AgentId;

--- a/specification/ai/Foundry/tools/models.tsp
+++ b/specification/ai/Foundry/tools/models.tsp
@@ -112,7 +112,7 @@ model FabricDataAgentToolParameters {
 /**
  * The input definition information for a Microsoft Fabric tool as used to configure an agent.
  */
-model MicrosoftFabricPreviewTool extends OpenAI.Tool {
+model MicrosoftFabricAgentTool extends OpenAI.Tool {
   /**
    * The object type, which is always 'fabric_dataagent_preview'.
    */
@@ -139,7 +139,7 @@ model SharepointGroundingToolParameters {
 /**
  * The input definition information for a sharepoint tool as used to configure an agent.
  */
-model SharepointPreviewTool extends OpenAI.Tool {
+model SharepointAgentTool extends OpenAI.Tool {
   /**
    * The object type, which is always 'sharepoint_grounding_preview'.
    */
@@ -258,7 +258,7 @@ model OpenApiTool extends OpenAI.Tool {
 /**
  * The input definition information for a Bing custom search tool as used to configure an agent.
  */
-model BingCustomSearchPreviewTool extends OpenAI.Tool {
+model BingCustomSearchAgentTool extends OpenAI.Tool {
   /**
    * The object type, which is always 'bing_custom_search_preview'.
    */
@@ -273,7 +273,7 @@ model BingCustomSearchPreviewTool extends OpenAI.Tool {
 /**
  * The input definition information for a Browser Automation Tool, as used to configure an Agent.
  */
-model BrowserAutomationPreviewTool extends OpenAI.Tool {
+model BrowserAutomationAgentTool extends OpenAI.Tool {
   /**
    * The object type, which is always 'browser_automation_preview'.
    */

--- a/specification/ai/Foundry/tools/models.tsp
+++ b/specification/ai/Foundry/tools/models.tsp
@@ -85,7 +85,7 @@ model WebSearchConfiguration {
 /**
  * The input definition information for a bing grounding search tool as used to configure an agent.
  */
-model BingGroundingAgentTool extends OpenAI.Tool {
+model BingGroundingTool extends OpenAI.Tool {
   /**
    * The object type, which is always 'bing_grounding'.
    */
@@ -112,9 +112,9 @@ model FabricDataAgentToolParameters {
 /**
  * The input definition information for a Microsoft Fabric tool as used to configure an agent.
  */
-model MicrosoftFabricAgentTool extends OpenAI.Tool {
+model MicrosoftFabricTool extends OpenAI.Tool {
   /**
-   * The object type, which is always 'fabric_dataagent'.
+   * The object type, which is always 'fabric_dataagent_preview'.
    */
   type: "fabric_dataagent_preview";
 
@@ -139,9 +139,9 @@ model SharepointGroundingToolParameters {
 /**
  * The input definition information for a sharepoint tool as used to configure an agent.
  */
-model SharepointAgentTool extends OpenAI.Tool {
+model SharepointTool extends OpenAI.Tool {
   /**
-   * The object type, which is always 'sharepoint_grounding'.
+   * The object type, which is always 'sharepoint_grounding_preview'.
    */
   type: "sharepoint_grounding_preview";
 
@@ -154,7 +154,7 @@ model SharepointAgentTool extends OpenAI.Tool {
 /**
  * The input definition information for an Azure AI search tool as used to configure an agent.
  */
-model AzureAISearchAgentTool extends OpenAI.Tool {
+model AzureAISearchTool extends OpenAI.Tool {
   /**
    * The object type, which is always 'azure_ai_search'.
    */
@@ -243,7 +243,7 @@ union AzureAISearchQueryType {
 /**
  * The input definition information for an OpenAPI tool as used to configure an agent.
  */
-model OpenApiAgentTool extends OpenAI.Tool {
+model OpenApiTool extends OpenAI.Tool {
   /**
    * The object type, which is always 'openapi'.
    */
@@ -258,9 +258,9 @@ model OpenApiAgentTool extends OpenAI.Tool {
 /**
  * The input definition information for a Bing custom search tool as used to configure an agent.
  */
-model BingCustomSearchAgentTool extends OpenAI.Tool {
+model BingCustomSearchTool extends OpenAI.Tool {
   /**
-   * The object type, which is always 'bing_custom_search'.
+   * The object type, which is always 'bing_custom_search_preview'.
    */
   type: "bing_custom_search_preview";
 
@@ -273,9 +273,9 @@ model BingCustomSearchAgentTool extends OpenAI.Tool {
 /**
  * The input definition information for a Browser Automation Tool, as used to configure an Agent.
  */
-model BrowserAutomationAgentTool extends OpenAI.Tool {
+model BrowserAutomationTool extends OpenAI.Tool {
   /**
-   * The object type, which is always 'browser_automation'.
+   * The object type, which is always 'browser_automation_preview'.
    */
   type: "browser_automation_preview";
 
@@ -308,9 +308,9 @@ model BrowserAutomationToolConnectionParameters {
 /**
  * The input definition information for an Azure Function Tool, as used to configure an Agent.
  */
-model AzureFunctionAgentTool extends OpenAI.Tool {
+model AzureFunctionTool extends OpenAI.Tool {
   /**
-   * The object type, which is always 'browser_automation'.
+   * The object type, which is always 'azure_function'.
    */
   type: "azure_function";
 
@@ -681,7 +681,7 @@ model CaptureStructuredOutputsTool extends OpenAI.Tool {
 @removed(Versions.v1)
 model A2ATool extends OpenAI.Tool {
   /**
-   * The type of the tool. Always `a2a`.
+   * The type of the tool. Always `a2a_preview`.
    */
   type: "a2a_preview";
 

--- a/specification/ai/Foundry/tools/models.tsp
+++ b/specification/ai/Foundry/tools/models.tsp
@@ -1,10 +1,12 @@
 import "@typespec/http";
 import "@azure-tools/typespec-azure-core/experimental";
 import "@azure-tools/openai-typespec/models/responses";
+import "@azure-tools/typespec-client-generator-core";
 
 import "../memory_stores/models.tsp";
 
 using Azure.Core.Experimental;
+using Azure.ClientGenerator.Core;
 using TypeSpec.Versioning;
 
 namespace Azure.AI.Projects;
@@ -32,6 +34,11 @@ union _AgentToolType {
 
 #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
 @@copyVariants(OpenAI.ToolType, Azure.AI.Projects._AgentToolType);
+
+@@clientName(Azure.AI.Projects._AgentToolType.a2a_preview,
+  "A2A_PREVIEW",
+  "python"
+);
 
 @added(Versions.v2025_11_15_preview)
 @removed(Versions.v1)

--- a/specification/ai/Foundry/tools/models.tsp
+++ b/specification/ai/Foundry/tools/models.tsp
@@ -112,7 +112,7 @@ model FabricDataAgentToolParameters {
 /**
  * The input definition information for a Microsoft Fabric tool as used to configure an agent.
  */
-model MicrosoftFabricTool extends OpenAI.Tool {
+model MicrosoftFabricPreviewTool extends OpenAI.Tool {
   /**
    * The object type, which is always 'fabric_dataagent_preview'.
    */
@@ -139,7 +139,7 @@ model SharepointGroundingToolParameters {
 /**
  * The input definition information for a sharepoint tool as used to configure an agent.
  */
-model SharepointTool extends OpenAI.Tool {
+model SharepointPreviewTool extends OpenAI.Tool {
   /**
    * The object type, which is always 'sharepoint_grounding_preview'.
    */
@@ -258,7 +258,7 @@ model OpenApiTool extends OpenAI.Tool {
 /**
  * The input definition information for a Bing custom search tool as used to configure an agent.
  */
-model BingCustomSearchTool extends OpenAI.Tool {
+model BingCustomSearchPreviewTool extends OpenAI.Tool {
   /**
    * The object type, which is always 'bing_custom_search_preview'.
    */
@@ -273,7 +273,7 @@ model BingCustomSearchTool extends OpenAI.Tool {
 /**
  * The input definition information for a Browser Automation Tool, as used to configure an Agent.
  */
-model BrowserAutomationTool extends OpenAI.Tool {
+model BrowserAutomationPreviewTool extends OpenAI.Tool {
   /**
    * The object type, which is always 'browser_automation_preview'.
    */
@@ -679,7 +679,7 @@ model CaptureStructuredOutputsTool extends OpenAI.Tool {
  */
 @added(Versions.v2025_11_15_preview)
 @removed(Versions.v1)
-model A2ATool extends OpenAI.Tool {
+model A2APreviewTool extends OpenAI.Tool {
   /**
    * The type of the tool. Always `a2a_preview`.
    */

--- a/specification/ai/Foundry/tools/models.tsp
+++ b/specification/ai/Foundry/tools/models.tsp
@@ -112,7 +112,11 @@ model FabricDataAgentToolParameters {
 /**
  * The input definition information for a Microsoft Fabric tool as used to configure an agent.
  */
+<<<<<<< HEAD
 model MicrosoftFabricAgentTool extends OpenAI.Tool {
+=======
+model MicrosoftFabricPreviewTool extends OpenAI.Tool {
+>>>>>>> 121a055c5e (Add 'Preview' to names of Azure tools in preview)
   /**
    * The object type, which is always 'fabric_dataagent_preview'.
    */
@@ -139,7 +143,11 @@ model SharepointGroundingToolParameters {
 /**
  * The input definition information for a sharepoint tool as used to configure an agent.
  */
+<<<<<<< HEAD
 model SharepointAgentTool extends OpenAI.Tool {
+=======
+model SharepointPreviewTool extends OpenAI.Tool {
+>>>>>>> 121a055c5e (Add 'Preview' to names of Azure tools in preview)
   /**
    * The object type, which is always 'sharepoint_grounding_preview'.
    */
@@ -258,7 +266,11 @@ model OpenApiTool extends OpenAI.Tool {
 /**
  * The input definition information for a Bing custom search tool as used to configure an agent.
  */
+<<<<<<< HEAD
 model BingCustomSearchAgentTool extends OpenAI.Tool {
+=======
+model BingCustomSearchPreviewTool extends OpenAI.Tool {
+>>>>>>> 121a055c5e (Add 'Preview' to names of Azure tools in preview)
   /**
    * The object type, which is always 'bing_custom_search_preview'.
    */
@@ -273,7 +285,11 @@ model BingCustomSearchAgentTool extends OpenAI.Tool {
 /**
  * The input definition information for a Browser Automation Tool, as used to configure an Agent.
  */
+<<<<<<< HEAD
 model BrowserAutomationAgentTool extends OpenAI.Tool {
+=======
+model BrowserAutomationPreviewTool extends OpenAI.Tool {
+>>>>>>> 121a055c5e (Add 'Preview' to names of Azure tools in preview)
   /**
    * The object type, which is always 'browser_automation_preview'.
    */

--- a/specification/ai/Foundry/tools/models.tsp
+++ b/specification/ai/Foundry/tools/models.tsp
@@ -119,11 +119,7 @@ model FabricDataAgentToolParameters {
 /**
  * The input definition information for a Microsoft Fabric tool as used to configure an agent.
  */
-<<<<<<< HEAD
-model MicrosoftFabricAgentTool extends OpenAI.Tool {
-=======
 model MicrosoftFabricPreviewTool extends OpenAI.Tool {
->>>>>>> 121a055c5e (Add 'Preview' to names of Azure tools in preview)
   /**
    * The object type, which is always 'fabric_dataagent_preview'.
    */
@@ -150,11 +146,7 @@ model SharepointGroundingToolParameters {
 /**
  * The input definition information for a sharepoint tool as used to configure an agent.
  */
-<<<<<<< HEAD
-model SharepointAgentTool extends OpenAI.Tool {
-=======
 model SharepointPreviewTool extends OpenAI.Tool {
->>>>>>> 121a055c5e (Add 'Preview' to names of Azure tools in preview)
   /**
    * The object type, which is always 'sharepoint_grounding_preview'.
    */
@@ -273,11 +265,7 @@ model OpenApiTool extends OpenAI.Tool {
 /**
  * The input definition information for a Bing custom search tool as used to configure an agent.
  */
-<<<<<<< HEAD
-model BingCustomSearchAgentTool extends OpenAI.Tool {
-=======
 model BingCustomSearchPreviewTool extends OpenAI.Tool {
->>>>>>> 121a055c5e (Add 'Preview' to names of Azure tools in preview)
   /**
    * The object type, which is always 'bing_custom_search_preview'.
    */
@@ -292,11 +280,7 @@ model BingCustomSearchPreviewTool extends OpenAI.Tool {
 /**
  * The input definition information for a Browser Automation Tool, as used to configure an Agent.
  */
-<<<<<<< HEAD
-model BrowserAutomationAgentTool extends OpenAI.Tool {
-=======
 model BrowserAutomationPreviewTool extends OpenAI.Tool {
->>>>>>> 121a055c5e (Add 'Preview' to names of Azure tools in preview)
   /**
    * The object type, which is always 'browser_automation_preview'.
    */

--- a/specification/ai/cspell.yaml
+++ b/specification/ai/cspell.yaml
@@ -137,3 +137,26 @@ overrides:
   - filename: '**/specification/ai/data-plane/OpenAI.Assistants/OpenApiV2/preview/2024-07-01-preview/assistants_generated.json'
     words:
       - ocurred
+  - filename: '**/specification/ai/Foundry/tools/models.tsp'
+    words:
+      - includable
+  - filename: '**/specification/ai/data-plane/Azure.AI.Projects/**/*.*'
+    words:
+      - agentic
+      - ckpt
+      - csdl
+      - davinci
+      - evals
+      - ftevent
+      - ftjob
+      - ftckpt
+      - gleu
+      - ilike
+      - includable
+      - includables
+      - inpainting
+      - logprobs
+      - mcpl
+      - mpxmy
+      - myregistry
+      - xhigh

--- a/specification/ai/data-plane/Azure.AI.Projects/openapi3/2025-11-15-preview/azure-ai-projects-openapi3.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/openapi3/2025-11-15-preview/azure-ai-projects-openapi3.json
@@ -7974,7 +7974,7 @@
       }
     },
     "schemas": {
-      "A2ATool": {
+      "A2APreviewTool": {
         "type": "object",
         "required": [
           "type"
@@ -7985,7 +7985,7 @@
             "enum": [
               "a2a_preview"
             ],
-            "description": "The type of the tool. Always `a2a`."
+            "description": "The type of the tool. Always `a2a_preview`."
           },
           "base_url": {
             "type": "string",
@@ -8964,36 +8964,6 @@
         ],
         "description": "Represents a data source for evaluation runs that are specific to Continuous Evaluation scenarios."
       },
-      "AzureAISearchAgentTool": {
-        "type": "object",
-        "required": [
-          "type",
-          "azure_ai_search"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "azure_ai_search"
-            ],
-            "description": "The object type, which is always 'azure_ai_search'."
-          },
-          "azure_ai_search": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/AzureAISearchToolResource"
-              }
-            ],
-            "description": "The azure ai search index resource."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Tool"
-          }
-        ],
-        "description": "The input definition information for an Azure AI search tool as used to configure an agent."
-      },
       "AzureAISearchIndex": {
         "type": "object",
         "required": [
@@ -9054,6 +9024,36 @@
         ],
         "description": "Available query types for Azure AI Search tool."
       },
+      "AzureAISearchTool": {
+        "type": "object",
+        "required": [
+          "type",
+          "azure_ai_search"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "azure_ai_search"
+            ],
+            "description": "The object type, which is always 'azure_ai_search'."
+          },
+          "azure_ai_search": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AzureAISearchToolResource"
+              }
+            ],
+            "description": "The azure ai search index resource."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.Tool"
+          }
+        ],
+        "description": "The input definition information for an Azure AI search tool as used to configure an agent."
+      },
       "AzureAISearchToolResource": {
         "type": "object",
         "required": [
@@ -9070,36 +9070,6 @@
           }
         },
         "description": "A set of index resources used by the `azure_ai_search` tool."
-      },
-      "AzureFunctionAgentTool": {
-        "type": "object",
-        "required": [
-          "type",
-          "azure_function"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "azure_function"
-            ],
-            "description": "The object type, which is always 'browser_automation'."
-          },
-          "azure_function": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/AzureFunctionDefinition"
-              }
-            ],
-            "description": "The Azure Function Tool definition."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Tool"
-          }
-        ],
-        "description": "The input definition information for an Azure Function Tool, as used to configure an Agent."
       },
       "AzureFunctionBinding": {
         "type": "object",
@@ -9192,6 +9162,36 @@
         },
         "description": "The structure for keeping storage queue name and URI."
       },
+      "AzureFunctionTool": {
+        "type": "object",
+        "required": [
+          "type",
+          "azure_function"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "azure_function"
+            ],
+            "description": "The object type, which is always 'azure_function'."
+          },
+          "azure_function": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AzureFunctionDefinition"
+              }
+            ],
+            "description": "The Azure Function Tool definition."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.Tool"
+          }
+        ],
+        "description": "The input definition information for an Azure Function Tool, as used to configure an Agent."
+      },
       "AzureOpenAIModelConfiguration": {
         "type": "object",
         "required": [
@@ -9246,36 +9246,6 @@
         },
         "description": "A base class for connection credentials"
       },
-      "BingCustomSearchAgentTool": {
-        "type": "object",
-        "required": [
-          "type",
-          "bing_custom_search_preview"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "bing_custom_search_preview"
-            ],
-            "description": "The object type, which is always 'bing_custom_search'."
-          },
-          "bing_custom_search_preview": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BingCustomSearchToolParameters"
-              }
-            ],
-            "description": "The bing custom search tool parameters."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Tool"
-          }
-        ],
-        "description": "The input definition information for a Bing custom search tool as used to configure an agent."
-      },
       "BingCustomSearchConfiguration": {
         "type": "object",
         "required": [
@@ -9311,6 +9281,36 @@
         },
         "description": "A bing custom search configuration."
       },
+      "BingCustomSearchPreviewTool": {
+        "type": "object",
+        "required": [
+          "type",
+          "bing_custom_search_preview"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "bing_custom_search_preview"
+            ],
+            "description": "The object type, which is always 'bing_custom_search_preview'."
+          },
+          "bing_custom_search_preview": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BingCustomSearchToolParameters"
+              }
+            ],
+            "description": "The bing custom search tool parameters."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.Tool"
+          }
+        ],
+        "description": "The input definition information for a Bing custom search tool as used to configure an agent."
+      },
       "BingCustomSearchToolParameters": {
         "type": "object",
         "required": [
@@ -9327,36 +9327,6 @@
           }
         },
         "description": "The bing custom search tool parameters."
-      },
-      "BingGroundingAgentTool": {
-        "type": "object",
-        "required": [
-          "type",
-          "bing_grounding"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "bing_grounding"
-            ],
-            "description": "The object type, which is always 'bing_grounding'."
-          },
-          "bing_grounding": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BingGroundingSearchToolParameters"
-              }
-            ],
-            "description": "The bing grounding search tool parameters."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Tool"
-          }
-        ],
-        "description": "The input definition information for a bing grounding search tool as used to configure an agent."
       },
       "BingGroundingSearchConfiguration": {
         "type": "object",
@@ -9405,6 +9375,36 @@
         },
         "description": "The bing grounding search tool parameters."
       },
+      "BingGroundingTool": {
+        "type": "object",
+        "required": [
+          "type",
+          "bing_grounding"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "bing_grounding"
+            ],
+            "description": "The object type, which is always 'bing_grounding'."
+          },
+          "bing_grounding": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BingGroundingSearchToolParameters"
+              }
+            ],
+            "description": "The bing grounding search tool parameters."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.Tool"
+          }
+        ],
+        "description": "The input definition information for a bing grounding search tool as used to configure an agent."
+      },
       "BlobReference": {
         "type": "object",
         "required": [
@@ -9432,7 +9432,7 @@
         },
         "description": "Blob reference details."
       },
-      "BrowserAutomationAgentTool": {
+      "BrowserAutomationPreviewTool": {
         "type": "object",
         "required": [
           "type",
@@ -9444,7 +9444,7 @@
             "enum": [
               "browser_automation_preview"
             ],
-            "description": "The object type, which is always 'browser_automation'."
+            "description": "The object type, which is always 'browser_automation_preview'."
           },
           "browser_automation_preview": {
             "allOf": [
@@ -13608,7 +13608,7 @@
         ],
         "description": "Status of a memory store update operation."
       },
-      "MicrosoftFabricAgentTool": {
+      "MicrosoftFabricPreviewTool": {
         "type": "object",
         "required": [
           "type",
@@ -13620,7 +13620,7 @@
             "enum": [
               "fabric_dataagent_preview"
             ],
-            "description": "The object type, which is always 'fabric_dataagent'."
+            "description": "The object type, which is always 'fabric_dataagent_preview'."
           },
           "fabric_dataagent_preview": {
             "allOf": [
@@ -28827,16 +28827,16 @@
             "custom": "#/components/schemas/OpenAI.CustomToolParam",
             "web_search_preview": "#/components/schemas/OpenAI.WebSearchPreviewTool",
             "apply_patch": "#/components/schemas/OpenAI.ApplyPatchToolParam",
-            "bing_grounding": "#/components/schemas/BingGroundingAgentTool",
-            "fabric_dataagent_preview": "#/components/schemas/MicrosoftFabricAgentTool",
-            "sharepoint_grounding_preview": "#/components/schemas/SharepointAgentTool",
-            "azure_ai_search": "#/components/schemas/AzureAISearchAgentTool",
-            "openapi": "#/components/schemas/OpenApiAgentTool",
-            "bing_custom_search_preview": "#/components/schemas/BingCustomSearchAgentTool",
-            "browser_automation_preview": "#/components/schemas/BrowserAutomationAgentTool",
-            "azure_function": "#/components/schemas/AzureFunctionAgentTool",
+            "bing_grounding": "#/components/schemas/BingGroundingTool",
+            "fabric_dataagent_preview": "#/components/schemas/MicrosoftFabricPreviewTool",
+            "sharepoint_grounding_preview": "#/components/schemas/SharepointPreviewTool",
+            "azure_ai_search": "#/components/schemas/AzureAISearchTool",
+            "openapi": "#/components/schemas/OpenApiTool",
+            "bing_custom_search_preview": "#/components/schemas/BingCustomSearchPreviewTool",
+            "browser_automation_preview": "#/components/schemas/BrowserAutomationPreviewTool",
+            "azure_function": "#/components/schemas/AzureFunctionTool",
             "capture_structured_outputs": "#/components/schemas/CaptureStructuredOutputsTool",
-            "a2a_preview": "#/components/schemas/A2ATool",
+            "a2a_preview": "#/components/schemas/A2APreviewTool",
             "memory_search": "#/components/schemas/MemorySearchTool"
           }
         },
@@ -29616,36 +29616,6 @@
         "type": "number",
         "format": "double"
       },
-      "OpenApiAgentTool": {
-        "type": "object",
-        "required": [
-          "type",
-          "openapi"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "openapi"
-            ],
-            "description": "The object type, which is always 'openapi'."
-          },
-          "openapi": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenApiFunctionDefinition"
-              }
-            ],
-            "description": "The openapi function definition."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Tool"
-          }
-        ],
-        "description": "The input definition information for an OpenAPI tool as used to configure an agent."
-      },
       "OpenApiAnonymousAuthDetails": {
         "type": "object",
         "required": [
@@ -29855,6 +29825,36 @@
           }
         },
         "description": "Security scheme for OpenApi managed_identity authentication"
+      },
+      "OpenApiTool": {
+        "type": "object",
+        "required": [
+          "type",
+          "openapi"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "openapi"
+            ],
+            "description": "The object type, which is always 'openapi'."
+          },
+          "openapi": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OpenApiFunctionDefinition"
+              }
+            ],
+            "description": "The openapi function definition."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.Tool"
+          }
+        ],
+        "description": "The input definition information for an OpenAPI tool as used to configure an agent."
       },
       "PageOrder": {
         "type": "string",
@@ -30892,7 +30892,21 @@
         ],
         "description": "Type of the task."
       },
-      "SharepointAgentTool": {
+      "SharepointGroundingToolParameters": {
+        "type": "object",
+        "properties": {
+          "project_connections": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ToolProjectConnection"
+            },
+            "maxItems": 1,
+            "description": "The project connections attached to this tool. There can be a maximum of 1 connection\nresource attached to the tool."
+          }
+        },
+        "description": "The sharepoint grounding tool parameters."
+      },
+      "SharepointPreviewTool": {
         "type": "object",
         "required": [
           "type",
@@ -30904,7 +30918,7 @@
             "enum": [
               "sharepoint_grounding_preview"
             ],
-            "description": "The object type, which is always 'sharepoint_grounding'."
+            "description": "The object type, which is always 'sharepoint_grounding_preview'."
           },
           "sharepoint_grounding_preview": {
             "allOf": [
@@ -30921,20 +30935,6 @@
           }
         ],
         "description": "The input definition information for a sharepoint tool as used to configure an agent."
-      },
-      "SharepointGroundingToolParameters": {
-        "type": "object",
-        "properties": {
-          "project_connections": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ToolProjectConnection"
-            },
-            "maxItems": 1,
-            "description": "The project connections attached to this tool. There can be a maximum of 1 connection\nresource attached to the tool."
-          }
-        },
-        "description": "The sharepoint grounding tool parameters."
       },
       "Sku": {
         "type": "object",

--- a/specification/ai/data-plane/Azure.AI.Projects/openapi3/v1/azure-ai-projects-openapi3.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/openapi3/v1/azure-ai-projects-openapi3.json
@@ -2214,36 +2214,6 @@
           }
         ]
       },
-      "AzureAISearchAgentTool": {
-        "type": "object",
-        "required": [
-          "type",
-          "azure_ai_search"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "azure_ai_search"
-            ],
-            "description": "The object type, which is always 'azure_ai_search'."
-          },
-          "azure_ai_search": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/AzureAISearchToolResource"
-              }
-            ],
-            "description": "The azure ai search index resource."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Tool"
-          }
-        ],
-        "description": "The input definition information for an Azure AI search tool as used to configure an agent."
-      },
       "AzureAISearchIndex": {
         "type": "object",
         "required": [
@@ -2304,6 +2274,36 @@
         ],
         "description": "Available query types for Azure AI Search tool."
       },
+      "AzureAISearchTool": {
+        "type": "object",
+        "required": [
+          "type",
+          "azure_ai_search"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "azure_ai_search"
+            ],
+            "description": "The object type, which is always 'azure_ai_search'."
+          },
+          "azure_ai_search": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AzureAISearchToolResource"
+              }
+            ],
+            "description": "The azure ai search index resource."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.Tool"
+          }
+        ],
+        "description": "The input definition information for an Azure AI search tool as used to configure an agent."
+      },
       "AzureAISearchToolResource": {
         "type": "object",
         "required": [
@@ -2320,36 +2320,6 @@
           }
         },
         "description": "A set of index resources used by the `azure_ai_search` tool."
-      },
-      "AzureFunctionAgentTool": {
-        "type": "object",
-        "required": [
-          "type",
-          "azure_function"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "azure_function"
-            ],
-            "description": "The object type, which is always 'browser_automation'."
-          },
-          "azure_function": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/AzureFunctionDefinition"
-              }
-            ],
-            "description": "The Azure Function Tool definition."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Tool"
-          }
-        ],
-        "description": "The input definition information for an Azure Function Tool, as used to configure an Agent."
       },
       "AzureFunctionBinding": {
         "type": "object",
@@ -2442,6 +2412,36 @@
         },
         "description": "The structure for keeping storage queue name and URI."
       },
+      "AzureFunctionTool": {
+        "type": "object",
+        "required": [
+          "type",
+          "azure_function"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "azure_function"
+            ],
+            "description": "The object type, which is always 'azure_function'."
+          },
+          "azure_function": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AzureFunctionDefinition"
+              }
+            ],
+            "description": "The Azure Function Tool definition."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.Tool"
+          }
+        ],
+        "description": "The input definition information for an Azure Function Tool, as used to configure an Agent."
+      },
       "BaseCredentials": {
         "type": "object",
         "required": [
@@ -2469,36 +2469,6 @@
           }
         },
         "description": "A base class for connection credentials"
-      },
-      "BingCustomSearchAgentTool": {
-        "type": "object",
-        "required": [
-          "type",
-          "bing_custom_search_preview"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "bing_custom_search_preview"
-            ],
-            "description": "The object type, which is always 'bing_custom_search'."
-          },
-          "bing_custom_search_preview": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BingCustomSearchToolParameters"
-              }
-            ],
-            "description": "The bing custom search tool parameters."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Tool"
-          }
-        ],
-        "description": "The input definition information for a Bing custom search tool as used to configure an agent."
       },
       "BingCustomSearchConfiguration": {
         "type": "object",
@@ -2535,6 +2505,36 @@
         },
         "description": "A bing custom search configuration."
       },
+      "BingCustomSearchPreviewTool": {
+        "type": "object",
+        "required": [
+          "type",
+          "bing_custom_search_preview"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "bing_custom_search_preview"
+            ],
+            "description": "The object type, which is always 'bing_custom_search_preview'."
+          },
+          "bing_custom_search_preview": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BingCustomSearchToolParameters"
+              }
+            ],
+            "description": "The bing custom search tool parameters."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.Tool"
+          }
+        ],
+        "description": "The input definition information for a Bing custom search tool as used to configure an agent."
+      },
       "BingCustomSearchToolParameters": {
         "type": "object",
         "required": [
@@ -2551,36 +2551,6 @@
           }
         },
         "description": "The bing custom search tool parameters."
-      },
-      "BingGroundingAgentTool": {
-        "type": "object",
-        "required": [
-          "type",
-          "bing_grounding"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "bing_grounding"
-            ],
-            "description": "The object type, which is always 'bing_grounding'."
-          },
-          "bing_grounding": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BingGroundingSearchToolParameters"
-              }
-            ],
-            "description": "The bing grounding search tool parameters."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Tool"
-          }
-        ],
-        "description": "The input definition information for a bing grounding search tool as used to configure an agent."
       },
       "BingGroundingSearchConfiguration": {
         "type": "object",
@@ -2629,6 +2599,36 @@
         },
         "description": "The bing grounding search tool parameters."
       },
+      "BingGroundingTool": {
+        "type": "object",
+        "required": [
+          "type",
+          "bing_grounding"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "bing_grounding"
+            ],
+            "description": "The object type, which is always 'bing_grounding'."
+          },
+          "bing_grounding": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BingGroundingSearchToolParameters"
+              }
+            ],
+            "description": "The bing grounding search tool parameters."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.Tool"
+          }
+        ],
+        "description": "The input definition information for a bing grounding search tool as used to configure an agent."
+      },
       "BlobReference": {
         "type": "object",
         "required": [
@@ -2656,7 +2656,7 @@
         },
         "description": "Blob reference details."
       },
-      "BrowserAutomationAgentTool": {
+      "BrowserAutomationPreviewTool": {
         "type": "object",
         "required": [
           "type",
@@ -2668,7 +2668,7 @@
             "enum": [
               "browser_automation_preview"
             ],
-            "description": "The object type, which is always 'browser_automation'."
+            "description": "The object type, which is always 'browser_automation_preview'."
           },
           "browser_automation_preview": {
             "allOf": [
@@ -4052,7 +4052,7 @@
         ],
         "description": "Managed Azure AI Search Index Definition"
       },
-      "MicrosoftFabricAgentTool": {
+      "MicrosoftFabricPreviewTool": {
         "type": "object",
         "required": [
           "type",
@@ -4064,7 +4064,7 @@
             "enum": [
               "fabric_dataagent_preview"
             ],
-            "description": "The object type, which is always 'fabric_dataagent'."
+            "description": "The object type, which is always 'fabric_dataagent_preview'."
           },
           "fabric_dataagent_preview": {
             "allOf": [
@@ -7209,14 +7209,14 @@
             "custom": "#/components/schemas/OpenAI.CustomToolParam",
             "web_search_preview": "#/components/schemas/OpenAI.WebSearchPreviewTool",
             "apply_patch": "#/components/schemas/OpenAI.ApplyPatchToolParam",
-            "bing_grounding": "#/components/schemas/BingGroundingAgentTool",
-            "fabric_dataagent_preview": "#/components/schemas/MicrosoftFabricAgentTool",
-            "sharepoint_grounding_preview": "#/components/schemas/SharepointAgentTool",
-            "azure_ai_search": "#/components/schemas/AzureAISearchAgentTool",
-            "openapi": "#/components/schemas/OpenApiAgentTool",
-            "bing_custom_search_preview": "#/components/schemas/BingCustomSearchAgentTool",
-            "browser_automation_preview": "#/components/schemas/BrowserAutomationAgentTool",
-            "azure_function": "#/components/schemas/AzureFunctionAgentTool",
+            "bing_grounding": "#/components/schemas/BingGroundingTool",
+            "fabric_dataagent_preview": "#/components/schemas/MicrosoftFabricPreviewTool",
+            "sharepoint_grounding_preview": "#/components/schemas/SharepointPreviewTool",
+            "azure_ai_search": "#/components/schemas/AzureAISearchTool",
+            "openapi": "#/components/schemas/OpenApiTool",
+            "bing_custom_search_preview": "#/components/schemas/BingCustomSearchPreviewTool",
+            "browser_automation_preview": "#/components/schemas/BrowserAutomationPreviewTool",
+            "azure_function": "#/components/schemas/AzureFunctionTool",
             "capture_structured_outputs": "#/components/schemas/CaptureStructuredOutputsTool"
           }
         },
@@ -7399,36 +7399,6 @@
       "OpenAI.numeric": {
         "type": "number",
         "format": "double"
-      },
-      "OpenApiAgentTool": {
-        "type": "object",
-        "required": [
-          "type",
-          "openapi"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "openapi"
-            ],
-            "description": "The object type, which is always 'openapi'."
-          },
-          "openapi": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenApiFunctionDefinition"
-              }
-            ],
-            "description": "The openapi function definition."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Tool"
-          }
-        ],
-        "description": "The input definition information for an OpenAPI tool as used to configure an agent."
       },
       "OpenApiAnonymousAuthDetails": {
         "type": "object",
@@ -7640,6 +7610,36 @@
         },
         "description": "Security scheme for OpenApi managed_identity authentication"
       },
+      "OpenApiTool": {
+        "type": "object",
+        "required": [
+          "type",
+          "openapi"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "openapi"
+            ],
+            "description": "The object type, which is always 'openapi'."
+          },
+          "openapi": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OpenApiFunctionDefinition"
+              }
+            ],
+            "description": "The openapi function definition."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.Tool"
+          }
+        ],
+        "description": "The input definition information for an OpenAPI tool as used to configure an agent."
+      },
       "PagedConnection": {
         "type": "object",
         "required": [
@@ -7832,7 +7832,21 @@
         },
         "description": "SAS Credential definition"
       },
-      "SharepointAgentTool": {
+      "SharepointGroundingToolParameters": {
+        "type": "object",
+        "properties": {
+          "project_connections": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ToolProjectConnection"
+            },
+            "maxItems": 1,
+            "description": "The project connections attached to this tool. There can be a maximum of 1 connection\nresource attached to the tool."
+          }
+        },
+        "description": "The sharepoint grounding tool parameters."
+      },
+      "SharepointPreviewTool": {
         "type": "object",
         "required": [
           "type",
@@ -7844,7 +7858,7 @@
             "enum": [
               "sharepoint_grounding_preview"
             ],
-            "description": "The object type, which is always 'sharepoint_grounding'."
+            "description": "The object type, which is always 'sharepoint_grounding_preview'."
           },
           "sharepoint_grounding_preview": {
             "allOf": [
@@ -7861,20 +7875,6 @@
           }
         ],
         "description": "The input definition information for a sharepoint tool as used to configure an agent."
-      },
-      "SharepointGroundingToolParameters": {
-        "type": "object",
-        "properties": {
-          "project_connections": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ToolProjectConnection"
-            },
-            "maxItems": 1,
-            "description": "The project connections attached to this tool. There can be a maximum of 1 connection\nresource attached to the tool."
-          }
-        },
-        "description": "The sharepoint grounding tool parameters."
       },
       "Sku": {
         "type": "object",

--- a/specification/ai/data-plane/Azure.AI.Projects/preview/2025-11-15-preview/azure-ai-projects.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/preview/2025-11-15-preview/azure-ai-projects.json
@@ -7034,7 +7034,7 @@
     }
   },
   "definitions": {
-    "A2ATool": {
+    "A2APreviewTool": {
       "type": "object",
       "description": "An agent implementing the A2A protocol.",
       "properties": {
@@ -8061,25 +8061,6 @@
       ],
       "x-ms-discriminator-value": "azure_ai_model"
     },
-    "AzureAISearchAgentTool": {
-      "type": "object",
-      "description": "The input definition information for an Azure AI search tool as used to configure an agent.",
-      "properties": {
-        "azure_ai_search": {
-          "$ref": "#/definitions/AzureAISearchToolResource",
-          "description": "The azure ai search index resource."
-        }
-      },
-      "required": [
-        "azure_ai_search"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/OpenAI.Tool"
-        }
-      ],
-      "x-ms-discriminator-value": "azure_ai_search"
-    },
     "AzureAISearchIndex": {
       "type": "object",
       "description": "Azure AI Search Index Definition",
@@ -8159,6 +8140,25 @@
         ]
       }
     },
+    "AzureAISearchTool": {
+      "type": "object",
+      "description": "The input definition information for an Azure AI search tool as used to configure an agent.",
+      "properties": {
+        "azure_ai_search": {
+          "$ref": "#/definitions/AzureAISearchToolResource",
+          "description": "The azure ai search index resource."
+        }
+      },
+      "required": [
+        "azure_ai_search"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/OpenAI.Tool"
+        }
+      ],
+      "x-ms-discriminator-value": "azure_ai_search"
+    },
     "AzureAISearchToolResource": {
       "type": "object",
       "description": "A set of index resources used by the `azure_ai_search` tool.",
@@ -8175,25 +8175,6 @@
       "required": [
         "indexes"
       ]
-    },
-    "AzureFunctionAgentTool": {
-      "type": "object",
-      "description": "The input definition information for an Azure Function Tool, as used to configure an Agent.",
-      "properties": {
-        "azure_function": {
-          "$ref": "#/definitions/AzureFunctionDefinition",
-          "description": "The Azure Function Tool definition."
-        }
-      },
-      "required": [
-        "azure_function"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/OpenAI.Tool"
-        }
-      ],
-      "x-ms-discriminator-value": "azure_function"
     },
     "AzureFunctionBinding": {
       "type": "object",
@@ -8277,6 +8258,25 @@
         "queue_name"
       ]
     },
+    "AzureFunctionTool": {
+      "type": "object",
+      "description": "The input definition information for an Azure Function Tool, as used to configure an Agent.",
+      "properties": {
+        "azure_function": {
+          "$ref": "#/definitions/AzureFunctionDefinition",
+          "description": "The Azure Function Tool definition."
+        }
+      },
+      "required": [
+        "azure_function"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/OpenAI.Tool"
+        }
+      ],
+      "x-ms-discriminator-value": "azure_function"
+    },
     "AzureOpenAIModelConfiguration": {
       "type": "object",
       "description": "Azure OpenAI model configuration. The API version would be selected by the service for querying the model.",
@@ -8310,25 +8310,6 @@
       "required": [
         "type"
       ]
-    },
-    "BingCustomSearchAgentTool": {
-      "type": "object",
-      "description": "The input definition information for a Bing custom search tool as used to configure an agent.",
-      "properties": {
-        "bing_custom_search_preview": {
-          "$ref": "#/definitions/BingCustomSearchToolParameters",
-          "description": "The bing custom search tool parameters."
-        }
-      },
-      "required": [
-        "bing_custom_search_preview"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/OpenAI.Tool"
-        }
-      ],
-      "x-ms-discriminator-value": "bing_custom_search_preview"
     },
     "BingCustomSearchConfiguration": {
       "type": "object",
@@ -8365,6 +8346,25 @@
         "instance_name"
       ]
     },
+    "BingCustomSearchPreviewTool": {
+      "type": "object",
+      "description": "The input definition information for a Bing custom search tool as used to configure an agent.",
+      "properties": {
+        "bing_custom_search_preview": {
+          "$ref": "#/definitions/BingCustomSearchToolParameters",
+          "description": "The bing custom search tool parameters."
+        }
+      },
+      "required": [
+        "bing_custom_search_preview"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/OpenAI.Tool"
+        }
+      ],
+      "x-ms-discriminator-value": "bing_custom_search_preview"
+    },
     "BingCustomSearchToolParameters": {
       "type": "object",
       "description": "The bing custom search tool parameters.",
@@ -8381,25 +8381,6 @@
       "required": [
         "search_configurations"
       ]
-    },
-    "BingGroundingAgentTool": {
-      "type": "object",
-      "description": "The input definition information for a bing grounding search tool as used to configure an agent.",
-      "properties": {
-        "bing_grounding": {
-          "$ref": "#/definitions/BingGroundingSearchToolParameters",
-          "description": "The bing grounding search tool parameters."
-        }
-      },
-      "required": [
-        "bing_grounding"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/OpenAI.Tool"
-        }
-      ],
-      "x-ms-discriminator-value": "bing_grounding"
     },
     "BingGroundingSearchConfiguration": {
       "type": "object",
@@ -8448,6 +8429,25 @@
         "search_configurations"
       ]
     },
+    "BingGroundingTool": {
+      "type": "object",
+      "description": "The input definition information for a bing grounding search tool as used to configure an agent.",
+      "properties": {
+        "bing_grounding": {
+          "$ref": "#/definitions/BingGroundingSearchToolParameters",
+          "description": "The bing grounding search tool parameters."
+        }
+      },
+      "required": [
+        "bing_grounding"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/OpenAI.Tool"
+        }
+      ],
+      "x-ms-discriminator-value": "bing_grounding"
+    },
     "BlobReference": {
       "type": "object",
       "description": "Blob reference details.",
@@ -8471,7 +8471,7 @@
         "credential"
       ]
     },
-    "BrowserAutomationAgentTool": {
+    "BrowserAutomationPreviewTool": {
       "type": "object",
       "description": "The input definition information for a Browser Automation Tool, as used to configure an Agent.",
       "properties": {
@@ -12097,7 +12097,7 @@
         ]
       }
     },
-    "MicrosoftFabricAgentTool": {
+    "MicrosoftFabricPreviewTool": {
       "type": "object",
       "description": "The input definition information for a Microsoft Fabric tool as used to configure an agent.",
       "properties": {
@@ -20458,25 +20458,6 @@
       "type": "number",
       "format": "double"
     },
-    "OpenApiAgentTool": {
-      "type": "object",
-      "description": "The input definition information for an OpenAPI tool as used to configure an agent.",
-      "properties": {
-        "openapi": {
-          "$ref": "#/definitions/OpenApiFunctionDefinition",
-          "description": "The openapi function definition."
-        }
-      },
-      "required": [
-        "openapi"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/OpenAI.Tool"
-        }
-      ],
-      "x-ms-discriminator-value": "openapi"
-    },
     "OpenApiAnonymousAuthDetails": {
       "type": "object",
       "description": "Security details for OpenApi anonymous authentication",
@@ -20649,6 +20630,25 @@
       "required": [
         "project_connection_id"
       ]
+    },
+    "OpenApiTool": {
+      "type": "object",
+      "description": "The input definition information for an OpenAPI tool as used to configure an agent.",
+      "properties": {
+        "openapi": {
+          "$ref": "#/definitions/OpenApiFunctionDefinition",
+          "description": "The openapi function definition."
+        }
+      },
+      "required": [
+        "openapi"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/OpenAI.Tool"
+        }
+      ],
+      "x-ms-discriminator-value": "openapi"
     },
     "PagedConnection": {
       "type": "object",
@@ -21549,7 +21549,21 @@
         ]
       }
     },
-    "SharepointAgentTool": {
+    "SharepointGroundingToolParameters": {
+      "type": "object",
+      "description": "The sharepoint grounding tool parameters.",
+      "properties": {
+        "project_connections": {
+          "type": "array",
+          "description": "The project connections attached to this tool. There can be a maximum of 1 connection\nresource attached to the tool.",
+          "maxItems": 1,
+          "items": {
+            "$ref": "#/definitions/ToolProjectConnection"
+          }
+        }
+      }
+    },
+    "SharepointPreviewTool": {
       "type": "object",
       "description": "The input definition information for a sharepoint tool as used to configure an agent.",
       "properties": {
@@ -21567,20 +21581,6 @@
         }
       ],
       "x-ms-discriminator-value": "sharepoint_grounding_preview"
-    },
-    "SharepointGroundingToolParameters": {
-      "type": "object",
-      "description": "The sharepoint grounding tool parameters.",
-      "properties": {
-        "project_connections": {
-          "type": "array",
-          "description": "The project connections attached to this tool. There can be a maximum of 1 connection\nresource attached to the tool.",
-          "maxItems": 1,
-          "items": {
-            "$ref": "#/definitions/ToolProjectConnection"
-          }
-        }
-      }
     },
     "Sku": {
       "type": "object",

--- a/specification/ai/data-plane/Azure.AI.Projects/readme.md
+++ b/specification/ai/data-plane/Azure.AI.Projects/readme.md
@@ -36,6 +36,13 @@ input-file:
   - preview/2025-05-15-preview/azure-ai-projects.json
 ```
 
+### Release v2025-11-15-preview
+These settings apply only when `--tag=2025-11-15-preview` is specified on the command line.
+``` yaml $(tag) == '2025-11-15-preview'
+input-file:
+  - preview/2025-11-15-preview/azure-ai-projects.json
+```
+
 # Suppressions
 ``` yaml
 suppressions:


### PR DESCRIPTION
To align with OpenAI naming conventions, use "Tool" suffix for stable Azure tools:
* `AzureAISearchAgentTool` renamed to  `AzureAISearchTool`
* `OpenApiAgentTool` ==> `OpenApiTool`
* `AzureFunctionAgentTool` ==>  `AzureFunctionTool`

And use "PreviewTool" as suffix for Azure tools in preview:
* `SharepointAgentTool` ==> `SharepointPreviewTool`
* `BingCustomSearchAgentTool` ==> `BingCustomSearchPreviewTool`
* `BrowserAutomationAgentTool` ==> `BrowserAutomationPreviewTool`
* `A2ATool` ==> `A2APreviewTool`

Still waiting on a call regarding renaming `MemorySearchTool`.

Also fix some of the doc string for 'type', as it seems like these were not updated when the "_preview" suffix was added to the type string.

This is not a breaking change in REST APIs. This will be a breaking change in emitted beta SDKs, and we will update samples and docs accordingly. 
