### PR TITLE
Run npm tsv for ai/Foundry

### DIFF
--- a/specification/ai/Foundry/client.tsp
+++ b/specification/ai/Foundry/client.tsp
@@ -167,7 +167,10 @@ using Azure.AI.Projects;
 @@clientName(OpenAI.CreateResponse, "CreateResponseRequest", "javascript");
 
 // Allow assigning a `dict[str, Any]` object directly to the "schema" property of TextResponseFormatJsonSchema
-@@alternateType(OpenAI.ResponseFormatJsonSchemaSchema, Record<unknown>, "python");
+@@alternateType(OpenAI.ResponseFormatJsonSchemaSchema,
+  Record<unknown>,
+  "python"
+);
 
 // --------------------------------------------------------------------------------
 // Usage / Public accessibility overrides

--- a/specification/ai/Foundry/openai-evaluations/models.tsp
+++ b/specification/ai/Foundry/openai-evaluations/models.tsp
@@ -90,6 +90,7 @@ model AzureAIDataSourceConfig extends DataSourceConfig {
 #suppress "@azure-tools/typespec-autorest/union-unsupported" "This union is defined according to the Azure OpenAI API."
 #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
 #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
+#suppress "deprecated"
 @@changePropertyType(OpenAI.Eval.data_source_config,
 
     | OpenAI.CreateEvalCustomDataSourceConfig
@@ -134,6 +135,7 @@ model Eval is OpenAI.Eval {
 #suppress "@azure-tools/typespec-autorest/union-unsupported" "This union is defined according to the Azure OpenAI API."
 #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
 #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
+#suppress "deprecated"
 @@changePropertyType(OpenAI.CreateEvalRequest.data_source_config,
 
     | OpenAI.CreateEvalCustomDataSourceConfig

--- a/specification/ai/data-plane/Azure.AI.Projects/openapi3/2025-11-15-preview/azure-ai-projects-openapi3.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/openapi3/2025-11-15-preview/azure-ai-projects-openapi3.json
@@ -6803,7 +6803,8 @@
                       },
                       "user": {
                         "type": "string",
-                        "description": "This field is being replaced by `safety_identifier` and `prompt_cache_key`. Use `prompt_cache_key` instead to maintain caching optimizations.\n  A stable identifier for your end-users.\n  Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](https://platform.openai.com/docs/guides/safety-best-practices#safety-identifiers)."
+                        "description": "This field is being replaced by `safety_identifier` and `prompt_cache_key`. Use `prompt_cache_key` instead to maintain caching optimizations.\n  A stable identifier for your end-users.\n  Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](https://platform.openai.com/docs/guides/safety-best-practices#safety-identifiers).",
+                        "deprecated": true
                       },
                       "safety_identifier": {
                         "type": "string",
@@ -13893,7 +13894,8 @@
             "container_file_citation": "#/components/schemas/OpenAI.ContainerFileCitationBody",
             "file_path": "#/components/schemas/OpenAI.FilePath"
           }
-        }
+        },
+        "description": "An annotation that applies to a span of output text."
       },
       "OpenAI.AnnotationType": {
         "anyOf": [
@@ -14600,7 +14602,8 @@
           },
           "encrypted_content": {
             "type": "string",
-            "maxLength": 10485760
+            "maxLength": 10485760,
+            "description": "The encrypted content of the compaction summary."
           }
         },
         "allOf": [
@@ -15573,7 +15576,8 @@
             "nullable": true
           },
           "created_by": {
-            "type": "string"
+            "type": "string",
+            "description": "The identifier of the actor that created the item."
           }
         },
         "allOf": [
@@ -15581,7 +15585,7 @@
             "$ref": "#/components/schemas/OpenAI.ConversationItem"
           }
         ],
-        "description": "The output of a shell tool call.",
+        "description": "The output of a shell tool call that was emitted.",
         "title": "Shell call output"
       },
       "OpenAI.ConversationItemFunctionToolCallOutputResource": {
@@ -16318,10 +16322,10 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique ID of the conversation."
+            "description": "The unique ID of the conversation that this response was associated with."
           }
         },
