### PR TITLE
Enabled the SDK PR creation when failure happens in the generation process

### DIFF
--- a/eng/common/pipelines/templates/steps/git-push-changes.yml
+++ b/eng/common/pipelines/templates/steps/git-push-changes.yml
@@ -8,12 +8,11 @@ parameters:
   WorkingDirectory: $(System.DefaultWorkingDirectory)'
   ScriptDirectory: eng/common/scripts
   SkipCheckingForChanges: false
-  CustomCondition: succeeded()
 
 steps:
 - task: PowerShell@2
   displayName: Check for changes
-  condition: and(${{ parameters.CustomCondition }}, eq(${{ parameters.SkipCheckingForChanges }}, false))
+  condition: and(succeeded(), eq(${{ parameters.SkipCheckingForChanges }}, false))
   inputs:
     pwsh: true
     workingDirectory: ${{ parameters.WorkingDirectory }}
@@ -26,7 +25,7 @@ steps:
     echo "##vso[task.setvariable variable=RepoNameWithoutOwner]$repoName"
     echo "RepoName = $repoName"
   displayName: Remove Repo Owner from Repo Name
-  condition: ${{ parameters.CustomCondition }}
+  condition: succeeded()
   workingDirectory: ${{ parameters.WorkingDirectory }}
 
 - template: /eng/common/pipelines/templates/steps/emit-rate-limit-metrics.yml
@@ -36,7 +35,7 @@ steps:
 
 - task: PowerShell@2
   displayName: Push changes
-  condition: and(${{ parameters.CustomCondition }}, eq(variables['HasChanges'], 'true'))
+  condition: and(succeeded(), eq(variables['HasChanges'], 'true'))
   inputs:
     pwsh: true
     workingDirectory: ${{ parameters.WorkingDirectory }}

--- a/eng/common/pipelines/templates/steps/git-push-changes.yml
+++ b/eng/common/pipelines/templates/steps/git-push-changes.yml
@@ -8,11 +8,12 @@ parameters:
   WorkingDirectory: $(System.DefaultWorkingDirectory)'
   ScriptDirectory: eng/common/scripts
   SkipCheckingForChanges: false
+  CustomCondition: succeeded()
 
 steps:
 - task: PowerShell@2
   displayName: Check for changes
-  condition: and(succeeded(), eq(${{ parameters.SkipCheckingForChanges }}, false))
+  condition: and(${{ parameters.CustomCondition }}, eq(${{ parameters.SkipCheckingForChanges }}, false))
   inputs:
     pwsh: true
     workingDirectory: ${{ parameters.WorkingDirectory }}
@@ -25,7 +26,7 @@ steps:
     echo "##vso[task.setvariable variable=RepoNameWithoutOwner]$repoName"
     echo "RepoName = $repoName"
   displayName: Remove Repo Owner from Repo Name
-  condition: succeeded()
+  condition: ${{ parameters.CustomCondition }}
   workingDirectory: ${{ parameters.WorkingDirectory }}
 
 - template: /eng/common/pipelines/templates/steps/emit-rate-limit-metrics.yml
@@ -35,7 +36,7 @@ steps:
 
 - task: PowerShell@2
   displayName: Push changes
-  condition: and(succeeded(), eq(variables['HasChanges'], 'true'))
+  condition: and(${{ parameters.CustomCondition }}, eq(variables['HasChanges'], 'true'))
   inputs:
     pwsh: true
     workingDirectory: ${{ parameters.WorkingDirectory }}

--- a/eng/pipelines/spec-gen-sdk.yml
+++ b/eng/pipelines/spec-gen-sdk.yml
@@ -29,6 +29,10 @@ parameters:
     type: boolean
     default: false
     displayName: 'Create SDK pull request'
+  - name: ForceCreateEvenWithFailures
+    type: boolean
+    default: false
+    displayName: 'Force create SDK pull request even with failures ("Create SDK Pull Request" must be checked)'
   - name: ReleasePlanWorkItemId
     type: number
     default: 0
@@ -47,4 +51,5 @@ extends:
     ApiVersion: ${{ parameters.ApiVersion }}
     SdkReleaseType: ${{ parameters.SdkReleaseType }}
     CreatePullRequest: ${{ parameters.CreatePullRequest }}
+    ForceCreateEvenWithFailures: ${{ parameters.ForceCreateEvenWithFailures }}
     ReleasePlanWorkItemId: ${{ parameters.ReleasePlanWorkItemId }}

--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -25,6 +25,9 @@ parameters:
   - name: CreatePullRequest
     type: boolean
     default: false
+  - name: ForceCreateEvenWithFailures
+    type: boolean
+    default: false
   - name: SpecBatchTypes
     type: string
     default: ''
@@ -282,6 +285,7 @@ stages:
             Write-Host "##vso[task.setvariable variable=SdkPullRequestSourceBranch]$sdkPrBranchName"
           workingDirectory: $(SdkRepoDirectory)
           displayName: "Create SDK PR branch variable"
+          condition: or(succeeded(), and(succeededOrFailed(), eq('${{ parameters.ForceCreateEvenWithFailures }}', true)))
 
         - ${{ if ne(parameters.ReleasePlanWorkItemId, 0) }}:
           - task: AzureCLI@2
