### PR TITLE
Added optional parameter for datamap remove classification api

### DIFF
--- a/specification/purview/data-plane/datamap/stable/2023-09-01/purviewdatamap.json
+++ b/specification/purview/data-plane/datamap/stable/2023-09-01/purviewdatamap.json
@@ -873,6 +873,13 @@
             "description": "The name of the classification.",
             "required": true,
             "type": "string"
+          },
+          {
+            "name": "suppressDeletedClassification",
+            "in": "query",
+            "description": "To prevent classification changes from being overridden during regular scans, set this parameter to true. The default value is false.",
+            "required": false,
+            "type": "boolean"
           }
         ],
         "responses": {


### PR DESCRIPTION
# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
