### PR TITLE
Fix template param order

### DIFF
--- a/specification/storage/Microsoft.BlobStorage/routes.tsp
+++ b/specification/storage/Microsoft.BlobStorage/routes.tsp
@@ -31,8 +31,8 @@ op StorageOperation<
   contentType: RequestMediaType,
 
   ...ApiVersionHeader,
-  ...TParams,
   ...ClientRequestIdHeader,
+  ...TParams,
 ): (TResponse & {
   /** Content-Type header */
   #suppress "@typespec/http/content-type-ignored" "Template for existing API"
@@ -51,7 +51,7 @@ op StorageOperationNoBody<
   TParams extends TypeSpec.Reflection.Model | void,
   TResponse extends TypeSpec.Reflection.Model | void,
   TError = StorageError
->(...ApiVersionHeader, ...TParams, ...ClientRequestIdHeader): (TResponse & {
+>(...ApiVersionHeader, ...ClientRequestIdHeader, ...TParams): (TResponse & {
   ...DateResponseHeaderPrivate;
   ...ApiVersionHeader;
   ...RequestIdResponseHeader;

--- a/specification/storage/data-plane/Microsoft.BlobStorage/stable/2025-11-05/generated_blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/stable/2025-11-05/generated_blob.json
@@ -954,6 +954,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -1287,15 +1296,6 @@
               true
             ],
             "x-ms-client-name": "requiresSync"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -1398,6 +1398,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "snapshot",
@@ -1522,15 +1531,6 @@
               ]
             },
             "x-ms-client-name": "blobDeleteType"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -1580,6 +1580,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "snapshot",
@@ -1692,15 +1701,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "ifTags"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -2152,6 +2152,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "x-ms-meta",
             "in": "header",
             "description": "The metadata headers.",
@@ -2396,15 +2405,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "blobType"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -2489,6 +2489,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "x-ms-meta",
@@ -2882,15 +2891,6 @@
             "x-ms-client-name": "blobType"
           },
           {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
-          },
-          {
             "name": "body",
             "in": "body",
             "description": "The body of the request.",
@@ -2984,6 +2984,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "x-ms-meta",
@@ -3425,15 +3434,6 @@
               ]
             },
             "x-ms-client-name": "fileRequestIntent"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -3518,6 +3518,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -3687,15 +3696,6 @@
             "x-ms-client-name": "structuredContentLength"
           },
           {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
-          },
-          {
             "name": "body",
             "in": "body",
             "description": "The body of the request.",
@@ -3799,6 +3799,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "x-ms-copy-source",
@@ -4038,15 +4047,6 @@
               ]
             },
             "x-ms-client-name": "fileRequestIntent"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -4229,6 +4229,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -4291,15 +4300,6 @@
               }
             },
             "collectionFormat": "csv"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -4357,6 +4357,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "blockid",
@@ -4475,15 +4484,6 @@
             "x-ms-client-name": "structuredContentLength"
           },
           {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
-          },
-          {
             "name": "body",
             "in": "body",
             "description": "The body of the request.",
@@ -4569,6 +4569,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "blockid",
@@ -4748,15 +4757,6 @@
               ]
             },
             "x-ms-client-name": "fileRequestIntent"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -4830,6 +4830,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -5183,15 +5192,6 @@
             "x-ms-client-name": "legalHold"
           },
           {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
-          },
-          {
             "name": "blocks",
             "in": "body",
             "description": "Blob Blocks.",
@@ -5284,6 +5284,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "snapshot",
             "in": "query",
             "description": "The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more information on working with blob snapshots, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob\">Creating a Snapshot of a Blob.</a>",
@@ -5348,15 +5357,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "ifTags"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -5427,6 +5427,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -5464,15 +5473,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "copyActionAbortConstant"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -5524,6 +5524,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -5893,15 +5902,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "requiresSync"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -5996,6 +5996,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -6052,15 +6061,6 @@
             "type": "string",
             "format": "date-time-rfc7231",
             "x-ms-client-name": "ExpiresOn"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -6121,6 +6121,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -6197,15 +6206,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "versionId"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -6294,6 +6294,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -6316,15 +6325,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "versionId"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -6376,6 +6376,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -6435,15 +6444,6 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "copySource"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -6546,6 +6546,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -6626,15 +6635,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "action"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -6699,6 +6699,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -6773,15 +6782,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "action"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -6849,6 +6849,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -6928,15 +6937,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "action"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -7001,6 +7001,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -7074,15 +7083,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "action"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -7143,6 +7143,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -7216,15 +7225,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "action"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -7291,6 +7291,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "x-ms-lease-duration",
             "in": "header",
             "description": "Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires. A non-infinite lease can be between 15 and 60 seconds. A lease duration cannot be changed using renew or change.",
@@ -7347,15 +7356,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "action"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -7422,6 +7422,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -7470,15 +7479,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "action"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -7546,6 +7546,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "x-ms-lease-id",
             "in": "header",
             "description": "Required.  A lease ID for the source path. If specified, the source path must have an active lease and the lease ID must match.",
@@ -7601,15 +7610,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "action"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -7676,6 +7676,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "x-ms-lease-id",
             "in": "header",
             "description": "Required.  A lease ID for the source path. If specified, the source path must have an active lease and the lease ID must match.",
@@ -7723,15 +7732,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "action"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -7794,6 +7794,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "x-ms-lease-id",
             "in": "header",
             "description": "Required.  A lease ID for the source path. If specified, the source path must have an active lease and the lease ID must match.",
@@ -7841,15 +7850,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "action"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -7916,6 +7916,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -7946,15 +7955,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "versionId"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -8007,6 +8007,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "prefix",
@@ -8076,15 +8085,6 @@
               }
             },
             "collectionFormat": "csv"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -8139,6 +8139,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -8252,15 +8261,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "ifTags"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -8340,6 +8340,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "Content-Length",
