### PR TITLE
Evaluator catalog fixes.

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/client.csharp.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/client.csharp.tsp
@@ -25,6 +25,11 @@ using Azure.ClientGenerator.Core;
 namespace Azure.AI.Projects;
 
 // --------------------------------------------------------------------------------
+// Fix the xref.
+// --------------------------------------------------------------------------------
+@@clientNamespace(OpenAI, "Azure.AI.Projects", "csharp");
+
+// --------------------------------------------------------------------------------
 // Root client
 // --------------------------------------------------------------------------------
 @@clientName(Azure.AI.Projects, "AIProjectClient");
@@ -138,3 +143,6 @@ namespace Azure.AI.Projects;
   "operationStatus",
   "csharp"
 );
+
+// Evaluators
+@@access(EvaluatorDefinitionType, Access.public);

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/2025-11-15-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/2025-11-15-preview/microsoft-foundry-openapi3.json
@@ -11953,14 +11953,12 @@
             "readOnly": true
           },
           "created_at": {
-            "type": "integer",
-            "format": "int64",
+            "type": "string",
             "description": "Creation date/time of the evaluator",
             "readOnly": true
           },
           "modified_at": {
-            "type": "integer",
-            "format": "int64",
+            "type": "string",
             "description": "Last modified date/time of the evaluator",
             "readOnly": true
           },

--- a/specification/ai-foundry/data-plane/Foundry/src/evaluators/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/evaluators/models.tsp
@@ -122,11 +122,11 @@ model EvaluatorVersion {
 
   @visibility(Lifecycle.Read)
   @doc("Creation date/time of the evaluator")
-  created_at: int64;
+  created_at: string;
 
   @visibility(Lifecycle.Read)
   @doc("Last modified date/time of the evaluator")
-  modified_at: int64;
+  modified_at: string;
 
   ...AssetBase;
 }


### PR DESCRIPTION
- Expose EvaluatorDefinitionType.
- Change type of `EvaluatorVersion` properties `modified_at` and `created_at` from int64 to string.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
