### PR TITLE
DO NOT MERGE - Add SKU support to DeidService with API version 2026-02-01-preview

### DIFF
--- a/specification/healthdataaiservices/HealthDataAIServices.Management/README.md
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/README.md
@@ -74,6 +74,8 @@ I need:
 - The sku property added to DeidUpdate for PATCH operations
 
 After making the TypeSpec changes, guide me through creating the API spec PR and generating SDKs. Use separate subagents for each SDK language.
+
+Create a markdown file to track the progress of each step throughout this process.
 ```
 
 ---

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/README.md
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/README.md
@@ -63,7 +63,7 @@ The complete workflow includes:
 Use this prompt with GitHub Copilot to implement the proposed changes. The Azure SDK MCP tools will guide you through the complete process.
 
 ```
-This is a demo environment. Any pull requests opened should have their title prefixed with "DO NOT MERGE" before the actual title.
+This is a demo environment. Any pull requests opened should have their title prefixed with "DO NOT MERGE" before the actual title. Since this is a demo of the local development experience, do not create a release plan.
 
 Add SKU support to the HealthDataAIServices DeidService with a new API version "2026-02-01-preview".
 
@@ -73,7 +73,7 @@ I need:
 - The sku property added to DeidService (marked as added in the new version)
 - The sku property added to DeidUpdate for PATCH operations
 
