### PR TITLE
[Public Preview] Make FileShareSnapshot time and initiator updatable in 2025-09-01-preview api version

### DIFF
--- a/specification/fileshares/resource-manager/Microsoft.FileShares/FileShares/examples/2025-06-01-preview/FileShareSnapshot_CreateOrUpdate_MaximumSet_Gen.json
+++ b/specification/fileshares/resource-manager/Microsoft.FileShares/FileShares/examples/2025-06-01-preview/FileShareSnapshot_CreateOrUpdate_MaximumSet_Gen.json
@@ -9,6 +9,8 @@
     "name": "testfilesharesnapshot",
     "resource": {
       "properties": {
+        "snapshotTime": "wgujspthevkfo",
+        "initiatorId": "ghublxbeifhvhwokvhppbw",
         "metadata": {
           "key9372": "jtc"
         }

--- a/specification/fileshares/resource-manager/Microsoft.FileShares/FileShares/examples/2025-06-01-preview/FileShareSnapshot_Update_MaximumSet_Gen.json
+++ b/specification/fileshares/resource-manager/Microsoft.FileShares/FileShares/examples/2025-06-01-preview/FileShareSnapshot_Update_MaximumSet_Gen.json
@@ -9,6 +9,8 @@
     "name": "testfilesharesnapshot",
     "properties": {
       "properties": {
+        "snapshotTime": "wgujspthevkfo",
+        "initiatorId": "ghublxbeifhvhwokvhppbw",
         "metadata": {
           "key491": "dalhvhxqhjszelfuueetvxmgkbukwa"
         }

--- a/specification/fileshares/resource-manager/Microsoft.FileShares/FileShares/examples/2025-09-01-preview/FileShareSnapshot_CreateOrUpdate_MaximumSet_Gen.json
+++ b/specification/fileshares/resource-manager/Microsoft.FileShares/FileShares/examples/2025-09-01-preview/FileShareSnapshot_CreateOrUpdate_MaximumSet_Gen.json
@@ -9,6 +9,8 @@
     "name": "testfilesharesnapshot",
     "resource": {
       "properties": {
+        "snapshotTime": "wgujspthevkfo",
+        "initiatorId": "ghublxbeifhvhwokvhppbw",
         "metadata": {
           "key9372": "jtc"
         }

--- a/specification/fileshares/resource-manager/Microsoft.FileShares/FileShares/examples/2025-09-01-preview/FileShareSnapshot_Update_MaximumSet_Gen.json
+++ b/specification/fileshares/resource-manager/Microsoft.FileShares/FileShares/examples/2025-09-01-preview/FileShareSnapshot_Update_MaximumSet_Gen.json
@@ -9,6 +9,8 @@
     "name": "testfilesharesnapshot",
     "properties": {
       "properties": {
+        "snapshotTime": "wgujspthevkfo",
+        "initiatorId": "ghublxbeifhvhwokvhppbw",
         "metadata": {
           "key491": "dalhvhxqhjszelfuueetvxmgkbukwa"
         }

--- a/specification/fileshares/resource-manager/Microsoft.FileShares/FileShares/fileshares.tsp
+++ b/specification/fileshares/resource-manager/Microsoft.FileShares/FileShares/fileshares.tsp
@@ -371,7 +371,6 @@ model FileShareSnapshot
 @doc("FileShareSnapshot properties")
 model FileShareSnapshotProperties {
   // The FileShareSnapshot time of the file share FileShareSnapshot.
-  @visibility(Lifecycle.Read)
   @doc("The FileShareSnapshot time in UTC in string representation")
   snapshotTime?: string;
 
@@ -380,7 +379,6 @@ model FileShareSnapshotProperties {
   // - Users in Company A might use aliases.
   // - Users in company B might use email addresses.
   // - Automated systems like MAB might use resource identifier of Azure Backup Vault.
-  @visibility(Lifecycle.Read)
   @doc("The initiator of the FileShareSnapshot. This is a user-defined value.")
   initiatorId?: string;
 

--- a/specification/fileshares/resource-manager/Microsoft.FileShares/FileShares/preview/2025-06-01-preview/examples/FileShareSnapshot_CreateOrUpdate_MaximumSet_Gen.json
+++ b/specification/fileshares/resource-manager/Microsoft.FileShares/FileShares/preview/2025-06-01-preview/examples/FileShareSnapshot_CreateOrUpdate_MaximumSet_Gen.json
@@ -9,6 +9,8 @@
     "name": "testfilesharesnapshot",
     "resource": {
       "properties": {
+        "snapshotTime": "wgujspthevkfo",
+        "initiatorId": "ghublxbeifhvhwokvhppbw",
         "metadata": {
           "key9372": "jtc"
         }

--- a/specification/fileshares/resource-manager/Microsoft.FileShares/FileShares/preview/2025-06-01-preview/examples/FileShareSnapshot_Update_MaximumSet_Gen.json
+++ b/specification/fileshares/resource-manager/Microsoft.FileShares/FileShares/preview/2025-06-01-preview/examples/FileShareSnapshot_Update_MaximumSet_Gen.json
@@ -9,6 +9,8 @@
     "name": "testfilesharesnapshot",
     "properties": {
       "properties": {
+        "snapshotTime": "wgujspthevkfo",
+        "initiatorId": "ghublxbeifhvhwokvhppbw",
         "metadata": {
           "key491": "dalhvhxqhjszelfuueetvxmgkbukwa"
         }

--- a/specification/fileshares/resource-manager/Microsoft.FileShares/FileShares/preview/2025-06-01-preview/fileshares.json
+++ b/specification/fileshares/resource-manager/Microsoft.FileShares/FileShares/preview/2025-06-01-preview/fileshares.json
@@ -1466,13 +1466,11 @@
       "properties": {
         "snapshotTime": {
           "type": "string",
-          "description": "The FileShareSnapshot time in UTC in string representation",
-          "readOnly": true
+          "description": "The FileShareSnapshot time in UTC in string representation"
         },
         "initiatorId": {
           "type": "string",
-          "description": "The initiator of the FileShareSnapshot. This is a user-defined value.",
-          "readOnly": true
+          "description": "The initiator of the FileShareSnapshot. This is a user-defined value."
         },
         "metadata": {
           "type": "object",
@@ -1497,6 +1495,14 @@
       "type": "object",
       "description": "The updatable properties of the FileShareSnapshot.",
       "properties": {
+        "snapshotTime": {
+          "type": "string",
+          "description": "The FileShareSnapshot time in UTC in string representation"
+        },
+        "initiatorId": {
+          "type": "string",
+          "description": "The initiator of the FileShareSnapshot. This is a user-defined value."
+        },
         "metadata": {
           "type": "object",
           "description": "The metadata",

--- a/specification/fileshares/resource-manager/Microsoft.FileShares/FileShares/preview/2025-09-01-preview/examples/FileShareSnapshot_CreateOrUpdate_MaximumSet_Gen.json
+++ b/specification/fileshares/resource-manager/Microsoft.FileShares/FileShares/preview/2025-09-01-preview/examples/FileShareSnapshot_CreateOrUpdate_MaximumSet_Gen.json
@@ -9,6 +9,8 @@
     "name": "testfilesharesnapshot",
     "resource": {
       "properties": {
+        "snapshotTime": "wgujspthevkfo",
+        "initiatorId": "ghublxbeifhvhwokvhppbw",
         "metadata": {
           "key9372": "jtc"
         }

--- a/specification/fileshares/resource-manager/Microsoft.FileShares/FileShares/preview/2025-09-01-preview/examples/FileShareSnapshot_Update_MaximumSet_Gen.json
+++ b/specification/fileshares/resource-manager/Microsoft.FileShares/FileShares/preview/2025-09-01-preview/examples/FileShareSnapshot_Update_MaximumSet_Gen.json
@@ -9,6 +9,8 @@
     "name": "testfilesharesnapshot",
     "properties": {
       "properties": {
+        "snapshotTime": "wgujspthevkfo",
+        "initiatorId": "ghublxbeifhvhwokvhppbw",
         "metadata": {
           "key491": "dalhvhxqhjszelfuueetvxmgkbukwa"
         }

--- a/specification/fileshares/resource-manager/Microsoft.FileShares/FileShares/preview/2025-09-01-preview/fileshares.json
+++ b/specification/fileshares/resource-manager/Microsoft.FileShares/FileShares/preview/2025-09-01-preview/fileshares.json
@@ -1840,13 +1840,11 @@
       "properties": {
         "snapshotTime": {
           "type": "string",
-          "description": "The FileShareSnapshot time in UTC in string representation",
-          "readOnly": true
+          "description": "The FileShareSnapshot time in UTC in string representation"
         },
         "initiatorId": {
           "type": "string",
-          "description": "The initiator of the FileShareSnapshot. This is a user-defined value.",
-          "readOnly": true
+          "description": "The initiator of the FileShareSnapshot. This is a user-defined value."
         },
         "metadata": {
           "type": "object",
@@ -1871,6 +1869,14 @@
       "type": "object",
       "description": "The updatable properties of the FileShareSnapshot.",
       "properties": {
+        "snapshotTime": {
+          "type": "string",
+          "description": "The FileShareSnapshot time in UTC in string representation"
+        },
+        "initiatorId": {
+          "type": "string",
+          "description": "The initiator of the FileShareSnapshot. This is a user-defined value."
+        },
         "metadata": {
           "type": "object",
           "description": "The metadata",


### PR DESCRIPTION
Remove read-only visibility for snapshotTime and initiatorId in the FileShareSnapshot model and update OpenAPI schemas to allow these properties to be set. Add snapshotTime and initiatorId to the updatable properties schema and include them in example requests across preview and stable example files (2025-06-01-preview and 2025-09-01-preview). This enables clients to provide snapshotTime and initiatorId when creating or updating FileShareSnapshot resources.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