@@ -8540,15 +8549,6 @@
             "x-ms-client-name": "pageWrite"
           },
           {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
-          },
-          {
             "name": "body",
             "in": "body",
             "description": "The body of the request.",
@@ -8648,6 +8648,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "Content-Length",
@@ -8813,15 +8822,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "pageWrite"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -8897,6 +8897,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "x-ms-copy-source",
@@ -9158,15 +9167,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "pageWrite"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -9251,6 +9251,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "snapshot",
@@ -9341,15 +9350,6 @@
             "type": "integer",
             "format": "int32",
             "minimum": 1
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -9415,6 +9415,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "snapshot",
@@ -9520,15 +9529,6 @@
             "type": "integer",
             "format": "int32",
             "minimum": 1
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -9597,6 +9597,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -9705,15 +9714,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "ifTags"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -9779,6 +9779,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -9893,15 +9902,6 @@
             "type": "integer",
             "format": "int64",
             "x-ms-client-name": "size"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -9967,6 +9967,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -10070,15 +10079,6 @@
             "format": "int64",
             "default": 0,
             "x-ms-client-name": "blobSequenceNumber"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -10145,6 +10145,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "snapshot",
@@ -10249,15 +10258,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "ifTags"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "queryRequest",
@@ -10862,6 +10862,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -10920,15 +10929,6 @@
             "type": "integer",
             "format": "int64",
             "x-ms-client-name": "appendPosition"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -10993,6 +10993,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -11106,15 +11115,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "leaseId"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -11186,6 +11186,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -11224,15 +11233,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "ifTags"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -11289,6 +11289,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -11338,15 +11347,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "leaseId"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "tags",
@@ -11407,6 +11407,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "snapshot",
@@ -11587,15 +11596,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "ifTags"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -11673,15 +11673,6 @@
             "x-ms-client-name": "version"
           },
           {
-            "name": "timeout",
-            "in": "query",
-            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
-            "required": false,
-            "type": "integer",
-            "format": "int32",
-            "minimum": 0
-          },
-          {
             "name": "x-ms-client-request-id",
             "in": "header",
             "description": "An opaque, globally-unique, client-generated string identifier for the request.",
@@ -11689,6 +11680,15 @@
             "type": "string",
             "format": "uuid",
             "x-ms-client-name": "clientRequestId"
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
           }
         ],
         "responses": {
@@ -11742,15 +11742,6 @@
             "x-ms-client-name": "version"
           },
           {
-            "name": "timeout",
-            "in": "query",
-            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
-            "required": false,
-            "type": "integer",
-            "format": "int32",
-            "minimum": 0
-          },
-          {
             "name": "x-ms-client-request-id",
             "in": "header",
             "description": "An opaque, globally-unique, client-generated string identifier for the request.",
@@ -11758,6 +11749,15 @@
             "type": "string",
             "format": "uuid",
             "x-ms-client-name": "clientRequestId"
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
           }
         ],
         "responses": {
@@ -11899,15 +11899,6 @@
             "x-ms-client-name": "version"
           },
           {
-            "name": "timeout",
-            "in": "query",
-            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
-            "required": false,
-            "type": "integer",
-            "format": "int32",
-            "minimum": 0
-          },
-          {
             "name": "x-ms-client-request-id",
             "in": "header",
             "description": "An opaque, globally-unique, client-generated string identifier for the request.",
@@ -11915,6 +11906,15 @@
             "type": "string",
             "format": "uuid",
             "x-ms-client-name": "clientRequestId"
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
           }
         ],
         "responses": {
@@ -12056,6 +12056,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -12115,15 +12124,6 @@
             "required": false,
             "type": "boolean",
             "x-ms-client-name": "PreventEncryptionScopeOverride"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -12186,6 +12186,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -12219,15 +12228,6 @@
             "type": "string",
             "format": "date-time-rfc7231",
             "x-ms-client-name": "ifUnmodifiedSince"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -12281,6 +12281,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -12296,15 +12305,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "leaseId"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -12502,6 +12502,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -12517,15 +12526,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "leaseId"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -12615,6 +12615,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -12676,15 +12685,6 @@
             "type": "string",
             "format": "date-time-rfc7231",
             "x-ms-client-name": "ifUnmodifiedSince"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "containerAcl",
@@ -12840,6 +12840,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -12902,15 +12911,6 @@
               }
             },
             "collectionFormat": "csv"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -12962,6 +12962,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "prefix",
@@ -13073,22 +13082,13 @@
             "type": "integer",
             "format": "int32",
             "minimum": 0
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
           "200": {
             "description": "The request has succeeded.",
             "schema": {
-              "$ref": "#/definitions/ListBlobsFlatSegmentResponse"
+              "$ref": "#/definitions/ListBlobsResponse"
             },
             "headers": {
               "Date": {
@@ -13133,6 +13133,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "delimiter",
@@ -13251,15 +13260,6 @@
             "type": "integer",
             "format": "int32",
             "minimum": 0
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -13316,6 +13316,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -13348,15 +13357,6 @@
             "type": "string",
             "format": "date-time-rfc7231",
             "x-ms-client-name": "ifModifiedSince"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -13419,6 +13419,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "x-ms-source-container-name",
             "in": "header",
             "description": "Required.  Specifies the name of the container to rename.",
@@ -13442,15 +13451,6 @@
             "type": "integer",
             "format": "int32",
             "minimum": 0
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -13504,6 +13504,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "x-ms-deleted-container-name",
             "in": "header",
             "description": "Optional.  Version 2019-12-12 and later.  Specifies the name of the deleted container to restore.",
@@ -13527,15 +13536,6 @@
             "type": "integer",
             "format": "int32",
             "minimum": 0
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -13589,15 +13589,6 @@
             "x-ms-client-name": "version"
           },
           {
-            "name": "timeout",
-            "in": "query",
-            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
-            "required": false,
-            "type": "integer",
-            "format": "int32",
-            "minimum": 0
-          },
-          {
             "name": "x-ms-client-request-id",
             "in": "header",
             "description": "An opaque, globally-unique, client-generated string identifier for the request.",
@@ -13605,6 +13596,15 @@
             "type": "string",
             "format": "uuid",
             "x-ms-client-name": "clientRequestId"
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
           },
           {
             "name": "storageServiceProperties",
@@ -13664,15 +13664,6 @@
             "x-ms-client-name": "version"
           },
           {
-            "name": "timeout",
-            "in": "query",
-            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
-            "required": false,
-            "type": "integer",
-            "format": "int32",
-            "minimum": 0
-          },
-          {
             "name": "x-ms-client-request-id",
             "in": "header",
             "description": "An opaque, globally-unique, client-generated string identifier for the request.",
@@ -13680,6 +13671,15 @@
             "type": "string",
             "format": "uuid",
             "x-ms-client-name": "clientRequestId"
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
           }
         ],
         "responses": {
@@ -13733,15 +13733,6 @@
             "x-ms-client-name": "version"
           },
           {
-            "name": "timeout",
-            "in": "query",
-            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
-            "required": false,
-            "type": "integer",
-            "format": "int32",
-            "minimum": 0
-          },
-          {
             "name": "x-ms-client-request-id",
             "in": "header",
             "description": "An opaque, globally-unique, client-generated string identifier for the request.",
@@ -13749,6 +13740,15 @@
             "type": "string",
             "format": "uuid",
             "x-ms-client-name": "clientRequestId"
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
           }
         ],
         "responses": {
@@ -13802,15 +13802,6 @@
             "x-ms-client-name": "version"
           },
           {
-            "name": "timeout",
-            "in": "query",
-            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
-            "required": false,
-            "type": "integer",
-            "format": "int32",
-            "minimum": 0
-          },
-          {
             "name": "x-ms-client-request-id",
             "in": "header",
             "description": "An opaque, globally-unique, client-generated string identifier for the request.",
@@ -13818,6 +13809,15 @@
             "type": "string",
             "format": "uuid",
             "x-ms-client-name": "clientRequestId"
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
           },
           {
             "name": "keyInfo",
@@ -15689,72 +15689,6 @@
         ]
       }
     },