@@ -306,10 +310,19 @@ stages:
             TargetRepoName: $(SdkRepoName)
             WorkingDirectory: $(SdkRepoDirectory)
             ScriptDirectory: $(SdkRepoDirectory)/eng/common/scripts
+            CustomCondition: or(succeeded(), and(succeededOrFailed(), eq('${{ parameters.ForceCreateEvenWithFailures }}', true)))
+
+        - pwsh: |
+            $currentTitle = "$(PrTitle)"
+            $updatedTitle = "Failed-$currentTitle"
+            Write-Host "##vso[task.setvariable variable=PrTitle]$updatedTitle"
+            Write-Host "Updated PR Title to: '$updatedTitle'"
+          displayName: "Set PR title prefix based on job status"
+          condition: and(or(eq('$(Agent.JobStatus)', 'SucceededWithIssues'), eq('$(Agent.JobStatus)', 'Failed')), eq('${{ parameters.ForceCreateEvenWithFailures }}', true))
 
         - task: PowerShell@2
           displayName: Create pull request
-          condition: and(succeeded(), eq(variables['HasChanges'], 'true'), ne(variables['Build.Reason'], 'PullRequest'), not(endsWith(variables['SdkRepoName'], '-pr')))
+          condition: and(or(succeeded(), and(succeededOrFailed(), eq('${{ parameters.ForceCreateEvenWithFailures }}', true))), eq(variables['HasChanges'], 'true'), ne(variables['Build.Reason'], 'PullRequest'), not(endsWith(variables['SdkRepoName'], '-pr')))
           inputs:
             pwsh: true
             workingDirectory: $(SdkRepoDirectory)

--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -260,6 +260,8 @@ stages:
             --spec-repo-url ${{ parameters.SpecRepoUrl }} \
             $optional_params || true # return true always to suppress exit error logging
         displayName: 'Generate SDK'
+        ${{ if eq(parameters.ForceCreateEvenWithFailures, true) }}:
+          continueOnError: true
 
       - template: /eng/common/pipelines/templates/steps/publish-artifact.yml
         parameters:
@@ -285,7 +287,7 @@ stages:
             Write-Host "##vso[task.setvariable variable=SdkPullRequestSourceBranch]$sdkPrBranchName"
           workingDirectory: $(SdkRepoDirectory)
           displayName: "Create SDK PR branch variable"
-          condition: or(succeeded(), and(succeededOrFailed(), eq('${{ parameters.ForceCreateEvenWithFailures }}', true)))
+          condition: succeededOrFailed()
 
         - ${{ if ne(parameters.ReleasePlanWorkItemId, 0) }}:
           - task: AzureCLI@2
@@ -310,7 +312,7 @@ stages:
             TargetRepoName: $(SdkRepoName)
             WorkingDirectory: $(SdkRepoDirectory)
             ScriptDirectory: $(SdkRepoDirectory)/eng/common/scripts
-            CustomCondition: or(succeeded(), and(succeededOrFailed(), eq('${{ parameters.ForceCreateEvenWithFailures }}', true)))
+            CustomCondition: succeededOrFailed()
 
         - pwsh: |
             $currentTitle = "$(PrTitle)"
@@ -318,11 +320,11 @@ stages:
             Write-Host "##vso[task.setvariable variable=PrTitle]$updatedTitle"
             Write-Host "Updated PR Title to: '$updatedTitle'"
           displayName: "Set PR title prefix based on job status"
-          condition: and(eq(variables['Agent.JobStatus'], 'Failed'), eq('${{ parameters.ForceCreateEvenWithFailures }}', true))
+          condition: eq(variables['Agent.JobStatus'], 'Failed')
 
         - task: PowerShell@2
           displayName: Create pull request
-          condition: and(or(succeeded(), and(succeededOrFailed(), eq('${{ parameters.ForceCreateEvenWithFailures }}', true))), eq(variables['HasChanges'], 'true'), ne(variables['Build.Reason'], 'PullRequest'), not(endsWith(variables['SdkRepoName'], '-pr')))
+          condition: and(succeededOrFailed(), eq(variables['HasChanges'], 'true'), ne(variables['Build.Reason'], 'PullRequest'), not(endsWith(variables['SdkRepoName'], '-pr')))
           inputs:
             pwsh: true
             workingDirectory: $(SdkRepoDirectory)

--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -318,7 +318,7 @@ stages:
             Write-Host "##vso[task.setvariable variable=PrTitle]$updatedTitle"
             Write-Host "Updated PR Title to: '$updatedTitle'"
           displayName: "Set PR title prefix based on job status"
-          condition: and(or(eq('$(Agent.JobStatus)', 'SucceededWithIssues'), eq('$(Agent.JobStatus)', 'Failed')), eq('${{ parameters.ForceCreateEvenWithFailures }}', true))
+          condition: and(eq('$(Agent.JobStatus)', 'Failed'), eq('${{ parameters.ForceCreateEvenWithFailures }}', true))
 
         - task: PowerShell@2
           displayName: Create pull request

