### PR TITLE
Fix the code generation problem.

### DIFF
--- a/specification/ai/Foundry/openai-evaluations/models.tsp
+++ b/specification/ai/Foundry/openai-evaluations/models.tsp
@@ -161,15 +161,26 @@ model CreateEvalRequest is OpenAI.CreateEvalRequest {
   properties?: Record<string>;
 }
 
+/** The types of parameters for red team item generation. */
+enum ItemGenerationParamsType {
+  /** The ResponseRetrieval item generation parameters.  */
+  responseRetrieval: "response_retrieval",
+  
+  /** Parameters for red team item generation. */
+  redTeam: "red_team",
+  
+  /** Parameters for red team seed prompts. */
+  redTeamSeedPrompts: "red_team_seed_prompts",
+  
+  /** Parameters for red team taxonomy item generation. */
+  redTeamTaxonomy: "red_team_taxonomy"
+}
+
 /** Represents the parameters for red team item generation. */
 @added(Versions.v2025_11_15_preview)
 @removed(Versions.v1)
 @discriminator("type")
 model RedTeamItemGenerationParams extends ItemGenerationParams {
-  /** The type of item generation parameters. */
-  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
-  type: "red_team" | "red_team_seed_prompts" | "red_team_taxonomy";
-
   /** The collection of attack strategies to be used. */
   attack_strategies: AttackStrategy[];
 
@@ -183,7 +194,7 @@ model RedTeamItemGenerationParams extends ItemGenerationParams {
 model RedTeamSeedPromptsItemGenerationParams
   extends RedTeamItemGenerationParams {
   /** The type of item generation parameters, always `red_team_seed_prompts`. */
-  type: "red_team_seed_prompts";
+  type: ItemGenerationParamsType.redTeamSeedPrompts;
 
   /** The source of JSONL content to be processed. */
   source: OpenAI.EvalJsonlFileContentSource;
@@ -194,7 +205,7 @@ model RedTeamSeedPromptsItemGenerationParams
 @removed(Versions.v1)
 model RedTeamTaxonomyItemGenerationParams extends RedTeamItemGenerationParams {
   /** The type of item generation parameters, always `red_team_taxonomy`. */
-  type: "red_team_taxonomy";
+  type: ItemGenerationParamsType.redTeamTaxonomy;
 
   /** The source from which JSONL content is read. */
   source: OpenAI.EvalJsonlFileContentSource;
@@ -206,7 +217,7 @@ model RedTeamTaxonomyItemGenerationParams extends RedTeamItemGenerationParams {
 @removed(Versions.v1)
 model ItemGenerationParams {
   /** The type of item generation parameters to use. */
-  type: string;
+  type: ItemGenerationParamsType;
 }
 
 /** Represents the parameters for continuous evaluation item generation. */
@@ -214,7 +225,7 @@ model ItemGenerationParams {
 @removed(Versions.v1)
 model ContinuousEvalItemGenerationParams extends ItemGenerationParams {
   /** The type of item generation parameters, always `ResponseRetrieval`. */
-  type: "response_retrieval";
+  type: ItemGenerationParamsType.responseRetrieval;
 
   /** The maximum number of turns of chat history to evaluate. */
   max_num_turns: int32;

--- a/specification/ai/Foundry/openai-evaluations/models.tsp
+++ b/specification/ai/Foundry/openai-evaluations/models.tsp
@@ -162,39 +162,31 @@ model CreateEvalRequest is OpenAI.CreateEvalRequest {
 }
 
 /** The types of parameters for red team item generation. */
-enum ItemGenerationParamsType {
-  /** The ResponseRetrieval item generation parameters.  */
+union ItemGenerationParamsType {
+  string,
+
+  /** The ResponseRetrieval item generation parameters. */
   responseRetrieval: "response_retrieval",
-  
-  /** Parameters for red team item generation. */
-  redTeam: "red_team",
-  
+
   /** Parameters for red team seed prompts. */
   redTeamSeedPrompts: "red_team_seed_prompts",
-  
+
   /** Parameters for red team taxonomy item generation. */
-  redTeamTaxonomy: "red_team_taxonomy"
-}
-
-/** Represents the parameters for red team item generation. */
-@added(Versions.v2025_11_15_preview)
-@removed(Versions.v1)
-@discriminator("type")
-model RedTeamItemGenerationParams extends ItemGenerationParams {
-  /** The collection of attack strategies to be used. */
-  attack_strategies: AttackStrategy[];
-
-  /** The number of turns allowed in the game. */
-  num_turns: int32 = 20;
+  redTeamTaxonomy: "red_team_taxonomy",
 }
 
 /** Represents the parameters for red team seed prompts item generation. */
 @added(Versions.v2025_11_15_preview)
 @removed(Versions.v1)
-model RedTeamSeedPromptsItemGenerationParams
-  extends RedTeamItemGenerationParams {
+model RedTeamSeedPromptsItemGenerationParams extends ItemGenerationParams {
   /** The type of item generation parameters, always `red_team_seed_prompts`. */
   type: ItemGenerationParamsType.redTeamSeedPrompts;
+
+  /** The collection of attack strategies to be used. */
+  attack_strategies: AttackStrategy[];
+
+  /** The number of turns allowed in the game. */
+  num_turns: int32 = 20;
 
   /** The source of JSONL content to be processed. */
   source: OpenAI.EvalJsonlFileContentSource;
@@ -203,9 +195,15 @@ model RedTeamSeedPromptsItemGenerationParams
 /** Represents the parameters for red team taxonomy item generation. */
 @added(Versions.v2025_11_15_preview)
 @removed(Versions.v1)
-model RedTeamTaxonomyItemGenerationParams extends RedTeamItemGenerationParams {
+model RedTeamTaxonomyItemGenerationParams extends ItemGenerationParams {
   /** The type of item generation parameters, always `red_team_taxonomy`. */
   type: ItemGenerationParamsType.redTeamTaxonomy;
+
+  /** The collection of attack strategies to be used. */
+  attack_strategies: AttackStrategy[];
+
+  /** The number of turns allowed in the game. */
+  num_turns: int32 = 20;
 
   /** The source from which JSONL content is read. */
   source: OpenAI.EvalJsonlFileContentSource;
@@ -385,7 +383,7 @@ model RedTeamEvalRunDataSource extends EvalRunDataSource {
   type: "azure_ai_red_team";
 
   /** The parameters for item generation. */
-  item_generation_params: RedTeamItemGenerationParams;
+  item_generation_params: ItemGenerationParams;
 
   /** The target configuration for the evaluation. */
   target: Target;

--- a/specification/ai/Foundry/tools/models.tsp
+++ b/specification/ai/Foundry/tools/models.tsp
@@ -57,13 +57,13 @@ union _AgentIncludable {
 #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
 @@copyProperties(OpenAI.WebSearchPreviewTool,
   {
- /**
-   * The project connections attached to this tool. There can be a maximum of 1 connection
-   * resource attached to the tool.
-   */
+    /**
+     * The project connections attached to this tool. There can be a maximum of 1 connection
+     * resource attached to the tool.
+     */
     @added(Versions.v2025_11_15_preview)
     @removed(Versions.v1)
-    custom_search_configuration?: WebSearchConfiguration;
+    custom_search_configuration?: WebSearchConfiguration,
   }
 );
 

--- a/specification/ai/data-plane/Azure.AI.Projects/openapi3/2025-11-15-preview/azure-ai-projects-openapi3.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/openapi3/2025-11-15-preview/azure-ai-projects-openapi3.json
@@ -12805,19 +12805,32 @@
         ],
         "properties": {
           "type": {
-            "type": "string",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ItemGenerationParamsType"
+              }
+            ],
             "description": "The type of item generation parameters to use."
           }
         },
         "discriminator": {
           "propertyName": "type",
           "mapping": {
-            "red_team": "#/components/schemas/RedTeamItemGenerationParams",
-            "red_team_seed_prompts": "#/components/schemas/RedTeamItemGenerationParams",
-            "red_team_taxonomy": "#/components/schemas/RedTeamItemGenerationParams"
+            "red_team_seed_prompts": "#/components/schemas/RedTeamSeedPromptsItemGenerationParams",
+            "red_team_taxonomy": "#/components/schemas/RedTeamTaxonomyItemGenerationParams"
           }
         },
         "description": "Represents the set of parameters used to control item generation operations."
+      },
+      "ItemGenerationParamsType": {
+        "type": "string",
+        "enum": [
+          "response_retrieval",
+          "red_team",
+          "red_team_seed_prompts",
+          "red_team_taxonomy"
+        ],
+        "description": "The types of parameters for red team item generation."
       },
       "ManagedAzureAISearchIndex": {
         "type": "object",
@@ -24014,20 +24027,11 @@
       "RedTeamItemGenerationParams": {
         "type": "object",
         "required": [
-          "type",
           "attack_strategies",
-          "num_turns"
+          "num_turns",
+          "type"
         ],
         "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "red_team",
-              "red_team_seed_prompts",
-              "red_team_taxonomy"
-            ],
-            "description": "The type of item generation parameters."
-          },
           "attack_strategies": {
             "type": "array",
             "items": {
@@ -24040,6 +24044,10 @@
             "format": "int32",
             "description": "The number of turns allowed in the game.",
             "default": 20
+          },
+          "type": {
+            "type": "string",
+            "description": "Discriminator property for RedTeamItemGenerationParams."
           }
         },
         "discriminator": {

--- a/specification/ai/data-plane/Azure.AI.Projects/openapi3/2025-11-15-preview/azure-ai-projects-openapi3.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/openapi3/2025-11-15-preview/azure-ai-projects-openapi3.json
@@ -12823,12 +12823,18 @@
         "description": "Represents the set of parameters used to control item generation operations."
       },
       "ItemGenerationParamsType": {
-        "type": "string",
-        "enum": [
-          "response_retrieval",
-          "red_team",
-          "red_team_seed_prompts",
-          "red_team_taxonomy"
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "response_retrieval",
+              "red_team_seed_prompts",
+              "red_team_taxonomy"
+            ]
+          }
         ],
         "description": "The types of parameters for red team item generation."
       },
@@ -24004,7 +24010,7 @@
           "item_generation_params": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/RedTeamItemGenerationParams"
+                "$ref": "#/components/schemas/ItemGenerationParams"
               }
             ],
             "description": "The parameters for item generation."
@@ -24024,14 +24030,22 @@
           }
         ]
       },
-      "RedTeamItemGenerationParams": {
+      "RedTeamSeedPromptsItemGenerationParams": {
         "type": "object",
         "required": [
+          "type",
           "attack_strategies",
           "num_turns",
-          "type"
+          "source"
         ],
         "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "red_team_seed_prompts"
+            ],
+            "description": "The type of item generation parameters, always `red_team_seed_prompts`."
+          },
           "attack_strategies": {
             "type": "array",
             "items": {
@@ -24045,39 +24059,6 @@
             "description": "The number of turns allowed in the game.",
             "default": 20
           },
-          "type": {
-            "type": "string",
-            "description": "Discriminator property for RedTeamItemGenerationParams."
-          }
-        },
-        "discriminator": {
-          "propertyName": "type",
-          "mapping": {
-            "red_team_seed_prompts": "#/components/schemas/RedTeamSeedPromptsItemGenerationParams",
-            "red_team_taxonomy": "#/components/schemas/RedTeamTaxonomyItemGenerationParams"
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ItemGenerationParams"
-          }
-        ],
-        "description": "Represents the parameters for red team item generation."
-      },
-      "RedTeamSeedPromptsItemGenerationParams": {
-        "type": "object",
-        "required": [
-          "type",
-          "source"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "red_team_seed_prompts"
-            ],
-            "description": "The type of item generation parameters, always `red_team_seed_prompts`."
-          },
           "source": {
             "allOf": [
               {
@@ -24089,7 +24070,7 @@
         },
         "allOf": [
           {
-            "$ref": "#/components/schemas/RedTeamItemGenerationParams"
+            "$ref": "#/components/schemas/ItemGenerationParams"
           }
         ],
         "description": "Represents the parameters for red team seed prompts item generation."
@@ -24098,6 +24079,8 @@
         "type": "object",
         "required": [
           "type",
+          "attack_strategies",
+          "num_turns",
           "source"
         ],
         "properties": {
@@ -24107,6 +24090,19 @@
               "red_team_taxonomy"
             ],
             "description": "The type of item generation parameters, always `red_team_taxonomy`."
+          },
+          "attack_strategies": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AttackStrategy"
+            },
+            "description": "The collection of attack strategies to be used."
+          },
+          "num_turns": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The number of turns allowed in the game.",
+            "default": 20
           },
           "source": {
             "allOf": [
@@ -24119,7 +24115,7 @@
         },
         "allOf": [
           {
-            "$ref": "#/components/schemas/RedTeamItemGenerationParams"
+            "$ref": "#/components/schemas/ItemGenerationParams"
           }
         ],
         "description": "Represents the parameters for red team taxonomy item generation."


### PR DESCRIPTION
The limiting of a "string" by the union of literal in the subtype is not supported by the cope generators in this PR we flatten the types of generated items parameters to one union.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
