### PR TITLE
Update Appliance TypeSpec model to fix dotnet SDK generation

### DIFF
--- a/specification/resourceconnector/resource-manager/Microsoft.ResourceConnector/ResourceConnector/Appliance.tsp
+++ b/specification/resourceconnector/resource-manager/Microsoft.ResourceConnector/ResourceConnector/Appliance.tsp
@@ -28,7 +28,7 @@ model Appliance is Azure.ResourceManager.TrackedResource<ApplianceProperties> {
   identity?: Identity;
 }
 
-@armResourceOperations
+@armResourceOperations(#{ allowStaticRoutes: true })
 interface Appliances {
   /**
    * Gets the details of an Appliance with a specified resource group and name.
@@ -115,7 +115,8 @@ interface Appliances {
    */
   @get
   @summary("Gets an Appliance upgrade graph.")
-  getUpgradeGraph is ArmResourceRead<
+  @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ResourceConnector/appliances/{resourceName}/upgradeGraphs/{upgradeGraph}")
+  getUpgradeGraph is ApplianceOps.ActionSync<
     Appliance,
     Parameters = {
       /**
@@ -126,9 +127,34 @@ interface Appliances {
       @segment("upgradeGraphs")
       upgradeGraph: string;
     },
+    Request = void,
     Response = ArmResponse<UpgradeGraph>
   >;
 }
+
+// This is needed to define the route for getUpgradeGraph operation since it does not follow standard ARM patterns.
+alias ApplianceOps = Azure.ResourceManager.Legacy.RoutedOperations<
+  {
+    ...ApiVersionParameter;
+    ...SubscriptionIdParameter;
+    ...ResourceGroupParameter;
+  },
+  {
+    /**
+     * Appliances name.
+     */
+    @path
+    @segment("appliances")
+    @key
+    @minLength(1)
+    @maxLength(63)
+    @pattern("^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$")
+    resourceName: string;
+  },
+  ResourceRoute = #{
+    route: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ResourceConnector/appliances/{resourceName}",
+  }
+>;
 
 @@maxLength(Appliance.name, 63);
 @@minLength(Appliance.name, 1);


### PR DESCRIPTION
# SDK configuration pull request

## Purpose of this PR

- [x] Make changes to the SDK configuration only when there are no modifications to the API specification, eliminating the need for an ARM or Stewardship Board API review.

## Due diligence checklist

To merge this PR, you **must** go through the following checklist and confirm you understood
and followed the instructions by checking all the boxes:

- [x] I confirm this PR is modifying only SDK configurations, and not API related specifications.
- [x] I have reviewed and used the respective `tspconfig.yaml` templates:
  - [ARM tspconfig template](https://aka.ms/azsdk/tspconfig-sample-mpg)
  - [Data plane tspconfig template](https://aka.ms/azsdk/tspconfig-sample-dpg)

## Getting help

- First, carefully read through this PR description, from top to bottom. Fill out the `Purpose of this PR` and `Due diligence checklist`.
- If you don't have permissions to remove or add labels to the PR, request `write access` per [aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories](https://aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories)
- To understand what you must do next to merge this PR, see the `Next Steps to Merge` comment. It will appear within few minutes of submitting this PR and will continue to be up-to-date with current PR state.
- For guidance on fixing this PR CI check failures, see the hyperlinks provided in given failure and https://aka.ms/ci-fix.
- If the PR CI checks appear to be stuck in `queued` state, please add a comment with contents `/azp run`.
  This should result in a new comment denoting a `PR validation pipeline` has started and the checks should be updated after few minutes.
- If the help provided by the previous points is not enough, post to https://aka.ms/azsdk/support/specreview-channel and link to this PR.
