### PR TITLE
Update description for Enum CachingTypes to remove confusion for PV2 and UltraSSD disk default values

### DIFF
--- a/specification/azurefleet/resource-manager/Microsoft.AzureFleet/AzureFleet/baseVirtualMachineProfile.tsp
+++ b/specification/azurefleet/resource-manager/Microsoft.AzureFleet/AzureFleet/baseVirtualMachineProfile.tsp
@@ -678,7 +678,7 @@ model VirtualMachineScaleSetOSDisk {
   /**
    * Specifies the caching requirements. Possible values are: **None,**
    * **ReadOnly,** **ReadWrite.** The default values are: **None for Standard
-   * storage. ReadOnly for Premium storage.**
+   * storage, Premium SSD v2, and Ultra Disk. ReadOnly for Premium SSD.**
    */
   caching?: CachingTypes;
 
@@ -851,7 +851,7 @@ model VirtualMachineScaleSetDataDisk {
   /**
    * Specifies the caching requirements. Possible values are: **None,**
    * **ReadOnly,** **ReadWrite.** The default values are: **None for Standard
-   * storage. ReadOnly for Premium storage.**
+   * storage, Premium SSD v2, and Ultra Disk. ReadOnly for Premium SSD.**
    */
   caching?: CachingTypes;
 
@@ -1874,12 +1874,12 @@ union CachingTypes {
   string,
 
   /**
-   * 'None' is default for Standard Storage
+   * 'None' is default for Standard Storage, Premium SSD v2, and Ultra Disk
    */
   None: "None",
 
   /**
-   * 'ReadOnly' is default for Premium Storage
+   * 'ReadOnly' is default for Premium SSD
    */
   ReadOnly: "ReadOnly",
 


### PR DESCRIPTION
## Purpose of this PR
In this PR, we are changing the description for the Enum CachingTypes to avoid confusion related to the default values for PremiumV1, PremiumV2 and Ultra SSD disks.

The target version for these changes is CRP API version **2025-11-01**.

## Due diligence checklist

To merge this PR, you **must** go through the following checklist and confirm you understood 
and followed the instructions by checking all the boxes:

- [x] I confirm this PR is modifying Azure Resource Manager (ARM) related specifications, and not data plane related specifications.
- [x] I have reviewed following [Resource Provider guidelines](https://aka.ms/rpguidelines), including
  [ARM resource provider contract](https://aka.ms/azurerpc) and
  [REST guidelines](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md) (estimated time: 4 hours).  
  I understand this is required before I can proceed to the diagram Step 2, "ARM API changes review", for this PR.
- [x] A [release plan](https://aka.ms/azsdkdocs/release-plans) has been created. If not, please create one as it will help guide you through the REST API and SDK creation process. 

## Additional information

<details>
<summary> Viewing API changes</summary>

For convenient view of the API changes made by this PR, refer to the URLs provided in the table 
in the `Generated ApiView` comment added to this PR. You can use ApiView to show API versions diff. 

</details>
<details>
<summary>Suppressing failures</summary>

If one or multiple validation error/warning suppression(s) is detected in your PR, please follow the 
[suppressions guide](https://aka.ms/azsdk/pr-suppressions) to get approval.

</details>

## Getting help

- First, please carefully read through this PR description, from top to bottom. Please fill out the `Purpose of this PR` and `Due diligence checklist`.
- If you don't have permissions to remove or add labels to the PR, request `write access` per [aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories](https://aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories)
- To understand what you must do next to merge this PR, see the `Next Steps to Merge` comment. It will appear within few minutes of submitting this PR and will continue to be up-to-date with current PR state.
- For guidance on fixing this PR CI check failures, see the hyperlinks provided in given failure 
  and https://aka.ms/ci-fix.
- For help with ARM review (PR workflow diagram Step 2), see https://aka.ms/azsdk/pr-arm-review.
- If the PR CI checks appear to be stuck in `queued` state, please add a comment with contents `/azp run`.
  This should result in a new comment denoting a `PR validation pipeline` has started and the checks should be updated after few minutes.
- If the help provided by the previous points is not enough, post to https://aka.ms/azsdk/support/specreview-channel and link to this PR.
- For guidance on SDK breaking change review, refer to https://aka.ms/ci-fix.
