### PR TITLE
Remove `name` for multipart ops

### DIFF
--- a/specification/storage/Microsoft.BlobStorage/models.tsp
+++ b/specification/storage/Microsoft.BlobStorage/models.tsp
@@ -2655,7 +2655,6 @@ alias BodyParameter = {
 alias MultipartBodyParameter = {
   /** The body of the request. */
   @multipartBody body: {
-    name: HttpPart<string>;
     body: HttpPart<bytes>;
   };
 };


### PR DESCRIPTION
Fixes #40321

The following commit added an extra name for multipart body requests that isn't part of the public rest api: [Improvement on 4e80be1 · Azure/azure-rest-api-specs@201a318](https://github.com/Azure/azure-rest-api-specs/commit/201a318efa3da6cc4dcf3e22c8e12ad3c43400eb). This PR corrects that. 