### PR TITLE
Increase API Doc Preview timeout from 10 to 20 minutes per attempt (4 total: 80 minutes)

### DIFF
--- a/eng/pipelines/swagger-api-doc-preview.yml
+++ b/eng/pipelines/swagger-api-doc-preview.yml
@@ -114,9 +114,9 @@ jobs:
 
             Write-Host "Waiting for build to finish: https://dev.azure.com/apidrop/Content%20CI/_build/results?buildId=$($buildStart.id)"
             
-            # Timeout in 10 minutes to avoid infinite waiting
+            # Timeout in 20 minutes to avoid infinite waiting
             $start = Get-Date
-            while (((Get-Date) - $start).TotalMinutes -lt 10) {
+            while (((Get-Date) - $start).TotalMinutes -lt 20) {
               $runStatusRaw = az pipelines runs show `
                 --organization "https://dev.azure.com/apidrop/" `
                 --project "Content CI" `


### PR DESCRIPTION
# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