-    "ListBlobsFlatSegmentResponse": {
-      "type": "object",
-      "description": "An enumeration of blobs.",
-      "properties": {
-        "serviceEndpoint": {
-          "type": "string",
-          "description": "The service endpoint.",
-          "xml": {
-            "name": "ServiceEndpoint",
-            "attribute": true
-          }
-        },
-        "containerName": {
-          "type": "string",
-          "description": "The container name.",
-          "xml": {
-            "name": "ContainerName",
-            "attribute": true
-          }
-        },
-        "prefix": {
-          "type": "string",
-          "description": "The prefix of the blobs.",
-          "xml": {
-            "name": "Prefix"
-          }
-        },
-        "marker": {
-          "type": "string",
-          "description": "The marker of the blobs.",
-          "xml": {
-            "name": "Marker"
-          }
-        },
-        "maxResults": {
-          "type": "integer",
-          "format": "int32",
-          "description": "The max results of the blobs.",
-          "xml": {
-            "name": "MaxResults"
-          }
-        },
-        "segment": {
-          "$ref": "#/definitions/BlobFlatListSegment",
-          "description": "The blob segment.",
-          "xml": {
-            "name": "Blobs"
-          }
-        },
-        "nextMarker": {
-          "type": "string",
-          "description": "The next marker of the blobs.",
-          "xml": {
-            "name": "NextMarker"
-          }
-        }
-      },
-      "required": [
-        "serviceEndpoint",
-        "containerName",
-        "segment"
-      ],
-      "xml": {
-        "name": "EnumerationResults"
-      }
-    },
     "ListBlobsHierarchySegmentResponse": {
       "type": "object",
       "description": "An enumeration of blobs",
@@ -15898,6 +15832,72 @@
             "description": "The include deleted with versions."
           }
         ]
+      }
+    },
+    "ListBlobsResponse": {
+      "type": "object",
+      "description": "An enumeration of blobs.",
+      "properties": {
+        "serviceEndpoint": {
+          "type": "string",
+          "description": "The service endpoint.",
+          "xml": {
+            "name": "ServiceEndpoint",
+            "attribute": true
+          }
+        },
+        "containerName": {
+          "type": "string",
+          "description": "The container name.",
+          "xml": {
+            "name": "ContainerName",
+            "attribute": true
+          }
+        },
+        "prefix": {
+          "type": "string",
+          "description": "The prefix of the blobs.",
+          "xml": {
+            "name": "Prefix"
+          }
+        },
+        "marker": {
+          "type": "string",
+          "description": "The marker of the blobs.",
+          "xml": {
+            "name": "Marker"
+          }
+        },
+        "maxResults": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The max results of the blobs.",
+          "xml": {
+            "name": "MaxResults"
+          }
+        },
+        "segment": {
+          "$ref": "#/definitions/BlobFlatListSegment",
+          "description": "The blob segment.",
+          "xml": {
+            "name": "Blobs"
+          }
+        },
+        "nextMarker": {
+          "type": "string",
+          "description": "The next marker of the blobs.",
+          "xml": {
+            "name": "NextMarker"
+          }
+        }
+      },
+      "required": [
+        "serviceEndpoint",
+        "containerName",
+        "segment"
+      ],
+      "xml": {
+        "name": "EnumerationResults"
       }
     },
     "ListContainersIncludeType": {

--- a/specification/storage/data-plane/Microsoft.BlobStorage/stable/2026-02-06/generated_blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/stable/2026-02-06/generated_blob.json
@@ -954,6 +954,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -1287,15 +1296,6 @@
               true
             ],
             "x-ms-client-name": "requiresSync"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -1398,6 +1398,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "snapshot",
@@ -1522,15 +1531,6 @@
               ]
             },
             "x-ms-client-name": "blobDeleteType"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -1580,6 +1580,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "snapshot",
@@ -1692,15 +1701,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "ifTags"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -2152,6 +2152,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "x-ms-meta",
             "in": "header",
             "description": "The metadata headers.",
@@ -2396,15 +2405,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "blobType"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -2489,6 +2489,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "x-ms-meta",
@@ -2882,15 +2891,6 @@
             "x-ms-client-name": "blobType"
           },
           {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
-          },
-          {
             "name": "body",
             "in": "body",
             "description": "The body of the request.",
@@ -2984,6 +2984,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "x-ms-meta",
@@ -3425,15 +3434,6 @@
               ]
             },
             "x-ms-client-name": "fileRequestIntent"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -3518,6 +3518,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -3687,15 +3696,6 @@
             "x-ms-client-name": "structuredContentLength"
           },
           {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
-          },
-          {
             "name": "body",
             "in": "body",
             "description": "The body of the request.",
@@ -3799,6 +3799,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "x-ms-copy-source",
@@ -4038,15 +4047,6 @@
               ]
             },
             "x-ms-client-name": "fileRequestIntent"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -4229,6 +4229,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -4291,15 +4300,6 @@
               }
             },
             "collectionFormat": "csv"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -4357,6 +4357,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "blockid",
