### PR TITLE
Evaluator catalog fixes.

### DIFF
--- a/specification/ai/Foundry/agents/routes.tsp
+++ b/specification/ai/Foundry/agents/routes.tsp
@@ -353,23 +353,23 @@ interface Agents {
   @route("/agents/{agent_name}/versions/{agent_version}/containers/default:logstream")
   @tag("Agents")
   @doc("""
-  Container log entry streamed from the container as text chunks.
-  Each chunk is a UTF-8 string that may be either a plain text log line
-  or a JSON-formatted log entry, depending on the type of container log being streamed.
-  Clients should treat each chunk as opaque text and, if needed, attempt
-  to parse it as JSON based on their logging requirements.
-  
-  For system logs, the format is JSON with the following structure:
-  {"TimeStamp":"2025-12-15T16:51:33Z","Type":"Normal","ContainerAppName":null,"RevisionName":null,"ReplicaName":null,"Msg":"Connecting to the events collector...","Reason":"StartingGettingEvents","EventSource":"ContainerAppController","Count":1}
-  {"TimeStamp":"2025-12-15T16:51:34Z","Type":"Normal","ContainerAppName":null,"RevisionName":null,"ReplicaName":null,"Msg":"Successfully connected to events server","Reason":"ConnectedToEventsServer","EventSource":"ContainerAppController","Count":1}
-  
-  For console logs, the format is plain text as emitted by the container's stdout/stderr.
-  2025-12-15T08:43:48.72656  Connecting to the container 'agent-container'...
-  2025-12-15T08:43:48.75451  Successfully Connected to container: 'agent-container' [Revision: 'je90fe655aa742ef9a188b9fd14d6764--7tca06b', Replica: 'je90fe655aa742ef9a188b9fd14d6764--7tca06b-6898b9c89f-mpkjc']
-  2025-12-15T08:33:59.0671054Z stdout F INFO:     127.0.0.1:42588 - "GET /readiness HTTP/1.1" 200 OK
-  2025-12-15T08:34:29.0649033Z stdout F INFO:     127.0.0.1:60246 - "GET /readiness HTTP/1.1" 200 OK
-  2025-12-15T08:34:59.0644467Z stdout F INFO:     127.0.0.1:43994 - "GET /readiness HTTP/1.1" 200 OK
-  """)
+    Container log entry streamed from the container as text chunks.
+    Each chunk is a UTF-8 string that may be either a plain text log line
+    or a JSON-formatted log entry, depending on the type of container log being streamed.
+    Clients should treat each chunk as opaque text and, if needed, attempt
+    to parse it as JSON based on their logging requirements.
+    
+    For system logs, the format is JSON with the following structure:
+    {"TimeStamp":"2025-12-15T16:51:33Z","Type":"Normal","ContainerAppName":null,"RevisionName":null,"ReplicaName":null,"Msg":"Connecting to the events collector...","Reason":"StartingGettingEvents","EventSource":"ContainerAppController","Count":1}
+    {"TimeStamp":"2025-12-15T16:51:34Z","Type":"Normal","ContainerAppName":null,"RevisionName":null,"ReplicaName":null,"Msg":"Successfully connected to events server","Reason":"ConnectedToEventsServer","EventSource":"ContainerAppController","Count":1}
+    
+    For console logs, the format is plain text as emitted by the container's stdout/stderr.
+    2025-12-15T08:43:48.72656  Connecting to the container 'agent-container'...
+    2025-12-15T08:43:48.75451  Successfully Connected to container: 'agent-container' [Revision: 'je90fe655aa742ef9a188b9fd14d6764--7tca06b', Replica: 'je90fe655aa742ef9a188b9fd14d6764--7tca06b-6898b9c89f-mpkjc']
+    2025-12-15T08:33:59.0671054Z stdout F INFO:     127.0.0.1:42588 - "GET /readiness HTTP/1.1" 200 OK
+    2025-12-15T08:34:29.0649033Z stdout F INFO:     127.0.0.1:60246 - "GET /readiness HTTP/1.1" 200 OK
+    2025-12-15T08:34:59.0644467Z stdout F INFO:     127.0.0.1:43994 - "GET /readiness HTTP/1.1" 200 OK
+    """)
   streamAgentContainerLogs is AgentOperation<
     {
       /** The name of the agent. */
@@ -380,15 +380,18 @@ interface Agents {
 
       /** The type of logs to stream. */
       @doc("console returns container stdout/stderr, system returns container app event stream. defaults to console")
-      @query kind?: ContainerLogKind;
+      @query
+      kind?: ContainerLogKind;
 
       /** The name of the replica to stream logs from. */
       @doc("When omitted, the server chooses the first replica for console logs. Required to target a specific replica.")
-      @query replica_name?: string;
+      @query
+      replica_name?: string;
 
       /** The number of lines from the end of the logs to show. */
       @doc("Number of trailing lines returned. Enforced to 1-300. Defaults to 20")
-      @query tail?: int32;
+      @query
+      tail?: int32;
     },
     Stream<{
       @header("content-type") contentType: "text/plain; charset=utf-8";

--- a/specification/ai/Foundry/client.csharp.tsp
+++ b/specification/ai/Foundry/client.csharp.tsp
@@ -143,3 +143,6 @@ namespace Azure.AI.Projects;
   "operationStatus",
   "csharp"
 );
+
+// Evaluators
+@@access(EvaluatorDefinitionType, Access.public);

--- a/specification/ai/Foundry/evaluators/models.tsp
+++ b/specification/ai/Foundry/evaluators/models.tsp
@@ -129,11 +129,11 @@ model EvaluatorVersion {
 
   @visibility(Lifecycle.Read)
   @doc("Creation date/time of the evaluator")
-  created_at: int64;
+  created_at: string;
 
   @visibility(Lifecycle.Read)
   @doc("Last modified date/time of the evaluator")
-  modified_at: int64;
+  modified_at: string;
 
   ...AssetBase;
 }

--- a/specification/ai/data-plane/Azure.AI.Projects/openapi3/2025-11-15-preview/azure-ai-projects-openapi3.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/openapi3/2025-11-15-preview/azure-ai-projects-openapi3.json
@@ -12130,14 +12130,12 @@
             "readOnly": true
           },
           "created_at": {
-            "type": "integer",
-            "format": "int64",
+            "type": "string",
             "description": "Creation date/time of the evaluator",
             "readOnly": true
           },
           "modified_at": {
-            "type": "integer",
-            "format": "int64",
+            "type": "string",
             "description": "Last modified date/time of the evaluator",
             "readOnly": true
           },

--- a/specification/ai/data-plane/Azure.AI.Projects/preview/2025-11-15-preview/azure-ai-projects.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/preview/2025-11-15-preview/azure-ai-projects.json
@@ -10857,14 +10857,12 @@
           "readOnly": true
         },
         "created_at": {
-          "type": "integer",
-          "format": "int64",
+          "type": "string",
           "description": "Creation date/time of the evaluator",
           "readOnly": true
         },
         "modified_at": {
-          "type": "integer",
-          "format": "int64",
+          "type": "string",
           "description": "Last modified date/time of the evaluator",
           "readOnly": true
         },


### PR DESCRIPTION
- Expose EvaluatorDefinitionType.
- Change type of `EvaluatorVersion` properties `modified_at` and `created_at` from int64 to string.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
