### PR TITLE
[NetApp] Add C# mgmt emitter configuration

### DIFF
--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/Cache.tsp
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/Cache.tsp
@@ -612,7 +612,7 @@ interface Caches {
     Cache,
     PoolChangeRequest,
     Cache,
-    LroHeaders = ArmLroLocationHeader<FinalResult = void> &
+    LroHeaders = ArmLroLocationHeader<FinalResult = Cache> &
       Azure.Core.Foundations.RetryAfterHeader
   >;
 
@@ -625,7 +625,7 @@ interface Caches {
     Resource = Cache,
     Request = void,
     Response = Cache,
-    LroHeaders = ArmLroLocationHeader<FinalResult = void> &
+    LroHeaders = ArmLroLocationHeader<FinalResult = Cache> &
       Azure.Core.Foundations.RetryAfterHeader
   >;
 }

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/Volume.tsp
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/Volume.tsp
@@ -829,7 +829,6 @@ union VolumeLanguage {
 /**
  * Set of export policy rules
  */
-@clientName("NetAppVolumeExportPolicyRule", "csharp")
 model VolumePropertiesExportPolicy {
   /**
    * Export policy rule

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/back-compatible.tsp
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/back-compatible.tsp
@@ -54,8 +54,14 @@ using Microsoft.NetApp;
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For backward compatibility"
 @@flattenProperty(BackupPatch.properties, "!javascript");
 
-@@clientLocation(SubscriptionQuotaItems.get, "NetAppResourceQuotaLimits");
-@@clientLocation(SubscriptionQuotaItems.list, "NetAppResourceQuotaLimits");
+@@clientLocation(SubscriptionQuotaItems.get,
+  "NetAppResourceQuotaLimits",
+  "!csharp"
+);
+@@clientLocation(SubscriptionQuotaItems.list,
+  "NetAppResourceQuotaLimits",
+  "!csharp"
+);
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For backward compatibility"
 @@flattenProperty(QuotaItem.properties, "!javascript");
 

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/client.tsp
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/client.tsp
@@ -387,6 +387,11 @@ union NetAppRelationshipStatusDef {
 @@clientName(BackupPatch, "NetAppBackupVaultBackupPatch", "csharp");
 @@clientName(UsageName, "NetAppUsageName", "csharp");
 @@clientName(UsageResult, "NetAppUsageResult", "csharp");
+@@clientName(PolicyStatus, "ElasticSnapshotPolicyStatus", "csharp");
+@@clientName(SecretPassword, "NetAppSecretPassword", "csharp");
+@@clientName(SecretPasswordIdentity, "NetAppSecretPasswordIdentity", "csharp");
+@@clientName(SnapshotUsage, "ElasticBackupSnapshotUsage", "csharp");
+@@clientName(VolumeSize, "ElasticBackupVolumeSize", "csharp");
 @@clientName(VolumeRelocationProperties,
   "NetAppVolumeRelocationProperties",
   "csharp"
@@ -471,6 +476,11 @@ union NetAppRelationshipStatusDef {
 );
 @@clientName(VolumeProperties.ldapEnabled, "IsLdapEnabled", "csharp");
 @@clientName(VolumeProperties.coolAccess, "IsCoolAccessEnabled", "csharp");
+@@clientName(VolumePatchProperties.coolAccess, "IsCoolAccessEnabled", "csharp");
+@@clientName(VolumePatchProperties.snapshotDirectoryVisible,
+  "IsSnapshotDirectoryVisible",
+  "csharp"
+);
 @@clientName(VolumeProperties.encrypted, "IsEncrypted", "csharp");
 @@clientName(ActiveDirectory.aesEncryption, "IsAesEncryptionEnabled", "csharp");
 @@clientName(ActiveDirectory.ldapSigning, "IsLdapSigningEnabled", "csharp");
@@ -622,11 +632,6 @@ union NetAppRelationshipStatusDef {
 @@alternateType(BackupsMigrationRequest.backupVaultId, string, "csharp");
 
 // Restore previous operation names that include the NetApp resource subject (csharp).
-// NOTE: We cannot also use `@@alternateType(Azure.ResourceManager.LocationParameter.location,
-// azureLocation, "csharp")` to convert the `string location` parameter to AzureLocation:
-// doing so causes the mgmt emitter to drop these subscription-scoped action operations
-// from the generated MockableNetAppSubscriptionResource entirely. The parameter therefore
-// stays `string`; AzureLocation backward-compat overloads are added in custom code.
 @@clientName(NetAppAccounts.listByNetAppAccount, "GetVolumeGroups", "csharp");
 @@clientName(NetAppResourceOperationGroup.checkNameAvailability,
   "CheckNetAppNameAvailability",
@@ -650,6 +655,14 @@ union NetAppRelationshipStatusDef {
 );
 @@clientName(NetAppResourceOperationGroup.updateNetworkSiblingSet,
   "UpdateNetworkSiblingSetNetAppResource",
+  "csharp"
+);
+@@clientName(NetAppResourceUsagesOperationGroup.list,
+  "GetNetAppResourceUsages",
+  "csharp"
+);
+@@clientName(NetAppResourceUsagesOperationGroup.get,
+  "GetNetAppResourceUsage",
   "csharp"
 );
 
@@ -793,6 +806,13 @@ union NetAppRelationshipStatusDef {
 @@alternateType(SnapshotPolicy.etag, Azure.Core.eTag, "csharp");
 @@alternateType(Volume.etag, Azure.Core.eTag, "csharp");
 @@alternateType(Cache.etag, Azure.Core.eTag, "csharp");
+@@alternateType(ActiveDirectoryConfig.etag, Azure.Core.eTag, "csharp");
+@@alternateType(ElasticAccount.eTag, Azure.Core.eTag, "csharp");
+@@alternateType(ElasticBackupPolicy.eTag, Azure.Core.eTag, "csharp");
+@@alternateType(ElasticBackupVault.eTag, Azure.Core.eTag, "csharp");
+@@alternateType(ElasticCapacityPool.eTag, Azure.Core.eTag, "csharp");
+@@alternateType(ElasticSnapshotPolicy.eTag, Azure.Core.eTag, "csharp");
+@@alternateType(ElasticVolume.eTag, Azure.Core.eTag, "csharp");
 
 // Capacity pool throughput: generate the original int?-typed property name and keep
 // the GA float?-typed CustomThroughputMibps as a compatibility alias in SDK custom code.

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/client.tsp
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/client.tsp
@@ -95,50 +95,33 @@ using Microsoft.NetApp;
 // C# customizations (csharp scope)
 // =============================================================================
 
-// --- C# backward-compat enum (closed enum to preserve System.Enum base) ---
+/** C# extensible replacement for NetApp provisioning state values. */
+union NetAppVolumeQuotaRuleProvisioningStateDef {
+  string,
 
-// --- Preserve SDK-facing NetAppProvisioningState naming for backward compat ---
-// Old SDK (1.15.0) had NetAppProvisioningState as a closed System.Enum. The spec models it
-// as an extensible union; using a union here would emit a `readonly partial struct`, breaking
-// ApiCompat. Use a closed `enum` so the C# emitter generates `public enum NetAppProvisioningState`.
-/** Compatibility alias for NetApp provisioning state values. */
-#suppress "@azure-tools/typespec-azure-core/no-enum" "Backward compat: must be closed enum to preserve System.Enum base type from v1.15.0."
-enum NetAppProvisioningStateDef {
-  /** The request has been accepted. */
+  /** Resource has been Accepted. */
   Accepted: "Accepted",
 
-  /** The resource is being created. */
+  /** Resource is being Created. */
   Creating: "Creating",
 
-  /** The resource is being patched. */
+  /** Resource is being Patched. */
   Patching: "Patching",
 
-  /** The resource is being updated. */
+  /** Resource is updating. */
   Updating: "Updating",
 
-  /** The resource is being deleted. */
+  /** Resource is being Deleted. */
   Deleting: "Deleting",
 
-  /** The resource is being moved. */
+  /** Resource is being Moved. */
   Moving: "Moving",
 
-  /** The operation failed. */
+  /** Resource has Failed. */
   Failed: "Failed",
 
-  /** The operation succeeded. */
+  /** Resource has Succeeded. */
   Succeeded: "Succeeded",
-
-  /** The operation was canceled. */
-  Canceled: "Canceled",
-
-  /** The resource is provisioning. */
-  Provisioning: "Provisioning",
-}
-
-/** Compatibility alias for NetApp volume quota rule provisioning state values. */
-union NetAppVolumeQuotaRuleProvisioningStateDef {
-  NetAppProvisioningState,
-  string,
 }
 
 // --- @@clientName: model and property renames for C# ---
@@ -549,7 +532,6 @@ union NetAppVolumeQuotaRuleProvisioningStateDef {
 @@clientName(AccountProperties.nfsV4IDDomain, "NfsV4IdDomain", "csharp");
 @@clientName(QuotaReport, "NetAppVolumeQuotaReport", "csharp");
 @@clientName(QuotaReportFilterRequest, "QuotaReportFilterContent", "csharp");
-@@clientName(NetAppProvisioningStateDef, "NetAppProvisioningState", "csharp");
 @@clientName(NetAppVolumeQuotaRuleProvisioningStateDef,
   "NetAppVolumeQuotaRuleProvisioningState",
   "csharp"
@@ -739,19 +721,8 @@ union NetAppVolumeQuotaRuleProvisioningStateDef {
 // TEMPORARY: reproduce DeserializeAzureLocation bug
 @@alternateType(VolumeGroup.id, armResourceIdentifier, "csharp");
 @@alternateType(VolumeGroup.location, azureLocation, "csharp");
-// NetAppProvisioningState shipped as a closed enum in v1.15.0. Keep that
-// type-level compatibility mapping, then override quota-rule properties back
-// to their shipped extensible quota-rule state type below.
-@@alternateType(NetAppProvisioningState, NetAppProvisioningStateDef, "csharp");
-@@alternateType(BucketProperties.provisioningState,
-  NetAppVolumeQuotaRuleProvisioningStateDef,
-  "csharp"
-);
-@@alternateType(BucketPatchProperties.provisioningState,
-  NetAppVolumeQuotaRuleProvisioningStateDef,
-  "csharp"
-);
-@@alternateType(VolumeQuotaRulesProperties.provisioningState,
+// Replace the spec provisioning-state union with the C# extensible union type.
+@@alternateType(NetAppProvisioningState,
   NetAppVolumeQuotaRuleProvisioningStateDef,
   "csharp"
 );

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/client.tsp
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/client.tsp
@@ -137,7 +137,7 @@ enum NetAppProvisioningStateDef {
 
 /** Compatibility alias for NetApp volume quota rule provisioning state values. */
 union NetAppVolumeQuotaRuleProvisioningStateDef {
-  NetAppProvisioningStateDef,
+  NetAppProvisioningState,
   string,
 }
 

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/client.tsp
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/client.tsp
@@ -533,7 +533,7 @@ union NetAppVolumeQuotaRuleProvisioningStateDef {
 @@clientName(QuotaReport, "NetAppVolumeQuotaReport", "csharp");
 @@clientName(QuotaReportFilterRequest, "QuotaReportFilterContent", "csharp");
 @@clientName(NetAppVolumeQuotaRuleProvisioningStateDef,
-  "NetAppVolumeQuotaRuleProvisioningState",
+  "NetAppProvisioningState",
   "csharp"
 );
 

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/client.tsp
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/client.tsp
@@ -141,27 +141,6 @@ union NetAppVolumeQuotaRuleProvisioningStateDef {
   string,
 }
 
-// --- C# backward-compat union (unified relationship status) ---
-
-// --- Fix status model RelationshipStatus type to use unified NetAppRelationshipStatus ---
-// Old SDK had RelationshipStatus as NetAppRelationshipStatus? on all three status models.
-/** Compatibility alias for NetApp relationship status values. */
-union NetAppRelationshipStatusDef {
-  string,
-
-  /** The relationship is idle. */
-  Idle: "Idle",
-
-  /** The relationship is transferring data. */
-  Transferring: "Transferring",
-
-  /** The relationship failed. */
-  Failed: "Failed",
-
-  /** The relationship state is unknown. */
-  Unknown: "Unknown",
-}
-
 // --- @@clientName: model and property renames for C# ---
 @@clientName(CachePropertiesExportPolicy,
   "NetAppCachePropertiesExportPolicy",
@@ -598,15 +577,18 @@ union NetAppRelationshipStatusDef {
 
 // VolumeRevert.snapshotId: armResourceIdentifier → string (old API had string)
 @@clientName(VolumeRevert.snapshotId, "SnapshotId", "csharp");
-@@clientName(NetAppRelationshipStatusDef, "NetAppRelationshipStatus", "csharp");
 @@clientName(VolumePropertiesExportPolicy,
   "NetAppVolumeExportPolicy",
   "csharp"
 );
 
 // --- @@alternateType: property type overrides for C# ---
-// BackupsMigrationRequest.backupVaultId: armResourceIdentifier → string (old API had string)
-@@alternateType(BackupsMigrationRequest.backupVaultId, string, "csharp");
+// BackupsMigrationRequest.backupVaultId: accept ResourceIdentifier and rename;
+// the old string BackupVaultId API is preserved by SDK customization.
+@@clientName(BackupsMigrationRequest.backupVaultId,
+  "BackupVaultResourceId",
+  "csharp"
+);
 
 // Restore previous operation names that include the NetApp resource subject (csharp).
 @@clientName(NetAppAccounts.listByNetAppAccount, "GetVolumeGroups", "csharp");
@@ -757,6 +739,9 @@ union NetAppRelationshipStatusDef {
 // TEMPORARY: reproduce DeserializeAzureLocation bug
 @@alternateType(VolumeGroup.id, armResourceIdentifier, "csharp");
 @@alternateType(VolumeGroup.location, azureLocation, "csharp");
+// NetAppProvisioningState shipped as a closed enum in v1.15.0. Keep that
+// type-level compatibility mapping, then override quota-rule properties back
+// to their shipped extensible quota-rule state type below.
 @@alternateType(NetAppProvisioningState, NetAppProvisioningStateDef, "csharp");
 @@alternateType(BucketProperties.provisioningState,
   NetAppVolumeQuotaRuleProvisioningStateDef,

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/client.tsp
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/client.tsp
@@ -605,7 +605,7 @@ union NetAppRelationshipStatusDef {
 
 // Body parameter rename to restore previous property name
 @@clientName(ListReplicationsRequest.exclude,
-  "Exclude",
+  "ExcludeReplicationsFilter",
   "csharp"
 );
 

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/client.tsp
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/client.tsp
@@ -95,40 +95,6 @@ using Microsoft.NetApp;
 // C# customizations (csharp scope)
 // =============================================================================
 
-/** C# provisioning state values used to compose the extensible replacement union. */
-#suppress "@azure-tools/typespec-azure-core/no-enum" "Backward compat: compose the replacement union from the existing enum values plus string."
-enum NetAppProvisioningStateDef {
-  /** The request has been accepted. */
-  Accepted: "Accepted",
-
-  /** The resource is being created. */
-  Creating: "Creating",
-
-  /** The resource is being patched. */
-  Patching: "Patching",
-
-  /** The resource is being updated. */
-  Updating: "Updating",
-
-  /** The resource is being deleted. */
-  Deleting: "Deleting",
-
-  /** The resource is being moved. */
-  Moving: "Moving",
-
-  /** The operation failed. */
-  Failed: "Failed",
-
-  /** The operation succeeded. */
-  Succeeded: "Succeeded",
-}
-
-/** C# extensible replacement for NetApp provisioning state values. */
-union NetAppVolumeQuotaRuleProvisioningStateDef {
-  NetAppProvisioningStateDef,
-  string,
-}
-
 // --- @@clientName: model and property renames for C# ---
 @@clientName(CachePropertiesExportPolicy,
   "NetAppCachePropertiesExportPolicy",
@@ -537,10 +503,6 @@ union NetAppVolumeQuotaRuleProvisioningStateDef {
 @@clientName(AccountProperties.nfsV4IDDomain, "NfsV4IdDomain", "csharp");
 @@clientName(QuotaReport, "NetAppVolumeQuotaReport", "csharp");
 @@clientName(QuotaReportFilterRequest, "QuotaReportFilterContent", "csharp");
-@@clientName(NetAppVolumeQuotaRuleProvisioningStateDef,
-  "NetAppProvisioningState",
-  "csharp"
-);
 
 // C# enum-member casing fixes (formerly exposed with these spellings)
 @@clientName(ApplicationType.`SAP-HANA`, "SapHana", "csharp");
@@ -726,11 +688,6 @@ union NetAppVolumeQuotaRuleProvisioningStateDef {
 // TEMPORARY: reproduce DeserializeAzureLocation bug
 @@alternateType(VolumeGroup.id, armResourceIdentifier, "csharp");
 @@alternateType(VolumeGroup.location, azureLocation, "csharp");
-// Replace the spec provisioning-state union with the C# extensible union type.
-@@alternateType(NetAppProvisioningState,
-  NetAppVolumeQuotaRuleProvisioningStateDef,
-  "csharp"
-);
 @@clientName(VolumeQuotaRulesProperties.provisioningState,
   "VolumeQuotaRuleProvisioningState",
   "csharp"
@@ -845,4 +802,3 @@ union NetAppVolumeQuotaRuleProvisioningStateDef {
 @@usage(VolumeBackupRelationshipStatus, Usage.input, "csharp");
 @@usage(VolumeReplicationRelationshipStatus, Usage.input, "csharp");
 @@usage(VolumeRestoreRelationshipStatus, Usage.input, "csharp");
-@@usage(NetAppVolumeQuotaRuleProvisioningStateDef, Usage.input, "csharp");

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/client.tsp
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/client.tsp
@@ -95,33 +95,38 @@ using Microsoft.NetApp;
 // C# customizations (csharp scope)
 // =============================================================================
 
-/** C# extensible replacement for NetApp provisioning state values. */
-union NetAppVolumeQuotaRuleProvisioningStateDef {
-  string,
-
-  /** Resource has been Accepted. */
+/** C# provisioning state values used to compose the extensible replacement union. */
+#suppress "@azure-tools/typespec-azure-core/no-enum" "Backward compat: compose the replacement union from the existing enum values plus string."
+enum NetAppProvisioningStateDef {
+  /** The request has been accepted. */
   Accepted: "Accepted",
 
-  /** Resource is being Created. */
+  /** The resource is being created. */
   Creating: "Creating",
 
-  /** Resource is being Patched. */
+  /** The resource is being patched. */
   Patching: "Patching",
 
-  /** Resource is updating. */
+  /** The resource is being updated. */
   Updating: "Updating",
 
-  /** Resource is being Deleted. */
+  /** The resource is being deleted. */
   Deleting: "Deleting",
 
-  /** Resource is being Moved. */
+  /** The resource is being moved. */
   Moving: "Moving",
 
-  /** Resource has Failed. */
+  /** The operation failed. */
   Failed: "Failed",
 
-  /** Resource has Succeeded. */
+  /** The operation succeeded. */
   Succeeded: "Succeeded",
+}
+
+/** C# extensible replacement for NetApp provisioning state values. */
+union NetAppVolumeQuotaRuleProvisioningStateDef {
+  NetAppProvisioningStateDef,
+  string,
 }
 
 // --- @@clientName: model and property renames for C# ---

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/client.tsp
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/client.tsp
@@ -2,6 +2,8 @@ import "@azure-tools/typespec-client-generator-core";
 import "./main.tsp";
 
 using Azure.ClientGenerator.Core;
+using Azure.ClientGenerator.Core.Legacy;
+using Azure.Core;
 using Microsoft.NetApp;
 
 @@clientName(Microsoft.NetApp,
@@ -89,7 +91,800 @@ using Microsoft.NetApp;
 @@clientName(QuotaItemList, "SubscriptionQuotaItemList", "go");
 @@clientName(QuotaItemProperties, "SubscriptionQuotaItemProperties", "go");
 
-@@clientName(Microsoft.NetApp.CachePropertiesExportPolicy,
+// =============================================================================
+// C# customizations (csharp scope)
+// =============================================================================
+
+// --- C# backward-compat enum (closed enum to preserve System.Enum base) ---
+
+// --- Preserve SDK-facing NetAppProvisioningState naming for backward compat ---
+// Old SDK (1.15.0) had NetAppProvisioningState as a closed System.Enum. The spec models it
+// as an extensible union; using a union here would emit a `readonly partial struct`, breaking
+// ApiCompat. Use a closed `enum` so the C# emitter generates `public enum NetAppProvisioningState`.
+/** Compatibility alias for NetApp provisioning state values. */
+#suppress "@azure-tools/typespec-azure-core/no-enum" "Backward compat: must be closed enum to preserve System.Enum base type from v1.15.0."
+enum NetAppProvisioningStateDef {
+  /** The request has been accepted. */
+  Accepted: "Accepted",
+
+  /** The resource is being created. */
+  Creating: "Creating",
+
+  /** The resource is being patched. */
+  Patching: "Patching",
+
+  /** The resource is being updated. */
+  Updating: "Updating",
+
+  /** The resource is being deleted. */
+  Deleting: "Deleting",
+
+  /** The resource is being moved. */
+  Moving: "Moving",
+
+  /** The operation failed. */
+  Failed: "Failed",
+
+  /** The operation succeeded. */
+  Succeeded: "Succeeded",
+
+  /** The operation was canceled. */
+  Canceled: "Canceled",
+
+  /** The resource is provisioning. */
+  Provisioning: "Provisioning",
+}
+
+/** Compatibility alias for NetApp volume quota rule provisioning state values. */
+union NetAppVolumeQuotaRuleProvisioningStateDef {
+  string,
+
+  /** The request has been accepted. */
+  Accepted: "Accepted",
+
+  /** The resource is being created. */
+  Creating: "Creating",
+
+  /** The resource is being patched. */
+  Patching: "Patching",
+
+  /** The resource is being deleted. */
+  Deleting: "Deleting",
+
+  /** The resource is being moved. */
+  Moving: "Moving",
+
+  /** The operation failed. */
+  Failed: "Failed",
+
+  /** The operation succeeded. */
+  Succeeded: "Succeeded",
+
+  /** The resource is being updated. */
+  Updating: "Updating",
+}
+
+// --- C# backward-compat union (unified relationship status) ---
+
+// --- Fix status model RelationshipStatus type to use unified NetAppRelationshipStatus ---
+// Old SDK had RelationshipStatus as NetAppRelationshipStatus? on all three status models.
+/** Compatibility alias for NetApp relationship status values. */
+union NetAppRelationshipStatusDef {
+  string,
+
+  /** The relationship is idle. */
+  Idle: "Idle",
+
+  /** The relationship is transferring data. */
+  Transferring: "Transferring",
+
+  /** The relationship failed. */
+  Failed: "Failed",
+
+  /** The relationship state is unknown. */
+  Unknown: "Unknown",
+}
+
+// --- @@clientName: model and property renames for C# ---
+@@clientName(CachePropertiesExportPolicy,
   "NetAppCachePropertiesExportPolicy",
   "csharp"
 );
+
+// C# model renames to match existing SDK API surface
+@@clientLocation(SubscriptionQuotaItems.get,
+  "NetAppSubscriptionQuotaItems",
+  "csharp"
+);
+@@clientLocation(SubscriptionQuotaItems.list,
+  "NetAppSubscriptionQuotaItems",
+  "csharp"
+);
+@@clientName(QosType, "CapacityPoolQosType", "csharp");
+@@clientName(ActiveDirectory, "NetAppAccountActiveDirectory", "csharp");
+@@clientName(AccountEncryption, "NetAppAccountEncryption", "csharp");
+@@clientName(Replication, "NetAppVolumeReplication", "csharp");
+@@clientName(CacheProperties, "NetAppCacheProperties", "csharp");
+@@clientName(CacheMountTargetProperties,
+  "NetAppCacheMountTargetProperties",
+  "csharp"
+);
+@@clientName(PeeringPassphrases, "NetAppPeeringPassphrases", "csharp");
+@@clientName(SmbSettings, "NetAppSmbSettings", "csharp");
+@@clientName(OriginClusterInformation,
+  "NetAppOriginClusterInformation",
+  "csharp"
+);
+@@clientName(DailySchedule, "SnapshotPolicyDailySchedule", "csharp");
+@@clientName(HourlySchedule, "SnapshotPolicyHourlySchedule", "csharp");
+@@clientName(MonthlySchedule, "SnapshotPolicyMonthlySchedule", "csharp");
+@@clientName(WeeklySchedule, "SnapshotPolicyWeeklySchedule", "csharp");
+@@clientName(CacheLifeCycleState, "NetAppCacheLifeCycleState", "csharp");
+@@clientName(CacheProvisioningState, "NetAppCacheProvisioningState", "csharp");
+@@clientName(CifsChangeNotifyState, "NetAppCifsChangeNotifyState", "csharp");
+@@clientName(EnableWriteBackState, "NetAppEnableWriteBackState", "csharp");
+@@clientName(EncryptionState, "NetAppEncryptionState", "csharp");
+@@clientName(ExternalReplicationSetupStatus,
+  "NetAppExternalReplicationSetupStatus",
+  "csharp"
+);
+@@clientName(GlobalFileLockingState, "NetAppGlobalFileLockingState", "csharp");
+@@clientName(KerberosState, "NetAppKerberosState", "csharp");
+@@clientName(LdapState, "NetAppLdapState", "csharp");
+@@clientName(LdapServerType, "NetAppLdapServerType", "csharp");
+@@clientName(ProtocolTypes, "NetAppProtocolType", "csharp");
+@@clientName(SmbEncryptionState, "NetAppSmbEncryptionState", "csharp");
+@@clientName(VolumeLanguage, "NetAppVolumeLanguage", "csharp");
+@@clientName(ActiveDirectoryStatus,
+  "NetAppAccountActiveDirectoryStatus",
+  "csharp"
+);
+@@clientName(LdapSearchScopeOpt,
+  "NetAppLdapSearchScopeConfiguration",
+  "csharp"
+);
+@@clientName(ReplicationSchedule, "NetAppReplicationSchedule", "csharp");
+
+// C# AZC0030/AZC0032 naming compliance: Request→Content, Response→Result
+@@clientName(AuthorizeRequest,
+  "NetAppVolumeAuthorizeReplicationContent",
+  "csharp"
+);
+@@clientName(BackupsMigrationRequest, "BackupsMigrationContent", "csharp");
+@@clientName(BreakFileLocksRequest,
+  "NetAppVolumeBreakFileLocksContent",
+  "csharp"
+);
+@@clientName(BreakFileLocksRequest.clientIp, "ClientIP", "csharp");
+@@alternateType(BreakFileLocksRequest.clientIp,
+  Azure.Core.ipV4Address,
+  "csharp"
+);
+@@clientName(BreakReplicationRequest,
+  "NetAppVolumeBreakReplicationContent",
+  "csharp"
+);
+@@clientName(ChangeZoneRequest, "ChangeZoneContent", "csharp");
+@@clientName(CheckAvailabilityResponse,
+  "NetAppCheckAvailabilityResult",
+  "csharp"
+);
+@@clientName(CheckElasticVolumeFilePathAvailabilityRequest,
+  "CheckElasticVolumeFilePathAvailabilityContent",
+  "csharp"
+);
+@@clientName(ClusterPeerCommandResponse, "ClusterPeerCommandResult", "csharp");
+@@clientName(EncryptionTransitionRequest,
+  "NetAppEncryptionTransitionContent",
+  "csharp"
+);
+@@clientName(FilePathAvailabilityRequest,
+  "NetAppFilePathAvailabilityContent",
+  "csharp"
+);
+@@clientName(GetGroupIdListForLdapUserRequest,
+  "GetGroupIdListForLdapUserContent",
+  "csharp"
+);
+@@clientName(GetGroupIdListForLdapUserResponse,
+  "GetGroupIdListForLdapUserResult",
+  "csharp"
+);
+@@clientName(GetKeyVaultStatusResponse, "NetAppKeyVaultStatusResult", "csharp");
+@@clientName(ListQuotaReportResponse,
+  "NetAppVolumeQuotaReportListResult",
+  "csharp"
+);
+@@clientName(ListReplicationsRequest, "ListReplicationsContent", "csharp");
+@@clientName(PeerClusterForVolumeMigrationRequest,
+  "PeerClusterForVolumeMigrationContent",
+  "csharp"
+);
+@@clientName(PoolChangeRequest, "NetAppVolumePoolChangeContent", "csharp");
+@@clientName(QueryNetworkSiblingSetRequest,
+  "QueryNetworkSiblingSetContent",
+  "csharp"
+);
+@@clientName(QuotaAvailabilityRequest,
+  "NetAppQuotaAvailabilityContent",
+  "csharp"
+);
+@@clientName(RansomwareSuspectsClearRequest,
+  "RansomwareSuspectsClearContent",
+  "csharp"
+);
+@@clientName(ReestablishReplicationRequest,
+  "NetAppVolumeReestablishReplicationContent",
+  "csharp"
+);
+@@clientName(RelocateVolumeRequest, "RelocateVolumeContent", "csharp");
+@@clientName(ResourceNameAvailabilityRequest,
+  "NetAppNameAvailabilityContent",
+  "csharp"
+);
+@@clientName(SvmPeerCommandResponse, "SvmPeerCommandResult", "csharp");
+@@clientName(UpdateNetworkSiblingSetRequest,
+  "UpdateNetworkSiblingSetContent",
+  "csharp"
+);
+@@clientName(VolumeGroupMetaData, "NetAppVolumeGroupMetadata", "csharp");
+
+// C# prepend-rp-prefix renames (restore NetApp prefix from old SDK)
+@@clientName(AvsDataStore, "NetAppAvsDataStore", "csharp");
+@@clientName(ChownMode, "NetAppChownMode", "csharp");
+@@clientName(DestinationReplication, "NetAppDestinationReplication", "csharp");
+@@clientName(EncryptionIdentity, "NetAppEncryptionIdentity", "csharp");
+@@clientName(EncryptionKeySource, "NetAppEncryptionKeySource", "csharp");
+@@clientName(KeySource, "NetAppKeySource", "csharp");
+@@clientName(KeyVaultPrivateEndpoint,
+  "NetAppKeyVaultPrivateEndpoint",
+  "csharp"
+);
+@@clientName(KeyVaultProperties, "NetAppKeyVaultProperties", "csharp");
+@@clientName(RegionInfo, "NetAppRegionInfo", "csharp");
+@@clientName(ReplicationObject, "NetAppReplicationObject", "csharp");
+@@clientName(ReplicationStatus, "NetAppVolumeReplicationStatus", "csharp");
+@@clientName(ReplicationType, "NetAppReplicationType", "csharp");
+@@clientName(VolumePatch, "NetAppVolumePatch", "csharp");
+
+// C# rename-mapping renames (backward compat with old autorest SDK names)
+@@clientName(EnableSubvolumes, "EnableNetAppSubvolume", "csharp");
+@@clientName(Exclude, "ExcludeReplicationsFilter", "csharp");
+@@clientName(FileAccessLogs, "NetAppFileAccessLog", "csharp");
+@@clientName(CheckNameResourceTypes,
+  "NetAppNameAvailabilityResourceType",
+  "csharp"
+);
+@@clientName(InAvailabilityReasonType, "NetAppNameUnavailableReason", "csharp");
+@@clientName(NetworkFeatures, "NetAppNetworkFeature", "csharp");
+@@clientName(CheckQuotaNameResourceTypes,
+  "NetAppQuotaAvailabilityResourceType",
+  "csharp"
+);
+@@clientName(SubvolumeModel, "NetAppSubvolumeMetadata", "csharp");
+@@clientName(VolumeBackups, "NetAppVolumeBackupDetail", "csharp");
+@@clientName(VolumePropertiesDataProtection,
+  "NetAppVolumeDataProtection",
+  "csharp"
+);
+@@clientName(VolumeGroup, "NetAppVolumeGroupResult", "csharp");
+@@clientName(MountTargetProperties, "NetAppVolumeMountTarget", "csharp");
+@@clientName(VolumePatchPropertiesDataProtection,
+  "NetAppVolumePatchDataProtection",
+  "csharp"
+);
+@@clientName(QuotaType, "NetAppVolumeQuotaType", "csharp");
+@@clientName(VolumeRevert, "NetAppVolumeRevertContent", "csharp");
+@@clientName(SecurityStyle, "NetAppVolumeSecurityStyle", "csharp");
+@@clientName(SnapshotRestoreFiles,
+  "NetAppVolumeSnapshotRestoreFilesContent",
+  "csharp"
+);
+@@clientName(VolumeStorageToNetworkProximity,
+  "NetAppVolumeStorageToNetworkProximity",
+  "csharp"
+);
+@@clientName(BackupPatch, "NetAppBackupVaultBackupPatch", "csharp");
+@@clientName(UsageName, "NetAppUsageName", "csharp");
+@@clientName(UsageResult, "NetAppUsageResult", "csharp");
+@@clientName(VolumeRelocationProperties,
+  "NetAppVolumeRelocationProperties",
+  "csharp"
+);
+@@clientName(BackupRestoreFiles,
+  "NetAppVolumeBackupBackupRestoreFilesContent",
+  "csharp"
+);
+@@clientName(VolumeGroupVolumeProperties, "NetAppVolumeGroupVolume", "csharp");
+@@clientName(VolumeGroupVolumeProperties.type, "ResourceType", "csharp");
+@@clientName(VolumeBackupProperties,
+  "NetAppVolumeBackupConfiguration",
+  "csharp"
+);
+@@clientName(SecretPasswordKeyVaultProperties,
+  "NetAppSecretPasswordKeyVaultPatchProperties",
+  "csharp"
+);
+@@clientName(FileSystemUser, "NetAppFileSystemUser", "csharp");
+@@clientName(NfsUser, "NetAppNfsUser", "csharp");
+@@clientName(BucketServerProperties, "NetAppBucketServerProperties", "csharp");
+@@clientName(BucketServerPatchProperties,
+  "NetAppBucketServerPatchProperties",
+  "csharp"
+);
+@@clientName(BucketPermissions, "NetAppBucketPermission", "csharp");
+@@clientName(BucketPatchPermissions, "NetAppBucketPatchPermission", "csharp");
+@@clientName(OnCertificateConflictAction,
+  "NetAppOnCertificateConflictAction",
+  "csharp"
+);
+@@clientName(BucketCredentialsExpiry,
+  "NetAppBucketCredentialsExpiry",
+  "csharp"
+);
+@@clientName(BucketGenerateCredentials,
+  "NetAppBucketGenerateCredentials",
+  "csharp"
+);
+@@clientName(BucketGenerateCredentials.keyPairExpiry,
+  "KeyPairExpiresOn",
+  "csharp"
+);
+@@clientName(AzureKeyVaultDetails, "NetAppKeyVaultDetails", "csharp");
+@@clientName(BucketProperties.akvDetails, "KeyVaultDetails", "csharp");
+@@clientName(BucketPatchProperties.akvDetails, "KeyVaultDetails", "csharp");
+@@clientName(CertificateAkvDetails, "CertificateKeyVaultDetails", "csharp");
+@@clientName(CredentialsAkvDetails, "CredentialsKeyVaultDetails", "csharp");
+@@clientName(AzureKeyVaultDetails.certificateAkvDetails,
+  "CertificateKeyVaultDetails",
+  "csharp"
+);
+@@clientName(AzureKeyVaultDetails.credentialsAkvDetails,
+  "CredentialsKeyVaultDetails",
+  "csharp"
+);
+@@clientName(CredentialsStatus, "NetAppCredentialsStatus", "csharp");
+@@clientName(Buckets.generateAkvCredentials,
+  "GenerateKeyVaultCredentials",
+  "csharp"
+);
+@@clientName(ExportPolicyRule, "NetAppVolumeExportPolicyRule", "csharp");
+@@clientName(ExportPolicyRule.unixReadOnly, "IsUnixReadOnly", "csharp");
+@@clientName(ExportPolicyRule.unixReadWrite, "IsUnixReadWrite", "csharp");
+@@clientName(ExportPolicyRule.cifs, "AllowCifsProtocol", "csharp");
+@@clientName(ExportPolicyRule.nfsv3, "AllowNfsV3Protocol", "csharp");
+@@clientName(ExportPolicyRule.nfsv41, "AllowNfsV41Protocol", "csharp");
+
+// C# boolean property renames (restore Is*/Has* prefix from old SDK)
+@@clientName(VolumeProperties.snapshotDirectoryVisible,
+  "IsSnapshotDirectoryVisible",
+  "csharp"
+);
+@@clientName(VolumeProperties.kerberosEnabled, "IsKerberosEnabled", "csharp");
+@@clientName(VolumeProperties.smbEncryption,
+  "IsSmbEncryptionEnabled",
+  "csharp"
+);
+@@clientName(VolumeProperties.smbContinuouslyAvailable,
+  "IsSmbContinuouslyAvailable",
+  "csharp"
+);
+@@clientName(VolumeProperties.ldapEnabled, "IsLdapEnabled", "csharp");
+@@clientName(VolumeProperties.coolAccess, "IsCoolAccessEnabled", "csharp");
+@@clientName(VolumeProperties.encrypted, "IsEncrypted", "csharp");
+@@clientName(ActiveDirectory.aesEncryption, "IsAesEncryptionEnabled", "csharp");
+@@clientName(ActiveDirectory.ldapSigning, "IsLdapSigningEnabled", "csharp");
+@@clientName(ActiveDirectory.ldapOverTLS, "IsLdapOverTlsEnabled", "csharp");
+@@clientName(LdapConfiguration.ldapOverTLS, "IsLdapOverTlsEnabled", "csharp");
+@@clientName(LdapConfigurationPatch.ldapOverTLS,
+  "IsLdapOverTlsEnabled",
+  "csharp"
+);
+@@clientName(PoolProperties.coolAccess, "IsCoolAccessEnabled", "csharp");
+@@clientName(PoolPatchProperties.coolAccess, "IsCoolAccessEnabled", "csharp");
+@@clientName(VolumeBackupProperties.policyEnforced,
+  "IsPolicyEnforced",
+  "csharp"
+);
+@@clientName(BackupPolicyProperties.enabled, "IsEnabled", "csharp");
+@@clientName(VolumeBackups.policyEnabled, "IsPolicyEnabled", "csharp");
+@@clientName(RestoreStatus.healthy, "IsHealthy", "csharp");
+@@clientName(BackupStatus.healthy, "IsHealthy", "csharp");
+@@clientName(ReplicationStatus.healthy, "IsHealthy", "csharp");
+@@clientName(ResourceNameAvailabilityRequest.type, "ResourceType", "csharp");
+@@clientName(QuotaAvailabilityRequest.type,
+  "AvailabilityResourceType",
+  "csharp"
+);
+@@clientName(ExportPolicyRule.kerberos5ReadOnly,
+  "IsKerberos5ReadOnly",
+  "csharp"
+);
+@@clientName(ExportPolicyRule.kerberos5ReadWrite,
+  "IsKerberos5ReadWrite",
+  "csharp"
+);
+@@clientName(ExportPolicyRule.kerberos5iReadOnly,
+  "IsKerberos5iReadOnly",
+  "csharp"
+);
+@@clientName(ExportPolicyRule.kerberos5iReadWrite,
+  "IsKerberos5iReadWrite",
+  "csharp"
+);
+@@clientName(ExportPolicyRule.kerberos5pReadOnly,
+  "IsKerberos5pReadOnly",
+  "csharp"
+);
+@@clientName(ExportPolicyRule.kerberos5pReadWrite,
+  "IsKerberos5pReadWrite",
+  "csharp"
+);
+@@clientName(ExportPolicyRule.hasRootAccess, "HasRootAccess", "csharp");
+
+// C# property renames for backward compat
+@@clientName(VolumeRelocationProperties.relocationRequested,
+  "IsRelocationRequested",
+  "csharp"
+);
+@@clientName(VolumeRelocationProperties.readyToBeFinalized,
+  "IsReadyToBeFinalized",
+  "csharp"
+);
+@@clientName(SubvolumeModelProperties.accessedTimeStamp,
+  "AccessedOn",
+  "csharp"
+);
+@@clientName(SubvolumeModelProperties.modifiedTimeStamp,
+  "ModifiedOn",
+  "csharp"
+);
+@@clientName(SubvolumeModelProperties.changedTimeStamp, "ChangedOn", "csharp");
+@@clientName(SubvolumeModelProperties.creationTimeStamp, "CreatedOn", "csharp");
+@@clientName(SnapshotPolicyProperties.enabled, "IsEnabled", "csharp");
+@@clientName(VolumeProperties.proximityPlacementGroup,
+  "ProximityPlacementGroupId",
+  "csharp"
+);
+
+// C# ARM resource renames (restore NetApp prefix on resource types)
+@@clientName(Volume, "NetAppVolume", "csharp");
+@@clientName(Bucket, "NetAppBucket", "csharp");
+@@clientName(Cache, "NetAppCache", "csharp");
+@@clientName(ActiveDirectoryConfig, "NetAppActiveDirectoryConfig", "csharp");
+@@clientName(BackupPolicy, "NetAppBackupPolicy", "csharp");
+@@clientName(BackupVault, "NetAppBackupVault", "csharp");
+@@clientName(Backup, "NetAppBackupVaultBackup", "csharp");
+@@clientName(SubvolumeInfo, "NetAppSubvolumeInfo", "csharp");
+@@clientName(VolumeQuotaRule, "NetAppVolumeQuotaRule", "csharp");
+@@clientName(Snapshot, "NetAppVolumeSnapshot", "csharp");
+@@clientName(VolumeGroupDetails, "NetAppVolumeGroup", "csharp");
+@@clientName(ElasticAccount, "NetAppElasticAccount", "csharp");
+@@clientName(ElasticBackup, "NetAppElasticBackup", "csharp");
+@@clientName(ElasticBackupPolicy, "NetAppElasticBackupPolicy", "csharp");
+@@clientName(ElasticBackupVault, "NetAppElasticBackupVault", "csharp");
+@@clientName(ElasticCapacityPool, "NetAppElasticCapacityPool", "csharp");
+@@clientName(ElasticSnapshot, "NetAppElasticSnapshot", "csharp");
+@@clientName(ElasticSnapshotPolicy, "NetAppElasticSnapshotPolicy", "csharp");
+@@clientName(ElasticVolume, "NetAppElasticVolume", "csharp");
+@@clientName(BackupPolicyPatch, "NetAppBackupPolicyPatch", "csharp");
+@@clientName(BackupVaultPatch, "NetAppBackupVaultPatch", "csharp");
+// SubvolumePatchParams rename removed — derived from SubvolumeInfo resource rename
+@@clientName(VolumeQuotaRulePatch, "NetAppVolumeQuotaRulePatch", "csharp");
+@@clientName(ChangeKeyVault, "NetAppChangeKeyVault", "csharp");
+
+// C# property name renames
+@@clientName(KeyVaultProperties.keyVaultResourceId,
+  "KeyVaultArmResourceId",
+  "csharp"
+);
+
+// C# property name casing fixes
+@@clientName(AccountProperties.nfsV4IDDomain, "NfsV4IdDomain", "csharp");
+@@clientName(QuotaReport, "NetAppVolumeQuotaReport", "csharp");
+@@clientName(QuotaReportFilterRequest, "QuotaReportFilterContent", "csharp");
+@@clientName(NetAppProvisioningStateDef, "NetAppProvisioningState", "csharp");
+@@clientName(NetAppVolumeQuotaRuleProvisioningStateDef,
+  "NetAppVolumeQuotaRuleProvisioningState",
+  "csharp"
+);
+
+// C# enum-member casing fixes (formerly exposed with these spellings)
+@@clientName(ApplicationType.`SAP-HANA`, "SapHana", "csharp");
+@@clientName(ApplicationType.ORACLE, "Oracle", "csharp");
+@@clientName(EndpointType.src, "Source", "csharp");
+@@clientName(EndpointType.dst, "Destination", "csharp");
+@@clientName(ServiceLevel.StandardZRS, "StandardZrs", "csharp");
+@@clientName(ProtocolTypes.NFSv3, "Nfsv3", "csharp");
+@@clientName(ProtocolTypes.NFSv4, "Nfsv4", "csharp");
+@@clientName(ProtocolTypes.SMB, "Smb", "csharp");
+@@clientName(LdapServerType.OpenLDAP, "OpenLdap", "csharp");
+@@clientName(VolumeLanguage.utf8mb4, "Utf8Mb4", "csharp");
+@@clientName(ElasticProtocolType.NFSv3, "Nfsv3", "csharp");
+@@clientName(ElasticProtocolType.NFSv4, "Nfsv4", "csharp");
+
+// Body parameter rename to restore previous property name
+@@clientName(ListReplicationsRequest.exclude,
+  "ExcludeReplicationsFilter",
+  "csharp"
+);
+
+// VolumeRevert.snapshotId: armResourceIdentifier → string (old API had string)
+@@clientName(VolumeRevert.snapshotId, "SnapshotId", "csharp");
+@@clientName(NetAppRelationshipStatusDef, "NetAppRelationshipStatus", "csharp");
+@@clientName(VolumePropertiesExportPolicy,
+  "NetAppVolumeExportPolicy",
+  "csharp"
+);
+
+// --- @@alternateType: property type overrides for C# ---
+// BackupsMigrationRequest.backupVaultId: armResourceIdentifier → string (old API had string)
+@@alternateType(BackupsMigrationRequest.backupVaultId, string, "csharp");
+
+// Restore previous operation names that include the NetApp resource subject (csharp).
+// NOTE: We cannot also use `@@alternateType(Azure.ResourceManager.LocationParameter.location,
+// azureLocation, "csharp")` to convert the `string location` parameter to AzureLocation:
+// doing so causes the mgmt emitter to drop these subscription-scoped action operations
+// from the generated MockableNetAppSubscriptionResource entirely. The parameter therefore
+// stays `string`; AzureLocation backward-compat overloads are added in custom code.
+@@clientName(NetAppAccounts.listByNetAppAccount, "GetVolumeGroups", "csharp");
+@@clientName(NetAppResourceOperationGroup.checkNameAvailability,
+  "CheckNetAppNameAvailability",
+  "csharp"
+);
+@@clientName(NetAppResourceOperationGroup.checkFilePathAvailability,
+  "CheckNetAppFilePathAvailability",
+  "csharp"
+);
+@@clientName(NetAppResourceOperationGroup.checkQuotaAvailability,
+  "CheckNetAppQuotaAvailability",
+  "csharp"
+);
+@@clientName(NetAppResourceOperationGroup.queryRegionInfo,
+  "QueryRegionInfoNetAppResource",
+  "csharp"
+);
+@@clientName(NetAppResourceOperationGroup.queryNetworkSiblingSet,
+  "QueryNetworkSiblingSetNetAppResource",
+  "csharp"
+);
+@@clientName(NetAppResourceOperationGroup.updateNetworkSiblingSet,
+  "UpdateNetworkSiblingSetNetAppResource",
+  "csharp"
+);
+
+// C# property type overrides for MountTargetProperties
+@@alternateType(MountTargetProperties.mountTargetId, uuid, "csharp");
+@@alternateType(MountTargetProperties.fileSystemId, uuid, "csharp");
+@@alternateType(MountTargetProperties.ipAddress,
+  Azure.Core.ipV4Address,
+  "csharp"
+);
+@@alternateType(CacheMountTargetProperties.ipAddress, string, "csharp");
+@@clientName(MountTargetProperties.ipAddress, "IPAddress", "csharp");
+@@clientName(CacheMountTargetProperties.ipAddress, "IPAddress", "csharp");
+@@clientName(NicInfo.ipAddress, "IPAddress", "csharp");
+@@clientName(BucketServerProperties.ipAddress, "IPAddress", "csharp");
+@@clientName(PeerClusterForVolumeMigrationRequest.peerIpAddresses,
+  "PeerIPAddresses",
+  "csharp"
+);
+
+// C# property type overrides for VolumeProperties
+@@alternateType(VolumeProperties.fileSystemId, uuid, "csharp");
+@@alternateType(VolumeProperties.networkSiblingSetId, uuid, "csharp");
+// dataStoreResourceId: string[] -> ResourceIdentifier[] (old SDK exposed Azure.Core.ResourceIdentifier)
+@@alternateType(VolumeProperties.dataStoreResourceId,
+  armResourceIdentifier[],
+  "csharp"
+);
+
+// C# ETag and Guid property type overrides
+@@alternateType(PoolProperties.poolId, uuid, "csharp");
+
+// C# hierarchy building (restore base types for backward compat)
+// First, align property types with TrackedResource expectations
+// CapacityPoolPatch: restore TrackedResourceData base
+@@alternateType(CapacityPoolPatch.id, armResourceIdentifier, "csharp");
+@@alternateType(CapacityPoolPatch.location, azureLocation, "csharp");
+@@alternateType(CapacityPoolPatch.id, armResourceIdentifier, "csharp");
+@@alternateType(CapacityPoolPatch.location, azureLocation, "csharp");
+
+// BackupPolicyPatch: restore TrackedResourceData base
+@@alternateType(BackupPolicyPatch.id, armResourceIdentifier, "csharp");
+@@alternateType(BackupPolicyPatch.location, azureLocation, "csharp");
+@@alternateType(SnapshotPolicyPatch.id, armResourceIdentifier, "csharp");
+@@alternateType(SnapshotPolicyPatch.location, azureLocation, "csharp");
+
+// VolumePatch (renamed to NetAppVolumePatch above): restore TrackedResourceData base
+@@alternateType(VolumePatch.id, armResourceIdentifier, "csharp");
+@@alternateType(VolumePatch.location, azureLocation, "csharp");
+
+// C# property type overrides (backward compat with old autorest SDK types)
+@@alternateType(ReplicationObject.remoteVolumeResourceId,
+  armResourceIdentifier,
+  "csharp"
+);
+@@clientName(BackupProperties.backupPolicyResourceId,
+  "BackupPolicyArmResourceId",
+  "csharp"
+);
+@@alternateType(VolumeSnapshotProperties.snapshotPolicyId,
+  armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(ActiveDirectory.kdcIP, Azure.Core.ipV4Address, "csharp");
+@@alternateType(BackupPolicyProperties.backupPolicyId,
+  armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(FilePathAvailabilityRequest.subnetId,
+  armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(AuthorizeRequest.remoteVolumeResourceId,
+  armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(BackupRestoreFiles.destinationVolumeId,
+  armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(VolumeProperties.keyVaultPrivateEndpointResourceId,
+  armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(VolumeProperties.originatingResourceId,
+  armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(VolumeProperties.proximityPlacementGroup,
+  armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(VolumeProperties.subnetId, armResourceIdentifier, "csharp");
+@@alternateType(VolumeGroupVolumeProperties.id,
+  armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(VolumeGroupVolumeProperties.type,
+  Azure.Core.armResourceType,
+  "csharp"
+);
+@@alternateType(PoolChangeRequest.newPoolResourceId,
+  armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(ReestablishReplicationRequest.sourceVolumeId,
+  armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(Replication.remoteVolumeResourceId,
+  armResourceIdentifier,
+  "csharp"
+);
+
+// TEMPORARY: reproduce DeserializeAzureLocation bug
+@@alternateType(VolumeGroup.id, armResourceIdentifier, "csharp");
+@@alternateType(VolumeGroup.location, azureLocation, "csharp");
+@@alternateType(NetAppProvisioningState, NetAppProvisioningStateDef, "csharp");
+@@alternateType(BucketProperties.provisioningState,
+  NetAppVolumeQuotaRuleProvisioningStateDef,
+  "csharp"
+);
+@@alternateType(BucketPatchProperties.provisioningState,
+  NetAppVolumeQuotaRuleProvisioningStateDef,
+  "csharp"
+);
+@@alternateType(VolumeQuotaRulesProperties.provisioningState,
+  NetAppVolumeQuotaRuleProvisioningStateDef,
+  "csharp"
+);
+@@clientName(VolumeQuotaRulesProperties.provisioningState,
+  "VolumeQuotaRuleProvisioningState",
+  "csharp"
+);
+
+// --- Fix property type mismatches via @@alternateType ---
+// ETag: string → Azure.Core.eTag
+@@alternateType(CapacityPool.etag, Azure.Core.eTag, "csharp");
+@@alternateType(NetAppAccount.etag, Azure.Core.eTag, "csharp");
+@@alternateType(BackupPolicy.etag, Azure.Core.eTag, "csharp");
+@@alternateType(SnapshotPolicy.etag, Azure.Core.eTag, "csharp");
+@@alternateType(Volume.etag, Azure.Core.eTag, "csharp");
+@@alternateType(Cache.etag, Azure.Core.eTag, "csharp");
+
+// Capacity pool throughput: generate the original int?-typed property name and keep
+// the GA float?-typed CustomThroughputMibps as a compatibility alias in SDK custom code.
+@@clientName(PoolProperties.customThroughputMibps,
+  "CustomThroughputMibpsInt",
+  "csharp"
+);
+
+// Snapshot location: string → azureLocation
+@@alternateType(Snapshot.location, azureLocation, "csharp");
+@@alternateType(VolumeRevert.snapshotId, string, "csharp");
+
+// VolumeProperties property type overrides for backward compat with old SDK
+@@alternateType(VolumeProperties.snapshotId, string, "csharp");
+@@alternateType(VolumeProperties.backupId, string, "csharp");
+@@alternateType(VolumeProperties.capacityPoolResourceId,
+  armResourceIdentifier,
+  "csharp"
+);
+
+// VolumeGroupDetails.location: string → azureLocation (old API had AzureLocation?)
+@@alternateType(VolumeGroupDetails.location, azureLocation, "csharp");
+@@alternateType(VolumeGroup.location, azureLocation, "csharp");
+@@clientName(BackupStatus.relationshipStatus,
+  "VolumeBackupRelationshipStatus",
+  "csharp"
+);
+@@clientName(ReplicationStatus.relationshipStatus,
+  "VolumeReplicationRelationshipStatus",
+  "csharp"
+);
+@@clientName(RestoreStatus.relationshipStatus,
+  "VolumeRestoreRelationshipStatus",
+  "csharp"
+);
+// Also fix ReplicationObject.relationshipStatus
+@@alternateType(ReplicationObject.relationshipStatus,
+  VolumeReplicationRelationshipStatus,
+  "csharp"
+);
+
+// --- @@access: visibility overrides for C# ---
+
+// Make types public for C# SDK backward compatibility
+@@access(VolumePropertiesExportPolicy, Access.public, "csharp");
+@@access(VolumeBackupRelationshipStatus, Access.public, "csharp");
+@@access(VolumeReplicationRelationshipStatus, Access.public, "csharp");
+@@access(VolumeRestoreRelationshipStatus, Access.public, "csharp");
+
+// --- @@hierarchyBuilding: restore base types for backward compat ---
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Restore TrackedResourceData base type for backward compat"
+@@hierarchyBuilding(CapacityPoolPatch,
+  Azure.ResourceManager.Foundations.TrackedResource,
+  "csharp"
+);
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Restore TrackedResourceData base type for backward compat"
+@@hierarchyBuilding(BackupPolicyPatch,
+  Azure.ResourceManager.Foundations.TrackedResource,
+  "csharp"
+);
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Restore TrackedResourceData base type for backward compat"
+@@hierarchyBuilding(SnapshotPolicyPatch,
+  Azure.ResourceManager.Foundations.TrackedResource,
+  "csharp"
+);
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Restore TrackedResourceData base type for backward compat"
+@@hierarchyBuilding(VolumePatch,
+  Azure.ResourceManager.Foundations.TrackedResource,
+  "csharp"
+);
+
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Restore ResourceData base type for backward compat"
+@@hierarchyBuilding(SubvolumeModel,
+  Azure.ResourceManager.Foundations.ProxyResource,
+  "csharp"
+);
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "test"
+@@hierarchyBuilding(VolumeGroup,
+  Azure.ResourceManager.Foundations.ProxyResource,
+  "csharp"
+);
+
+// --- @@usage: add Usage.input to make output-only models also serializable as input (decorator appends) ---
+@@usage(BackupsMigrationRequest, Usage.input, "csharp");
+@@usage(RegionInfoAvailabilityZoneMappingsItem, Usage.input, "csharp");
+@@usage(ReplicationObject, Usage.input, "csharp");
+@@usage(VolumeRevert, Usage.input, "csharp");
+@@usage(RansomwareReport, Usage.input, "csharp");
+@@usage(RegionInfoResource, Usage.input, "csharp");
+@@usage(Snapshot, Usage.input, "csharp");
+@@usage(QuotaItem, Usage.input, "csharp");
+@@usage(VolumeBackupRelationshipStatus, Usage.input, "csharp");
+@@usage(VolumeReplicationRelationshipStatus, Usage.input, "csharp");
+@@usage(VolumeRestoreRelationshipStatus, Usage.input, "csharp");
+@@usage(NetAppVolumeQuotaRuleProvisioningStateDef, Usage.input, "csharp");

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/client.tsp
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/client.tsp
@@ -605,7 +605,7 @@ union NetAppRelationshipStatusDef {
 
 // Body parameter rename to restore previous property name
 @@clientName(ListReplicationsRequest.exclude,
-  "ExcludeReplicationsFilter",
+  "Exclude",
   "csharp"
 );
 

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/client.tsp
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/client.tsp
@@ -137,31 +137,8 @@ enum NetAppProvisioningStateDef {
 
 /** Compatibility alias for NetApp volume quota rule provisioning state values. */
 union NetAppVolumeQuotaRuleProvisioningStateDef {
+  NetAppProvisioningStateDef,
   string,
-
-  /** The request has been accepted. */
-  Accepted: "Accepted",
-
-  /** The resource is being created. */
-  Creating: "Creating",
-
-  /** The resource is being patched. */
-  Patching: "Patching",
-
-  /** The resource is being deleted. */
-  Deleting: "Deleting",
-
-  /** The resource is being moved. */
-  Moving: "Moving",
-
-  /** The operation failed. */
-  Failed: "Failed",
-
-  /** The operation succeeded. */
-  Succeeded: "Succeeded",
-
-  /** The resource is being updated. */
-  Updating: "Updating",
 }
 
 // --- C# backward-compat union (unified relationship status) ---

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/preview/2025-12-15-preview/netapp.json
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/preview/2025-12-15-preview/netapp.json
@@ -249,7 +249,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "body",
@@ -295,7 +295,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "body",
@@ -341,7 +341,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "body",
@@ -387,7 +387,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "body",
@@ -522,7 +522,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           }
         ],
         "responses": {
@@ -640,7 +640,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "body",
@@ -705,7 +705,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           }
         ],
         "responses": {
@@ -745,7 +745,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "usageType",
@@ -23018,15 +23018,5 @@
       }
     }
   },
-  "parameters": {
-    "NetAppLocationParameter": {
-      "name": "location",
-      "in": "path",
-      "description": "The location name.",
-      "required": true,
-      "type": "string",
-      "minLength": 1,
-      "x-ms-parameter-location": "method"
-    }
-  }
+  "parameters": {}
 }

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/preview/2025-12-15-preview/netapp.json
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/preview/2025-12-15-preview/netapp.json
@@ -249,7 +249,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "body",
@@ -295,7 +295,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "body",
@@ -341,7 +341,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "body",
@@ -387,7 +387,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "body",
@@ -522,7 +522,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           }
         ],
         "responses": {
@@ -640,7 +640,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "body",
@@ -705,7 +705,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           }
         ],
         "responses": {
@@ -745,7 +745,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "usageType",
@@ -23018,5 +23018,15 @@
       }
     }
   },
-  "parameters": {}
+  "parameters": {
+    "NetAppLocationParameter": {
+      "name": "location",
+      "in": "path",
+      "description": "The location name.",
+      "required": true,
+      "type": "string",
+      "minLength": 1,
+      "x-ms-parameter-location": "method"
+    }
+  }
 }

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/preview/2025-12-15-preview/netapp.json
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/preview/2025-12-15-preview/netapp.json
@@ -6668,7 +6668,8 @@
           }
         },
         "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/Cache"
         },
         "x-ms-long-running-operation": true
       }
@@ -6753,7 +6754,8 @@
           }
         },
         "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/Cache"
         },
         "x-ms-long-running-operation": true
       }

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/preview/2026-01-15-preview/netapp.json
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/preview/2026-01-15-preview/netapp.json
@@ -249,7 +249,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "body",
@@ -295,7 +295,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "body",
@@ -341,7 +341,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "body",
@@ -387,7 +387,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "body",
@@ -522,7 +522,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           }
         ],
         "responses": {
@@ -640,7 +640,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "body",
@@ -705,7 +705,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           }
         ],
         "responses": {
@@ -745,7 +745,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "usageType",
@@ -23033,5 +23033,15 @@
       }
     }
   },
-  "parameters": {}
+  "parameters": {
+    "NetAppLocationParameter": {
+      "name": "location",
+      "in": "path",
+      "description": "The location name.",
+      "required": true,
+      "type": "string",
+      "minLength": 1,
+      "x-ms-parameter-location": "method"
+    }
+  }
 }

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/preview/2026-01-15-preview/netapp.json
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/preview/2026-01-15-preview/netapp.json
@@ -6668,7 +6668,8 @@
           }
         },
         "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/Cache"
         },
         "x-ms-long-running-operation": true
       }
@@ -6753,7 +6754,8 @@
           }
         },
         "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/Cache"
         },
         "x-ms-long-running-operation": true
       }

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/preview/2026-01-15-preview/netapp.json
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/preview/2026-01-15-preview/netapp.json
@@ -249,7 +249,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "body",
@@ -295,7 +295,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "body",
@@ -341,7 +341,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "body",
@@ -387,7 +387,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "body",
@@ -522,7 +522,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           }
         ],
         "responses": {
@@ -640,7 +640,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "body",
@@ -705,7 +705,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           }
         ],
         "responses": {
@@ -745,7 +745,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "usageType",
@@ -23033,15 +23033,5 @@
       }
     }
   },
