### PR TITLE
DO NOT MERGE - Add SKU support to HealthDataAIServices.Management

### DIFF
--- a/specification/healthdataaiservices/HealthDataAIServices.Management/DEMO_PROGRESS.md
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/DEMO_PROGRESS.md
@@ -1,0 +1,88 @@
+# Demo Progress: Adding SKU Support to HealthDataAIServices.Management
+
+**Date**: January 28, 2026  
+**Branch**: ronniegeraghty/azsdktoolsagent-demo  
+**Demo Goal**: Add SKU support to HealthDataAIServices.Management TypeSpec and update all corresponding SDKs
+
+---
+
+## Progress Summary
+
+| Step | Description | Status |
+|------|-------------|--------|
+| 1 | Read current TypeSpec files | ✅ Completed |
+| 2 | Create progress tracking file | ✅ Completed |
+| 3 | Add SKU support to TypeSpec | ✅ Completed |
+| 4 | Validate TypeSpec changes | ✅ Completed |
+| 5 | Commit and push spec changes | 🔄 In Progress |
+| 6 | Create spec PR | ⏳ Pending |
+| 7 | Generate .NET SDK | ⏳ Pending |
+| 8 | Generate Java SDK | ⏳ Pending |
+| 9 | Generate JavaScript SDK | ⏳ Pending |
+| 10 | Generate Python SDK | ⏳ Pending |
+| 11 | Generate Go SDK | ⏳ Pending |
+| 12 | Create SDK PRs | ⏳ Pending |
+
+---
+
+## Detailed Log
+
+### Step 1: Read Current TypeSpec Files ✅
+
+- Read [main.tsp](main.tsp) - contains DeidService TrackedResource definition
+- Read [tspconfig.yaml](tspconfig.yaml) - has emitters for .NET, Python, Java, JavaScript, Go
+- Read [client.tsp](client.tsp) - client customizations for SDK generation
+- Current DeidService model uses TrackedResource<DeidServiceProperties>
+
+### Step 2: Create Progress Tracking File ✅
+
+- Created this DEMO_PROGRESS.md file to track work progress
+
+### Step 3: Add SKU Support to TypeSpec 🔄
+
+**Approach**: Using ARM common-types `ResourceSkuProperty` model
+- This is the standard pattern for adding SKU support
+- Uses spread operator (...ResourceSkuProperty) on the DeidService model
+- Also need to add SKU to the DeidUpdate model for PATCH operations
+
+**Changes planned**:
+1. Add `...ResourceSkuProperty` to DeidService model
+2. Add optional `sku?` property to DeidUpdate model for updates
+
+**Changes applied** ✅:
+- Modified [main.tsp](main.tsp) - Added `...ResourceSkuProperty` spread to DeidService model
+- Modified [main.tsp](main.tsp) - Added `sku?: Azure.ResourceManager.CommonTypes.Sku` to DeidUpdate model
+
+### Step 4: Validate TypeSpec Changes ✅
+
+- Ran `azsdk_run_typespec_validation` tool
+- **Result**: Succeeded
+- TypeSpec compiles without errors
+
+### Step 5: Commit and Push Spec Changes 🔄
+
+Once TypeSpec changes are validated, we will:
+
+1. **Update tsp-location.yaml** in each SDK repo to point to our branch
+2. **Generate SDKs** locally using azure-sdk-mcp tools
+3. **Build/Compile** each SDK
+4. **Run validation checks**
+5. **Create PRs** with "DO NOT MERGE - " prefix
+
+### SDK Repositories
+
+| Language | Repository | Package |
+|----------|------------|---------|
+| .NET | azure-sdk-for-net | Azure.ResourceManager.HealthDataAIServices |
+| Java | azure-sdk-for-java | azure-resourcemanager-healthdataaiservices |
+| JavaScript | azure-sdk-for-js | @azure/arm-healthdataaiservices |
+| Python | azure-sdk-for-python | azure-mgmt-healthdataaiservices |
+| Go | azure-sdk-for-go | sdk/resourcemanager/healthdataaiservices/armhealthdataaiservices |
+
+---
+
+## Notes
+
+- This is a **DEMO** - all PRs will be prefixed with "DO NOT MERGE - "
+- No release plans will be created
+- SKU support uses ARM common-types v5 (already referenced in the spec)

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/main.tsp
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/main.tsp
@@ -40,6 +40,9 @@ model DeidService is TrackedResource<DeidServiceProperties> {
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "Adding property for versioning"
   @doc("The managed service identities assigned to this resource.")
   identity?: Azure.ResourceManager.Foundations.ManagedIdentityProperties;
+
+  /** The SKU (Stock Keeping Unit) assigned to this resource. */
+  ...ResourceSkuProperty;
 }
 
 /** Patch request body for DeidService */
@@ -51,6 +54,9 @@ model DeidUpdate {
 
   /** RP-specific properties */
   properties?: DeidPropertiesUpdate;
+
+  /** The SKU (Stock Keeping Unit) assigned to this resource. */
+  sku?: Azure.ResourceManager.CommonTypes.Sku;
 }
 
 model DeidPropertiesUpdate


### PR DESCRIPTION
## Demo PR - DO NOT MERGE

This PR adds SKU support to the HealthDataAIServices.Management TypeSpec project.

### Changes
- Added `...ResourceSkuProperty` spread to the `DeidService` model to support ARM standard SKU
- Added `sku?: Azure.ResourceManager.CommonTypes.Sku` to the `DeidUpdate` model for PATCH operations

### Purpose
This is a demonstration of the Azure SDK MCP tools for end-to-end SDK generation workflow.

### Notes
- This PR should **NOT** be merged
- Created as part of Azure SDK MCP tools demo