### PR TITLE
Fix Storage blob range header

### DIFF
--- a/specification/storage/Microsoft.BlobStorage/models.tsp
+++ b/specification/storage/Microsoft.BlobStorage/models.tsp
@@ -2048,7 +2048,7 @@ alias IfNoneMatchParameter = {
 /** The range parameter. */
 alias RangeParameter = {
   /** Return only the bytes of the blob in the specified range. */
-  @header("Range")
+  @header("x-ms-range")
   range?: string;
 };
 

--- a/specification/storage/Microsoft.BlobStorage/routes.tsp
+++ b/specification/storage/Microsoft.BlobStorage/routes.tsp
@@ -1603,7 +1603,7 @@ namespace Storage.Blob {
             ...TimeoutParameter;
 
             /** Bytes of data in the specified range. */
-            @header("Range")
+            @header("x-ms-range")
             range: string;
 
             ...LeaseIdOptionalParameter;
@@ -1658,7 +1658,7 @@ namespace Storage.Blob {
             ...TimeoutParameter;
 
             /** Bytes of data in the specified range. */
-            @header("Range")
+            @header("x-ms-range")
             range: string;
 
             ...LeaseIdOptionalParameter;

--- a/specification/storage/data-plane/Microsoft.BlobStorage/stable/2025-11-05/generated_blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/stable/2025-11-05/generated_blob.json
@@ -120,7 +120,7 @@
             "minimum": 0
           },
           {
-            "name": "Range",
+            "name": "x-ms-range",
             "in": "header",
             "description": "Return only the bytes of the blob in the specified range.",
             "required": false,
@@ -8959,7 +8959,7 @@
             "minimum": 0
           },
           {
-            "name": "Range",
+            "name": "x-ms-range",
             "in": "header",
             "description": "Bytes of data in the specified range.",
             "required": true,
@@ -9280,7 +9280,7 @@
             "minimum": 0
           },
           {
-            "name": "Range",
+            "name": "x-ms-range",
             "in": "header",
             "description": "Bytes of data in the specified range.",
             "required": true,
@@ -9940,7 +9940,7 @@
             "minimum": 0
           },
           {
-            "name": "Range",
+            "name": "x-ms-range",
             "in": "header",
             "description": "Return only the bytes of the blob in the specified range.",
             "required": false,
@@ -10151,7 +10151,7 @@
             "x-ms-client-name": "prevSnapshotUrl"
           },
           {
-            "name": "Range",
+            "name": "x-ms-range",
             "in": "header",
             "description": "Return only the bytes of the blob in the specified range.",
             "required": false,

--- a/specification/storage/data-plane/Microsoft.BlobStorage/stable/2026-02-06/generated_blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/stable/2026-02-06/generated_blob.json
@@ -120,7 +120,7 @@
             "minimum": 0
           },
           {
-            "name": "Range",
+            "name": "x-ms-range",
             "in": "header",
             "description": "Return only the bytes of the blob in the specified range.",
             "required": false,
@@ -9041,7 +9041,7 @@
             "minimum": 0
           },
           {
-            "name": "Range",
+            "name": "x-ms-range",
             "in": "header",
             "description": "Bytes of data in the specified range.",
             "required": true,
@@ -9362,7 +9362,7 @@
             "minimum": 0
           },
           {
-            "name": "Range",
+            "name": "x-ms-range",
             "in": "header",
             "description": "Bytes of data in the specified range.",
             "required": true,
@@ -10022,7 +10022,7 @@
             "minimum": 0
           },
           {
-            "name": "Range",
+            "name": "x-ms-range",
             "in": "header",
             "description": "Return only the bytes of the blob in the specified range.",
             "required": false,
@@ -10233,7 +10233,7 @@
             "x-ms-client-name": "prevSnapshotUrl"
           },
           {
-            "name": "Range",
+            "name": "x-ms-range",
             "in": "header",
             "description": "Return only the bytes of the blob in the specified range.",
             "required": false,

--- a/specification/storage/data-plane/Microsoft.BlobStorage/stable/2026-04-06/generated_blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/stable/2026-04-06/generated_blob.json
@@ -120,7 +120,7 @@
             "minimum": 0
           },
           {
-            "name": "Range",
+            "name": "x-ms-range",
             "in": "header",
             "description": "Return only the bytes of the blob in the specified range.",
             "required": false,
@@ -9095,7 +9095,7 @@
             "minimum": 0
           },
           {
-            "name": "Range",
+            "name": "x-ms-range",
             "in": "header",
             "description": "Bytes of data in the specified range.",
             "required": true,
@@ -9416,7 +9416,7 @@
             "minimum": 0
           },
           {
-            "name": "Range",
+            "name": "x-ms-range",
             "in": "header",
             "description": "Bytes of data in the specified range.",
             "required": true,
@@ -10114,7 +10114,7 @@
             "minimum": 0
           },
           {
-            "name": "Range",
+            "name": "x-ms-range",
             "in": "header",
             "description": "Return only the bytes of the blob in the specified range.",
             "required": false,
@@ -10325,7 +10325,7 @@
             "x-ms-client-name": "prevSnapshotUrl"
           },
           {
-            "name": "Range",
+            "name": "x-ms-range",
             "in": "header",
             "description": "Return only the bytes of the blob in the specified range.",
             "required": false,


### PR DESCRIPTION
The [handwritten swagger specified this header as `x-ms-range`](https://github.com/Azure/azure-rest-api-specs/blob/e311ec9e3ab1ca23655eb571cf9dc48303458932/specification/storage/data-plane/Microsoft.BlobStorage/stable/2025-07-05/blob.json#L12266) instead of `Range`. The client libraries that generate off of this specification relied on the behavior of the `x-ms-range` header which is slightly different than `Range`. Updating the TypeSpec to match previous behavior for this service. 