### PR TITLE
Remove "humanEvaluation" as type discriminator from v1. Python/JS emitters use more unique name for OpenAI "Error" class.

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/client.tsp
@@ -3,23 +3,25 @@
 // the JS client (package @azure/ai-projects).
 //
 
-// Stable operations (GA routes)
+// Stable operations (GA routes) with preview features (optional opt-in request headers)
 import "./src/agents/routes.tsp";
-import "./src/common/custom-types.tsp";
-import "./src/common/service.tsp";
+import "./src/evaluation-rules/routes.tsp";
+
+// Stable operation (GA routes) without preview features
 import "./src/connections/routes.tsp";
 import "./src/datasets/routes.tsp";
 import "./src/deployments/routes.tsp";
 import "./src/indexes/routes.tsp";
-import "./src/evaluation-rules/routes.tsp";
 
-// Beta operations (preview routes, requiring opt-in HTTP request header)
+// Beta operations (preview routes, requiring opt-in request header)
 import "./src/evaluation-taxonomies/routes.tsp";
 import "./src/evaluators/routes.tsp";
 import "./src/insights/routes.tsp";
 import "./src/memory-stores/routes.tsp";
 import "./src/red-teams/routes.tsp";
 import "./src/schedules/routes.tsp";
+
+// Create a ".beta" subclient for the above beta operations
 import "./relocate-beta-operations.tsp";
 
 using Azure.ClientGenerator.Core;
@@ -155,3 +157,14 @@ using Azure.AI.Projects;
 
 // Less generic names
 @@clientName(Sku, "ModelDeploymentSku");
+
+
+// --------------------------------------------------------------------------------
+// Other
+// --------------------------------------------------------------------------------
+
+// Rename OpenAI.Error to avoid conflict with Azure.Core.Foundations.Error.
+// OpenAI.Error is the object type of the `error` properties in `ApiErrorResponse` 
+// and `MemoryStoreUpdateResponse`.
+@@clientName(OpenAI.Error, "ApiError");
+

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -12348,7 +12348,6 @@
             "type": "string",
             "enum": [
               "continuousEvaluation",
-              "humanEvaluation",
               "humanEvaluationPreview"
             ]
           }

--- a/specification/ai-foundry/data-plane/Foundry/src/evaluation-rules/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/evaluation-rules/models.tsp
@@ -18,6 +18,7 @@ union EvaluationRuleActionType {
   continuousEvaluation: "continuousEvaluation",
 
   @doc("Human evaluation.")
+  @removed(Versions.v1)
   humanEvaluation: "humanEvaluation",
 
   @doc("Human evaluation preview.")


### PR DESCRIPTION
1. "humanEvaluation" is no longer an option in v1 as a "type" discriminator in Evaluation Rule Actions. Remove it. A recent TypeSpec change removed the TypeSpec mode `HumanEvaluationRuleAction` from v1, but did not remove the discriminator from v1.
2. Latest Python emitter is complaining that OpenAI.Error (emitted as class name "Error" in azure.ai.projects namespace) collides with the class "Error" from Azure.Core.Foundations.Error. Give the OpenAI Error class a more unique name.
3. Move around some import lines and update comments in `client.tsp`, now that the `evaluation-rules` route is GA, with some preview features on it (similar to agent route).