### PR TITLE
Update package.json to add dependency on "@azure-tools/openai-typespec"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "azure-rest-api-specs",
       "devDependencies": {
         "@autorest/openapi-to-typespec": "0.11.12",
+        "@azure-tools/openai-typespec": "0.1.11",
         "@azure-tools/spec-gen-sdk": "~0.9.1",
         "@azure-tools/specs-shared": "file:.github/shared",
         "@azure-tools/typespec-apiview": "0.7.2",
@@ -774,6 +775,17 @@
     "node_modules/@azure-tools/oav-runner": {
       "resolved": "eng/tools/oav-runner",
       "link": true
+    },
+    "node_modules/@azure-tools/openai-typespec": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@azure-tools/openai-typespec/-/openai-typespec-0.1.11.tgz",
+      "integrity": "sha512-xTzET3UsL+P2GfzcZEf4sUf+emCpYyCEFk6odX10F0uH+T/M8T46K1mllaQkiizP1UklkVMXrKX4I9vhOlNMPA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@typespec/http": "*",
+        "@typespec/openapi": "*"
+      }
     },
     "node_modules/@azure-tools/openapi": {
       "version": "3.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "azure-rest-api-specs",
   "devDependencies": {
+    "@azure-tools/openai-typespec":"0.1.11",
     "@azure-tools/spec-gen-sdk": "~0.9.1",
     "@azure-tools/specs-shared": "file:.github/shared",
     "@azure-tools/typespec-apiview": "0.7.2",


### PR DESCRIPTION
Since the TypeSpec for Foundry data-plane APIs now takes a dependency on it.

Run "npm install" to update the lock file.