### PR TITLE
Add suppressions for TypeSpec-converted MachineLearningServices 2025-…

### DIFF
--- a/specification/machinelearningservices/resource-manager/readme.md
+++ b/specification/machinelearningservices/resource-manager/readme.md
@@ -182,6 +182,24 @@ suppressions:
     where:
       - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/managedNetworks/{managedNetworkName}/outboundRules/{ruleName}"].put
       - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/managedNetworks/{managedNetworkName}"].put
+  - code: TrackedResourcePatchOperation
+    reason: PrivateEndpointConnection does not support PATCH operation, consistent with previous API versions.
+    where:
+      - $.definitions.PrivateEndpointConnection
+  - code: GetCollectionOnlyHasValueAndNextLink
+    reason: Existing API pagination patterns from TypeSpec conversion, consistent with previous versions.
+    where:
+      - $.paths["/subscriptions/{subscriptionId}/providers/Microsoft.MachineLearningServices/locations/{location}/availableQuota"].get.responses.200.schema
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.MachineLearningServices/workspaces/{workspaceName}/listStorageAccountKeys"].post.responses.200.schema
+  - code: XmsSecretPropertyMissing
+    reason: publicNetworkAccess is not a secret property, it controls network access policy.
+    where:
+      - $.definitions.WorkspaceProperties.properties.publicNetworkAccess
+      - $.definitions.RegistryProperties.properties.publicNetworkAccess
+      - $.definitions.ServerlessEndpointProperties.properties.publicNetworkAccess
+  - code: ResourceNameRestriction
+    reason: Parameter exists in previous API versions without pattern, cannot add now without breaking change.
+    from: openapi.json
 ```
 
 ### Tag: package-2025-09-01


### PR DESCRIPTION
…10-01-preview

- Added TrackedResourcePatchOperation suppression for PrivateEndpointConnection
- Added GetCollectionOnlyHasValueAndNextLink suppression for pagination responses
- Added XmsSecretPropertyMissing suppression for publicNetworkAccess properties
- Added ResourceNameRestriction suppression for backward compatibility

These suppressions address CI lint failures after TypeSpec conversion.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
