### PR TITLE
Fix red teams

### DIFF
--- a/specification/ai/Foundry/openai-evaluations/models.tsp
+++ b/specification/ai/Foundry/openai-evaluations/models.tsp
@@ -161,15 +161,26 @@ model CreateEvalRequest is OpenAI.CreateEvalRequest {
   properties?: Record<string>;
 }
 
+/** The types of parameters for red team item generation. */
+enum ItemGenerationParamsType {
+  /** The ResponseRetrieval item generation parameters.  */
+  responseRetrieval: "response_retrieval",
+
+  /** Parameters for red team item generation. */
+  redTeam: "red_team",
+
+  /** Parameters for red team seed prompts. */
+  redTeamSeedPrompts: "red_team_seed_prompts",
+
+  /** Parameters for red team taxonomy item generation. */
+  redTeamTaxonomy: "red_team_taxonomy"
+}
+
 /** Represents the parameters for red team item generation. */
 @added(Versions.v2025_11_15_preview)
 @removed(Versions.v1)
 @discriminator("type")
 model RedTeamItemGenerationParams extends ItemGenerationParams {
-  /** The type of item generation parameters. */
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
-  type: "red_team" | "red_team_seed_prompts" | "red_team_taxonomy";
-
   /** The collection of attack strategies to be used. */
   attack_strategies: AttackStrategy[];
 

--- a/specification/ai/Foundry/red-teams/models.tsp
+++ b/specification/ai/Foundry/red-teams/models.tsp
@@ -181,7 +181,7 @@ model RedTeam {
   displayName?: string;
 
   @doc("Number of simulation rounds.")
-  numTurns?: int32;
+  numTurns?: string;
 
   @doc("List of attack strategies or nested lists of attack strategies.")
   attackStrategies?: AttackStrategy[];

--- a/specification/ai/data-plane/Azure.AI.Projects/openapi3/2025-05-15-preview/azure-ai-projects-openapi3.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/openapi3/2025-05-15-preview/azure-ai-projects-openapi3.json
@@ -3135,8 +3135,7 @@
             "description": "Name of the red-team run."
           },
           "numTurns": {
-            "type": "integer",
-            "format": "int32",
+            "type": "string",
             "description": "Number of simulation rounds."
           },
           "attackStrategies": {

--- a/specification/ai/data-plane/Azure.AI.Projects/openapi3/2025-11-15-preview/azure-ai-projects-openapi3.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/openapi3/2025-11-15-preview/azure-ai-projects-openapi3.json
@@ -12812,9 +12812,8 @@
         "discriminator": {
           "propertyName": "type",
           "mapping": {
-            "red_team": "#/components/schemas/RedTeamItemGenerationParams",
-            "red_team_seed_prompts": "#/components/schemas/RedTeamItemGenerationParams",
-            "red_team_taxonomy": "#/components/schemas/RedTeamItemGenerationParams"
+            "red_team_seed_prompts": "#/components/schemas/RedTeamSeedPromptsItemGenerationParams",
+            "red_team_taxonomy": "#/components/schemas/RedTeamTaxonomyItemGenerationParams"
           }
         },
         "description": "Represents the set of parameters used to control item generation operations."
@@ -23916,8 +23915,7 @@
             "description": "Name of the red-team run."
           },
           "numTurns": {
-            "type": "integer",
-            "format": "int32",
+            "type": "string",
             "description": "Number of simulation rounds."
           },
           "attackStrategies": {
@@ -24014,20 +24012,11 @@
       "RedTeamItemGenerationParams": {
         "type": "object",
         "required": [
-          "type",
           "attack_strategies",
-          "num_turns"
+          "num_turns",
+          "type"
         ],
         "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "red_team",
-              "red_team_seed_prompts",
-              "red_team_taxonomy"
-            ],
-            "description": "The type of item generation parameters."
-          },
           "attack_strategies": {
             "type": "array",
             "items": {
@@ -24040,6 +24029,10 @@
             "format": "int32",
             "description": "The number of turns allowed in the game.",
             "default": 20
+          },
+          "type": {
+            "type": "string",
+            "description": "Discriminator property for RedTeamItemGenerationParams."
           }
         },
         "discriminator": {

--- a/specification/ai/data-plane/Azure.AI.Projects/preview/2025-05-15-preview/azure-ai-projects.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/preview/2025-05-15-preview/azure-ai-projects.json
@@ -3056,8 +3056,7 @@
           "description": "Name of the red-team run."
         },
         "numTurns": {
-          "type": "integer",
-          "format": "int32",
+          "type": "string",
           "description": "Number of simulation rounds."
         },
         "attackStrategies": {

--- a/specification/ai/data-plane/Azure.AI.Projects/preview/2025-11-15-preview/azure-ai-projects.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/preview/2025-11-15-preview/azure-ai-projects.json
@@ -19340,8 +19340,7 @@
           "description": "Name of the red-team run."
         },
         "numTurns": {
-          "type": "integer",
-          "format": "int32",
+          "type": "string",
           "description": "Number of simulation rounds."
         },
         "attackStrategies": {


### PR DESCRIPTION
- `numTurns` is returned from the service as a string so we are changing data contract accordingly.
- the type RedTeamItemGenerationParams was defined a union of several literals, but it is not ssupported by the C# emitter, so the ItemGenerationParams type was converted to enum.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