@@ -4475,15 +4484,6 @@
             "x-ms-client-name": "structuredContentLength"
           },
           {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
-          },
-          {
             "name": "body",
             "in": "body",
             "description": "The body of the request.",
@@ -4569,6 +4569,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "blockid",
@@ -4748,15 +4757,6 @@
               ]
             },
             "x-ms-client-name": "fileRequestIntent"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -4830,6 +4830,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -5183,15 +5192,6 @@
             "x-ms-client-name": "legalHold"
           },
           {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
-          },
-          {
             "name": "blocks",
             "in": "body",
             "description": "Blob Blocks.",
@@ -5284,6 +5284,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "snapshot",
             "in": "query",
             "description": "The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more information on working with blob snapshots, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob\">Creating a Snapshot of a Blob.</a>",
@@ -5348,15 +5357,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "ifTags"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -5427,6 +5427,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -5464,15 +5473,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "copyActionAbortConstant"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -5524,6 +5524,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -5893,15 +5902,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "requiresSync"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -5996,6 +5996,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -6052,15 +6061,6 @@
             "type": "string",
             "format": "date-time-rfc7231",
             "x-ms-client-name": "ExpiresOn"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -6121,6 +6121,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -6197,15 +6206,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "versionId"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -6294,6 +6294,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -6316,15 +6325,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "versionId"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -6376,6 +6376,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -6435,15 +6444,6 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "copySource"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -6546,6 +6546,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -6626,15 +6635,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "action"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -6699,6 +6699,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -6773,15 +6782,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "action"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -6849,6 +6849,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -6928,15 +6937,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "action"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -7001,6 +7001,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -7074,15 +7083,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "action"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -7143,6 +7143,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -7216,15 +7225,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "action"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -7291,6 +7291,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "x-ms-lease-duration",
             "in": "header",
             "description": "Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires. A non-infinite lease can be between 15 and 60 seconds. A lease duration cannot be changed using renew or change.",
@@ -7347,15 +7356,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "action"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -7422,6 +7422,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -7470,15 +7479,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "action"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -7546,6 +7546,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "x-ms-lease-id",
             "in": "header",
             "description": "Required.  A lease ID for the source path. If specified, the source path must have an active lease and the lease ID must match.",
@@ -7601,15 +7610,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "action"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -7676,6 +7676,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "x-ms-lease-id",
             "in": "header",
             "description": "Required.  A lease ID for the source path. If specified, the source path must have an active lease and the lease ID must match.",
@@ -7723,15 +7732,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "action"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -7794,6 +7794,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "x-ms-lease-id",
             "in": "header",
             "description": "Required.  A lease ID for the source path. If specified, the source path must have an active lease and the lease ID must match.",
@@ -7841,15 +7850,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "action"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -7916,6 +7916,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -7946,15 +7955,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "versionId"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -8007,6 +8007,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "prefix",
@@ -8076,15 +8085,6 @@
               }
             },
             "collectionFormat": "csv"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -8139,6 +8139,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -8252,15 +8261,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "ifTags"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -8340,6 +8340,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "Content-Length",
@@ -8540,15 +8549,6 @@
             "x-ms-client-name": "pageWrite"
           },
           {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
-          },
-          {
             "name": "body",
             "in": "body",
             "description": "The body of the request.",
@@ -8648,6 +8648,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "Content-Length",
@@ -8813,15 +8822,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "pageWrite"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -8897,6 +8897,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "x-ms-copy-source",
@@ -9158,15 +9167,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "pageWrite"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -9251,6 +9251,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "snapshot",
@@ -9341,15 +9350,6 @@
             "type": "integer",
             "format": "int32",
             "minimum": 1
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -9415,6 +9415,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "snapshot",
@@ -9520,15 +9529,6 @@
             "type": "integer",
             "format": "int32",
             "minimum": 1
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -9597,6 +9597,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -9705,15 +9714,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "ifTags"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -9779,6 +9779,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -9893,15 +9902,6 @@
             "type": "integer",
             "format": "int64",
             "x-ms-client-name": "size"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -9967,6 +9967,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -10070,15 +10079,6 @@
             "format": "int64",
             "default": 0,
             "x-ms-client-name": "blobSequenceNumber"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -10145,6 +10145,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "snapshot",
@@ -10249,15 +10258,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "ifTags"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "queryRequest",
@@ -10862,6 +10862,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -10920,15 +10929,6 @@
             "type": "integer",
             "format": "int64",
             "x-ms-client-name": "appendPosition"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -10993,6 +10993,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -11106,15 +11115,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "leaseId"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -11184,6 +11184,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -11258,15 +11267,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "ifNoneMatch"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -11321,6 +11321,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -11408,15 +11417,6 @@
             "x-ms-client-name": "ifNoneMatch"
           },
           {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
-          },
-          {
             "name": "tags",
             "in": "body",
             "description": "The blob tags.",
@@ -11475,6 +11475,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "snapshot",
@@ -11655,15 +11664,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "ifTags"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -11741,15 +11741,6 @@
             "x-ms-client-name": "version"
           },
           {
-            "name": "timeout",
-            "in": "query",
-            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
-            "required": false,
-            "type": "integer",
-            "format": "int32",
-            "minimum": 0
-          },
-          {
             "name": "x-ms-client-request-id",
             "in": "header",
             "description": "An opaque, globally-unique, client-generated string identifier for the request.",
@@ -11757,6 +11748,15 @@
             "type": "string",
             "format": "uuid",
             "x-ms-client-name": "clientRequestId"
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
           }
         ],
         "responses": {
@@ -11810,15 +11810,6 @@
             "x-ms-client-name": "version"
           },
           {
-            "name": "timeout",
-            "in": "query",
-            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
-            "required": false,
-            "type": "integer",
-            "format": "int32",
-            "minimum": 0
-          },
-          {
             "name": "x-ms-client-request-id",
             "in": "header",
             "description": "An opaque, globally-unique, client-generated string identifier for the request.",
@@ -11826,6 +11817,15 @@
             "type": "string",
             "format": "uuid",
             "x-ms-client-name": "clientRequestId"
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
           }
         ],
         "responses": {
@@ -11967,15 +11967,6 @@
             "x-ms-client-name": "version"
           },
           {
-            "name": "timeout",
-            "in": "query",
-            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
-            "required": false,
-            "type": "integer",
-            "format": "int32",
-            "minimum": 0
-          },
-          {
             "name": "x-ms-client-request-id",
             "in": "header",
             "description": "An opaque, globally-unique, client-generated string identifier for the request.",
@@ -11983,6 +11974,15 @@
             "type": "string",
             "format": "uuid",
             "x-ms-client-name": "clientRequestId"
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
           }
         ],
         "responses": {
@@ -12124,6 +12124,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -12183,15 +12192,6 @@
             "required": false,
             "type": "boolean",
             "x-ms-client-name": "PreventEncryptionScopeOverride"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -12254,6 +12254,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -12287,15 +12296,6 @@
             "type": "string",
             "format": "date-time-rfc7231",
             "x-ms-client-name": "ifUnmodifiedSince"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -12349,6 +12349,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -12364,15 +12373,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "leaseId"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -12570,6 +12570,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -12585,15 +12594,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "leaseId"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -12683,6 +12683,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -12744,15 +12753,6 @@
             "type": "string",
             "format": "date-time-rfc7231",
             "x-ms-client-name": "ifUnmodifiedSince"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "containerAcl",
@@ -12908,6 +12908,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -12970,15 +12979,6 @@
               }
             },
             "collectionFormat": "csv"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -13030,6 +13030,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "prefix",
