### PR TITLE
Make sure opt-in flag values can be any string, for extensibility purposes (while still documenting the current supported value)

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -68,6 +68,9 @@
             "schema": {
               "anyOf": [
                 {
+                  "type": "string"
+                },
+                {
                   "type": "string",
                   "enum": [
                     "ContainerAgents=V1Preview"
@@ -325,6 +328,9 @@
             "schema": {
               "anyOf": [
                 {
+                  "type": "string"
+                },
+                {
                   "type": "string",
                   "enum": [
                     "ContainerAgents=V1Preview"
@@ -525,9 +531,16 @@
             "required": false,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "ContainerAgents=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "ContainerAgents=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -662,9 +675,16 @@
             "required": false,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "ContainerAgents=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "ContainerAgents=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -741,6 +761,9 @@
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
               "anyOf": [
+                {
+                  "type": "string"
+                },
                 {
                   "type": "string",
                   "enum": [
@@ -1076,9 +1099,16 @@
             "required": false,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "ContainerAgents=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "ContainerAgents=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -1154,9 +1184,16 @@
             "required": false,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "ContainerAgents=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "ContainerAgents=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -1300,9 +1337,16 @@
             "required": false,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "ContainerAgents=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "ContainerAgents=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -1387,9 +1431,16 @@
             "required": false,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "ContainerAgents=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "ContainerAgents=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -1489,9 +1540,16 @@
             "required": false,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "ContainerAgents=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "ContainerAgents=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -1600,9 +1658,16 @@
             "required": false,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "ContainerAgents=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "ContainerAgents=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -1687,9 +1752,16 @@
             "required": false,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "ContainerAgents=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "ContainerAgents=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -3193,9 +3265,16 @@
             "required": false,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "Evaluations=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "Evaluations=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -3278,9 +3357,16 @@
             "required": false,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "Evaluations=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "Evaluations=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -3387,9 +3473,16 @@
             "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "Evaluations=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "Evaluations=V1Preview"
+                  ]
+                }
               ]
             }
           }
@@ -3485,9 +3578,16 @@
             "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "Evaluations=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "Evaluations=V1Preview"
+                  ]
+                }
               ]
             }
           }
@@ -3549,9 +3649,16 @@
             "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "Evaluations=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "Evaluations=V1Preview"
+                  ]
+                }
               ]
             }
           }
@@ -3625,9 +3732,16 @@
             "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "Evaluations=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "Evaluations=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -3698,9 +3812,16 @@
             "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "Evaluations=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "Evaluations=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -3764,9 +3885,16 @@
             "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "Evaluations=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "Evaluations=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -4139,9 +4267,16 @@
             "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "Insights=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "Insights=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -4404,9 +4539,16 @@
             "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "MemoryStores=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "MemoryStores=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -4545,9 +4687,16 @@
             "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "MemoryStores=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "MemoryStores=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -4640,9 +4789,16 @@
             "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "MemoryStores=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "MemoryStores=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -4731,9 +4887,16 @@
             "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "MemoryStores=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "MemoryStores=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -4798,9 +4961,16 @@
             "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "MemoryStores=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "MemoryStores=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -4876,9 +5046,16 @@
             "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "MemoryStores=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "MemoryStores=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -4945,9 +5122,16 @@
             "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "MemoryStores=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "MemoryStores=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -5033,9 +5217,16 @@
             "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "MemoryStores=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "MemoryStores=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -5140,9 +5331,16 @@
             "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "MemoryStores=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "MemoryStores=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -8096,9 +8294,16 @@
             "required": false,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "RedTeams=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "RedTeams=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -8520,9 +8725,16 @@
             "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "Insights=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "Insights=V1Preview"
+                  ]
+                }
               ]
             }
           },

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -68,6 +68,9 @@
             "schema": {
               "anyOf": [
                 {
+                  "type": "string"
+                },
+                {
                   "type": "string",
                   "enum": [
                     "ContainerAgents=V1Preview"
@@ -325,6 +328,9 @@
             "schema": {
               "anyOf": [
                 {
+                  "type": "string"
+                },
+                {
                   "type": "string",
                   "enum": [
                     "ContainerAgents=V1Preview"
@@ -525,9 +531,16 @@
             "required": false,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "ContainerAgents=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "ContainerAgents=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -662,9 +675,16 @@
             "required": false,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "ContainerAgents=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "ContainerAgents=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -741,6 +761,9 @@
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
               "anyOf": [
+                {
+                  "type": "string"
+                },
                 {
                   "type": "string",
                   "enum": [
@@ -1076,9 +1099,16 @@
             "required": false,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "ContainerAgents=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "ContainerAgents=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -1154,9 +1184,16 @@
             "required": false,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "ContainerAgents=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "ContainerAgents=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -1300,9 +1337,16 @@
             "required": false,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "ContainerAgents=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "ContainerAgents=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -1387,9 +1431,16 @@
             "required": false,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "ContainerAgents=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "ContainerAgents=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -1489,9 +1540,16 @@
             "required": false,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "ContainerAgents=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "ContainerAgents=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -1600,9 +1658,16 @@
             "required": false,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "ContainerAgents=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "ContainerAgents=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -1687,9 +1752,16 @@
             "required": false,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "ContainerAgents=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "ContainerAgents=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -3526,9 +3598,16 @@
             "required": false,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "Evaluations=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "Evaluations=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -3611,9 +3690,16 @@
             "required": false,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "Evaluations=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "Evaluations=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -3720,9 +3806,16 @@
             "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "Evaluations=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "Evaluations=V1Preview"
+                  ]
+                }
               ]
             }
           }
@@ -3818,9 +3911,16 @@
             "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "Evaluations=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "Evaluations=V1Preview"
+                  ]
+                }
               ]
             }
           }
@@ -3882,9 +3982,16 @@
             "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "Evaluations=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "Evaluations=V1Preview"
+                  ]
+                }
               ]
             }
           }
