### PR TITLE
Add CRUD for memory items

### DIFF
--- a/specification/ai/Foundry/memory_stores/models.tsp
+++ b/specification/ai/Foundry/memory_stores/models.tsp
@@ -250,6 +250,9 @@ union MemoryItemKind {
 @doc("A single memory item stored in the memory store, containing content and metadata.")
 @discriminator("kind")
 model MemoryItem {
+  @doc("The object type, which is always 'memory_store.item'.")
+  object: "memory_store.item";
+
   @doc("The unique ID of the memory item.")
   memory_id: string;
 
@@ -403,5 +406,90 @@ alias MemoryStoreDeleteScopeRequest = {
   name: string;
 
   @doc("The namespace that logically groups and isolates memories to delete, such as a user ID.")
+  scope: string;
+};
+
+@doc("Response for deleting a memory item.")
+model DeleteMemoryItemResponse {
+  @doc("The object type. Always 'memory_store.item.deleted'.")
+  object: "memory_store.item.deleted";
+
+  @doc("The ID of the deleted memory item.")
+  memory_id: string;
+
+  @doc("Whether the memory item was successfully deleted.")
+  deleted: boolean;
+}
+
+alias CreateMemoryItemRequest = {
+  @doc("The name of the memory store.")
+  @path
+  name: string;
+
+  @doc("The namespace that logically groups and isolates memories, such as a user ID.")
+  scope: string;
+
+  @doc("The content of the memory.")
+  content: string;
+
+  @doc("The kind of the memory item.")
+  kind: MemoryItemKind;
+};
+
+alias GetMemoryItemRequest = {
+  @doc("The name of the memory store.")
+  @path
+  name: string;
+
+  @doc("The ID of the memory item.")
+  @path
+  memory_id: string;
+};
+
+alias UpdateMemoryItemRequest = {
+  @doc("The name of the memory store.")
+  @path
+  name: string;
+
+  @doc("The ID of the memory item.")
+  @path
+  memory_id: string;
+
+  @doc("The updated content of the memory.")
+  content: string;
+};
+
+alias DeleteMemoryItemRequest = {
+  @doc("The name of the memory store.")
+  @path
+  name: string;
+
+  @doc("The ID of the memory item.")
+  @path
+  memory_id: string;
+};
+
+alias MemoryItemsPageOrderQueryParameter = {
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Align with OpenAI.PageOrderQueryParameter."
+  @doc("Sort order by the updated_at timestamp of the memory items. 'asc' for ascending order and 'desc' for descending order.")
+  @query
+  order?: "asc" | "desc";
+};
+
+alias ListMemoryItemsRequest = {
+  @doc("The name of the memory store.")
+  @path
+  name: string;
+
+  ...OpenAI.PageLimitQueryParameter;
+  ...OpenAI.PageAfterQueryParameter;
+  ...OpenAI.PageBeforeQueryParameter;
+  ...MemoryItemsPageOrderQueryParameter;
+
+  @doc("Filter by memory item kind. If provided, only items of the specified kind will be returned.")
+  @query
+  kind?: MemoryItemKind;
+
+  @doc("The namespace that logically groups and isolates memories, such as a user ID.")
   scope: string;
 };

--- a/specification/ai/Foundry/memory_stores/routes.tsp
+++ b/specification/ai/Foundry/memory_stores/routes.tsp
@@ -65,6 +65,47 @@ interface MemoryStores {
   >;
 
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "not yet an Azure operation"
+  @doc("Create a memory item in a memory store.")
+  @operationId("createMemoryItem")
+  @post
+  @route("/memory_stores/{name}/items")
+  createMemoryItem is AgentOperation<CreateMemoryItemRequest, MemoryItem>;
+
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "not yet an Azure operation"
+  @doc("Retrieve a memory item from a memory store.")
+  @operationId("getMemoryItem")
+  @get
+  @route("/memory_stores/{name}/items/{memory_id}")
+  getMemoryItem is AgentOperation<GetMemoryItemRequest, MemoryItem>;
+
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "not yet an Azure operation"
+  @doc("Update the content of an existing memory item in a memory store.")
+  @operationId("updateMemoryItem")
+  @post
+  @route("/memory_stores/{name}/items/{memory_id}")
+  updateMemoryItem is AgentOperation<UpdateMemoryItemRequest, MemoryItem>;
+
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "not yet an Azure operation"
+  @doc("Delete an existing memory item from a memory store.")
+  @operationId("deleteMemoryItem")
+  @delete
+  @route("/memory_stores/{name}/items/{memory_id}")
+  deleteMemoryItem is AgentOperation<
+    DeleteMemoryItemRequest,
+    DeleteMemoryItemResponse
+  >;
+
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "not yet an Azure operation"
+  @doc("List memory items for a specific scope in a memory store.")
+  @operationId("listMemoryItems")
+  @post
+  @route("/memory_stores/{name}/items:list")
+  listMemoryItems is AgentOperation<
+    ListMemoryItemsRequest,
+    AgentsPagedResult<MemoryItem>
+  >;
+
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "not yet an Azure operation"
   @doc("Search for relevant memories from a memory store based on conversation context.")
   @operationId("searchMemories")
   @post

--- a/specification/ai/data-plane/Azure.AI.Projects/openapi3/2025-11-15-preview/azure-ai-projects-openapi3.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/openapi3/2025-11-15-preview/azure-ai-projects-openapi3.json
@@ -4211,6 +4211,447 @@
         ]
       }
     },