--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -319,8 +319,8 @@ stages:
             $updatedTitle = "Failed-$currentTitle"
             Write-Host "##vso[task.setvariable variable=PrTitle]$updatedTitle"
             Write-Host "Updated PR Title to: '$updatedTitle'"
-          displayName: "Set PR title prefix based on job status"
-          condition: eq(variables['Agent.JobStatus'], 'Failed')
+          displayName: "Set PR title prefix on failures"
+          condition: or(eq(variables['Agent.JobStatus'], 'Failed'), eq(variables['Agent.JobStatus'], 'SucceededWithIssues'))
 
         - task: PowerShell@2
           displayName: Create pull request

--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -318,7 +318,7 @@ stages:
             Write-Host "##vso[task.setvariable variable=PrTitle]$updatedTitle"
             Write-Host "Updated PR Title to: '$updatedTitle'"
           displayName: "Set PR title prefix based on job status"
-          condition: and(eq('$(Agent.JobStatus)', 'Failed'), eq('${{ parameters.ForceCreateEvenWithFailures }}', true))
+          condition: and(eq(variables['Agent.JobStatus'], 'Failed'), eq('${{ parameters.ForceCreateEvenWithFailures }}', true))
 
         - task: PowerShell@2
           displayName: Create pull request

--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -287,7 +287,6 @@ stages:
             Write-Host "##vso[task.setvariable variable=SdkPullRequestSourceBranch]$sdkPrBranchName"
           workingDirectory: $(SdkRepoDirectory)
           displayName: "Create SDK PR branch variable"
-          condition: succeededOrFailed()
 
         - ${{ if ne(parameters.ReleasePlanWorkItemId, 0) }}:
           - task: AzureCLI@2
@@ -312,7 +311,6 @@ stages:
             TargetRepoName: $(SdkRepoName)
             WorkingDirectory: $(SdkRepoDirectory)
             ScriptDirectory: $(SdkRepoDirectory)/eng/common/scripts
-            CustomCondition: succeededOrFailed()
 
         - pwsh: |
             $currentTitle = "$(PrTitle)"
@@ -324,7 +322,7 @@ stages:
 
         - task: PowerShell@2
           displayName: Create pull request
-          condition: and(succeededOrFailed(), eq(variables['HasChanges'], 'true'), ne(variables['Build.Reason'], 'PullRequest'), not(endsWith(variables['SdkRepoName'], '-pr')))
+          condition: and(succeeded(), eq(variables['HasChanges'], 'true'), ne(variables['Build.Reason'], 'PullRequest'), not(endsWith(variables['SdkRepoName'], '-pr')))
           inputs:
             pwsh: true
             workingDirectory: $(SdkRepoDirectory)

--- a/eng/tools/spec-gen-sdk-runner/src/commands.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/commands.ts
@@ -50,24 +50,23 @@ export async function generateSdkForSingleSpec(): Promise<number> {
     logMessage(`Runner: error reading execution-report.json:${error}`, LogLevel.Error);
     statusCode = 1;
   }
-  
+
   // Always set the pipeline variables for the SDK pull request even if
   // there are failures in the generation process since we allow the PR creation for such cases.
   let packageName = "";
   let installationInstructions = "";
-  if (executionReport){
-    packageName = executionReport.packages[0]?.packageName ??
-                  commandInput.tspConfigPath ??
-                  commandInput.readmePath ??
-                  "missing-package-name";
+  if (executionReport) {
+    packageName =
+      executionReport.packages[0]?.packageName ??
+      commandInput.tspConfigPath ??
+      commandInput.readmePath ??
+      "missing-package-name";
     installationInstructions = executionReport.packages[0]?.installationInstructions;
   } else {
-    packageName = commandInput.tspConfigPath ??
-                  commandInput.readmePath ??
-                  "missing-package-name";
+    packageName = commandInput.tspConfigPath ?? commandInput.readmePath ?? "missing-package-name";
   }
 
-  packageName = packageName.replace("/", "-");  
+  packageName = packageName.replace("/", "-");
   setPipelineVariables(
     executionReport?.stagedArtifactsFolder ?? "",
     false,

--- a/eng/tools/spec-gen-sdk-runner/test/commands.test.ts
+++ b/eng/tools/spec-gen-sdk-runner/test/commands.test.ts
@@ -131,7 +131,7 @@ describe("generateSdkForSingleSpec", () => {
       `Runner: error executing command:Error: Command failed`,
       LogLevel.Error,
     );
-    expect(commandHelpers.setPipelineVariables).not.toHaveBeenCalled();
+    expect(commandHelpers.setPipelineVariables).toHaveBeenCalled();
   });
 
   test("should handle errors during execution report reading", async () => {


### PR DESCRIPTION
Resolved https://github.com/Azure/azure-rest-api-specs/issues/38221

**Key changes**:
- added a new parameter to pipeline to force create the SDK PR
- always set pipeline variables so that the SDK PR can be created using them

[Test Run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5733188&view=logs&j=83516c17-6666-5250-abde-63983ce72a49&t=53495029-6fd7-5fbf-3ed4-5fd95aecc3eb)