-        "description": "The conversation that this response belongs to. Input items and output items from this response are automatically added to this conversation.",
+        "description": "The conversation that this response belonged to. Input items and output items from this response were automatically added to this conversation.",
         "title": "Conversation"
       },
       "OpenAI.ConversationResource": {
@@ -16901,6 +16905,7 @@
         },
         "description": "Deprecated in favor of LogsDataSourceConfig.",
         "title": "StoredCompletionsDataSourceConfig",
+        "deprecated": true,
         "x-oaiMeta": {
           "name": "The stored completions data source object for evals",
           "group": "evals",
@@ -16942,7 +16947,8 @@
                 "$ref": "#/components/schemas/OpenAI.CreateFineTuningJobRequestHyperparameters"
               }
             ],
-            "description": "The hyperparameters used for the fine-tuning job.\n  This value is now deprecated in favor of `method`, and should be passed in under the `method` parameter."
+            "description": "The hyperparameters used for the fine-tuning job.\n  This value is now deprecated in favor of `method`, and should be passed in under the `method` parameter.",
+            "deprecated": true
           },
           "suffix": {
             "type": "string",
@@ -17123,7 +17129,8 @@
           },
           "user": {
             "type": "string",
-            "description": "This field is being replaced by `safety_identifier` and `prompt_cache_key`. Use `prompt_cache_key` instead to maintain caching optimizations.\n  A stable identifier for your end-users.\n  Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](https://platform.openai.com/docs/guides/safety-best-practices#safety-identifiers)."
+            "description": "This field is being replaced by `safety_identifier` and `prompt_cache_key`. Use `prompt_cache_key` instead to maintain caching optimizations.\n  A stable identifier for your end-users.\n  Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](https://platform.openai.com/docs/guides/safety-best-practices#safety-identifiers).",
+            "deprecated": true
           },
           "safety_identifier": {
             "type": "string",
@@ -19971,10 +19978,12 @@
         ],
         "properties": {
           "stdout": {
-            "type": "string"
+            "type": "string",
+            "description": "The standard output that was captured."
           },
           "stderr": {
-            "type": "string"
+            "type": "string",
+            "description": "The standard error output that was captured."
           },
           "outcome": {
             "allOf": [
@@ -19985,10 +19994,11 @@
             "description": "Represents either an exit outcome (with an exit code) or a timeout outcome for a shell call output chunk."
           },
           "created_by": {
-            "type": "string"
+            "type": "string",
+            "description": "The identifier of the actor that created the item."
           }
         },
-        "description": "The content of a shell call output.",
+        "description": "The content of a shell tool call output that was emitted.",
         "title": "Shell call output content"
       },
       "OpenAI.FunctionShellCallOutputContentParam": {
@@ -22638,7 +22648,8 @@
             "nullable": true
           },
           "created_by": {
-            "type": "string"
+            "type": "string",
+            "description": "The identifier of the actor that created the item."
           }
         },
         "allOf": [
@@ -22646,7 +22657,7 @@
             "$ref": "#/components/schemas/OpenAI.ItemResource"
           }
         ],
-        "description": "The output of a shell tool call.",
+        "description": "The output of a shell tool call that was emitted.",
         "title": "Shell call output"
       },
       "OpenAI.ItemResourceFunctionToolCallOutputResource": {
@@ -24183,10 +24194,12 @@
             "description": "The unique ID of the compaction item."
           },
           "encrypted_content": {
-            "type": "string"
+            "type": "string",
+            "description": "The encrypted content that was produced by compaction."
           },
           "created_by": {
-            "type": "string"
+            "type": "string",
+            "description": "The identifier of the actor that created the item."
           }
         },
         "allOf": [
@@ -24449,7 +24462,8 @@
             "nullable": true
           },
           "created_by": {
-            "type": "string"
+            "type": "string",
+            "description": "The identifier of the actor that created the item."
           }
         },
         "allOf": [
@@ -24457,7 +24471,7 @@
             "$ref": "#/components/schemas/OpenAI.OutputItem"
           }
         ],
