### PR TITLE
Remove Python client name mappings for containers

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/client.tsp
@@ -66,11 +66,6 @@ using Azure.AI.Projects;
 // Rename models ending with 'Object' to end with 'Details' for Python
 @@clientName(AgentObject, "AgentDetails", "python");
 @@clientName(AgentVersionObject, "AgentVersionDetails", "python");
-@@clientName(AgentContainerObject, "AgentContainerDetails", "python");
-@@clientName(AgentContainerOperationObject,
-  "AgentContainerOperationDetails",
-  "python"
-);
 
 @@clientName(AgentObject, "Agent", "javascript");
 @@clientName(AgentVersionObject, "AgentVersion", "javascript");


### PR DESCRIPTION
Removed client name mapping for AgentContainerObject and AgentContainerOperationObject in Python.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