+    "/memory_stores/{name}/items": {
+      "post": {
+        "operationId": "createMemoryItem",
+        "description": "Create a memory item in a memory store.",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "explode": false
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the memory store.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MemoryItem"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Memory stores"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "scope": {
+                    "type": "string",
+                    "description": "The namespace that logically groups and isolates memories, such as a user ID."
+                  },
+                  "content": {
+                    "type": "string",
+                    "description": "The content of the memory."
+                  },
+                  "kind": {
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/MemoryItemKind"
+                      }
+                    ],
+                    "description": "The kind of the memory item."
+                  }
+                },
+                "required": [
+                  "scope",
+                  "content",
+                  "kind"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/memory_stores/{name}/items/{memory_id}": {
+      "get": {
+        "operationId": "getMemoryItem",
+        "description": "Retrieve a memory item from a memory store.",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "explode": false
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the memory store.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "memory_id",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the memory item.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MemoryItem"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Memory stores"
+        ]
+      },
+      "post": {
+        "operationId": "updateMemoryItem",
+        "description": "Update the content of an existing memory item in a memory store.",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "explode": false
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the memory store.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "memory_id",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the memory item.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MemoryItem"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Memory stores"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "content": {
+                    "type": "string",
+                    "description": "The updated content of the memory."
+                  }
+                },
+                "required": [
+                  "content"
+                ]
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteMemoryItem",
+        "description": "Delete an existing memory item from a memory store.",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "explode": false
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the memory store.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "memory_id",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the memory item.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteMemoryItemResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Memory stores"
+        ]
+      }
+    },
+    "/memory_stores/{name}/items:list": {
+      "post": {
+        "operationId": "listMemoryItems",
+        "description": "List memory items for a specific scope in a memory store.",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "explode": false
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the memory store.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the\ndefault is 20.",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 20
+            },
+            "explode": false
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "required": false,
+            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include after=obj_foo in order to fetch the next page of the list.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "before",
+            "in": "query",
+            "required": false,
+            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include before=obj_foo in order to fetch the previous page of the list.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "required": false,
+            "description": "Sort order by the updated_at timestamp of the memory items. 'asc' for ascending order and 'desc' for descending order.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            },
+            "explode": false
+          },
+          {
+            "name": "kind",
+            "in": "query",
+            "required": false,
+            "description": "Filter by memory item kind. If provided, only items of the specified kind will be returned.",
+            "schema": {
+              "$ref": "#/components/schemas/MemoryItemKind"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "has_more"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/MemoryItem"
+                      },
+                      "description": "The requested list of items."
+                    },
+                    "first_id": {
+                      "type": "string",
+                      "description": "The first ID represented in this list."
+                    },
+                    "last_id": {
+                      "type": "string",
+                      "description": "The last ID represented in this list."
+                    },
+                    "has_more": {
+                      "type": "boolean",
+                      "description": "A value indicating whether there are additional values available not captured in this list."
+                    }
+                  },
+                  "description": "The response data for a requested list of items."
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Memory stores"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "scope": {
+                    "type": "string",
+                    "description": "The namespace that logically groups and isolates memories, such as a user ID."
+                  }
+                },
+                "required": [
+                  "scope"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
     "/memory_stores/{name}/updates/{update_id}": {
       "get": {
         "operationId": "getUpdateResult",
@@ -10516,6 +10957,32 @@
         },
         "description": "A deleted evaluation run Object."
       },
+      "DeleteMemoryItemResponse": {
+        "type": "object",
+        "required": [
+          "object",
+          "memory_id",
+          "deleted"
+        ],
+        "properties": {
+          "object": {
+            "type": "string",
+            "enum": [
+              "memory_store.item.deleted"
+            ],
+            "description": "The object type. Always 'memory_store.item.deleted'."
+          },
+          "memory_id": {
+            "type": "string",
+            "description": "The ID of the deleted memory item."
+          },
+          "deleted": {
+            "type": "boolean",
+            "description": "Whether the memory item was successfully deleted."
+          }
+        },
+        "description": "Response for deleting a memory item."
+      },
       "DeleteMemoryStoreResponse": {
         "type": "object",
         "required": [
@@ -12883,6 +13350,7 @@
       "MemoryItem": {
         "type": "object",
         "required": [
+          "object",
           "memory_id",
           "updated_at",
           "scope",
@@ -12890,6 +13358,13 @@
           "kind"
         ],
         "properties": {
+          "object": {
+            "type": "string",
+            "enum": [
+              "memory_store.item"
+            ],
+            "description": "The object type, which is always 'memory_store.item'."
+          },
           "memory_id": {
             "type": "string",
             "description": "The unique ID of the memory item."

--- a/specification/ai/data-plane/Azure.AI.Projects/preview/2025-11-15-preview/azure-ai-projects.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/preview/2025-11-15-preview/azure-ai-projects.json
@@ -3933,6 +3933,379 @@
         }
       }
     },
+    "/memory_stores/{name}/items": {
+      "post": {
+        "operationId": "createMemoryItem",
+        "tags": [
+          "Memory stores"
+        ],
+        "description": "Create a memory item in a memory store.",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "description": "The API version to use for this operation.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "x-ms-client-name": "apiVersion"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "The name of the memory store.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "scope": {
+                  "type": "string",
+                  "description": "The namespace that logically groups and isolates memories, such as a user ID."
+                },
+                "content": {
+                  "type": "string",
+                  "description": "The content of the memory."
+                },
+                "kind": {
+                  "$ref": "#/definitions/MemoryItemKind",
+                  "description": "The kind of the memory item."
+                }
+              },
+              "required": [
+                "scope",
+                "content",
+                "kind"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/MemoryItem"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ApiErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/memory_stores/{name}/items/{memory_id}": {
+      "get": {
+        "operationId": "getMemoryItem",
+        "tags": [
+          "Memory stores"
+        ],
+        "description": "Retrieve a memory item from a memory store.",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "description": "The API version to use for this operation.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "x-ms-client-name": "apiVersion"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "The name of the memory store.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "memory_id",
+            "in": "path",
+            "description": "The ID of the memory item.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/MemoryItem"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ApiErrorResponse"
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "updateMemoryItem",
+        "tags": [
+          "Memory stores"
+        ],
+        "description": "Update the content of an existing memory item in a memory store.",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "description": "The API version to use for this operation.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "x-ms-client-name": "apiVersion"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "The name of the memory store.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "memory_id",
+            "in": "path",
+            "description": "The ID of the memory item.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "content": {
+                  "type": "string",
+                  "description": "The updated content of the memory."
+                }
+              },
+              "required": [
+                "content"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/MemoryItem"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ApiErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteMemoryItem",
+        "tags": [
+          "Memory stores"
+        ],
+        "description": "Delete an existing memory item from a memory store.",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "description": "The API version to use for this operation.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "x-ms-client-name": "apiVersion"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "The name of the memory store.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "memory_id",
+            "in": "path",
+            "description": "The ID of the memory item.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/DeleteMemoryItemResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ApiErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/memory_stores/{name}/items:list": {
+      "post": {
+        "operationId": "listMemoryItems",
+        "tags": [
+          "Memory stores"
+        ],
+        "description": "List memory items for a specific scope in a memory store.",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "description": "The API version to use for this operation.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "x-ms-client-name": "apiVersion"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "The name of the memory store.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the\ndefault is 20.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "default": 20
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include after=obj_foo in order to fetch the next page of the list.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "before",
+            "in": "query",
+            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include before=obj_foo in order to fetch the previous page of the list.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "description": "Sort order by the updated_at timestamp of the memory items. 'asc' for ascending order and 'desc' for descending order.",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "x-ms-enum": {
+              "modelAsString": false
+            }
+          },
+          {
+            "name": "kind",
+            "in": "query",
+            "description": "Filter by memory item kind. If provided, only items of the specified kind will be returned.",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "user_profile",
+              "chat_summary"
+            ],
+            "x-ms-enum": {
+              "name": "MemoryItemKind",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "user_profile",
+                  "value": "user_profile",
+                  "description": "User profile information extracted from conversations."
+                },
+                {
+                  "name": "chat_summary",
+                  "value": "chat_summary",
+                  "description": "Summary of chat conversations."
+                }
+              ]
+            }
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "scope": {
+                  "type": "string",
+                  "description": "The namespace that logically groups and isolates memories, such as a user ID."
+                }
+              },
+              "required": [
+                "scope"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "type": "object",
+              "description": "The response data for a requested list of items.",
+              "properties": {
+                "data": {
+                  "type": "array",
+                  "description": "The requested list of items.",
+                  "items": {
+                    "$ref": "#/definitions/MemoryItem"
+                  }
+                },
+                "first_id": {
+                  "type": "string",
+                  "description": "The first ID represented in this list."
+                },
+                "last_id": {
+                  "type": "string",
+                  "description": "The last ID represented in this list."
+                },
+                "has_more": {
+                  "type": "boolean",
+                  "description": "A value indicating whether there are additional values available not captured in this list."
+                }
+              },
+              "required": [
+                "data",
+                "has_more"
+              ]
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ApiErrorResponse"
+            }
+          }
+        }
+      }
+    },
     "/memory_stores/{name}/updates/{update_id}": {
       "get": {
         "operationId": "getUpdateResult",
@@ -9360,6 +9733,35 @@
         }
       }
     },
