### PR TITLE
[Storage] Housekeeping TypeSpec Changes

### DIFF
--- a/specification/storage/Microsoft.BlobStorage/client.tsp
+++ b/specification/storage/Microsoft.BlobStorage/client.tsp
@@ -65,6 +65,5 @@ namespace Customizations;
 @@scope(Storage.Blob.Blob.setExpiry, "!rust");
 @@scope(Storage.Blob.Blob.startCopyFromUrl, "!rust");
 @@scope(Storage.Blob.BlockBlob.query, "!rust");
-@@scope(Storage.Blob.BlockBlob.stageBlockFromUrl, "!rust");
 @@scope(Storage.Blob.PageBlob.copyIncremental, "!rust");
 @@scope(Storage.Blob.PageBlob.getPageRangesDiff, "!rust");

--- a/specification/storage/Microsoft.BlobStorage/client.tsp
+++ b/specification/storage/Microsoft.BlobStorage/client.tsp
@@ -27,10 +27,10 @@ namespace Customizations;
 @@clientName(ContainerProperties.immutableStorageWithVersioningEnabled,
   "IsImmutableStorageWithVersioningEnabled"
 );
-@@clientName(BlobPropertiesInternal.expiryTime, "ExpiresOn");
-@@clientName(BlobPropertiesInternal.sealed, "IsSealed");
-@@clientName(BlobPropertiesInternal.lastAccessTime, "LastAccessedOn");
-@@clientName(BlobPropertiesInternal.immutabilityPolicyUntilDate,
+@@clientName(BlobProperties.expiryTime, "ExpiresOn");
+@@clientName(BlobProperties.sealed, "IsSealed");
+@@clientName(BlobProperties.lastAccessTime, "LastAccessedOn");
+@@clientName(BlobProperties.immutabilityPolicyUntilDate,
   "ImmutabilityPolicyExpiresOn"
 );
 @@clientName(MetadataHeaders.metadata, "metadata", "rust");
@@ -41,7 +41,7 @@ namespace Customizations;
 @@clientName(ImmutabilityPolicyExpiryRequiredParameter.immutabilityPolicyExpiry,
   "expiry"
 );
-@@alternateType(BlobPropertiesInternal.contentLength, uint64, "rust");
+@@alternateType(BlobProperties.contentLength, uint64, "rust");
 @@alternateType(BlobContentLengthRequired.size, uint64, "rust");
 @@alternateType(ContentLengthResponseHeader.contentLength, uint64, "rust");
 @@alternateType(ContentLengthParameter.contentLength, uint64, "rust");
@@ -56,3 +56,15 @@ namespace Customizations;
 
 @@scope(Storage.Blob.Container.submitBatch, "!rust");
 @@scope(Storage.Blob.Service.submitBatch, "!rust");
+@@scope(Storage.Blob.Service.getUserDelegationKey, "!rust");
+@@scope(Storage.Blob.Container.listBlobHierarchySegment, "!rust");
+@@scope(Storage.Blob.Container.rename, "!rust");
+@@scope(Storage.Blob.Container.restore, "!rust");
+@@scope(Storage.Blob.Blob.abortCopyFromUrl, "!rust");
+@@scope(Storage.Blob.Blob.copyFromUrl, "!rust");
+@@scope(Storage.Blob.Blob.setExpiry, "!rust");
+@@scope(Storage.Blob.Blob.startCopyFromUrl, "!rust");
+@@scope(Storage.Blob.BlockBlob.query, "!rust");
+@@scope(Storage.Blob.BlockBlob.stageBlockFromUrl, "!rust");
+@@scope(Storage.Blob.PageBlob.copyIncremental, "!rust");
+@@scope(Storage.Blob.PageBlob.getPageRangesDiff, "!rust");

--- a/specification/storage/Microsoft.BlobStorage/models.tsp
+++ b/specification/storage/Microsoft.BlobStorage/models.tsp
@@ -17,6 +17,10 @@ scalar base64Bytes extends bytes;
 /** The error response. */
 @error
 model StorageError {
+  /** The error code. */
+  #suppress "@azure-tools/typespec-azure-core/casing-style" "Existing API"
+  Code?: StorageErrorCode;
+
   /** The error message. */
   #suppress "@azure-tools/typespec-azure-core/casing-style" "Existing API"
   Message?: string;

--- a/specification/storage/Microsoft.BlobStorage/models.tsp
+++ b/specification/storage/Microsoft.BlobStorage/models.tsp
@@ -14,7 +14,11 @@ namespace Storage.Blob;
 @encode(BytesKnownEncoding.base64)
 scalar base64Bytes extends bytes;
 
-/** The error response. */
+/**
+ * The error response.
+ *
+ * This defines the wire format only. Language SDKs wrap this in idiomatic error types.
+ */
 @error
 model StorageError {
   /** The error code. */

--- a/specification/storage/Microsoft.BlobStorage/models.tsp
+++ b/specification/storage/Microsoft.BlobStorage/models.tsp
@@ -14,38 +14,6 @@ namespace Storage.Blob;
 @encode(BytesKnownEncoding.base64)
 scalar base64Bytes extends bytes;
 
-/** The error response. */
-@error
-@mediaTypeHint("application/xml")
-model StorageError {
-  /** The error code. */
-  @header("x-ms-error-code")
-  errorCode?: StorageErrorCode;
-
-  /** The error code for the copy source. */
-  @header("x-ms-copy-source-error-code")
-  xMsCopySourceErrorCode?: string;
-
-  /** The status code for the copy source. */
-  @header("x-ms-copy-source-status-code")
-  xMsCopySourceStatusCode?: int32;
-
-  /** The error code. */
-  @Xml.name("Code") code?: string;
-
-  /** The error message. */
-  @Xml.name("Message") message?: string;
-
-  /** Copy source status code */
-  @Xml.name("CopySourceStatusCode") copySourceStatusCode?: int32;
-
-  /** Copy source error code */
-  @Xml.name("CopySourceErrorCode") copySourceErrorCode?: string;
-
-  /** Copy source error message */
-  @Xml.name("CopySourceErrorMessage") copySourceErrorMessage?: string;
-}
-
 /** Error codes returned by the Azure Blob Storage service. */
 #suppress "@azure-tools/typespec-azure-core/no-enum" "Existing API"
 union StorageErrorCode {
@@ -894,7 +862,7 @@ union ArchiveStatus {
 
 /** An Azure Storage Blob */
 @Xml.name("Blob")
-model BlobItemInternal {
+model BlobItem {
   /** The name of the blob. */
   @Xml.name("Name") name: BlobName;
 
@@ -911,7 +879,7 @@ model BlobItemInternal {
   @Xml.name("IsCurrentVersion") isCurrentVersion?: boolean;
 
   /** The properties of the blob. */
-  @Xml.name("Properties") properties: BlobPropertiesInternal;
+  @Xml.name("Properties") properties: BlobProperties;
 
   /** The metadata of the blob. */
   @Xml.name("Metadata") metadata?: BlobMetadata;
@@ -930,7 +898,7 @@ model BlobItemInternal {
 
 /** The properties of a blob. */
 @Xml.name("Properties")
-model BlobPropertiesInternal {
+model BlobProperties {
   /** The date-time the blob was created in RFC1123 format. */
   #suppress "@azure-tools/typespec-azure-core/known-encoding" "Existing API"
   @encode("rfc7231")
@@ -1292,7 +1260,7 @@ model BlobFlatListSegment {
   @pageItems
   @Xml.name("Blob")
   @Xml.unwrapped
-  blobItems: BlobItemInternal[];
+  blobItems: BlobItem[];
 }
 
 /** Represents a page list. */
@@ -2457,7 +2425,7 @@ model BlobHierarchyListSegment {
   @pageItems
   @Xml.name("Blob")
   @Xml.unwrapped
-  blobItems: BlobItemInternal[];
+  blobItems: BlobItem[];
 
   /** The blob prefixes. */
   @Xml.name("BlobPrefix")

--- a/specification/storage/Microsoft.BlobStorage/models.tsp
+++ b/specification/storage/Microsoft.BlobStorage/models.tsp
@@ -14,6 +14,14 @@ namespace Storage.Blob;
 @encode(BytesKnownEncoding.base64)
 scalar base64Bytes extends bytes;
 
+/** The error response. */
+@error
+model StorageError {
+  /** The error message. */
+  #suppress "@azure-tools/typespec-azure-core/casing-style" "Existing API"
+  Message?: string;
+}
+
 /** Error codes returned by the Azure Blob Storage service. */
 #suppress "@azure-tools/typespec-azure-core/no-enum" "Existing API"
 union StorageErrorCode {

--- a/specification/storage/Microsoft.BlobStorage/tspconfig.yaml
+++ b/specification/storage/Microsoft.BlobStorage/tspconfig.yaml
@@ -41,6 +41,8 @@ options:
     crate-version: "0.1.0"
     flavor: azure
     temp-omit-doc-links: true
+  # TODO: Replace this with client.tsp solution once it lands (issue: https://github.com/Azure/typespec-rust/issues/806)
+    omit-constructors: true
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/data-plane"


### PR DESCRIPTION
- Remove `Internal` suffixes from `BlobProperties` and `BlobItem`
- Revert `StorageError` model to the most basic original definition (aside from adding `Code` to allow that to be used and thus generated)
- Use `@@scope(....., !rust)` to hide methods we don't want to be generated at all
- Uses temporary emitter flag `omit-constructors` to get rid of constructors from being generated