### PR TITLE
DO NOT MERGE: Add SKU support to HealthDataAIServices DeidService resource

### DIFF
--- a/specification/healthdataaiservices/HealthDataAIServices.Management/client.tsp
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/client.tsp
@@ -34,10 +34,11 @@ namespace Microsoft.HealthDataAIServices {
     "HealthDataAIServicesSku",
     "csharp"
   );
-  @@clientName(DeidServiceSkuTier,
-    "HealthDataAIServicesSkuTier",
+  @@clientName(DeidServiceSkuName,
+    "HealthDataAIServicesSkuName",
     "csharp"
   );
+  @@access(DeidServiceSkuName, Access.public, "csharp");
 
   @@clientName(Versions.v2024_09_20,
     "$DO_NOT_NORMALIZE$V2024_09_20",

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/client.tsp
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/client.tsp
@@ -30,6 +30,15 @@ namespace Microsoft.HealthDataAIServices {
   );
   @@clientName(PrivateLinks.listByDeidService, "GetPrivateLinks", "csharp");
 
+  @@clientName(DeidServiceSku,
+    "HealthDataAIServicesSku",
+    "csharp"
+  );
+  @@clientName(DeidServiceSkuTier,
+    "HealthDataAIServicesSkuTier",
+    "csharp"
+  );
+
   @@clientName(Versions.v2024_09_20,
     "$DO_NOT_NORMALIZE$V2024_09_20",
     "javascript"

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/main.tsp
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/main.tsp
@@ -24,6 +24,20 @@ enum Versions {
 
 interface Operations extends Azure.ResourceManager.Operations {}
 
+/** The SKU tier for the DeidService resource. */
+union DeidServiceSkuTier {
+  string,
+
+  /** Free tier with limited capabilities. */
+  Free: "Free",
+
+  /** Basic tier with standard capabilities. */
+  Basic: "Basic",
+
+  /** Standard tier with full capabilities. */
+  Standard: "Standard",
+}
+
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-path-segment-invalid-chars" "Existing Template"
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-key-invalid-chars" "Existing template"
 #suppress "@azure-tools/typespec-azure-core/casing-style" "Case-sensitive name"
@@ -40,6 +54,27 @@ model DeidService is TrackedResource<DeidServiceProperties> {
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "Adding property for versioning"
   @doc("The managed service identities assigned to this resource.")
   identity?: Azure.ResourceManager.Foundations.ManagedIdentityProperties;
+
+  /** The SKU (Stock Keeping Unit) assigned to this resource. */
+  sku?: DeidServiceSku;
+}
+
+/** The SKU for the DeidService resource. */
+model DeidServiceSku {
+  /** The name of the SKU. Ex - Free, Basic, Standard. */
+  name: DeidServiceSkuTier;
+
+  /** The SKU tier. This is based on the SKU name. */
+  tier?: Azure.ResourceManager.CommonTypes.SkuTier;
+
+  /** The SKU size. When the name field is the combination of tier and some other value, this would be the standalone code. */
+  size?: string;
+
+  /** If the service has different generations of hardware, for the same SKU, then that can be captured here. */
+  family?: string;
+
+  /** If the SKU supports scale out/in then the capacity integer should be included. If scale out/in is not possible for the resource this may be omitted. */
+  capacity?: int32;
 }
 
 /** Patch request body for DeidService */
@@ -51,6 +86,9 @@ model DeidUpdate {
 
   /** RP-specific properties */
   properties?: DeidPropertiesUpdate;
+
+  /** The SKU (Stock Keeping Unit) assigned to this resource. */
+  sku?: DeidServiceSku;
 }
 
 model DeidPropertiesUpdate

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/main.tsp
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/main.tsp
@@ -55,6 +55,7 @@ model DeidService is TrackedResource<DeidServiceProperties> {
   @doc("The managed service identities assigned to this resource.")
   identity?: Azure.ResourceManager.Foundations.ManagedIdentityProperties;
 
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "SKU is a standard ARM envelope property"
   /** The SKU (Stock Keeping Unit) assigned to this resource. */
   sku?: DeidServiceSku;
 }

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/main.tsp
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/main.tsp
@@ -24,8 +24,8 @@ enum Versions {
 
 interface Operations extends Azure.ResourceManager.Operations {}
 
-/** The SKU tier for the DeidService resource. */
-union DeidServiceSkuTier {
+/** The SKU name for the DeidService resource. */
+union DeidServiceSkuName {
   string,
 
   /** Free tier with limited capabilities. */
@@ -63,7 +63,7 @@ model DeidService is TrackedResource<DeidServiceProperties> {
 /** The SKU for the DeidService resource. */
 model DeidServiceSku {
   /** The name of the SKU. Ex - Free, Basic, Standard. */
-  name: DeidServiceSkuTier;
+  name: DeidServiceSkuName;
 
   /** The SKU tier. This is based on the SKU name. */
   tier?: Azure.ResourceManager.CommonTypes.SkuTier;

--- a/specification/healthdataaiservices/resource-manager/Microsoft.HealthDataAIServices/stable/2024-09-20/openapi.json
+++ b/specification/healthdataaiservices/resource-manager/Microsoft.HealthDataAIServices/stable/2024-09-20/openapi.json
@@ -740,6 +740,10 @@
         "identity": {
           "$ref": "../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/ManagedServiceIdentity",
           "description": "The managed service identities assigned to this resource."
+        },
+        "sku": {
+          "$ref": "#/definitions/DeidServiceSku",
+          "description": "The SKU (Stock Keeping Unit) assigned to this resource."
         }
       },
       "allOf": [
@@ -797,6 +801,66 @@
         }
       }
     },
+    "DeidServiceSku": {
+      "type": "object",
+      "description": "The SKU for the DeidService resource.",
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/DeidServiceSkuTier",
+          "description": "The name of the SKU. Ex - Free, Basic, Standard."
+        },
+        "tier": {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/SkuTier",
+          "description": "The SKU tier. This is based on the SKU name."
+        },
+        "size": {
+          "type": "string",
+          "description": "The SKU size. When the name field is the combination of tier and some other value, this would be the standalone code."
+        },
+        "family": {
+          "type": "string",
+          "description": "If the service has different generations of hardware, for the same SKU, then that can be captured here."
+        },
+        "capacity": {
+          "type": "integer",
+          "format": "int32",
+          "description": "If the SKU supports scale out/in then the capacity integer should be included. If scale out/in is not possible for the resource this may be omitted."
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "DeidServiceSkuTier": {
+      "type": "string",
+      "description": "The SKU tier for the DeidService resource.",
+      "enum": [
+        "Free",
+        "Basic",
+        "Standard"
+      ],
+      "x-ms-enum": {
+        "name": "DeidServiceSkuTier",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Free",
+            "value": "Free",
+            "description": "Free tier with limited capabilities."
+          },
+          {
+            "name": "Basic",
+            "value": "Basic",
+            "description": "Basic tier with standard capabilities."
+          },
+          {
+            "name": "Standard",
+            "value": "Standard",
+            "description": "Standard tier with full capabilities."
+          }
+        ]
+      }
+    },
     "DeidUpdate": {
       "type": "object",
       "description": "Patch request body for DeidService",
@@ -815,6 +879,10 @@
         "properties": {
           "$ref": "#/definitions/DeidPropertiesUpdate",
           "description": "RP-specific properties"
+        },
+        "sku": {
+          "$ref": "#/definitions/DeidServiceSku",
+          "description": "The SKU (Stock Keeping Unit) assigned to this resource."
         }
       }
     },

--- a/specification/healthdataaiservices/resource-manager/Microsoft.HealthDataAIServices/stable/2024-09-20/openapi.json
+++ b/specification/healthdataaiservices/resource-manager/Microsoft.HealthDataAIServices/stable/2024-09-20/openapi.json
@@ -806,7 +806,7 @@
       "description": "The SKU for the DeidService resource.",
       "properties": {
         "name": {
-          "$ref": "#/definitions/DeidServiceSkuTier",
+          "$ref": "#/definitions/DeidServiceSkuName",
           "description": "The name of the SKU. Ex - Free, Basic, Standard."
         },
         "tier": {
@@ -831,16 +831,16 @@
         "name"
       ]
     },
-    "DeidServiceSkuTier": {
+    "DeidServiceSkuName": {
       "type": "string",
-      "description": "The SKU tier for the DeidService resource.",
+      "description": "The SKU name for the DeidService resource.",
       "enum": [
         "Free",
         "Basic",
         "Standard"
       ],
       "x-ms-enum": {
-        "name": "DeidServiceSkuTier",
+        "name": "DeidServiceSkuName",
         "modelAsString": true,
         "values": [
           {


### PR DESCRIPTION
## DEMO - DO NOT MERGE

This is a demo PR showing the addition of SKU support to the HealthDataAIServices.Management TypeSpec project.

### Changes

- Added `DeidServiceSkuTier` union with Free, Basic, and Standard options
- Added `DeidServiceSku` model with standard ARM SKU properties (name, tier, size, family, capacity)
- Updated `DeidService` model to include optional `sku` property
- Updated `DeidUpdate` model to include SKU for PATCH operations
- Added C# client names for SKU types in client.tsp

### TypeSpec Validation

TypeSpec validation passed successfully.