-  "parameters": {
-    "NetAppLocationParameter": {
-      "name": "location",
-      "in": "path",
-      "description": "The location name.",
-      "required": true,
-      "type": "string",
-      "minLength": 1,
-      "x-ms-parameter-location": "method"
-    }
-  }
+  "parameters": {}
 }

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/routes.tsp
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/routes.tsp
@@ -13,15 +13,6 @@ using TypeSpec.OpenAPI;
 
 namespace Microsoft.NetApp;
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Parameter model only wraps the documented location path parameter and should continue emitting the shared ARM LocationParameter."
-model NetAppLocationParameter {
-  @path
-  @minLength(1)
-  @segment("locations")
-  @doc("The location name.")
-  location: Azure.Core.azureLocation;
-}
-
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-interface-requires-decorator" "For backward compatibility"
 interface NetAppResourceOperationGroup {
   /**
@@ -33,7 +24,7 @@ interface NetAppResourceOperationGroup {
     Request = ResourceNameAvailabilityRequest,
     Response = CheckAvailabilityResponse,
     Scope = SubscriptionActionScope,
-    Parameters = NetAppLocationParameter
+    Parameters = LocationResourceParameter
   >;
   /**
    * Check if a file path is available.
@@ -44,7 +35,7 @@ interface NetAppResourceOperationGroup {
     Request = FilePathAvailabilityRequest,
     Response = CheckAvailabilityResponse,
     Scope = SubscriptionActionScope,
-    Parameters = NetAppLocationParameter
+    Parameters = LocationResourceParameter
   >;
   /**
    * Check if a quota is available.
@@ -55,7 +46,7 @@ interface NetAppResourceOperationGroup {
     Request = QuotaAvailabilityRequest,
     Response = CheckAvailabilityResponse,
     Scope = SubscriptionActionScope,
-    Parameters = NetAppLocationParameter
+    Parameters = LocationResourceParameter
   >;
   /**
    * Provides storage to network proximity and logical zone mapping information.
@@ -67,7 +58,7 @@ interface NetAppResourceOperationGroup {
   queryRegionInfo is ArmProviderActionSync<
     Response = RegionInfo,
     Scope = SubscriptionActionScope,
-    Parameters = NetAppLocationParameter
+    Parameters = LocationResourceParameter
   >;
   /**
    * Get details of the specified network sibling set.
@@ -78,7 +69,7 @@ interface NetAppResourceOperationGroup {
     Request = QueryNetworkSiblingSetRequest,
     Response = NetworkSiblingSet,
     Scope = SubscriptionActionScope,
-    Parameters = NetAppLocationParameter
+    Parameters = LocationResourceParameter
   >;
   /**
    * Update the network features of the specified network sibling set.
@@ -89,7 +80,7 @@ interface NetAppResourceOperationGroup {
     Request = UpdateNetworkSiblingSetRequest,
     Response = NetworkSiblingSet,
     Scope = SubscriptionActionScope,
-    Parameters = NetAppLocationParameter
+    Parameters = LocationResourceParameter
   >;
 }
 
@@ -106,7 +97,7 @@ interface NetAppResourceUsagesOperationGroup {
   list is ArmProviderActionSync<
     Response = UsagesListResult,
     Scope = SubscriptionActionScope,
-    Parameters = NetAppLocationParameter
+    Parameters = LocationResourceParameter
   >;
   /**
    * Get current subscription usage of the specific type
@@ -117,7 +108,7 @@ interface NetAppResourceUsagesOperationGroup {
   get(
     ...ApiVersionParameter,
     ...SubscriptionIdParameter,
-    ...NetAppLocationParameter,
+    ...LocationResourceParameter,
 
     /**
      * The type of usage

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/routes.tsp
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/routes.tsp
@@ -13,6 +13,7 @@ using TypeSpec.OpenAPI;
 
 namespace Microsoft.NetApp;
 
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Parameter model only wraps the documented location path parameter and should continue emitting the shared ARM LocationParameter."
 model NetAppLocationParameter {
   @path
   @minLength(1)

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/routes.tsp
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/routes.tsp
@@ -13,6 +13,14 @@ using TypeSpec.OpenAPI;
 
 namespace Microsoft.NetApp;
 
+model NetAppLocationParameter {
+  @path
+  @minLength(1)
+  @segment("locations")
+  @doc("The location name.")
+  location: Azure.Core.azureLocation;
+}
+
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-interface-requires-decorator" "For backward compatibility"
 interface NetAppResourceOperationGroup {
   /**
@@ -24,7 +32,7 @@ interface NetAppResourceOperationGroup {
     Request = ResourceNameAvailabilityRequest,
     Response = CheckAvailabilityResponse,
     Scope = SubscriptionActionScope,
-    Parameters = LocationParameter
+    Parameters = NetAppLocationParameter
   >;
   /**
    * Check if a file path is available.
@@ -35,7 +43,7 @@ interface NetAppResourceOperationGroup {
     Request = FilePathAvailabilityRequest,
     Response = CheckAvailabilityResponse,
     Scope = SubscriptionActionScope,
-    Parameters = LocationParameter
+    Parameters = NetAppLocationParameter
   >;
   /**
    * Check if a quota is available.
@@ -46,7 +54,7 @@ interface NetAppResourceOperationGroup {
     Request = QuotaAvailabilityRequest,
     Response = CheckAvailabilityResponse,
     Scope = SubscriptionActionScope,
-    Parameters = LocationParameter
+    Parameters = NetAppLocationParameter
   >;
   /**
    * Provides storage to network proximity and logical zone mapping information.
@@ -58,7 +66,7 @@ interface NetAppResourceOperationGroup {
   queryRegionInfo is ArmProviderActionSync<
     Response = RegionInfo,
     Scope = SubscriptionActionScope,
-    Parameters = LocationParameter
+    Parameters = NetAppLocationParameter
   >;
   /**
    * Get details of the specified network sibling set.
@@ -69,7 +77,7 @@ interface NetAppResourceOperationGroup {
     Request = QueryNetworkSiblingSetRequest,
     Response = NetworkSiblingSet,
     Scope = SubscriptionActionScope,
-    Parameters = LocationParameter
+    Parameters = NetAppLocationParameter
   >;
   /**
    * Update the network features of the specified network sibling set.
@@ -80,7 +88,7 @@ interface NetAppResourceOperationGroup {
     Request = UpdateNetworkSiblingSetRequest,
     Response = NetworkSiblingSet,
     Scope = SubscriptionActionScope,
-    Parameters = LocationParameter
+    Parameters = NetAppLocationParameter
   >;
 }
 
@@ -97,7 +105,7 @@ interface NetAppResourceUsagesOperationGroup {
   list is ArmProviderActionSync<
     Response = UsagesListResult,
     Scope = SubscriptionActionScope,
-    Parameters = LocationParameter
+    Parameters = NetAppLocationParameter
   >;
   /**
    * Get current subscription usage of the specific type
@@ -108,7 +116,7 @@ interface NetAppResourceUsagesOperationGroup {
   get(
     ...ApiVersionParameter,
     ...SubscriptionIdParameter,
-    ...LocationResourceParameter,
+    ...NetAppLocationParameter,
 
     /**
      * The type of usage

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/stable/2025-06-01/netapp.json
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/stable/2025-06-01/netapp.json
@@ -132,7 +132,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "body",
@@ -178,7 +178,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "body",
@@ -224,7 +224,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "body",
@@ -270,7 +270,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "body",
@@ -405,7 +405,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           }
         ],
         "responses": {
@@ -523,7 +523,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "body",
@@ -588,7 +588,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           }
         ],
         "responses": {
@@ -628,7 +628,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "usageType",
@@ -12679,15 +12679,5 @@
       }
     }
   },
-  "parameters": {
-    "NetAppLocationParameter": {
-      "name": "location",
-      "in": "path",
-      "description": "The location name.",
-      "required": true,
-      "type": "string",
-      "minLength": 1,
-      "x-ms-parameter-location": "method"
-    }
-  }
+  "parameters": {}
 }

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/stable/2025-06-01/netapp.json
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/stable/2025-06-01/netapp.json
@@ -132,7 +132,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "body",
@@ -178,7 +178,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "body",
@@ -224,7 +224,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "body",
@@ -270,7 +270,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "body",
@@ -405,7 +405,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           }
         ],
         "responses": {
@@ -523,7 +523,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "body",
@@ -588,7 +588,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           }
         ],
         "responses": {
@@ -628,7 +628,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "usageType",
@@ -12679,5 +12679,15 @@
       }
     }
   },
-  "parameters": {}
+  "parameters": {
+    "NetAppLocationParameter": {
+      "name": "location",
+      "in": "path",
+      "description": "The location name.",
+      "required": true,
+      "type": "string",
+      "minLength": 1,
+      "x-ms-parameter-location": "method"
+    }
+  }
 }

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/stable/2025-08-01/netapp.json
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/stable/2025-08-01/netapp.json
@@ -135,7 +135,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "body",
@@ -181,7 +181,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "body",
@@ -227,7 +227,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "body",
@@ -273,7 +273,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "body",
@@ -408,7 +408,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           }
         ],
         "responses": {
@@ -526,7 +526,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "body",
@@ -591,7 +591,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           }
         ],
         "responses": {
@@ -631,7 +631,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "usageType",
@@ -12886,15 +12886,5 @@
       }
     }
   },
-  "parameters": {
-    "NetAppLocationParameter": {
-      "name": "location",
-      "in": "path",
-      "description": "The location name.",
-      "required": true,
-      "type": "string",
-      "minLength": 1,
-      "x-ms-parameter-location": "method"
-    }
-  }
+  "parameters": {}
 }

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/stable/2025-08-01/netapp.json
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/stable/2025-08-01/netapp.json
@@ -135,7 +135,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "body",
@@ -181,7 +181,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "body",
@@ -227,7 +227,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "body",
@@ -273,7 +273,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "body",
@@ -408,7 +408,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           }
         ],
         "responses": {
@@ -526,7 +526,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "body",
@@ -591,7 +591,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           }
         ],
         "responses": {
@@ -631,7 +631,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "usageType",
@@ -12886,5 +12886,15 @@
       }
     }
   },
-  "parameters": {}
+  "parameters": {
+    "NetAppLocationParameter": {
+      "name": "location",
+      "in": "path",
+      "description": "The location name.",
+      "required": true,
+      "type": "string",
+      "minLength": 1,
+      "x-ms-parameter-location": "method"
+    }
+  }
 }

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/stable/2025-09-01/netapp.json
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/stable/2025-09-01/netapp.json
@@ -135,7 +135,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "body",
@@ -181,7 +181,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "body",
@@ -227,7 +227,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "body",
@@ -273,7 +273,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "body",
@@ -408,7 +408,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           }
         ],
         "responses": {
@@ -526,7 +526,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "body",
@@ -591,7 +591,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           }
         ],
         "responses": {
@@ -631,7 +631,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "usageType",
@@ -12916,5 +12916,15 @@
       }
     }
   },
-  "parameters": {}
+  "parameters": {
+    "NetAppLocationParameter": {
+      "name": "location",
+      "in": "path",
+      "description": "The location name.",
+      "required": true,
+      "type": "string",
+      "minLength": 1,
+      "x-ms-parameter-location": "method"
+    }
+  }
 }

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/stable/2025-09-01/netapp.json
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/stable/2025-09-01/netapp.json
@@ -135,7 +135,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "body",
@@ -181,7 +181,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "body",
@@ -227,7 +227,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "body",
@@ -273,7 +273,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "body",
@@ -408,7 +408,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           }
         ],
         "responses": {
@@ -526,7 +526,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "body",
@@ -591,7 +591,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           }
         ],
         "responses": {
@@ -631,7 +631,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "usageType",
@@ -12916,15 +12916,5 @@
       }
     }
   },
-  "parameters": {
-    "NetAppLocationParameter": {
-      "name": "location",
-      "in": "path",
-      "description": "The location name.",
-      "required": true,
-      "type": "string",
-      "minLength": 1,
-      "x-ms-parameter-location": "method"
-    }
-  }
+  "parameters": {}
 }

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/stable/2025-12-01/netapp.json
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/stable/2025-12-01/netapp.json
@@ -138,7 +138,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "body",
@@ -184,7 +184,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "body",
@@ -230,7 +230,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "body",
@@ -276,7 +276,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "body",
@@ -411,7 +411,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           }
         ],
         "responses": {
@@ -529,7 +529,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "body",
@@ -594,7 +594,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           }
         ],
         "responses": {
@@ -634,7 +634,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "usageType",
@@ -13683,15 +13683,5 @@
       }
     }
   },
-  "parameters": {
-    "NetAppLocationParameter": {
-      "name": "location",
-      "in": "path",
-      "description": "The location name.",
-      "required": true,
-      "type": "string",
-      "minLength": 1,
-      "x-ms-parameter-location": "method"
-    }
-  }
+  "parameters": {}
 }

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/stable/2025-12-01/netapp.json
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/stable/2025-12-01/netapp.json
@@ -138,7 +138,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "body",
@@ -184,7 +184,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "body",
@@ -230,7 +230,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "body",
@@ -276,7 +276,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "body",
@@ -411,7 +411,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           }
         ],
         "responses": {
@@ -529,7 +529,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "body",
@@ -594,7 +594,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           }
         ],
         "responses": {
@@ -634,7 +634,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "usageType",
@@ -13683,5 +13683,15 @@
       }
     }
   },
-  "parameters": {}
+  "parameters": {
+    "NetAppLocationParameter": {
+      "name": "location",
+      "in": "path",
+      "description": "The location name.",
+      "required": true,
+      "type": "string",
+      "minLength": 1,
+      "x-ms-parameter-location": "method"
+    }
+  }
 }

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/stable/2026-01-01/netapp.json
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/stable/2026-01-01/netapp.json
@@ -144,7 +144,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "body",
@@ -190,7 +190,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "body",
@@ -236,7 +236,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "body",
@@ -282,7 +282,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "body",
@@ -417,7 +417,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           }
         ],
         "responses": {
@@ -535,7 +535,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "body",
@@ -600,7 +600,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           }
         ],
         "responses": {
@@ -640,7 +640,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
+            "$ref": "#/parameters/NetAppLocationParameter"
           },
           {
             "name": "usageType",
@@ -16769,5 +16769,15 @@
       }
     }
   },
-  "parameters": {}
+  "parameters": {
+    "NetAppLocationParameter": {
+      "name": "location",
+      "in": "path",
+      "description": "The location name.",
+      "required": true,
+      "type": "string",
+      "minLength": 1,
+      "x-ms-parameter-location": "method"
+    }
+  }
 }

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/stable/2026-01-01/netapp.json
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/stable/2026-01-01/netapp.json
@@ -3093,7 +3093,8 @@
           }
         },
         "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/Cache"
         },
         "x-ms-long-running-operation": true
       }
@@ -3178,7 +3179,8 @@
           }
         },
         "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/Cache"
         },
         "x-ms-long-running-operation": true
       }

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/stable/2026-01-01/netapp.json
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/stable/2026-01-01/netapp.json
@@ -144,7 +144,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "body",
@@ -190,7 +190,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "body",
@@ -236,7 +236,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "body",
@@ -282,7 +282,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "body",
@@ -417,7 +417,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           }
         ],
         "responses": {
@@ -535,7 +535,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "body",
@@ -600,7 +600,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           }
         ],
         "responses": {
@@ -640,7 +640,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "#/parameters/NetAppLocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "usageType",
@@ -16769,15 +16769,5 @@
       }
     }
   },
-  "parameters": {
-    "NetAppLocationParameter": {
-      "name": "location",
-      "in": "path",
-      "description": "The location name.",
-      "required": true,
-      "type": "string",
-      "minLength": 1,
-      "x-ms-parameter-location": "method"
-    }
-  }
+  "parameters": {}
 }

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/tspconfig.yaml
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/tspconfig.yaml
@@ -36,6 +36,9 @@ options:
     ignore-nullable-on-optional: false
     package-details:
       name: "@azure/arm-netapp"
+  "@azure-typespec/http-client-csharp-mgmt":
+    namespace: "Azure.ResourceManager.NetApp"
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
   "@azure-tools/typespec-go":
     emitter-output-dir: "{output-dir}/{service-dir}/armnetapp"
     service-dir: "sdk/resourcemanager/netapp"


### PR DESCRIPTION
## Description

Add \@azure-typespec/http-client-csharp-mgmt\ emitter configuration to the NetApp TypeSpec tspconfig.yaml to enable .NET SDK generation from the TypeSpec spec.

### Changes
- Add csharp mgmt emitter options to \	spconfig.yaml\ with namespace \Azure.ResourceManager.NetApp\

### Related
- SDK PR: https://github.com/Azure/azure-sdk-for-net/pull/55560
- Tracking issue: https://github.com/Azure/azure-sdk-for-net/issues/54761