-After making the TypeSpec changes, guide me through creating the API spec PR and generating SDKs. Use separate subagents for each SDK language.
+After making the TypeSpec changes, guide me through creating the API spec PR and generating SDKs locally. Stay in the current branch (ronniegeraghty/azsdktoolsagent-demo) for the API spec changes. All SDK language repositories (azure-sdk-for-net, azure-sdk-for-python, azure-sdk-for-java, azure-sdk-for-js, azure-sdk-for-go) are already cloned locally in the same parent directory as the azure-rest-api-specs repo. Create a branch named "ronniegeraghty/azsdktoolsagent-demo" in each SDK repo to work on the new library generations. Use separate subagents for each SDK language.
 
 Create a markdown file to track the progress of each step throughout this process.
 ```

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/README.md
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/README.md
@@ -73,7 +73,7 @@ I need:
 - The sku property added to DeidService (marked as added in the new version)
 - The sku property added to DeidUpdate for PATCH operations
 
-After making the TypeSpec changes, guide me through creating the API spec PR and generating SDKs locally. Stay in the current branch (ronniegeraghty/azsdktoolsagent-demo) for the API spec changes. All SDK language repositories (azure-sdk-for-net, azure-sdk-for-python, azure-sdk-for-java, azure-sdk-for-js, azure-sdk-for-go) are already cloned locally in the same parent directory as the azure-rest-api-specs repo. Create a branch named "ronniegeraghty/azsdktoolsagent-demo" in each SDK repo to work on the new library generations. Use separate subagents for each SDK language.
+After making the TypeSpec changes, guide me through creating the API spec PR and generating SDKs locally. Stay in the current branch (ronniegeraghty/azsdktoolsagent-demo) for the API spec changes. All SDK language repositories (azure-sdk-for-net, azure-sdk-for-python, azure-sdk-for-java, azure-sdk-for-js, azure-sdk-for-go) are already cloned locally in the same parent directory as the azure-rest-api-specs repo. Create a branch named "ronniegeraghty/azsdktoolsagent-demo" in each SDK repo to work on the new library generations. Use separate subagents in parallel sfor each SDK language.
 
 Create a markdown file to track the progress of each step throughout this process.
 ```

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/README.md
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/README.md
@@ -1,0 +1,100 @@
+# HealthDataAIServices Management TypeSpec Project
+
+This TypeSpec project defines the Azure Resource Manager (ARM) API for the HealthDataAIServices DeidService.
+
+## Project Structure
+
+| File | Description |
+|------|-------------|
+| `main.tsp` | Main service definition with resource models and operations |
+| `client.tsp` | Client customizations for SDK generation |
+| `tspconfig.yaml` | Emitter configuration for OpenAPI and language SDKs |
+| `examples/` | Example JSON files for API operations |
+
+## Getting Started
+
+```powershell
+# From the repository root, install dependencies
+npm ci
+
+# Compile the TypeSpec project
+cd specification/healthdataaiservices/HealthDataAIServices.Management
+npx tsp compile .
+```
+
+---
+
+## Proposed API Change: Add SKU Support with New API Version
+
+### Overview
+
+Add pricing tier (SKU) support to the DeidService resource, introduced in a new preview API version `2026-02-01-preview`. This document covers the **complete end-to-end process** from API spec changes through SDK generation and release.
+
+### Proposed Changes
+
+1. **Add new API version** `2026-02-01-preview` to the `Versions` enum
+2. **Define SKU tier options**: Free, Basic, Standard
+3. **Add `Sku` model** with `name`, `tier`, and `capacity` properties
+4. **Add `sku` property** to `DeidService` resource (available from the new version)
+5. **Add `sku` to `DeidUpdate`** for PATCH operations
+
+### Why a New Version?
+
+- SKU support is a significant new capability
+- Cleaner versioning for customers to adopt new features explicitly
+- Follows Azure best practices for API evolution
+
+### End-to-End Process
+
+The complete workflow includes:
+
+1. **API Spec Update** - Modify TypeSpec, compile, and validate
+2. **Create API Spec PR** - Submit changes to `Azure/azure-rest-api-specs`
+3. **API Review** - Get approval from API reviewers
+4. **SDK Generation** - Generate SDKs in parallel using separate subagents for each language (.NET, Python, Java, JavaScript, Go)
+5. **SDK PR Review** - Review generated SDK pull requests
+6. **Release Planning** - Create release plan and link SDK PRs
+7. **SDK Release** - Publish packages to public registries
+
+---
+
+## Sample Copilot Prompt
+
+Use this prompt with GitHub Copilot to implement the proposed changes. The Azure SDK MCP tools will guide you through the complete process.
+
+```
+This is a demo environment. Any pull requests opened should have their title prefixed with "DO NOT MERGE" before the actual title.
+
+Add SKU support to the HealthDataAIServices DeidService with a new API version "2026-02-01-preview".
+
+I need:
+- A SkuTier union with Free, Basic, and Standard options
+- A Sku model with name, tier, and capacity properties  
+- The sku property added to DeidService (marked as added in the new version)
+- The sku property added to DeidUpdate for PATCH operations
+
+After making the TypeSpec changes, guide me through creating the API spec PR and generating SDKs. Use separate subagents for each SDK language.
+```
+
+---
+
+## SDK Generation
+
+This project is configured to generate SDKs for:
+
+| Language | Package Name |
+|----------|--------------|
+| **.NET** | `Azure.ResourceManager.HealthDataAIServices` |
+| **Python** | `azure-mgmt-healthdataaiservices` |
+| **Java** | `azure-resourcemanager-healthdataaiservices` |
+| **JavaScript** | `@azure/arm-healthdataaiservices` |
+| **Go** | `armhealthdataaiservices` |
+
+See `tspconfig.yaml` for emitter configuration details.
+
+### SDK Generation Options
+
+- **Pipeline Generation**: Use the Azure SDK generation pipeline for automated PR creation (supports parallel subagents per language)
+- **Local Generation**: Generate SDKs locally for testing and customization before creating PRs
+
+For more details on the SDK generation process, refer to the Azure SDK release documentation.

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/README.md
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/README.md
@@ -73,7 +73,7 @@ I need:
 - The sku property added to DeidService (marked as added in the new version)
 - The sku property added to DeidUpdate for PATCH operations
 
