### PR TITLE
[TSV-C#] Remove existed  CSharp specific subrules

### DIFF
--- a/eng/tools/typespec-validation/test/sdk-tspconfig-validation.test.ts
+++ b/eng/tools/typespec-validation/test/sdk-tspconfig-validation.test.ts
@@ -10,11 +10,6 @@ import { stringify } from "yaml";
 import {
   SdkTspConfigValidationRule,
   TspConfigCommonAzServiceDirMatchPatternSubRule,
-  TspConfigCsharpAzClearOutputFolderTrueSubRule,
-  TspConfigCsharpAzEmitterOutputDirSubRule,
-  TspConfigCsharpAzNamespaceSubRule,
-  TspConfigCsharpMgmtEmitterOutputDirSubRule,
-  TspConfigCsharpMgmtNamespaceSubRule,
   TspConfigGoContainingModuleMatchPatternSubRule,
   TspConfigGoDpEmitterOutputDirMatchPatternSubRule,
   TspConfigGoDpServiceDirMatchPatternSubRule,
@@ -75,11 +70,6 @@ export function createEmitterOptionExample(
   }
   const content = stringify(obj);
   return content;
-}
-
-// TODO: remove when @azure-tools/typespec-csharp is ready for validating tspconfig
-function shouldBeTrueOnFailSubRuleValidation(emitterName: string) {
-  return emitterName === "@azure-tools/typespec-csharp" ? true : false;
 }
 
 function createParameterTestCases(
@@ -155,7 +145,7 @@ function createEmitterOptionTestCases(
       },
       ...Object.entries(additionalOptions).map(([key, value]) => ({ key, value })),
     ),
-    success: shouldBeTrueOnFailSubRuleValidation(emitterName),
+    success: false,
     subRules,
   });
 
@@ -166,7 +156,7 @@ function createEmitterOptionTestCases(
       emitterName,
       ...Object.entries(additionalOptions).map(([key, value]) => ({ key, value })),
     ),
-    success: allowUndefined ? true : shouldBeTrueOnFailSubRuleValidation(emitterName),
+    success: allowUndefined ? true : false,
     subRules,
   });
 
@@ -182,7 +172,7 @@ function createEmitterOptionTestCases(
         },
         ...Object.entries(additionalOptions).map(([key, value]) => ({ key, value })),
       ),
-      success: shouldBeTrueOnFailSubRuleValidation(emitterName),
+      success: false,
       subRules,
     });
   }
@@ -581,51 +571,6 @@ const pythonDpEmitterOutputTestCases = createEmitterOptionTestCases(
   [new TspConfigPythonDpEmitterOutputDirSubRule()],
 );
 
-const csharpAzEmitterOutputTestCases = createEmitterOptionTestCases(
-  "@azure-tools/typespec-csharp",
-  "",
-  "emitter-output-dir",
-  "{output-dir}/{service-dir}/Azure.AAA",
-  "{output-dir}/{service-dir}/AAA",
-  [new TspConfigCsharpAzEmitterOutputDirSubRule()],
-);
-
-const csharpAzNamespaceTestCases = createEmitterOptionTestCases(
-  "@azure-tools/typespec-csharp",
-  "",
-  "namespace",
-  "Azure.AAA",
-  "AAA",
-  [new TspConfigCsharpAzNamespaceSubRule()],
-);
-
-const csharpAzClearOutputFolderTestCases = createEmitterOptionTestCases(
-  "@azure-tools/typespec-csharp",
-  "",
-  "clear-output-folder",
-  true,
-  false,
-  [new TspConfigCsharpAzClearOutputFolderTrueSubRule()],
-);
-
-const csharpMgmtEmitterOutputDirTestCases = createEmitterOptionTestCases(
-  "@azure-tools/typespec-csharp",
-  managementTspconfigFolder,
-  "emitter-output-dir",
-  "{output-dir}/{service-dir}/Azure.ResourceManager.AAA",
-  "{output-dir}/{service-dir}/Azure.Management.AAA",
-  [new TspConfigCsharpMgmtEmitterOutputDirSubRule()],
-);
-
-const csharpMgmtNamespaceTestCases = createEmitterOptionTestCases(
-  "@azure-tools/typespec-csharp",
-  managementTspconfigFolder,
-  "namespace",
-  "Azure.ResourceManager.AAA",
-  "Azure.Management.AAA",
-  [new TspConfigCsharpMgmtNamespaceSubRule()],
-);
-
 // Test cases for emitter-output-dir with namespace variable resolution
 const emitterOutputDirWithNamespaceVariableTestCases: Case[] = [
   {
@@ -687,7 +632,7 @@ parameters:
   service-dir: "sdk/test"
 `,
     success: true,
-    subRules: [new TspConfigCsharpAzNamespaceSubRule()],
+    subRules: [new TspConfigJavaMgmtNamespaceFormatSubRule()],
   },
   {
     description: "Optional rule: multiple rules should be skipped when emitter is not configured",
@@ -698,8 +643,8 @@ parameters:
 `,
     success: true,
     subRules: [
-      new TspConfigCsharpAzNamespaceSubRule(),
-      new TspConfigCsharpAzClearOutputFolderTrueSubRule(),
+      new TspConfigJavaMgmtNamespaceFormatSubRule(),
+      new TspConfigTsRlcDpPackageNameMatchPatternSubRule(),
     ],
   },
 ];
@@ -813,12 +758,6 @@ describe("tspconfig", function () {
   ];
 
   const optionalTestCases = [
-    // csharp
-    ...csharpAzEmitterOutputTestCases,
-    ...csharpAzNamespaceTestCases,
-    ...csharpAzClearOutputFolderTestCases,
-    ...csharpMgmtEmitterOutputDirTestCases,
-    ...csharpMgmtNamespaceTestCases,
     // Test cases for optional rules when emitter is not configured
     ...optionalRulesWithoutEmitterConfigTestCases,
   ];


### PR DESCRIPTION
fixes https://github.com/Azure/azure-sdk-tools/issues/12435
Remove CSharp specific subrules and related test cases from Tspconfig validation
because of we are deprecating the old emitter, will add tsv rules for new csharp emitters.
[new tsv rules]https://github.com/Azure/azure-rest-api-specs/pull/38924