+    "DeleteMemoryItemResponse": {
+      "type": "object",
+      "description": "Response for deleting a memory item.",
+      "properties": {
+        "object": {
+          "type": "string",
+          "description": "The object type. Always 'memory_store.item.deleted'.",
+          "enum": [
+            "memory_store.item.deleted"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        },
+        "memory_id": {
+          "type": "string",
+          "description": "The ID of the deleted memory item."
+        },
+        "deleted": {
+          "type": "boolean",
+          "description": "Whether the memory item was successfully deleted."
+        }
+      },
+      "required": [
+        "object",
+        "memory_id",
+        "deleted"
+      ]
+    },
     "DeleteMemoryStoreResponse": {
       "type": "object",
       "properties": {
@@ -11354,6 +11756,16 @@
       "type": "object",
       "description": "A single memory item stored in the memory store, containing content and metadata.",
       "properties": {
+        "object": {
+          "type": "string",
+          "description": "The object type, which is always 'memory_store.item'.",
+          "enum": [
+            "memory_store.item"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        },
         "memory_id": {
           "type": "string",
           "description": "The unique ID of the memory item."
@@ -11378,6 +11790,7 @@
       },
       "discriminator": "kind",
       "required": [
+        "object",
         "memory_id",
         "updated_at",
         "scope",


### PR DESCRIPTION
This pull request adds full CRUD (Create, Read, Update, Delete) and listing support for individual memory items in the memory store API specification. It introduces new request and response models, updates the `MemoryStores` interface with new operations, and enhances the `MemoryItem` model with an explicit object type.

**API Model and Operation Additions:**

* Added new request and response models for creating, retrieving, updating, deleting, and listing memory items, including `CreateMemoryItemRequest`, `GetMemoryItemRequest`, `UpdateMemoryItemRequest`, `DeleteMemoryItemRequest`, `DeleteMemoryItemResponse`, and `ListMemoryItemsRequest` (`specification/ai/Foundry/memory_stores/models.tsp`).
* Enhanced the `MemoryItem` model to include an explicit `object` property with the value `'memory_store.item'` for clearer object typing (`specification/ai/Foundry/memory_stores/models.tsp`).

**API Endpoint Updates:**

* Updated the `MemoryStores` interface to add new endpoints for creating, retrieving, updating, deleting, and listing memory items, each with appropriate HTTP methods, routes, and operation IDs (`specification/ai/Foundry/memory_stores/routes.tsp`).
* Added support for filtering and ordering when listing memory items, including a query parameter for sort order and filtering by item kind (`specification/ai/Foundry/memory_stores/models.tsp`).

These changes significantly expand the functionality of the memory store API by allowing clients to manage individual memory items directly.