### PR TITLE
Move client definition to client.tsp

### DIFF
--- a/specification/storage/Microsoft.BlobStorage/client.tsp
+++ b/specification/storage/Microsoft.BlobStorage/client.tsp
@@ -7,6 +7,54 @@ using Storage.Blob;
 
 namespace Customizations;
 
+@client(
+  {
+    service: Storage.Blob,
+  },
+  "rust"
+)
+interface BlobServiceClient extends Storage.Blob.Service {}
+
+@client(
+  {
+    service: Storage.Blob,
+  },
+  "rust"
+)
+interface BlobContainerClient extends Storage.Blob.Container {}
+
+@client(
+  {
+    service: Storage.Blob,
+  },
+  "rust"
+)
+interface BlobClient extends Storage.Blob.Blob {}
+
+@client(
+  {
+    service: Storage.Blob,
+  },
+  "rust"
+)
+interface AppendBlobClient extends Storage.Blob.AppendBlob {}
+
+@client(
+  {
+    service: Storage.Blob,
+  },
+  "rust"
+)
+interface BlockBlobClient extends Storage.Blob.BlockBlob {}
+
+@client(
+  {
+    service: Storage.Blob,
+  },
+  "rust"
+)
+interface PageBlobClient extends Storage.Blob.PageBlob {}
+
 @@clientNamespace(Storage.Blob, "Azure.Storage.Blobs");
 @@clientNamespace(Storage.Blob.Container, "Azure.Storage.Blobs");
 @@clientNamespace(Storage.Blob.Blob, "Azure.Storage.Blobs");
@@ -14,12 +62,12 @@ namespace Customizations;
 @@clientNamespace(Storage.Blob.BlockBlob, "Azure.Storage.Blobs");
 @@clientNamespace(Storage.Blob.PageBlob, "Azure.Storage.Blobs");
 
-@@clientName(Storage.Blob.Service, "BlobServiceClient", "rust");
-@@clientName(Storage.Blob.Container, "BlobContainerClient", "rust");
-@@clientName(Storage.Blob.Blob, "BlobClient", "rust");
-@@clientName(Storage.Blob.AppendBlob, "AppendBlobClient", "rust");
-@@clientName(Storage.Blob.BlockBlob, "BlockBlobClient", "rust");
-@@clientName(Storage.Blob.PageBlob, "PageBlobClient", "rust");
+// @@clientName(Storage.Blob.Service, "BlobServiceClient", "rust");
+// @@clientName(Storage.Blob.Container, "BlobContainerClient", "rust");
+// @@clientName(Storage.Blob.Blob, "BlobClient", "rust");
+// @@clientName(Storage.Blob.AppendBlob, "AppendBlobClient", "rust");
+// @@clientName(Storage.Blob.BlockBlob, "BlockBlobClient", "rust");
+// @@clientName(Storage.Blob.PageBlob, "PageBlobClient", "rust");
 
 @@clientName(ContainerProperties.denyEncryptionScopeOverride,
   "PreventEncryptionScopeOverride"

--- a/specification/storage/Microsoft.BlobStorage/routes.tsp
+++ b/specification/storage/Microsoft.BlobStorage/routes.tsp
@@ -59,7 +59,6 @@ op StorageOperationNoBody<
 }) | TError;
 
 #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "Existing API. Storage API version parameter pre-dates current guidance."
-@client
 interface Service {
   /** Sets properties for a storage account's Blob service endpoint, including properties for Storage Analytics and CORS (Cross-Origin Resource Sharing) rules */
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Existing API"
@@ -204,7 +203,6 @@ interface Service {
 }
 
 #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "Existing API. Storage API version parameter pre-dates current guidance."
-@client
 interface Container {
   /** Creates a new container under the specified account. If the container with the same name already exists, the operation fails. */
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Existing API"
@@ -624,7 +622,6 @@ interface Container {
 }
 
 #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "Existing API. Storage API version parameter pre-dates current guidance."
-@client
 interface Blob {
   /** The Download operation reads or downloads a blob from the system, including its metadata and properties. You can also call Download to read a snapshot. */
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Existing API"
@@ -1414,7 +1411,6 @@ interface Blob {
 }
 
 #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "Existing API. Storage API version parameter pre-dates current guidance."
-@client
 interface PageBlob {
   /** The Create operation creates a new page blob. */
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Existing API"
@@ -1777,7 +1773,6 @@ interface PageBlob {
 }
 
 #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "Existing API. Storage API version parameter pre-dates current guidance."
-@client
 interface AppendBlob {
   /** The Create operation creates a new append blob. */
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Existing API"
@@ -1955,7 +1950,6 @@ interface AppendBlob {
 }
 
 #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "Existing API. Storage API version parameter pre-dates current guidance."
-@client
 interface BlockBlob {
   /** The Upload Block Blob operation updates the content of an existing block blob. Updating an existing block blob overwrites any existing metadata on the blob. Partial updates are not supported with Put Blob; the content of the existing blob is overwritten with the content of the new blob. To perform a partial update of the content of a block blob, use the Put Block List operation. */
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Existing API"


### PR DESCRIPTION
The `@client` decorator should be defined in client.tsp and also scoped down to rust, otherwise the change will trickle down to the other sdks which impacts migration efforts. 

This is just a one time configuration whenever you need to add a new client. 