### PR TITLE
Fix ANSI attack strategy spelling in red-teams TypeSpec

### DIFF
--- a/specification/ai/Foundry/red-teams/models.tsp
+++ b/specification/ai/Foundry/red-teams/models.tsp
@@ -49,7 +49,7 @@ union AttackStrategy {
   Jailbreak: "jailbreak",
 
   @doc("Utilizes ANSI escape sequences to manipulate text appearance and behavior.")
-  AnsiiAttack: "ansii_attack",
+  AnsiAttack: "ansi_attack",
 
   @doc("Swaps characters within text to create variations or obfuscate the original content.")
   CharacterSwap: "character_swap",


### PR DESCRIPTION
Corrects the spelling from "AnsiiAttack"/"ansii_attack" to "AnsiAttack"/"ansi_attack" to match the correct acronym "ANSI" (American National Standards Institute).

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
