### PR TITLE
Add specific file paths to extendedlocation cspell.yaml

### DIFF
--- a/specification/extendedlocation/cspell.yaml
+++ b/specification/extendedlocation/cspell.yaml
@@ -1,0 +1,17 @@
+# This file configures spell checking. Items in "words" were initially populated
+# with words that might be spelling errors. Review these words and take
+# appropriate action. For more information, see: https://aka.ms/ci-fix#spell-check
+
+# Spell checking is not case sensitive
+# Keep word lists in alphabetical order so the file is easier to manage
+import:
+  - ../../cspell.yaml
+
+# Paths to include for spell checking (only files containing kubeconfig)
+paths:
+  - "resource-manager/Microsoft.ExtendedLocation/CustomLocations/preview/2021-03-15-preview/customlocations.json"
+  - "resource-manager/Microsoft.ExtendedLocation/CustomLocations/preview/2021-08-31-preview/customlocations.json"
+  - "resource-manager/Microsoft.ExtendedLocation/CustomLocations/stable/2021-08-15/customlocations.json"
+
+words:
+  - kubeconfig


### PR DESCRIPTION
This PR updates the cspell.yaml file for extendedlocation to use specific file paths instead of wildcard patterns.

**Changes:**
- Updated cspell.yaml to include only the 3 files that contain 'kubeconfig'
- Replaced wildcard patterns (, ) with explicit file paths
- Files included:
  - preview/2021-03-15-preview/customlocations.json
  - preview/2021-08-31-preview/customlocations.json
  - stable/2021-08-15/customlocations.json

**Reason:**
Using specific paths prevents new files from bypassing spell check validation.