@@ -13148,22 +13157,13 @@
             "description": "Specifies the relative path to list paths from. For non-recursive list, only one entity level is supported; For recursive list, multiple entity levels are supported. (Inclusive)",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
           "200": {
             "description": "The request has succeeded.",
             "schema": {
-              "$ref": "#/definitions/ListBlobsFlatSegmentResponse"
+              "$ref": "#/definitions/ListBlobsResponse"
             },
             "headers": {
               "Date": {
@@ -13208,6 +13208,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "delimiter",
@@ -13333,15 +13342,6 @@
             "description": "Specifies the relative path to list paths from. For non-recursive list, only one entity level is supported; For recursive list, multiple entity levels are supported. (Inclusive)",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -13398,6 +13398,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -13430,15 +13439,6 @@
             "type": "string",
             "format": "date-time-rfc7231",
             "x-ms-client-name": "ifModifiedSince"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -13501,6 +13501,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "x-ms-source-container-name",
             "in": "header",
             "description": "Required.  Specifies the name of the container to rename.",
@@ -13524,15 +13533,6 @@
             "type": "integer",
             "format": "int32",
             "minimum": 0
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -13586,6 +13586,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "x-ms-deleted-container-name",
             "in": "header",
             "description": "Optional.  Version 2019-12-12 and later.  Specifies the name of the deleted container to restore.",
@@ -13609,15 +13618,6 @@
             "type": "integer",
             "format": "int32",
             "minimum": 0
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -13671,15 +13671,6 @@
             "x-ms-client-name": "version"
           },
           {
-            "name": "timeout",
-            "in": "query",
-            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
-            "required": false,
-            "type": "integer",
-            "format": "int32",
-            "minimum": 0
-          },
-          {
             "name": "x-ms-client-request-id",
             "in": "header",
             "description": "An opaque, globally-unique, client-generated string identifier for the request.",
@@ -13687,6 +13678,15 @@
             "type": "string",
             "format": "uuid",
             "x-ms-client-name": "clientRequestId"
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
           },
           {
             "name": "storageServiceProperties",
@@ -13746,15 +13746,6 @@
             "x-ms-client-name": "version"
           },
           {
-            "name": "timeout",
-            "in": "query",
-            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
-            "required": false,
-            "type": "integer",
-            "format": "int32",
-            "minimum": 0
-          },
-          {
             "name": "x-ms-client-request-id",
             "in": "header",
             "description": "An opaque, globally-unique, client-generated string identifier for the request.",
@@ -13762,6 +13753,15 @@
             "type": "string",
             "format": "uuid",
             "x-ms-client-name": "clientRequestId"
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
           }
         ],
         "responses": {
@@ -13815,15 +13815,6 @@
             "x-ms-client-name": "version"
           },
           {
-            "name": "timeout",
-            "in": "query",
-            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
-            "required": false,
-            "type": "integer",
-            "format": "int32",
-            "minimum": 0
-          },
-          {
             "name": "x-ms-client-request-id",
             "in": "header",
             "description": "An opaque, globally-unique, client-generated string identifier for the request.",
@@ -13831,6 +13822,15 @@
             "type": "string",
             "format": "uuid",
             "x-ms-client-name": "clientRequestId"
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
           }
         ],
         "responses": {
@@ -13884,15 +13884,6 @@
             "x-ms-client-name": "version"
           },
           {
-            "name": "timeout",
-            "in": "query",
-            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
-            "required": false,
-            "type": "integer",
-            "format": "int32",
-            "minimum": 0
-          },
-          {
             "name": "x-ms-client-request-id",
             "in": "header",
             "description": "An opaque, globally-unique, client-generated string identifier for the request.",
@@ -13900,6 +13891,15 @@
             "type": "string",
             "format": "uuid",
             "x-ms-client-name": "clientRequestId"
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
           },
           {
             "name": "keyInfo",
@@ -15771,72 +15771,6 @@
         ]
       }
     },
-    "ListBlobsFlatSegmentResponse": {
-      "type": "object",
-      "description": "An enumeration of blobs.",
-      "properties": {
-        "serviceEndpoint": {
-          "type": "string",
-          "description": "The service endpoint.",
-          "xml": {
-            "name": "ServiceEndpoint",
-            "attribute": true
-          }
-        },
-        "containerName": {
-          "type": "string",
-          "description": "The container name.",
-          "xml": {
-            "name": "ContainerName",
-            "attribute": true
-          }
-        },
-        "prefix": {
-          "type": "string",
-          "description": "The prefix of the blobs.",
-          "xml": {
-            "name": "Prefix"
-          }
-        },
-        "marker": {
-          "type": "string",
-          "description": "The marker of the blobs.",
-          "xml": {
-            "name": "Marker"
-          }
-        },
-        "maxResults": {
-          "type": "integer",
-          "format": "int32",
-          "description": "The max results of the blobs.",
-          "xml": {
-            "name": "MaxResults"
-          }
-        },
-        "segment": {
-          "$ref": "#/definitions/BlobFlatListSegment",
-          "description": "The blob segment.",
-          "xml": {
-            "name": "Blobs"
-          }
-        },
-        "nextMarker": {
-          "type": "string",
-          "description": "The next marker of the blobs.",
-          "xml": {
-            "name": "NextMarker"
-          }
-        }
-      },
-      "required": [
-        "serviceEndpoint",
-        "containerName",
-        "segment"
-      ],
-      "xml": {
-        "name": "EnumerationResults"
-      }
-    },
     "ListBlobsHierarchySegmentResponse": {
       "type": "object",
       "description": "An enumeration of blobs",
@@ -15980,6 +15914,72 @@
             "description": "The include deleted with versions."
           }
         ]