@@ -3958,9 +4065,16 @@
             "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "Evaluations=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "Evaluations=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -4031,9 +4145,16 @@
             "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "Evaluations=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "Evaluations=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -4097,9 +4218,16 @@
             "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "Evaluations=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "Evaluations=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -4472,9 +4600,16 @@
             "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "Insights=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "Insights=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -4737,9 +4872,16 @@
             "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "MemoryStores=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "MemoryStores=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -4878,9 +5020,16 @@
             "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "MemoryStores=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "MemoryStores=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -4973,9 +5122,16 @@
             "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "MemoryStores=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "MemoryStores=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -5064,9 +5220,16 @@
             "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "MemoryStores=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "MemoryStores=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -5131,9 +5294,16 @@
             "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "MemoryStores=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "MemoryStores=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -5209,9 +5379,16 @@
             "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "MemoryStores=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "MemoryStores=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -5278,9 +5455,16 @@
             "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "MemoryStores=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "MemoryStores=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -5366,9 +5550,16 @@
             "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "MemoryStores=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "MemoryStores=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -5473,9 +5664,16 @@
             "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "MemoryStores=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "MemoryStores=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -8445,9 +8643,16 @@
             "required": false,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "RedTeams=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "RedTeams=V1Preview"
+                  ]
+                }
               ]
             }
           },
@@ -8869,9 +9074,16 @@
             "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
-              "type": "string",
-              "enum": [
-                "Insights=V1Preview"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "Insights=V1Preview"
+                  ]
+                }
               ]
             }
           },

--- a/specification/ai-foundry/data-plane/Foundry/src/common/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/common/models.tsp
@@ -48,7 +48,8 @@ op FoundryDataPlaneOperation<
   ErrorResponse = ApiErrorResponse
 >(...Params, ...FoundryDataPlaneApiVersionParameter): Response | ErrorResponse;
 
-enum FoundryFeaturesOptInKeys {
+union FoundryFeaturesOptInKeys {
+  string,
   container_agents_v1_preview: "ContainerAgents=V1Preview",
   hosted_agents_v1_preview: "HostedAgents=V1Preview",
   workflow_agents_v1_preview: "WorkflowAgents=V1Preview",

--- a/specification/ai-foundry/data-plane/Foundry/src/common/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/common/models.tsp
@@ -48,7 +48,7 @@ op FoundryDataPlaneOperation<
   ErrorResponse = ApiErrorResponse
 >(...Params, ...FoundryDataPlaneApiVersionParameter): Response | ErrorResponse;
 
-union FoundryFeaturesOptInKeys {
+enum FoundryFeaturesOptInKeys {
   container_agents_v1_preview: "ContainerAgents=V1Preview",
   hosted_agents_v1_preview: "HostedAgents=V1Preview",
   workflow_agents_v1_preview: "WorkflowAgents=V1Preview",

--- a/specification/ai-foundry/data-plane/Foundry/src/common/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/common/models.tsp
@@ -49,7 +49,6 @@ op FoundryDataPlaneOperation<
 >(...Params, ...FoundryDataPlaneApiVersionParameter): Response | ErrorResponse;
 
 union FoundryFeaturesOptInKeys {
-  string,
   container_agents_v1_preview: "ContainerAgents=V1Preview",
   hosted_agents_v1_preview: "HostedAgents=V1Preview",
   workflow_agents_v1_preview: "WorkflowAgents=V1Preview",
@@ -59,20 +58,22 @@ union FoundryFeaturesOptInKeys {
   memory_stores_v1_preview: "MemoryStores=V1Preview",
 }
 
-alias WithRequiredFoundryPreviewHeader<RequiredPreviewOptInHeader extends FoundryFeaturesOptInKeys> = {
+#suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Union with template parameter cannot be named"
+alias WithRequiredFoundryPreviewHeader<RequiredPreviewOptInHeader> = {
   /**
    * A feature flag opt-in required when using preview operations or modifying persisted preview resources.
    */
   @header("Foundry-Features")
-  foundry_features: RequiredPreviewOptInHeader;
+  foundry_features: string | RequiredPreviewOptInHeader;
 };
 
-alias WithConditionalFoundryPreviewHeader<OptionalPreviewOptInHeader extends FoundryFeaturesOptInKeys> = {
+#suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Union with template parameter cannot be named"
+alias WithConditionalFoundryPreviewHeader<OptionalPreviewOptInHeader> = {
   /**
    * A feature flag opt-in required when using preview operations or modifying persisted preview resources.
    */
   @header("Foundry-Features")
-  foundry_features?: OptionalPreviewOptInHeader;
+  foundry_features?: string | OptionalPreviewOptInHeader;
 };
 
 #suppress "@azure-tools/typespec-azure-core/long-running-polling-operation-required" ""


### PR DESCRIPTION
Emitted Python code looks good. It allows me to pass in any string, without quality gates complaining about it. 