### PR TITLE
Minor corrections to tsp-config and forcing emission of IncludeEnum

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-agents/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-agents/client.tsp
@@ -50,6 +50,9 @@ using Azure.AI.Projects;
 // Usage / Public accessibility overrides
 // --------------------------------------------------------------------------------
 
+@@usage(OpenAI.IncludeEnum, Usage.input);
+@@access(OpenAI.IncludeEnum, Access.public);
+
 @@usage(OpenAI.ItemResource, Usage.json);
 @@usage(OpenAI.CreateResponseStreamingResponse, Usage.json);
 

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-agents/tspconfig.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-agents/tspconfig.yaml
@@ -13,8 +13,8 @@ options:
     generate-samples: false
     custom-types-subpackage: "implementation.models"
     rename-model:
-      MCPToolAllowedTools1: MCPToolAllowedTools
-      MCPToolRequireApproval1: MCPToolRequireApproval
+      GrammarSyntax1: GrammarSyntax
+      ReasoningEffort1: ReasoningEffort
     customization-class: customizations/src/main/java/AgentsCustomizations.java
     flavor: azure
   "@typespec/json-schema":


### PR DESCRIPTION
- Replacing renames for Java emission
- Forcing emission of `IncludeEnum` as it's customized under [src/tools/models.tsp](https://github.com/Azure/azure-rest-api-specs/blob/ab4166228f5b22900d5629e60971729da949a41a/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp#L35-L41) and the Azure-ism doesn't get picked up by SDK emitters. (at least Java)