### PR TITLE
DO NOT MERGE - Add SKU support to HealthDataAIServices DeidService

### DIFF
--- a/specification/healthdataaiservices/HealthDataAIServices.Management/DEMO_PROGRESS.md
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/DEMO_PROGRESS.md
@@ -1,0 +1,52 @@
+# Demo Progress: Adding SKU Support to HealthDataAIServices.Management
+
+## Overview
+This document tracks the progress of adding SKU support to the HealthDataAIServices.Management TypeSpec project and updating all corresponding SDKs.
+
+---
+
+## API Specification Updates
+
+### Step 1: Analyze TypeSpec Project Structure
+- **Status**: ✅ Completed
+- **Notes**: 
+  - Project location: `specification/healthdataaiservices/HealthDataAIServices.Management`
+  - Main resource: `DeidService` (TrackedResource)
+  - Current features: Managed Identity, Private Endpoints, Public Network Access
+
+### Step 2: Add SKU Support Using ARM Common-Types
+- **Status**: ✅ Completed
+- **Approach**: Use `ResourceSkuProperty` from `Azure.ResourceManager` to add standard SKU envelope property
+- **Changes Made**:
+  - Spread `...ResourceSkuProperty` into `DeidService` model
+  - Added `sku?: Azure.ResourceManager.CommonTypes.Sku` to `DeidUpdate` patch model for updates
+
+### Step 3: Validate TypeSpec Changes
+- **Status**: ✅ Completed
+- **Result**: TypeSpec validation succeeded
+
+### Step 4: Commit and Push Spec Changes
+- **Status**: 🔄 In Progress
+
+### Step 5: Create Spec Pull Request
+- **Status**: ⏳ Pending
+
+---
+
+## SDK Updates
+
+| Language   | Generate | Build | Validate | Test | Metadata | PR Created |
+|------------|----------|-------|----------|------|----------|------------|
+| .NET       | ⏳       | ⏳    | ⏳       | ⏳   | ⏳       | ⏳         |
+| Java       | ⏳       | ⏳    | ⏳       | ⏳   | ⏳       | ⏳         |
+| JavaScript | ⏳       | ⏳    | ⏳       | ⏳   | ⏳       | ⏳         |
+| Python     | ⏳       | ⏳    | ⏳       | ⏳   | ⏳       | ⏳         |
+| Go         | ⏳       | ⏳    | ⏳       | ⏳   | ⏳       | ⏳         |
+
+---
+
+## Legend
+- ✅ Completed
+- 🔄 In Progress
+- ⏳ Pending
+- ❌ Failed/Blocked

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/main.tsp
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/main.tsp
@@ -40,6 +40,9 @@ model DeidService is TrackedResource<DeidServiceProperties> {
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "Adding property for versioning"
   @doc("The managed service identities assigned to this resource.")
   identity?: Azure.ResourceManager.Foundations.ManagedIdentityProperties;
+
+  /** The SKU (Stock Keeping Unit) assigned to this resource. */
+  ...ResourceSkuProperty;
 }
 
 /** Patch request body for DeidService */
@@ -48,6 +51,9 @@ model DeidUpdate {
 
   /** Updatable managed service identity */
   identity?: ManagedServiceIdentityUpdate;
+
+  /** The SKU (Stock Keeping Unit) assigned to this resource. */
+  sku?: Azure.ResourceManager.CommonTypes.Sku;
 
   /** RP-specific properties */
   properties?: DeidPropertiesUpdate;

--- a/specification/healthdataaiservices/resource-manager/Microsoft.HealthDataAIServices/stable/2024-09-20/openapi.json
+++ b/specification/healthdataaiservices/resource-manager/Microsoft.HealthDataAIServices/stable/2024-09-20/openapi.json
@@ -740,6 +740,10 @@
         "identity": {
           "$ref": "../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/ManagedServiceIdentity",
           "description": "The managed service identities assigned to this resource."
+        },
+        "sku": {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/Sku",
+          "description": "The SKU (Stock Keeping Unit) assigned to this resource."
         }
       },
       "allOf": [
@@ -811,6 +815,10 @@
         "identity": {
           "$ref": "#/definitions/ManagedServiceIdentityUpdate",
           "description": "Updatable managed service identity"
+        },
+        "sku": {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/Sku",
+          "description": "The SKU (Stock Keeping Unit) assigned to this resource."
         },
         "properties": {
           "$ref": "#/definitions/DeidPropertiesUpdate",


### PR DESCRIPTION
## Summary

This PR adds SKU (Stock Keeping Unit) support to the HealthDataAIServices.Management TypeSpec project.

### Changes Made

- Added `ResourceSkuProperty` spread to `DeidService` model for standard ARM SKU envelope property support
- Added `sku` property to `DeidUpdate` model for PATCH operations

### API Changes

The `DeidService` resource now includes an optional `sku` property that follows ARM common-types SKU pattern:
- `name` (required): The name of the SKU (e.g., P3)
- `tier` (optional): The service tier (Free, Basic, Standard, Premium)
- `size` (optional): The SKU size
- `family` (optional): Hardware generation
- `capacity` (optional): Scale out/in capacity

---

**⚠️ DO NOT MERGE - This is a demo PR for Azure SDK MCP workflow demonstration.**