### PR TITLE
Use @@override for a patch operation to avoid JS sdk breakings for resourceconnector

### DIFF
--- a/specification/resourceconnector/resource-manager/Microsoft.ResourceConnector/ResourceConnector/client.tsp
+++ b/specification/resourceconnector/resource-manager/Microsoft.ResourceConnector/ResourceConnector/client.tsp
@@ -1,7 +1,11 @@
 import "@azure-tools/typespec-client-generator-core";
+import "@azure-tools/typespec-azure-resource-manager";
+import "@typespec/rest";
 import "./main.tsp";
 
+using Http;
 using Azure.ClientGenerator.Core;
+using TypeSpec.Rest;
 using Microsoft.ResourceConnector;
 
 @@clientName(Microsoft.ResourceConnector,
@@ -42,3 +46,27 @@ using Microsoft.ResourceConnector;
   Azure.Core.armResourceIdentifier,
   "csharp"
 );
+
+#suppress "@azure-tools/typespec-azure-core/casing-style" "customization"
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "customization"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "override"
+op AppliancesUpdateCustomized(
+  ...Azure.ResourceManager.CommonTypes.ApiVersionParameter,
+  ...Azure.ResourceManager.CommonTypes.SubscriptionIdParameter,
+  ...Azure.ResourceManager.CommonTypes.ResourceGroupNameParameter,
+  ...Azure.ResourceManager.Legacy.Provider,
+
+  @path
+  @maxLength(63)
+  @minLength(1)
+  @doc("Appliances name.")
+  @segment("appliances")
+  @pattern("^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$")
+  resourceName: string,
+
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "override"
+  @doc("Resource tags")
+  @body
+  tags?: Record<string>,
+): Appliance;
+@@override(Appliances.update, AppliancesUpdateCustomized, "javascript");


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-for-js/pull/37005/files#r2681026239
JS doesn't support flatten in request parameter level.
customize `appliances_update` operation for JS side only to avoid unexpected breakings.

This PR should only impact JS client.