-After making the TypeSpec changes, guide me through creating the API spec PR and generating SDKs locally. Stay in the current branch (ronniegeraghty/azsdktoolsagent-demo) for the API spec changes. All SDK language repositories (azure-sdk-for-net, azure-sdk-for-python, azure-sdk-for-java, azure-sdk-for-js, azure-sdk-for-go) are already cloned locally in the same parent directory as the azure-rest-api-specs repo. Create a branch named "ronniegeraghty/azsdktoolsagent-demo" in each SDK repo to work on the new library generations. Use separate subagents in parallel sfor each SDK language.
+After making the TypeSpec changes, guide me through creating the API spec PR and generating SDKs locally. Create a branch named "ronniegeraghty/azsdktoolsagent-demo-#" (where # is the lowest number available that hasn't already been used) in the azure-rest-api-specs repo for the API spec changes. All SDK language repositories (azure-sdk-for-net, azure-sdk-for-python, azure-sdk-for-java, azure-sdk-for-js, azure-sdk-for-go) are already cloned locally in the same parent directory as the azure-rest-api-specs repo. Create a branch with the same name in each SDK repo to work on the new library generations. Use separate subagents in parallel for each SDK language.
 
 Create a markdown file in the typespec project dir to track the progress of each step throughout this process.
 ```

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/README.md
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/README.md
@@ -75,7 +75,7 @@ I need:
 
 After making the TypeSpec changes, guide me through creating the API spec PR and generating SDKs locally. Stay in the current branch (ronniegeraghty/azsdktoolsagent-demo) for the API spec changes. All SDK language repositories (azure-sdk-for-net, azure-sdk-for-python, azure-sdk-for-java, azure-sdk-for-js, azure-sdk-for-go) are already cloned locally in the same parent directory as the azure-rest-api-specs repo. Create a branch named "ronniegeraghty/azsdktoolsagent-demo" in each SDK repo to work on the new library generations. Use separate subagents in parallel sfor each SDK language.
 
-Create a markdown file to track the progress of each step throughout this process.
+Create a markdown file in the typespec project dir to track the progress of each step throughout this process.
 ```
 
 ---

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/SDK_RELEASE_PROGRESS.md
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/SDK_RELEASE_PROGRESS.md
@@ -1,0 +1,70 @@
+# SDK Release Progress Tracker
+
+## API Spec Branch
+- **Branch Name**: `ronniegeraghty/azsdktoolsagent-demo-2`
+- **Repository**: `azure-rest-api-specs`
+
+## Changes Summary
+Adding SKU support to DeidService with new API version `2026-02-01-preview`:
+- Added `SkuTier` union (Free, Basic, Standard)
+- Added `Sku` model (name, tier, capacity properties)
+- Added `sku` property to `DeidService` (marked with `@added` for new version)
+- Added `sku` property to `DeidUpdate` for PATCH operations
+
+---
+
+## Progress Checklist
+
+### TypeSpec Changes
+- [x] Add new API version `2026-02-01-preview`
+- [x] Add `SkuTier` union with Free, Basic, Standard options
+- [x] Add `Sku` model with name, tier, and capacity properties
+- [x] Add `sku` property to `DeidService` (versioned)
+- [x] Add `sku` property to `DeidUpdate` for PATCH operations
+- [x] Validate TypeSpec specification
+- [ ] Commit and push changes
+
+### API Spec PR
+- [ ] Create PR in azure-rest-api-specs
+- [ ] PR Link: _pending_
+
+### SDK Generation - .NET
+- [ ] Branch created: `ronniegeraghty/azsdktoolsagent-demo-2`
+- [ ] SDK generated
+- [ ] SDK built successfully
+- [ ] Tests passed
+- [ ] Changelog updated
+
+### SDK Generation - Python
+- [ ] Branch created: `ronniegeraghty/azsdktoolsagent-demo-2`
+- [ ] SDK generated
+- [ ] SDK built successfully
+- [ ] Tests passed
+- [ ] Changelog updated
+
+### SDK Generation - Java
+- [ ] Branch created: `ronniegeraghty/azsdktoolsagent-demo-2`
+- [ ] SDK generated
+- [ ] SDK built successfully
+- [ ] Tests passed
+- [ ] Changelog updated
+
+### SDK Generation - JavaScript
+- [ ] Branch created: `ronniegeraghty/azsdktoolsagent-demo-2`
+- [ ] SDK generated
+- [ ] SDK built successfully
+- [ ] Tests passed
+- [ ] Changelog updated
+
+### SDK Generation - Go
+- [ ] Branch created: `ronniegeraghty/azsdktoolsagent-demo-2`
+- [ ] SDK generated
+- [ ] SDK built successfully
+- [ ] Tests passed
+- [ ] Changelog updated
+
+---
+
+## Notes
+- This is a demo environment - all PRs should be prefixed with "DO NOT MERGE"
+- No release plan will be created for this demo

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/main.tsp
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/main.tsp
@@ -20,6 +20,10 @@ enum Versions {
   @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v5)
   @doc("The 2024-09-20 version.")
   v2024_09_20: "2024-09-20",
+
+  @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v5)
+  @doc("The 2026-02-01-preview version.")
+  v2026_02_01_preview: "2026-02-01-preview",
 }
 
 interface Operations extends Azure.ResourceManager.Operations {}
