### PR TITLE
[SDK Validation] Making the stage runs in parallel without depending on each other

### DIFF
--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -38,6 +38,7 @@ parameters:
 stages:
 - stage: ${{ iif(eq(parameters.SpecBatchTypes, ''), 'Build', format('Build_{0}', replace(parameters.SpecBatchTypes, '-', '_'))) }}
   displayName: ${{ iif(eq(parameters.SpecBatchTypes, ''), 'SDK Generation', format('Batch SDK Generation for ({0})', parameters.SpecBatchTypes)) }}
+  # Explicitly set to no dependencies so multiple instances of this template can run in parallel when called in a loop
   dependsOn: []
   jobs:
   - job:

--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -38,6 +38,7 @@ parameters:
 stages:
 - stage: ${{ iif(eq(parameters.SpecBatchTypes, ''), 'Build', format('Build_{0}', replace(parameters.SpecBatchTypes, '-', '_'))) }}
   displayName: ${{ iif(eq(parameters.SpecBatchTypes, ''), 'SDK Generation', format('Batch SDK Generation for ({0})', parameters.SpecBatchTypes)) }}
+  dependsOn: []
   jobs:
   - job:
     timeoutInMinutes: 2400


### PR DESCRIPTION
Fixed the chained runs issue: the failure of the first batch type run stage would block the second batch type run stage. https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5775250&view=results

- added the default empty value for the `dependsOn`

[Test Spec PR](https://github.com/Azure/azure-rest-api-specs/pull/39780)
[Test Batch Run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5776839&view=results)