### PR TITLE
[Storage] Thinner handwritten convenience layer changes for `azure_storage_blob`

### DIFF
--- a/specification/storage/Microsoft.BlobStorage/client.tsp
+++ b/specification/storage/Microsoft.BlobStorage/client.tsp
@@ -21,6 +21,9 @@ namespace Customizations;
 @@clientName(Storage.Blob.BlockBlob, "BlockBlobClient", "rust");
 @@clientName(Storage.Blob.PageBlob, "PageBlobClient", "rust");
 
+@@clientName(Storage.Blob.BlockBlob.upload, "upload_internal", "rust");
+@@clientName(Storage.Blob.Blob.download, "download_internal", "rust");
+
 @@clientName(ContainerProperties.denyEncryptionScopeOverride,
   "PreventEncryptionScopeOverride"
 );

--- a/specification/storage/Microsoft.BlobStorage/client.tsp
+++ b/specification/storage/Microsoft.BlobStorage/client.tsp
@@ -21,8 +21,8 @@ namespace Customizations;
 @@clientName(Storage.Blob.BlockBlob, "BlockBlobClient", "rust");
 @@clientName(Storage.Blob.PageBlob, "PageBlobClient", "rust");
 
-@@access(Storage.Blob.BlockBlob.upload, Access.internal, "rust");
-@@access(Storage.Blob.Blob.download, Access.internal, "rust");
+@@clientName(Storage.Blob.BlockBlob.upload, "upload_internal", "rust");
+@@clientName(Storage.Blob.Blob.download, "download_internal", "rust");
 
 @@clientName(ContainerProperties.denyEncryptionScopeOverride,
   "PreventEncryptionScopeOverride"

--- a/specification/storage/Microsoft.BlobStorage/client.tsp
+++ b/specification/storage/Microsoft.BlobStorage/client.tsp
@@ -21,8 +21,8 @@ namespace Customizations;
 @@clientName(Storage.Blob.BlockBlob, "BlockBlobClient", "rust");
 @@clientName(Storage.Blob.PageBlob, "PageBlobClient", "rust");
 
-@@clientName(Storage.Blob.BlockBlob.upload, "upload_internal", "rust");
-@@clientName(Storage.Blob.Blob.download, "download_internal", "rust");
+@@access(Storage.Blob.BlockBlob.upload, Access.internal, "rust");
+@@access(Storage.Blob.Blob.download, Access.internal, "rust");
 
 @@clientName(ContainerProperties.denyEncryptionScopeOverride,
   "PreventEncryptionScopeOverride"

--- a/specification/storage/Microsoft.BlobStorage/client.tsp
+++ b/specification/storage/Microsoft.BlobStorage/client.tsp
@@ -24,6 +24,14 @@ namespace Customizations;
 @@clientName(Storage.Blob.BlockBlob.upload, "upload_internal", "rust");
 @@clientName(Storage.Blob.Blob.download, "download_internal", "rust");
 
+@@clientName(Storage.Blob.Container.create, "create_container", "rust");
+@@clientName(Storage.Blob.Container.delete, "delete_container", "rust");
+@@clientName(Storage.Blob.Container.listBlobFlatSegment, "list_blobs", "rust");
+@@clientName(Storage.Blob.Service.listContainersSegment,
+  "list_containers",
+  "rust"
+);
+
 @@clientName(ContainerProperties.denyEncryptionScopeOverride,
   "PreventEncryptionScopeOverride"
 );

--- a/specification/storage/Microsoft.BlobStorage/client.tsp
+++ b/specification/storage/Microsoft.BlobStorage/client.tsp
@@ -24,14 +24,6 @@ namespace Customizations;
 @@clientName(Storage.Blob.BlockBlob.upload, "upload_internal", "rust");
 @@clientName(Storage.Blob.Blob.download, "download_internal", "rust");
 
-@@clientName(Storage.Blob.Container.create, "create_container", "rust");
-@@clientName(Storage.Blob.Container.delete, "delete_container", "rust");
-@@clientName(Storage.Blob.Container.listBlobFlatSegment, "list_blobs", "rust");
-@@clientName(Storage.Blob.Service.listContainersSegment,
-  "list_containers",
-  "rust"
-);
-
 @@clientName(ContainerProperties.denyEncryptionScopeOverride,
   "PreventEncryptionScopeOverride"
 );

--- a/specification/storage/Microsoft.BlobStorage/routes.tsp
+++ b/specification/storage/Microsoft.BlobStorage/routes.tsp
@@ -104,7 +104,7 @@ interface Service {
   @get
   @list
   @route("?comp=list")
-  listContainersSegment is StorageOperation<
+  listContainers is StorageOperation<
     {
       ...PrefixParameter;
       ...MarkerParameter;
@@ -558,7 +558,7 @@ interface Container {
   @list
   @sharedRoute
   @route("?restype=container&comp=list")
-  listBlobFlatSegment is StorageOperation<
+  listBlobs is StorageOperation<
     {
       ...PrefixParameter;
       ...MarkerParameter;


### PR DESCRIPTION
This PR contains the other renames necessary to remove the thick handwritten convenience layer.