### PR TITLE
Fix invalid use of template reference

### DIFF
--- a/specification/ai/ContentUnderstanding/routes.tsp
+++ b/specification/ai/ContentUnderstanding/routes.tsp
@@ -32,7 +32,7 @@ alias AllowReplaceTrait = QueryParametersTrait<
 alias ServiceTraits = Traits.NoRepeatableRequests &
   Traits.NoConditionalRequests &
   Traits.SupportsClientRequestId;
-alias Operations<Trait> = ResourceOperations<ServiceTraits & Trait>;
+alias Operations = ResourceOperations<ServiceTraits>;
 
 interface ContentAnalyzers {
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "This is a custom operation status endpoint."


### PR DESCRIPTION
Fixing spec that a recent change uncovered some bad pattern that was silently not failing https://github.com/microsoft/typespec/issues/9655

That interface template was referecenced below as if it wasn't a template. The template argument isn't actually used anywhere so this fixes it.