+      }
+    },
+    "ListBlobsResponse": {
+      "type": "object",
+      "description": "An enumeration of blobs.",
+      "properties": {
+        "serviceEndpoint": {
+          "type": "string",
+          "description": "The service endpoint.",
+          "xml": {
+            "name": "ServiceEndpoint",
+            "attribute": true
+          }
+        },
+        "containerName": {
+          "type": "string",
+          "description": "The container name.",
+          "xml": {
+            "name": "ContainerName",
+            "attribute": true
+          }
+        },
+        "prefix": {
+          "type": "string",
+          "description": "The prefix of the blobs.",
+          "xml": {
+            "name": "Prefix"
+          }
+        },
+        "marker": {
+          "type": "string",
+          "description": "The marker of the blobs.",
+          "xml": {
+            "name": "Marker"
+          }
+        },
+        "maxResults": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The max results of the blobs.",
+          "xml": {
+            "name": "MaxResults"
+          }
+        },
+        "segment": {
+          "$ref": "#/definitions/BlobFlatListSegment",
+          "description": "The blob segment.",
+          "xml": {
+            "name": "Blobs"
+          }
+        },
+        "nextMarker": {
+          "type": "string",
+          "description": "The next marker of the blobs.",
+          "xml": {
+            "name": "NextMarker"
+          }
+        }
+      },
+      "required": [
+        "serviceEndpoint",
+        "containerName",
+        "segment"
+      ],
+      "xml": {
+        "name": "EnumerationResults"
       }
     },
     "ListContainersIncludeType": {

--- a/specification/storage/data-plane/Microsoft.BlobStorage/stable/2026-04-06/generated_blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/stable/2026-04-06/generated_blob.json
@@ -954,6 +954,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -1287,15 +1296,6 @@
               true
             ],
             "x-ms-client-name": "requiresSync"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -1398,6 +1398,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "snapshot",
@@ -1540,15 +1549,6 @@
             "type": "string",
             "format": "date-time-rfc7231",
             "x-ms-client-name": "accessTierIfUnmodifiedSince"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -1598,6 +1598,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "snapshot",
@@ -1710,15 +1719,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "ifTags"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -2170,6 +2170,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "x-ms-meta",
             "in": "header",
             "description": "The metadata headers.",
@@ -2414,15 +2423,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "blobType"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -2507,6 +2507,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "x-ms-meta",
@@ -2900,15 +2909,6 @@
             "x-ms-client-name": "blobType"
           },
           {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
-          },
-          {
             "name": "body",
             "in": "body",
             "description": "The body of the request.",
@@ -3002,6 +3002,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "x-ms-meta",
@@ -3481,15 +3490,6 @@
               ]
             },
             "x-ms-client-name": "sourceEncryptionAlgorithm"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -3574,6 +3574,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -3743,15 +3752,6 @@
             "x-ms-client-name": "structuredContentLength"
           },
           {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
-          },
-          {
             "name": "body",
             "in": "body",
             "description": "The body of the request.",
@@ -3855,6 +3855,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "x-ms-copy-source",
@@ -4132,15 +4141,6 @@
               ]
             },
             "x-ms-client-name": "sourceEncryptionAlgorithm"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -4323,6 +4323,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -4385,15 +4394,6 @@
               }
             },
             "collectionFormat": "csv"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -4451,6 +4451,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "blockid",
@@ -4569,15 +4578,6 @@
             "x-ms-client-name": "structuredContentLength"
           },
           {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
-          },
-          {
             "name": "body",
             "in": "body",
             "description": "The body of the request.",
@@ -4663,6 +4663,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "blockid",
@@ -4880,15 +4889,6 @@
               ]
             },
             "x-ms-client-name": "sourceEncryptionAlgorithm"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -4962,6 +4962,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -5315,15 +5324,6 @@
             "x-ms-client-name": "legalHold"
           },
           {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
-          },
-          {
             "name": "blocks",
             "in": "body",
             "description": "Blob Blocks.",
@@ -5416,6 +5416,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "snapshot",
             "in": "query",
             "description": "The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more information on working with blob snapshots, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob\">Creating a Snapshot of a Blob.</a>",
@@ -5480,15 +5489,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "ifTags"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -5559,6 +5559,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -5596,15 +5605,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "copyActionAbortConstant"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -5656,6 +5656,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -6025,15 +6034,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "requiresSync"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -6128,6 +6128,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -6184,15 +6193,6 @@
             "type": "string",
             "format": "date-time-rfc7231",
             "x-ms-client-name": "ExpiresOn"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -6253,6 +6253,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -6329,15 +6338,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "versionId"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -6426,6 +6426,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -6448,15 +6457,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "versionId"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -6508,6 +6508,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -6567,15 +6576,6 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "copySource"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -6678,6 +6678,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -6758,15 +6767,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "action"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -6831,6 +6831,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -6905,15 +6914,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "action"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -6981,6 +6981,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -7060,15 +7069,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "action"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -7133,6 +7133,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -7206,15 +7215,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "action"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -7275,6 +7275,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -7348,15 +7357,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "action"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -7423,6 +7423,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "x-ms-lease-duration",
             "in": "header",
             "description": "Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires. A non-infinite lease can be between 15 and 60 seconds. A lease duration cannot be changed using renew or change.",
@@ -7479,15 +7488,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "action"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -7554,6 +7554,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -7602,15 +7611,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "action"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -7678,6 +7678,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "x-ms-lease-id",
             "in": "header",
             "description": "Required.  A lease ID for the source path. If specified, the source path must have an active lease and the lease ID must match.",
@@ -7733,15 +7742,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "action"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -7808,6 +7808,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "x-ms-lease-id",
             "in": "header",
             "description": "Required.  A lease ID for the source path. If specified, the source path must have an active lease and the lease ID must match.",
@@ -7855,15 +7864,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "action"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -7926,6 +7926,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "x-ms-lease-id",
             "in": "header",
             "description": "Required.  A lease ID for the source path. If specified, the source path must have an active lease and the lease ID must match.",
@@ -7973,15 +7982,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "action"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -8048,6 +8048,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -8078,15 +8087,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "versionId"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -8139,6 +8139,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "prefix",
@@ -8208,15 +8217,6 @@
               }
             },
             "collectionFormat": "csv"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -8271,6 +8271,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -8384,15 +8393,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "ifTags"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -8472,6 +8472,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "Content-Length",
