### PR TITLE
change endpoint to url

### DIFF
--- a/specification/cognitiveservices/AnomalyDetector/main.tsp
+++ b/specification/cognitiveservices/AnomalyDetector/main.tsp
@@ -19,7 +19,7 @@ using TypeSpec.Versioning;
       Supported Azure Cognitive Services endpoints (protocol and host name, such as
       https://westus2.api.cognitive.microsoft.com).
       """)
-    Endpoint: string,
+    Endpoint: url,
 
     @doc("Api Version")
     @path


### PR DESCRIPTION
Endpoint in spec being string instead of URL causes generation issues. 