### PR TITLE
Fix invalid use of provider placeholder

### DIFF
--- a/specification/compute/Common.Management/legacy.tsp
+++ b/specification/compute/Common.Management/legacy.tsp
@@ -17,18 +17,13 @@ namespace Azure.ResourceManager.Legacy {
     #suppress "@azure-tools/typespec-azure-core/no-private-usage"
     @tag("Operations")
     @autoRoute
-    @Azure.ResourceManager.Private.armUpdateProviderNamespace
     @doc("List the operations for the provider")
     @segment("operations")
     @get
     @list
     list(
       ...ApiVersionParameter,
-
-      @path
-      @segment("providers")
-      @doc("The provider namespace (this parameter will not show up in operations).")
-      provider: "Microsoft.ThisWillBeReplaced",
+      ...Azure.ResourceManager.Legacy.Provider,
     ): ArmResponse<Azure.ResourceManager.Foundations.OperationListResult> | Microsoft.Compute.CloudError;
   }
 

--- a/specification/confluent/Confluent.Management/main.tsp
+++ b/specification/confluent/Confluent.Management/main.tsp
@@ -61,17 +61,12 @@ interface Operations {
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
   @tag("Operations")
   @autoRoute
-  @Azure.ResourceManager.Private.armUpdateProviderNamespace
   @doc("List the operations for the provider")
   @segment("operations")
   @get
   @list
   list(
     ...ApiVersionParameter,
-
-    @path
-    @segment("providers")
-    @doc("The provider namespace (this parameter will not show up in operations).")
-    provider: "Microsoft.ThisWillBeReplaced",
+    ...Azure.ResourceManager.Legacy.Provider,
   ): ArmResponse<OperationListResult> | ResourceProviderDefaultErrorResponse;
 }

--- a/specification/databox/resource-manager/Microsoft.DataBox/DataBox/main.tsp
+++ b/specification/databox/resource-manager/Microsoft.DataBox/DataBox/main.tsp
@@ -50,10 +50,6 @@ interface Operations {
   @list
   list(
     ...ApiVersionParameter,
-
-    @path
-    @segment("providers")
-    @doc("The provider namespace (this parameter will not show up in operations).")
-    provider: "Microsoft.ThisWillBeReplaced",
+    ...Azure.ResourceManager.Legacy.Provider,
   ): ArmResponse<OperationList> | ApiError;
 }

--- a/specification/fileshares/resource-manager/Microsoft.FileShares/FileShares/fileshares.tsp
+++ b/specification/fileshares/resource-manager/Microsoft.FileShares/FileShares/fileshares.tsp
@@ -344,11 +344,7 @@ interface Operations {
   @list
   list(
     ...ApiVersionParameter,
-
-    @path
-    @segment("providers")
-    @doc("The provider namespace (this parameter will not show up in operations).")
-    provider: "Microsoft.ThisWillBeReplaced",
+    ...Azure.ResourceManager.Legacy.Provider,
   ): ArmResponse<OperationListResult> | ErrorResponse;
 }
 

--- a/specification/mysql/resource-manager/Microsoft.DBforMySQL/FlexibleServers/main.tsp
+++ b/specification/mysql/resource-manager/Microsoft.DBforMySQL/FlexibleServers/main.tsp
@@ -68,16 +68,11 @@ interface Operations {
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
   @tag("Operations")
   @autoRoute
-  @Azure.ResourceManager.Private.armUpdateProviderNamespace
   @doc("List the operations for the provider")
   @segment("operations")
   @list
   list(
     ...ApiVersionParameter,
-
-    @path
-    @segment("providers")
-    @doc("The provider namespace (this parameter will not show up in operations).")
-    provider: "Microsoft.ThisWillBeReplaced",
+    ...Azure.ResourceManager.Legacy.Provider,
   ): ArmResponse<OperationListResult> | ErrorResponse;
 }

--- a/specification/sqlvirtualmachine/resource-manager/Microsoft.SqlVirtualMachine/SqlVirtualMachine/main.tsp
+++ b/specification/sqlvirtualmachine/resource-manager/Microsoft.SqlVirtualMachine/SqlVirtualMachine/main.tsp
@@ -58,11 +58,7 @@ interface Operations {
   @list
   list(
     ...ApiVersionParameter,
-
-    @path
-    @segment("providers")
-    @doc("The provider namespace (this parameter will not show up in operations).")
-    provider: "Microsoft.ThisWillBeReplaced",
+    ...Azure.ResourceManager.Legacy.Provider,
   ): ArmResponse<OperationListResult> | ErrorResponse;
 }
 

--- a/specification/storagesync/resource-manager/Microsoft.StorageSync/StorageSync/main.tsp
+++ b/specification/storagesync/resource-manager/Microsoft.StorageSync/StorageSync/main.tsp
@@ -57,11 +57,7 @@ interface Operations {
   @list
   list(
     ...ApiVersionParameter,
-
-    @path
-    @segment("providers")
-    @doc("The provider namespace (this parameter will not show up in operations).")
-    provider: "Microsoft.ThisWillBeReplaced",
+    ...Azure.ResourceManager.Legacy.Provider,
   ): (ArmResponse<OperationEntityListResult> & {
     @header("x-ms-correlation-request-id")
     @doc("correlation request id.")

--- a/specification/webpubsub/resource-manager/Microsoft.SignalRService/SignalRService/main.tsp
+++ b/specification/webpubsub/resource-manager/Microsoft.SignalRService/SignalRService/main.tsp
@@ -64,10 +64,6 @@ interface Operations {
   @list
   list(
     ...ApiVersionParameter,
-
-    @path
-    @segment("providers")
-    @doc("The provider namespace (this parameter will not show up in operations).")
-    provider: "Microsoft.ThisWillBeReplaced",
+    ...Azure.ResourceManager.Legacy.Provider,
   ): ArmResponse<OperationList> | ErrorResponse;
 }


### PR DESCRIPTION
Those copy pasted the operations for some customization and the only reason it worked is a bug that modified the string instance to match everywhere but this is completely blocking mutli service support

https://github.com/Azure/typespec-azure/pull/3787 