### PR TITLE
Allow older preview swaggers in TypeSpec validation to support @previewVersion in tsp

### DIFF
--- a/eng/tools/typespec-validation/src/rules/compile.ts
+++ b/eng/tools/typespec-validation/src/rules/compile.ts
@@ -164,7 +164,7 @@ export class CompileRule implements Rule {
           if (extraSwaggers.length > 0) {
             // Helper function to extract version from swagger path
             const extractVersion = (swaggerPath: string): string | null => {
-              const match = swaggerPath.match(/\/(preview|stable)\/([^\/]+)\//);
+              const match = swaggerPath.match(/\/(preview|stable)\/([^/]+)\//);
               return match ? match[2] : null;
             };
 

--- a/eng/tools/typespec-validation/test/compile.test.ts
+++ b/eng/tools/typespec-validation/test/compile.test.ts
@@ -143,10 +143,10 @@ describe("compile", function () {
 
     runNpmSpy.mockImplementation(
       async (): Promise<[Error | null, string, string]> =>
-        Promise.resolve([null, latestPreviewPath, ""]),
+        Promise.resolve([null, path.normalize(latestPreviewPath), ""]),
     );
 
-    // Simulate extra older preview swagger
+    // Simulate extra older preview swagger (globby always returns posix paths)
     vi.mocked(globby.globby).mockImplementation(() =>
       Promise.resolve([latestPreviewPath, olderPreviewPath]),
     );
@@ -168,10 +168,10 @@ describe("compile", function () {
 
     runNpmSpy.mockImplementation(
       async (): Promise<[Error | null, string, string]> =>
-        Promise.resolve([null, latestPreviewPath, ""]),
+        Promise.resolve([null, path.normalize(latestPreviewPath), ""]),
     );
 
-    // Simulate extra swagger from the latest preview
+    // Simulate extra swagger from the latest preview (globby always returns posix paths)
     vi.mocked(globby.globby).mockImplementation(() =>
       Promise.resolve([latestPreviewPath, anotherLatestPreviewPath]),
     );
@@ -191,10 +191,11 @@ describe("compile", function () {
     const stablePath = "data-plane/Azure.Foo/stable/2023-01-01/foo.json";
 
     runNpmSpy.mockImplementation(
-      async (): Promise<[Error | null, string, string]> => Promise.resolve([null, previewPath, ""]),
+      async (): Promise<[Error | null, string, string]> =>
+        Promise.resolve([null, path.normalize(previewPath), ""]),
     );
 
-    // Simulate extra stable swagger
+    // Simulate extra stable swagger (globby always returns posix paths)
     vi.mocked(globby.globby).mockImplementation(() => Promise.resolve([previewPath, stablePath]));
 
     vi.mocked(fsPromises.readFile).mockImplementation(() =>
@@ -214,10 +215,10 @@ describe("compile", function () {
 
     runNpmSpy.mockImplementation(
       async (): Promise<[Error | null, string, string]> =>
-        Promise.resolve([null, latestPreviewPath, ""]),
+        Promise.resolve([null, path.normalize(latestPreviewPath), ""]),
     );
 
-    // Simulate multiple extra older preview swaggers
+    // Simulate multiple extra older preview swaggers (globby always returns posix paths)
     vi.mocked(globby.globby).mockImplementation(() =>
       Promise.resolve([latestPreviewPath, olderPreview1Path, olderPreview2Path]),
     );
@@ -239,10 +240,11 @@ describe("compile", function () {
     const stablePath = "data-plane/Azure.Foo/stable/2023-01-01/foo.json";
 
     runNpmSpy.mockImplementation(
-      async (): Promise<[Error | null, string, string]> => Promise.resolve([null, previewPath, ""]),
+      async (): Promise<[Error | null, string, string]> =>
+        Promise.resolve([null, path.normalize(previewPath), ""]),
     );
 
-    // Simulate extra swaggers with mix of preview and stable
+    // Simulate extra swaggers with mix of preview and stable (globby always returns posix paths)
     vi.mocked(globby.globby).mockImplementation(() =>
       Promise.resolve([previewPath, olderPreviewPath, stablePath]),
     );

--- a/eng/tools/typespec-validation/test/compile.test.ts
+++ b/eng/tools/typespec-validation/test/compile.test.ts
@@ -136,6 +136,127 @@ describe("compile", function () {
     });
   });
 
+  it("should succeed if extra swaggers are only older preview versions", async function () {
+    // Latest preview is 2024-03-01-preview, extra swagger is from 2022-11-01-preview
+    const latestPreviewPath = "data-plane/Azure.Foo/preview/2024-03-01-preview/foo.json";
+    const olderPreviewPath = "data-plane/Azure.Foo/preview/2022-11-01-preview/foo.json";
+
+    runNpmSpy.mockImplementation(
+      async (): Promise<[Error | null, string, string]> =>
+        Promise.resolve([null, latestPreviewPath, ""]),
+    );
+
+    // Simulate extra older preview swagger
+    vi.mocked(globby.globby).mockImplementation(() =>
+      Promise.resolve([latestPreviewPath, olderPreviewPath]),
+    );
+
+    vi.mocked(fsPromises.readFile).mockImplementation(() =>
+      Promise.resolve('{"info": {"x-typespec-generated": true}}'),
+    );
+
+    const result = await new CompileRule().execute(mockFolder);
+    expect(result).toMatchObject({
+      success: true,
+      stdOutput: expect.stringContaining("older versions") as unknown,
+    });
+  });
+
+  it("should fail if extra swaggers include latest preview version", async function () {
+    const latestPreviewPath = "data-plane/Azure.Foo/preview/2024-03-01-preview/foo.json";
+    const anotherLatestPreviewPath = "data-plane/Azure.Foo/preview/2024-03-01-preview/bar.json";
+
+    runNpmSpy.mockImplementation(
+      async (): Promise<[Error | null, string, string]> =>
+        Promise.resolve([null, latestPreviewPath, ""]),
+    );
+
+    // Simulate extra swagger from the latest preview
+    vi.mocked(globby.globby).mockImplementation(() =>
+      Promise.resolve([latestPreviewPath, anotherLatestPreviewPath]),
+    );
+
+    vi.mocked(fsPromises.readFile).mockImplementation(() =>
+      Promise.resolve('{"info": {"x-typespec-generated": true}}'),
+    );
+
+    await expect(new CompileRule().execute(mockFolder)).resolves.toMatchObject({
+      success: false,
+      errorOutput: expect.stringContaining("not generated from the current") as unknown,
+    });
+  });
+
+  it("should fail if extra swaggers include stable versions", async function () {
+    const previewPath = "data-plane/Azure.Foo/preview/2024-03-01-preview/foo.json";
+    const stablePath = "data-plane/Azure.Foo/stable/2023-01-01/foo.json";
+
+    runNpmSpy.mockImplementation(
+      async (): Promise<[Error | null, string, string]> => Promise.resolve([null, previewPath, ""]),
+    );
+
+    // Simulate extra stable swagger
+    vi.mocked(globby.globby).mockImplementation(() => Promise.resolve([previewPath, stablePath]));
+
+    vi.mocked(fsPromises.readFile).mockImplementation(() =>
+      Promise.resolve('{"info": {"x-typespec-generated": true}}'),
+    );
+
+    await expect(new CompileRule().execute(mockFolder)).resolves.toMatchObject({
+      success: false,
+      errorOutput: expect.stringContaining("not generated from the current") as unknown,
+    });
+  });
+
+  it("should succeed with multiple older preview versions", async function () {
+    const latestPreviewPath = "data-plane/Azure.Foo/preview/2024-03-01-preview/foo.json";
+    const olderPreview1Path = "data-plane/Azure.Foo/preview/2023-01-01-preview/foo.json";
+    const olderPreview2Path = "data-plane/Azure.Foo/preview/2022-11-01-preview/foo.json";
+
+    runNpmSpy.mockImplementation(
+      async (): Promise<[Error | null, string, string]> =>
+        Promise.resolve([null, latestPreviewPath, ""]),
+    );
+
+    // Simulate multiple extra older preview swaggers
+    vi.mocked(globby.globby).mockImplementation(() =>
+      Promise.resolve([latestPreviewPath, olderPreview1Path, olderPreview2Path]),
+    );
+
+    vi.mocked(fsPromises.readFile).mockImplementation(() =>
+      Promise.resolve('{"info": {"x-typespec-generated": true}}'),
+    );
+
+    const result = await new CompileRule().execute(mockFolder);
+    expect(result).toMatchObject({
+      success: true,
+      stdOutput: expect.stringContaining("older versions") as unknown,
+    });
+  });
+
+  it("should fail if extra swaggers mix preview and stable versions", async function () {
+    const previewPath = "data-plane/Azure.Foo/preview/2024-03-01-preview/foo.json";
+    const olderPreviewPath = "data-plane/Azure.Foo/preview/2022-11-01-preview/foo.json";
+    const stablePath = "data-plane/Azure.Foo/stable/2023-01-01/foo.json";
+
+    runNpmSpy.mockImplementation(
+      async (): Promise<[Error | null, string, string]> => Promise.resolve([null, previewPath, ""]),
+    );
+
+    // Simulate extra swaggers with mix of preview and stable
+    vi.mocked(globby.globby).mockImplementation(() =>
+      Promise.resolve([previewPath, olderPreviewPath, stablePath]),
+    );
+
+    vi.mocked(fsPromises.readFile).mockImplementation(() =>
+      Promise.resolve('{"info": {"x-typespec-generated": true}}'),
+    );
+
+    await expect(new CompileRule().execute(mockFolder)).resolves.toMatchObject({
+      success: false,
+      errorOutput: expect.stringContaining("not generated from the current") as unknown,
+    });
+  });
+
   it("supports suppressions", async function () {
     runNpmSpy.mockImplementation(
       async (): Promise<[Error | null, string, string]> => Promise.resolve([null, swaggerPath, ""]),

--- a/eng/tools/typespec-validation/test/compile.test.ts
+++ b/eng/tools/typespec-validation/test/compile.test.ts
@@ -48,7 +48,7 @@ describe("compile", function () {
       // ensure paths are trimmed
       `\t${swaggerPath} \n` +
       // ensure paths are normalized
-      `${path.win32.normalize(swaggerPath)}\n` +
+      `${path.normalize(swaggerPath)}\n` +
       // ensure filtered to JSON files
       "data-plane/readme.md\n" +
       // ensure examples are skipped
@@ -143,7 +143,7 @@ describe("compile", function () {
 
     runNpmSpy.mockImplementation(
       async (): Promise<[Error | null, string, string]> =>
-        Promise.resolve([null, path.normalize(latestPreviewPath), ""]),
+        Promise.resolve([null, latestPreviewPath, ""]),
     );
 
     // Simulate extra older preview swagger (globby always returns posix paths)
@@ -168,7 +168,7 @@ describe("compile", function () {
 
     runNpmSpy.mockImplementation(
       async (): Promise<[Error | null, string, string]> =>
-        Promise.resolve([null, path.normalize(latestPreviewPath), ""]),
+        Promise.resolve([null, latestPreviewPath, ""]),
     );
 
     // Simulate extra swagger from the latest preview (globby always returns posix paths)
@@ -191,8 +191,7 @@ describe("compile", function () {
     const stablePath = "data-plane/Azure.Foo/stable/2023-01-01/foo.json";
 
     runNpmSpy.mockImplementation(
-      async (): Promise<[Error | null, string, string]> =>
-        Promise.resolve([null, path.normalize(previewPath), ""]),
+      async (): Promise<[Error | null, string, string]> => Promise.resolve([null, previewPath, ""]),
     );
 
     // Simulate extra stable swagger (globby always returns posix paths)
@@ -215,7 +214,7 @@ describe("compile", function () {
 
     runNpmSpy.mockImplementation(
       async (): Promise<[Error | null, string, string]> =>
-        Promise.resolve([null, path.normalize(latestPreviewPath), ""]),
+        Promise.resolve([null, latestPreviewPath, ""]),
     );
 
     // Simulate multiple extra older preview swaggers (globby always returns posix paths)
@@ -240,8 +239,7 @@ describe("compile", function () {
     const stablePath = "data-plane/Azure.Foo/stable/2023-01-01/foo.json";
 
     runNpmSpy.mockImplementation(
-      async (): Promise<[Error | null, string, string]> =>
-        Promise.resolve([null, path.normalize(previewPath), ""]),
+      async (): Promise<[Error | null, string, string]> => Promise.resolve([null, previewPath, ""]),
     );
 
     // Simulate extra swaggers with mix of preview and stable (globby always returns posix paths)


### PR DESCRIPTION
fixes #39674 

## Description

This PR enhances the TypeSpec validation compile rule to allow older preview versions of swaggers to remain in the repository without causing validation failures.

## Changes

- **compile.ts**: Added logic to detect if extra swaggers are only from older preview versions (not the latest preview)
  - Extracts version information from swagger paths
  - Identifies the latest preview version
  - Allows extra swaggers if they are only from older previews
  - Still fails validation for:
    - Extra swaggers from the latest preview version
    - Extra swaggers from stable versions
    - Mixed preview and stable extra swaggers

- **compile.test.ts**: Added comprehensive test cases:
  - Test for allowing older preview versions
  - Test for failing on latest preview versions
  - Test for failing on stable versions
  - Test for allowing multiple older previews
  - Test for failing on mixed preview/stable versions

## Benefits

This change allows services to maintain older preview swagger files in the repository while still enforcing validation that the latest TypeSpec sources generate the expected output. This is useful for maintaining historical API versions without requiring suppression rules.