-        "description": "The output of a shell tool call.",
+        "description": "The output of a shell tool call that was emitted.",
         "title": "Shell call output"
       },
       "OpenAI.OutputItemFunctionToolCall": {
@@ -25300,7 +25314,8 @@
           },
           "user": {
             "type": "string",
-            "description": "This field is being replaced by `safety_identifier` and `prompt_cache_key`. Use `prompt_cache_key` instead to maintain caching optimizations.\n  A stable identifier for your end-users.\n  Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](https://platform.openai.com/docs/guides/safety-best-practices#safety-identifiers)."
+            "description": "This field is being replaced by `safety_identifier` and `prompt_cache_key`. Use `prompt_cache_key` instead to maintain caching optimizations.\n  A stable identifier for your end-users.\n  Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](https://platform.openai.com/docs/guides/safety-best-practices#safety-identifiers).",
+            "deprecated": true
           },
           "safety_identifier": {
             "type": "string",
@@ -25414,6 +25429,11 @@
             "type": "integer",
             "format": "unixtime",
             "description": "Unix timestamp (in seconds) of when this Response was created."
+          },
+          "completed_at": {
+            "type": "integer",
+            "format": "unixtime",
+            "nullable": true
           },
           "error": {
             "type": "object",
@@ -25899,7 +25919,7 @@
         "x-oaiMeta": {
           "name": "response.completed",
           "group": "responses",
-          "example": "{\n  \"type\": \"response.completed\",\n  \"response\": {\n    \"id\": \"resp_123\",\n    \"object\": \"response\",\n    \"created_at\": 1740855869,\n    \"status\": \"completed\",\n    \"error\": null,\n    \"incomplete_details\": null,\n    \"input\": [],\n    \"instructions\": null,\n    \"max_output_tokens\": null,\n    \"model\": \"gpt-4o-mini-2024-07-18\",\n    \"output\": [\n      {\n        \"id\": \"msg_123\",\n        \"type\": \"message\",\n        \"role\": \"assistant\",\n        \"content\": [\n          {\n            \"type\": \"output_text\",\n            \"text\": \"In a shimmering forest under a sky full of stars, a lonely unicorn named Lila discovered a hidden pond that glowed with moonlight. Every night, she would leave sparkling, magical flowers by the water's edge, hoping to share her beauty with others. One enchanting evening, she woke to find a group of friendly animals gathered around, eager to be friends and share in her magic.\",\n            \"annotations\": []\n          }\n        ]\n      }\n    ],\n    \"previous_response_id\": null,\n    \"reasoning_effort\": null,\n    \"store\": false,\n    \"temperature\": 1,\n    \"text\": {\n      \"format\": {\n        \"type\": \"text\"\n      }\n    },\n    \"tool_choice\": \"auto\",\n    \"tools\": [],\n    \"top_p\": 1,\n    \"truncation\": \"disabled\",\n    \"usage\": {\n      \"input_tokens\": 0,\n      \"output_tokens\": 0,\n      \"output_tokens_details\": {\n        \"reasoning_tokens\": 0\n      },\n      \"total_tokens\": 0\n    },\n    \"user\": null,\n    \"metadata\": {}\n  },\n  \"sequence_number\": 1\n}\n"
+          "example": "{\n  \"type\": \"response.completed\",\n  \"response\": {\n    \"id\": \"resp_123\",\n    \"object\": \"response\",\n    \"created_at\": 1740855869,\n    \"status\": \"completed\",\n    \"completed_at\": 1740855870,\n    \"error\": null,\n    \"incomplete_details\": null,\n    \"input\": [],\n    \"instructions\": null,\n    \"max_output_tokens\": null,\n    \"model\": \"gpt-4o-mini-2024-07-18\",\n    \"output\": [\n      {\n        \"id\": \"msg_123\",\n        \"type\": \"message\",\n        \"role\": \"assistant\",\n        \"content\": [\n          {\n            \"type\": \"output_text\",\n            \"text\": \"In a shimmering forest under a sky full of stars, a lonely unicorn named Lila discovered a hidden pond that glowed with moonlight. Every night, she would leave sparkling, magical flowers by the water's edge, hoping to share her beauty with others. One enchanting evening, she woke to find a group of friendly animals gathered around, eager to be friends and share in her magic.\",\n            \"annotations\": []\n          }\n        ]\n      }\n    ],\n    \"previous_response_id\": null,\n    \"reasoning_effort\": null,\n    \"store\": false,\n    \"temperature\": 1,\n    \"text\": {\n      \"format\": {\n        \"type\": \"text\"\n      }\n    },\n    \"tool_choice\": \"auto\",\n    \"tools\": [],\n    \"top_p\": 1,\n    \"truncation\": \"disabled\",\n    \"usage\": {\n      \"input_tokens\": 0,\n      \"output_tokens\": 0,\n      \"output_tokens_details\": {\n        \"reasoning_tokens\": 0\n      },\n      \"total_tokens\": 0\n    },\n    \"user\": null,\n    \"metadata\": {}\n  },\n  \"sequence_number\": 1\n}\n"
         }
       },
       "OpenAI.ResponseContentPartAddedEvent": {
@@ -26065,7 +26085,7 @@
         "x-oaiMeta": {
           "name": "response.created",
           "group": "responses",
-          "example": "{\n  \"type\": \"response.created\",\n  \"response\": {\n    \"id\": \"resp_67ccfcdd16748190a91872c75d38539e09e4d4aac714747c\",\n    \"object\": \"response\",\n    \"created_at\": 1741487325,\n    \"status\": \"in_progress\",\n    \"error\": null,\n    \"incomplete_details\": null,\n    \"instructions\": null,\n    \"max_output_tokens\": null,\n    \"model\": \"gpt-4o-2024-08-06\",\n    \"output\": [],\n    \"parallel_tool_calls\": true,\n    \"previous_response_id\": null,\n    \"reasoning\": {\n      \"effort\": null,\n      \"summary\": null\n    },\n    \"store\": true,\n    \"temperature\": 1,\n    \"text\": {\n      \"format\": {\n        \"type\": \"text\"\n      }\n    },\n    \"tool_choice\": \"auto\",\n    \"tools\": [],\n    \"top_p\": 1,\n    \"truncation\": \"disabled\",\n    \"usage\": null,\n    \"user\": null,\n    \"metadata\": {}\n  },\n  \"sequence_number\": 1\n}\n"
+          "example": "{\n  \"type\": \"response.created\",\n  \"response\": {\n    \"id\": \"resp_67ccfcdd16748190a91872c75d38539e09e4d4aac714747c\",\n    \"object\": \"response\",\n    \"created_at\": 1741487325,\n    \"status\": \"in_progress\",\n    \"completed_at\": null,\n    \"error\": null,\n    \"incomplete_details\": null,\n    \"instructions\": null,\n    \"max_output_tokens\": null,\n    \"model\": \"gpt-4o-2024-08-06\",\n    \"output\": [],\n    \"parallel_tool_calls\": true,\n    \"previous_response_id\": null,\n    \"reasoning\": {\n      \"effort\": null,\n      \"summary\": null\n    },\n    \"store\": true,\n    \"temperature\": 1,\n    \"text\": {\n      \"format\": {\n        \"type\": \"text\"\n      }\n    },\n    \"tool_choice\": \"auto\",\n    \"tools\": [],\n    \"top_p\": 1,\n    \"truncation\": \"disabled\",\n    \"usage\": null,\n    \"user\": null,\n    \"metadata\": {}\n  },\n  \"sequence_number\": 1\n}\n"
         }
       },
       "OpenAI.ResponseCustomToolCallInputDeltaEvent": {
@@ -26294,7 +26314,7 @@
         "x-oaiMeta": {
           "name": "response.failed",
           "group": "responses",
-          "example": "{\n  \"type\": \"response.failed\",\n  \"response\": {\n    \"id\": \"resp_123\",\n    \"object\": \"response\",\n    \"created_at\": 1740855869,\n    \"status\": \"failed\",\n    \"error\": {\n      \"code\": \"server_error\",\n      \"message\": \"The model failed to generate a response.\"\n    },\n    \"incomplete_details\": null,\n    \"instructions\": null,\n    \"max_output_tokens\": null,\n    \"model\": \"gpt-4o-mini-2024-07-18\",\n    \"output\": [],\n    \"previous_response_id\": null,\n    \"reasoning_effort\": null,\n    \"store\": false,\n    \"temperature\": 1,\n    \"text\": {\n      \"format\": {\n        \"type\": \"text\"\n      }\n    },\n    \"tool_choice\": \"auto\",\n    \"tools\": [],\n    \"top_p\": 1,\n    \"truncation\": \"disabled\",\n    \"usage\": null,\n    \"user\": null,\n    \"metadata\": {}\n  }\n}\n"
+          "example": "{\n  \"type\": \"response.failed\",\n  \"response\": {\n    \"id\": \"resp_123\",\n    \"object\": \"response\",\n    \"created_at\": 1740855869,\n    \"status\": \"failed\",\n    \"completed_at\": null,\n    \"error\": {\n      \"code\": \"server_error\",\n      \"message\": \"The model failed to generate a response.\"\n    },\n    \"incomplete_details\": null,\n    \"instructions\": null,\n    \"max_output_tokens\": null,\n    \"model\": \"gpt-4o-mini-2024-07-18\",\n    \"output\": [],\n    \"previous_response_id\": null,\n    \"reasoning_effort\": null,\n    \"store\": false,\n    \"temperature\": 1,\n    \"text\": {\n      \"format\": {\n        \"type\": \"text\"\n      }\n    },\n    \"tool_choice\": \"auto\",\n    \"tools\": [],\n    \"top_p\": 1,\n    \"truncation\": \"disabled\",\n    \"usage\": null,\n    \"user\": null,\n    \"metadata\": {}\n  }\n}\n"
         }
       },
       "OpenAI.ResponseFileSearchCallCompletedEvent": {
@@ -26867,7 +26887,7 @@
         "x-oaiMeta": {
           "name": "response.in_progress",
           "group": "responses",
-          "example": "{\n  \"type\": \"response.in_progress\",\n  \"response\": {\n    \"id\": \"resp_67ccfcdd16748190a91872c75d38539e09e4d4aac714747c\",\n    \"object\": \"response\",\n    \"created_at\": 1741487325,\n    \"status\": \"in_progress\",\n    \"error\": null,\n    \"incomplete_details\": null,\n    \"instructions\": null,\n    \"max_output_tokens\": null,\n    \"model\": \"gpt-4o-2024-08-06\",\n    \"output\": [],\n    \"parallel_tool_calls\": true,\n    \"previous_response_id\": null,\n    \"reasoning\": {\n      \"effort\": null,\n      \"summary\": null\n    },\n    \"store\": true,\n    \"temperature\": 1,\n    \"text\": {\n      \"format\": {\n        \"type\": \"text\"\n      }\n    },\n    \"tool_choice\": \"auto\",\n    \"tools\": [],\n    \"top_p\": 1,\n    \"truncation\": \"disabled\",\n    \"usage\": null,\n    \"user\": null,\n    \"metadata\": {}\n  },\n  \"sequence_number\": 1\n}\n"
+          "example": "{\n  \"type\": \"response.in_progress\",\n  \"response\": {\n    \"id\": \"resp_67ccfcdd16748190a91872c75d38539e09e4d4aac714747c\",\n    \"object\": \"response\",\n    \"created_at\": 1741487325,\n    \"status\": \"in_progress\",\n    \"completed_at\": null,\n    \"error\": null,\n    \"incomplete_details\": null,\n    \"instructions\": null,\n    \"max_output_tokens\": null,\n    \"model\": \"gpt-4o-2024-08-06\",\n    \"output\": [],\n    \"parallel_tool_calls\": true,\n    \"previous_response_id\": null,\n    \"reasoning\": {\n      \"effort\": null,\n      \"summary\": null\n    },\n    \"store\": true,\n    \"temperature\": 1,\n    \"text\": {\n      \"format\": {\n        \"type\": \"text\"\n      }\n    },\n    \"tool_choice\": \"auto\",\n    \"tools\": [],\n    \"top_p\": 1,\n    \"truncation\": \"disabled\",\n    \"usage\": null,\n    \"user\": null,\n    \"metadata\": {}\n  },\n  \"sequence_number\": 1\n}\n"
         }
       },
       "OpenAI.ResponseIncompleteDetails": {
@@ -26919,7 +26939,7 @@
         "x-oaiMeta": {
           "name": "response.incomplete",
           "group": "responses",
-          "example": "{\n  \"type\": \"response.incomplete\",\n  \"response\": {\n    \"id\": \"resp_123\",\n    \"object\": \"response\",\n    \"created_at\": 1740855869,\n    \"status\": \"incomplete\",\n    \"error\": null,\n    \"incomplete_details\": {\n      \"reason\": \"max_tokens\"\n    },\n    \"instructions\": null,\n    \"max_output_tokens\": null,\n    \"model\": \"gpt-4o-mini-2024-07-18\",\n    \"output\": [],\n    \"previous_response_id\": null,\n    \"reasoning_effort\": null,\n    \"store\": false,\n    \"temperature\": 1,\n    \"text\": {\n      \"format\": {\n        \"type\": \"text\"\n      }\n    },\n    \"tool_choice\": \"auto\",\n    \"tools\": [],\n    \"top_p\": 1,\n    \"truncation\": \"disabled\",\n    \"usage\": null,\n    \"user\": null,\n    \"metadata\": {}\n  },\n  \"sequence_number\": 1\n}\n"
+          "example": "{\n  \"type\": \"response.incomplete\",\n  \"response\": {\n    \"id\": \"resp_123\",\n    \"object\": \"response\",\n    \"created_at\": 1740855869,\n    \"status\": \"incomplete\",\n    \"completed_at\": null,\n    \"error\": null,\n    \"incomplete_details\": {\n      \"reason\": \"max_tokens\"\n    },\n    \"instructions\": null,\n    \"max_output_tokens\": null,\n    \"model\": \"gpt-4o-mini-2024-07-18\",\n    \"output\": [],\n    \"previous_response_id\": null,\n    \"reasoning_effort\": null,\n    \"store\": false,\n    \"temperature\": 1,\n    \"text\": {\n      \"format\": {\n        \"type\": \"text\"\n      }\n    },\n    \"tool_choice\": \"auto\",\n    \"tools\": [],\n    \"top_p\": 1,\n    \"truncation\": \"disabled\",\n    \"usage\": null,\n    \"user\": null,\n    \"metadata\": {}\n  },\n  \"sequence_number\": 1\n}\n"
         }
       },
       "OpenAI.ResponseLogProb": {
@@ -29372,7 +29392,7 @@
           "type": {
             "type": "string",
             "enum": [
-              "find"
+              "find_in_page"
             ],
             "description": "The action type.",
             "x-stainless-const": true
@@ -29431,7 +29451,16 @@
           },
           "query": {
             "type": "string",
-            "description": "The search query."
+            "description": "[DEPRECATED] The search query.",
+            "deprecated": true
+          },
+          "queries": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The search queries.",
+            "title": "Search queries"
           },
           "sources": {
             "type": "array",

--- a/specification/ai/data-plane/Azure.AI.Projects/openapi3/v1/azure-ai-projects-openapi3.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/openapi3/v1/azure-ai-projects-openapi3.json
@@ -5011,6 +5011,7 @@
         },
         "description": "Deprecated in favor of LogsDataSourceConfig.",
         "title": "StoredCompletionsDataSourceConfig",