@@ -40,6 +44,11 @@ model DeidService is TrackedResource<DeidServiceProperties> {
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "Adding property for versioning"
   @doc("The managed service identities assigned to this resource.")
   identity?: Azure.ResourceManager.Foundations.ManagedIdentityProperties;
+
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "Adding SKU property"
+  @added(Versions.v2026_02_01_preview)
+  @doc("The SKU (Stock Keeping Unit) assigned to this resource.")
+  sku?: Sku;
 }
 
 /** Patch request body for DeidService */
@@ -51,6 +60,10 @@ model DeidUpdate {
 
   /** RP-specific properties */
   properties?: DeidPropertiesUpdate;
+
+  @added(Versions.v2026_02_01_preview)
+  @doc("The SKU (Stock Keeping Unit) assigned to this resource.")
+  sku?: Sku;
 }
 
 model DeidPropertiesUpdate
@@ -89,6 +102,33 @@ enum PublicNetworkAccess {
 
   @doc("The public network access is disabled")
   Disabled,
+}
+
+#suppress "@azure-tools/typespec-azure-core/no-enum" "Suppress the warning for using enum keyword."
+@doc("The tier of the SKU.")
+union SkuTier {
+  string,
+
+  @doc("The Free tier.")
+  Free: "Free",
+
+  @doc("The Basic tier.")
+  Basic: "Basic",
+
+  @doc("The Standard tier.")
+  Standard: "Standard",
+}
+
+@doc("The SKU (Stock Keeping Unit) assigned to this resource.")
+model Sku {
+  @doc("The name of the SKU, e.g. F0, S1.")
+  name: string;
+
+  @doc("The tier of the SKU.")
+  tier?: SkuTier;
+
+  @doc("The capacity of the SKU (number of units).")
+  capacity?: int32;
 }
 
 @doc("Details of the HealthDataAIServices DeidService.")


### PR DESCRIPTION
## Summary

This PR adds SKU (Stock Keeping Unit) support to the HealthDataAIServices DeidService with a new API version `2026-02-01-preview`.

## Changes

- Added new API version `2026-02-01-preview`
- Added `SkuTier` union with Free, Basic, and Standard options
- Added `Sku` model with:
  - `name` (string): The name of the SKU (e.g., F0, S1)
  - `tier` (SkuTier): The tier of the SKU
  - `capacity` (int32): The capacity of the SKU (number of units)
- Added `sku` property to `DeidService` model (marked with `@added` for the new version)
- Added `sku` property to `DeidUpdate` model for PATCH operations

## Demo Note

This is a demo PR and should NOT be merged.