### PR TITLE
java, sdk, Add public access/usage for FHIR models

### DIFF
--- a/specification/ai/HealthInsights/HealthInsights.RadiologyInsights/client.tsp
+++ b/specification/ai/HealthInsights/HealthInsights.RadiologyInsights/client.tsp
@@ -309,7 +309,7 @@ interface RadiologyInsightsClient {
   "csharp"
 );
 
-// generate the models, even if they are not directly refererenced by API, to avoid breaking changes to Java
+// generate the models, even if they are not directly referenced by API, to avoid breaking changes to Java
 @@usage(Fhir.R4.Condition, Usage.output, "java");
 @@access(Fhir.R4.Condition, Access.public, "java");
 @@usage(Fhir.R4.ResearchStudy, Usage.output, "java");

--- a/specification/ai/HealthInsights/HealthInsights.RadiologyInsights/client.tsp
+++ b/specification/ai/HealthInsights/HealthInsights.RadiologyInsights/client.tsp
@@ -61,8 +61,6 @@ interface RadiologyInsightsClient {
 @@clientName(Fhir.R4.DomainResource, "Fhir_R4_DomainResource", "csharp");
 @@clientName(Fhir.R4.Condition, "Fhir_R4_Condition", "java");
 @@clientName(Fhir.R4.Condition, "Fhir_R4_Condition", "csharp");
-@@usage(Fhir.R4.Condition, Usage.input | Usage.output);
-@@access(Fhir.R4.Condition, Access.public);
 @@clientName(Fhir.R4.ConditionStage, "Fhir_R4_ConditionStage", "java");
 @@clientName(Fhir.R4.ConditionStage, "Fhir_R4_ConditionStage", "csharp");
 @@clientName(Fhir.R4.Observation, "Fhir_R4_Observation", "java");
@@ -85,8 +83,6 @@ interface RadiologyInsightsClient {
 );
 @@clientName(Fhir.R4.ResearchStudy, "Fhir_R4_ResearchStudy", "java");
 @@clientName(Fhir.R4.ResearchStudy, "Fhir_R4_ResearchStudy", "csharp");
-@@usage(Fhir.R4.ResearchStudy, Usage.input | Usage.output);
-@@access(Fhir.R4.ResearchStudy, Access.public);
 
 @@clientName(AzureHealthInsights.FollowupCommunicationInference.wasAcknowledged,
   "acknowledged",
@@ -312,3 +308,9 @@ interface RadiologyInsightsClient {
   "FraxScore",
   "csharp"
 );
+
+// generate the models, even if they are not directly refererenced by API, to avoid breaking changes to Java
+@@usage(Fhir.R4.Condition, Usage.output, "java");
+@@access(Fhir.R4.Condition, Access.public, "java");
+@@usage(Fhir.R4.ResearchStudy, Usage.output, "java");
+@@access(Fhir.R4.ResearchStudy, Access.public, "java");

--- a/specification/ai/HealthInsights/HealthInsights.RadiologyInsights/client.tsp
+++ b/specification/ai/HealthInsights/HealthInsights.RadiologyInsights/client.tsp
@@ -61,6 +61,8 @@ interface RadiologyInsightsClient {
 @@clientName(Fhir.R4.DomainResource, "Fhir_R4_DomainResource", "csharp");
 @@clientName(Fhir.R4.Condition, "Fhir_R4_Condition", "java");
 @@clientName(Fhir.R4.Condition, "Fhir_R4_Condition", "csharp");
+@@usage(Fhir.R4.Condition, Usage.input | Usage.output);
+@@access(Fhir.R4.Condition, Access.public);
 @@clientName(Fhir.R4.ConditionStage, "Fhir_R4_ConditionStage", "java");
 @@clientName(Fhir.R4.ConditionStage, "Fhir_R4_ConditionStage", "csharp");
 @@clientName(Fhir.R4.Observation, "Fhir_R4_Observation", "java");
@@ -83,6 +85,8 @@ interface RadiologyInsightsClient {
 );
 @@clientName(Fhir.R4.ResearchStudy, "Fhir_R4_ResearchStudy", "java");
 @@clientName(Fhir.R4.ResearchStudy, "Fhir_R4_ResearchStudy", "csharp");
+@@usage(Fhir.R4.ResearchStudy, Usage.input | Usage.output);
+@@access(Fhir.R4.ResearchStudy, Access.public);
 
 @@clientName(AzureHealthInsights.FollowupCommunicationInference.wasAcknowledged,
   "acknowledged",


### PR DESCRIPTION
Add access=public and usage=input|output for Fhir.R4.Condition and Fhir.R4.ResearchStudy.