@@ -8672,15 +8681,6 @@
             "x-ms-client-name": "pageWrite"
           },
           {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
-          },
-          {
             "name": "body",
             "in": "body",
             "description": "The body of the request.",
@@ -8780,6 +8780,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "Content-Length",
@@ -8945,15 +8954,6 @@
               "modelAsString": false
             },
             "x-ms-client-name": "pageWrite"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -9029,6 +9029,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "x-ms-copy-source",
@@ -9328,15 +9337,6 @@
               ]
             },
             "x-ms-client-name": "sourceEncryptionAlgorithm"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -9421,6 +9421,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "snapshot",
@@ -9511,15 +9520,6 @@
             "type": "integer",
             "format": "int32",
             "minimum": 1
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -9585,6 +9585,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "snapshot",
@@ -9690,15 +9699,6 @@
             "type": "integer",
             "format": "int32",
             "minimum": 1
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -9767,6 +9767,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -9875,15 +9884,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "ifTags"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -9949,6 +9949,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -10063,15 +10072,6 @@
             "type": "integer",
             "format": "int64",
             "x-ms-client-name": "size"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -10137,6 +10137,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -10240,15 +10249,6 @@
             "format": "int64",
             "default": 0,
             "x-ms-client-name": "blobSequenceNumber"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -10315,6 +10315,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "snapshot",
@@ -10419,15 +10428,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "ifTags"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "queryRequest",
@@ -11032,6 +11032,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -11090,15 +11099,6 @@
             "type": "integer",
             "format": "int64",
             "x-ms-client-name": "appendPosition"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -11163,6 +11163,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -11276,15 +11285,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "leaseId"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -11354,6 +11354,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -11428,15 +11437,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "ifNoneMatch"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -11491,6 +11491,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "timeout",
@@ -11578,15 +11587,6 @@
             "x-ms-client-name": "ifNoneMatch"
           },
           {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
-          },
-          {
             "name": "tags",
             "in": "body",
             "description": "The blob tags.",
@@ -11645,6 +11645,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "snapshot",
@@ -11825,15 +11834,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "ifTags"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -11911,15 +11911,6 @@
             "x-ms-client-name": "version"
           },
           {
-            "name": "timeout",
-            "in": "query",
-            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
-            "required": false,
-            "type": "integer",
-            "format": "int32",
-            "minimum": 0
-          },
-          {
             "name": "x-ms-client-request-id",
             "in": "header",
             "description": "An opaque, globally-unique, client-generated string identifier for the request.",
@@ -11927,6 +11918,15 @@
             "type": "string",
             "format": "uuid",
             "x-ms-client-name": "clientRequestId"
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
           }
         ],
         "responses": {
@@ -11980,15 +11980,6 @@
             "x-ms-client-name": "version"
           },
           {
-            "name": "timeout",
-            "in": "query",
-            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
-            "required": false,
-            "type": "integer",
-            "format": "int32",
-            "minimum": 0
-          },
-          {
             "name": "x-ms-client-request-id",
             "in": "header",
             "description": "An opaque, globally-unique, client-generated string identifier for the request.",
@@ -11996,6 +11987,15 @@
             "type": "string",
             "format": "uuid",
             "x-ms-client-name": "clientRequestId"
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
           }
         ],
         "responses": {
@@ -12155,15 +12155,6 @@
             "x-ms-client-name": "version"
           },
           {
-            "name": "timeout",
-            "in": "query",
-            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
-            "required": false,
-            "type": "integer",
-            "format": "int32",
-            "minimum": 0
-          },
-          {
             "name": "x-ms-client-request-id",
             "in": "header",
             "description": "An opaque, globally-unique, client-generated string identifier for the request.",
@@ -12171,6 +12162,15 @@
             "type": "string",
             "format": "uuid",
             "x-ms-client-name": "clientRequestId"
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
           }
         ],
         "responses": {
@@ -12330,6 +12330,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -12389,15 +12398,6 @@
             "required": false,
             "type": "boolean",
             "x-ms-client-name": "PreventEncryptionScopeOverride"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -12460,6 +12460,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -12493,15 +12502,6 @@
             "type": "string",
             "format": "date-time-rfc7231",
             "x-ms-client-name": "ifUnmodifiedSince"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -12555,6 +12555,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -12570,15 +12579,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "leaseId"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -12776,6 +12776,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -12791,15 +12800,6 @@
             "required": false,
             "type": "string",
             "x-ms-client-name": "leaseId"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -12889,6 +12889,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -12950,15 +12959,6 @@
             "type": "string",
             "format": "date-time-rfc7231",
             "x-ms-client-name": "ifUnmodifiedSince"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "containerAcl",
@@ -13114,6 +13114,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -13176,15 +13185,6 @@
               }
             },
             "collectionFormat": "csv"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -13236,6 +13236,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "prefix",
