### PR TITLE
Schedule parameter rename

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/client.java.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/client.java.tsp
@@ -54,6 +54,7 @@ namespace Azure.AI.Projects;
 @@clientName(EvalRunResultComparison, "EvaluationRunResultComparison");
 @@clientName(EvalRunResultSummary, "EvaluationRunResultSummary");
 
+@@clientName(Azure.Core.Foundations.ResourceBody.resource, "schedule");
 // --------------------------------------------------------------------------------
 // Usage / Public accessibility overrides
 // --------------------------------------------------------------------------------


### PR DESCRIPTION
This pull request makes a minor update to the Azure AI Foundry client specification. It assigns a specific client name to the `Azure.Core.Foundations.ResourceBody.resource` for improved clarity and consistency.

* Assigned the client name "schedule" to `Azure.Core.Foundations.ResourceBody.resource` in the client specification.