### PR TITLE
Add BehaviorTaxonomyInput and BehaviorBasedEvaluatorDefinition TypeSpec models

### DIFF
--- a/specification/ai/Foundry/evaluation_taxonomies/models.tsp
+++ b/specification/ai/Foundry/evaluation_taxonomies/models.tsp
@@ -40,6 +40,9 @@ union EvaluationTaxonomyInputType {
 
   @doc("Policy.")
   policy: "policy",
+
+  @doc("Behavior definition.")
+  behavior: "behavior",
 }
 
 @added(Versions.v2025_11_15_preview)
@@ -63,6 +66,25 @@ model AgentTaxonomyInput extends EvaluationTaxonomyInput {
 
   @doc("List of risk categories to evaluate against.")
   riskCategories: RiskCategory[];
+}
+
+@added(Versions.v2025_11_15_preview)
+@removed(Versions.v1)
+@doc("Input configuration for the evaluation taxonomy when the input type is behavior.")
+model BehaviorTaxonomyInput extends EvaluationTaxonomyInput {
+  @doc("Input type of the evaluation taxonomy.")
+  type: EvaluationTaxonomyInputType.behavior;
+
+  @doc("Name of the behavior to evaluate (e.g., 'Gaslighting').")
+  behaviorName: string;
+
+  @doc("Detailed definition of the behavior in natural language (10-2000 characters).")
+  @minLength(10)
+  @maxLength(2000)
+  behaviorDefinition: string;
+
+  @doc("Description of the target application to condition seed prompt generation (e.g., 'GitHub Copilot for enterprise software engineers').")
+  applicationScenario?: string;
 }
 
 @added(Versions.v2025_11_15_preview)

--- a/specification/ai/Foundry/evaluators/models.tsp
+++ b/specification/ai/Foundry/evaluators/models.tsp
@@ -60,6 +60,9 @@ union EvaluatorDefinitionType {
 
   @doc("OpenAI graders")
   openai_graders: "openai_graders",
+
+  @doc("Behavior-based evaluator with auto-generated taxonomy")
+  behavior: "behavior",
 }
 
 #suppress "@azure-tools/typespec-azure-core/no-unknown"
@@ -99,6 +102,29 @@ model PromptBasedEvaluatorDefinition extends EvaluatorDefinition {
 
   @doc("The prompt text used for evaluation")
   prompt_text: string;
+}
+
+@doc("Behavior-based evaluator definition that auto-creates a linked taxonomy from a natural language behavior description.")
+@added(Versions.v2025_11_15_preview)
+@removed(Versions.v1)
+model BehaviorBasedEvaluatorDefinition extends EvaluatorDefinition {
+  type: EvaluatorDefinitionType.behavior;
+
+  @doc("Name of the behavior to evaluate (e.g., 'Gaslighting').")
+  behaviorName: string;
+
+  @doc("Detailed definition of the behavior in natural language (10-2000 characters).")
+  @minLength(10)
+  @maxLength(2000)
+  behaviorDefinition: string;
+
+  @doc("Identifier of the auto-created taxonomy linked to this evaluator. Set by the service.")
+  @visibility(Lifecycle.Read)
+  taxonomyId?: string;
+
+  @doc("Version of the linked taxonomy. The evaluator uses the latest taxonomy version by default.")
+  @visibility(Lifecycle.Read)
+  taxonomyVersion?: string;
 }
 
 @doc("Evaluator Definition")


### PR DESCRIPTION
## Custom Behavior Red Teaming - TypeSpec Models

### Overview
Adds TypeSpec models to support custom behavior red teaming.

### Changes
- **evaluation_taxonomies/models.tsp**: Added `behavior` to EvaluationTaxonomyInputType union, added BehaviorTaxonomyInput model (behaviorName, behaviorDefinition, applicationScenario)
- **evaluators/models.tsp**: Added `behavior` to EvaluatorDefinitionType union, added BehaviorBasedEvaluatorDefinition model (behaviorName, behaviorDefinition, applicationScenario, read-only taxonomyId/taxonomyVersion)

### Design
- Evaluator-first flow: creating behavior evaluator auto-creates linked taxonomy
- Versioned with @added(Versions.v2025_11_15_preview)
- Uses existing @discriminator pattern