@@ -13354,22 +13363,13 @@
             "description": "Specifies the relative path to list paths from. For non-recursive list, only one entity level is supported; For recursive list, multiple entity levels are supported. (Inclusive)",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
           "200": {
             "description": "The request has succeeded.",
             "schema": {
-              "$ref": "#/definitions/ListBlobsFlatSegmentResponse"
+              "$ref": "#/definitions/ListBlobsResponse"
             },
             "headers": {
               "Date": {
@@ -13414,6 +13414,15 @@
             "required": true,
             "type": "string",
             "x-ms-client-name": "version"
+          },
+          {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
           },
           {
             "name": "delimiter",
@@ -13539,15 +13548,6 @@
             "description": "Specifies the relative path to list paths from. For non-recursive list, only one entity level is supported; For recursive list, multiple entity levels are supported. (Inclusive)",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -13604,6 +13604,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "timeout",
             "in": "query",
             "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
@@ -13636,15 +13645,6 @@
             "type": "string",
             "format": "date-time-rfc7231",
             "x-ms-client-name": "ifModifiedSince"
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -13707,6 +13707,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "x-ms-source-container-name",
             "in": "header",
             "description": "Required.  Specifies the name of the container to rename.",
@@ -13730,15 +13739,6 @@
             "type": "integer",
             "format": "int32",
             "minimum": 0
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -13792,6 +13792,15 @@
             "x-ms-client-name": "version"
           },
           {
+            "name": "x-ms-client-request-id",
+            "in": "header",
+            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "x-ms-client-name": "clientRequestId"
+          },
+          {
             "name": "x-ms-deleted-container-name",
             "in": "header",
             "description": "Optional.  Version 2019-12-12 and later.  Specifies the name of the deleted container to restore.",
@@ -13815,15 +13824,6 @@
             "type": "integer",
             "format": "int32",
             "minimum": 0
-          },
-          {
-            "name": "x-ms-client-request-id",
-            "in": "header",
-            "description": "An opaque, globally-unique, client-generated string identifier for the request.",
-            "required": false,
-            "type": "string",
-            "format": "uuid",
-            "x-ms-client-name": "clientRequestId"
           }
         ],
         "responses": {
@@ -13877,15 +13877,6 @@
             "x-ms-client-name": "version"
           },
           {
-            "name": "timeout",
-            "in": "query",
-            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
-            "required": false,
-            "type": "integer",
-            "format": "int32",
-            "minimum": 0
-          },
-          {
             "name": "x-ms-client-request-id",
             "in": "header",
             "description": "An opaque, globally-unique, client-generated string identifier for the request.",
@@ -13893,6 +13884,15 @@
             "type": "string",
             "format": "uuid",
             "x-ms-client-name": "clientRequestId"
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
           },
           {
             "name": "storageServiceProperties",
@@ -13952,15 +13952,6 @@
             "x-ms-client-name": "version"
           },
           {
-            "name": "timeout",
-            "in": "query",
-            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
-            "required": false,
-            "type": "integer",
-            "format": "int32",
-            "minimum": 0
-          },
-          {
             "name": "x-ms-client-request-id",
             "in": "header",
             "description": "An opaque, globally-unique, client-generated string identifier for the request.",
@@ -13968,6 +13959,15 @@
             "type": "string",
             "format": "uuid",
             "x-ms-client-name": "clientRequestId"
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
           }
         ],
         "responses": {
@@ -14021,15 +14021,6 @@
             "x-ms-client-name": "version"
           },
           {
-            "name": "timeout",
-            "in": "query",
-            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
-            "required": false,
-            "type": "integer",
-            "format": "int32",
-            "minimum": 0
-          },
-          {
             "name": "x-ms-client-request-id",
             "in": "header",
             "description": "An opaque, globally-unique, client-generated string identifier for the request.",
@@ -14037,6 +14028,15 @@
             "type": "string",
             "format": "uuid",
             "x-ms-client-name": "clientRequestId"
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
           }
         ],
         "responses": {
@@ -14090,15 +14090,6 @@
             "x-ms-client-name": "version"
           },
           {
-            "name": "timeout",
-            "in": "query",
-            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
-            "required": false,
-            "type": "integer",
-            "format": "int32",
-            "minimum": 0
-          },
-          {
             "name": "x-ms-client-request-id",
             "in": "header",
             "description": "An opaque, globally-unique, client-generated string identifier for the request.",
@@ -14106,6 +14097,15 @@
             "type": "string",
             "format": "uuid",
             "x-ms-client-name": "clientRequestId"
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations\">Setting Timeouts for Blob Service Operations.</a>",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
           },
           {
             "name": "keyInfo",
@@ -15984,72 +15984,6 @@
         ]
       }
     },
-    "ListBlobsFlatSegmentResponse": {
-      "type": "object",
-      "description": "An enumeration of blobs.",
-      "properties": {
-        "serviceEndpoint": {
-          "type": "string",
-          "description": "The service endpoint.",
-          "xml": {
-            "name": "ServiceEndpoint",
-            "attribute": true
-          }
-        },
-        "containerName": {
-          "type": "string",
-          "description": "The container name.",
-          "xml": {
-            "name": "ContainerName",
-            "attribute": true
-          }
-        },
-        "prefix": {
-          "type": "string",
-          "description": "The prefix of the blobs.",
-          "xml": {
-            "name": "Prefix"
-          }
-        },
-        "marker": {
-          "type": "string",
-          "description": "The marker of the blobs.",
-          "xml": {
-            "name": "Marker"
-          }
-        },
-        "maxResults": {
-          "type": "integer",
-          "format": "int32",
-          "description": "The max results of the blobs.",
-          "xml": {
-            "name": "MaxResults"
-          }
-        },
-        "segment": {
-          "$ref": "#/definitions/BlobFlatListSegment",
-          "description": "The blob segment.",
-          "xml": {
-            "name": "Blobs"
-          }
-        },
-        "nextMarker": {
-          "type": "string",
-          "description": "The next marker of the blobs.",
-          "xml": {
-            "name": "NextMarker"
-          }
-        }
-      },
-      "required": [
-        "serviceEndpoint",
-        "containerName",
-        "segment"
-      ],
-      "xml": {
-        "name": "EnumerationResults"
-      }
-    },
     "ListBlobsHierarchySegmentResponse": {
       "type": "object",
       "description": "An enumeration of blobs",
@@ -16193,6 +16127,72 @@
             "description": "The include deleted with versions."
           }
         ]
+      }
+    },
+    "ListBlobsResponse": {
+      "type": "object",
+      "description": "An enumeration of blobs.",
+      "properties": {
+        "serviceEndpoint": {
+          "type": "string",
+          "description": "The service endpoint.",
+          "xml": {
+            "name": "ServiceEndpoint",
+            "attribute": true
+          }
+        },
+        "containerName": {
+          "type": "string",
+          "description": "The container name.",
+          "xml": {
+            "name": "ContainerName",
+            "attribute": true
+          }
+        },
+        "prefix": {
+          "type": "string",
+          "description": "The prefix of the blobs.",
+          "xml": {
+            "name": "Prefix"
+          }
+        },
+        "marker": {
+          "type": "string",
+          "description": "The marker of the blobs.",
+          "xml": {
+            "name": "Marker"
+          }
+        },
+        "maxResults": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The max results of the blobs.",
+          "xml": {
+            "name": "MaxResults"
+          }
+        },
+        "segment": {
+          "$ref": "#/definitions/BlobFlatListSegment",
+          "description": "The blob segment.",
+          "xml": {
+            "name": "Blobs"
+          }
+        },
+        "nextMarker": {
+          "type": "string",
+          "description": "The next marker of the blobs.",
+          "xml": {
+            "name": "NextMarker"
+          }
+        }
+      },
+      "required": [
+        "serviceEndpoint",
+        "containerName",
+        "segment"
+      ],
+      "xml": {
+        "name": "EnumerationResults"
       }
     },
     "ListContainersIncludeType": {


### PR DESCRIPTION
This fix was merged into main a few months ago, seems like a regression in the template. 

TParams should be at the end of the template params, otherwise every time a new param is added to an operation, the client request id header will change position in the generated swagger causing breaking change reports. 