+        "deprecated": true,
         "x-oaiMeta": {
           "name": "The stored completions data source object for evals",
           "group": "evals",

--- a/specification/ai/data-plane/Azure.AI.Projects/preview/2025-11-15-preview/azure-ai-projects.json
+++ b/specification/ai/data-plane/Azure.AI.Projects/preview/2025-11-15-preview/azure-ai-projects.json
@@ -12313,6 +12313,7 @@
     },
     "OpenAI.Annotation": {
       "type": "object",
+      "description": "An annotation that applies to a span of output text.",
       "properties": {
         "type": {
           "$ref": "#/definitions/OpenAI.AnnotationType"
@@ -12771,6 +12772,7 @@
         },
         "encrypted_content": {
           "type": "string",
+          "description": "The encrypted content of the compaction summary.",
           "maxLength": 10485760
         }
       },
@@ -13380,7 +13382,7 @@
     "OpenAI.ConversationItemFunctionShellCallOutput": {
       "type": "object",
       "title": "Shell call output",
-      "description": "The output of a shell tool call.",
+      "description": "The output of a shell tool call that was emitted.",
       "properties": {
         "id": {
           "type": "string",
@@ -13402,7 +13404,8 @@
           "x-nullable": true
         },
         "created_by": {
-          "type": "string"
+          "type": "string",
+          "description": "The identifier of the actor that created the item."
         }
       },
       "required": [
@@ -13983,11 +13986,11 @@
     "OpenAI.ConversationReference": {
       "type": "object",
       "title": "Conversation",
-      "description": "The conversation that this response belongs to. Input items and output items from this response are automatically added to this conversation.",
+      "description": "The conversation that this response belonged to. Input items and output items from this response were automatically added to this conversation.",
       "properties": {
         "id": {
           "type": "string",
-          "description": "The unique ID of the conversation."
+          "description": "The unique ID of the conversation that this response was associated with."
         }
       },
       "required": [
@@ -15512,20 +15515,23 @@
     "OpenAI.FunctionShellCallOutputContent": {
       "type": "object",
       "title": "Shell call output content",
-      "description": "The content of a shell call output.",
+      "description": "The content of a shell tool call output that was emitted.",
       "properties": {
         "stdout": {
-          "type": "string"
+          "type": "string",
+          "description": "The standard output that was captured."
         },
         "stderr": {
-          "type": "string"
+          "type": "string",
+          "description": "The standard error output that was captured."
         },
         "outcome": {
           "$ref": "#/definitions/OpenAI.FunctionShellCallOutputOutcome",
           "description": "Represents either an exit outcome (with an exit code) or a timeout outcome for a shell call output chunk."
         },
         "created_by": {
-          "type": "string"
+          "type": "string",
+          "description": "The identifier of the actor that created the item."
         }
       },
       "required": [
@@ -17140,7 +17146,7 @@
     "OpenAI.ItemResourceFunctionShellCallOutput": {
       "type": "object",
       "title": "Shell call output",
-      "description": "The output of a shell tool call.",
+      "description": "The output of a shell tool call that was emitted.",
       "properties": {
         "id": {
           "type": "string",
@@ -17162,7 +17168,8 @@
           "x-nullable": true
         },
         "created_by": {
-          "type": "string"
+          "type": "string",
+          "description": "The identifier of the actor that created the item."
         }
       },
       "required": [
@@ -18502,10 +18509,12 @@
           "description": "The unique ID of the compaction item."
         },
         "encrypted_content": {
-          "type": "string"
+          "type": "string",
+          "description": "The encrypted content that was produced by compaction."
         },
         "created_by": {
-          "type": "string"
+          "type": "string",
+          "description": "The identifier of the actor that created the item."
         }
       },
       "required": [
@@ -18695,7 +18704,7 @@
     "OpenAI.OutputItemFunctionShellCallOutput": {
       "type": "object",
       "title": "Shell call output",
-      "description": "The output of a shell tool call.",
+      "description": "The output of a shell tool call that was emitted.",
       "properties": {
         "id": {
           "type": "string",
@@ -18717,7 +18726,8 @@
           "x-nullable": true
         },
         "created_by": {
-          "type": "string"
+          "type": "string",
+          "description": "The identifier of the actor that created the item."
         }
       },
       "required": [
@@ -19477,6 +19487,11 @@
           "type": "integer",
           "format": "unixtime",
           "description": "Unix timestamp (in seconds) of when this Response was created."
+        },
+        "completed_at": {
+          "type": "integer",
+          "format": "unixtime",
+          "x-nullable": true
         },
         "error": {
           "$ref": "#/definitions/OpenAI.ResponseError",


### PR DESCRIPTION
I did two things in the `specification/ai/Foundry` directory:

- Added `#suppress "deprecated"` directives to `openai-evaluations/models.tsp` because otherwise I got errors running `npx tsv .`
- Ran `npx tsv .` several times to get specs formatted and compiled, then checked those in