### PR TITLE
Allows more descriptive labeling for SDK generation stage

### DIFF
--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -36,8 +36,8 @@ parameters:
     default: 0
 
 stages:
-- stage: Build
-  displayName: 'SDK Generation'
+- stage: ${{ iif(eq(parameters.SpecBatchTypes, ''), 'Build', format('Build_{0}', replace(parameters.SpecBatchTypes, '-', '_'))) }}
+  displayName: ${{ iif(eq(parameters.SpecBatchTypes, ''), 'SDK Generation', format('Batch SDK Generation for ({0})', parameters.SpecBatchTypes)) }}
   jobs:
   - job:
     timeoutInMinutes: 2400


### PR DESCRIPTION
The scheduled batch run needs the stage name to be unique.

* Made the `stage` and `displayName` values dynamic based on the `SpecBatchTypes` parameter

[Test spec PR](https://github.com/Azure/azure-rest-api-specs/pull/39762)

[Test batch run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5774800&view=results)
