### PR TITLE
Suppressing emission for duplicate types exposed by Stainless SDK

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-agents/tspconfig.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-agents/tspconfig.yaml
@@ -12,7 +12,7 @@ options:
     generate-tests: false
     generate-samples: false
     custom-types-subpackage: "implementation.models"
-    custom-types: "ItemReferenceParam, EasyInputMessage"
+    custom-types: "ItemReferenceParam,EasyInputMessage,EasyInputMessageRole,EasyInputMessageStatus"
     rename-model:
       GrammarSyntax1: GrammarSyntax
       ReasoningEffort1: ReasoningEffort

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-agents/tspconfig.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-agents/tspconfig.yaml
@@ -13,9 +13,6 @@ options:
     generate-samples: false
     custom-types-subpackage: "implementation.models"
     custom-types: "ItemReferenceParam,EasyInputMessage,EasyInputMessageRole,EasyInputMessageStatus"
-    rename-model:
-      GrammarSyntax1: GrammarSyntax
-      ReasoningEffort1: ReasoningEffort
     customization-class: customizations/src/main/java/AgentsCustomizations.java
     flavor: azure
   "@typespec/json-schema":

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-agents/tspconfig.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-agents/tspconfig.yaml
@@ -12,6 +12,7 @@ options:
     generate-tests: false
     generate-samples: false
     custom-types-subpackage: "implementation.models"
+    custom-types: "ItemReferenceParam, EasyInputMessage"
     rename-model:
       GrammarSyntax1: GrammarSyntax
       ReasoningEffort1: ReasoningEffort

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-agents/tspconfig.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-agents/tspconfig.yaml
@@ -13,6 +13,9 @@ options:
     generate-samples: false
     custom-types-subpackage: "implementation.models"
     custom-types: "ItemReferenceParam,EasyInputMessage,EasyInputMessageRole,EasyInputMessageStatus"
+    rename-model:
+      GrammarSyntax1: GrammarSyntax
+      ReasoningEffort1: ReasoningEffort
     customization-class: customizations/src/main/java/AgentsCustomizations.java
     flavor: azure
   "@typespec/json-schema":


### PR DESCRIPTION
Suppressing types related to `ItemReferenceParam` and `EasyInputMessage` duplicating what's available in the Stainless library. 

**One caveat:**

The spec adds the `status` field to `EasyInputMessage` as the sole diff between these models. 