### PR TITLE
Fix error model duplicate name

### DIFF
--- a/specification/cognitiveservices/data-plane/LanguageQuestionAnsweringAuthoring/client.tsp
+++ b/specification/cognitiveservices/data-plane/LanguageQuestionAnsweringAuthoring/client.tsp
@@ -83,3 +83,4 @@ interface QuestionAnsweringAuthoringClientOperations {
 @@clientName(ExportQueryParameters.format, "fileFormat", "python");
 @@clientName(ImportQueryParameters.format, "fileFormat", "python");
 @@clientName(AssestKind, "AssetKind");
+@@clientName(Error, "QuestionAnsweringError", "csharp");

--- a/specification/cognitiveservices/data-plane/LanguageQuestionAnsweringAuthoring/client.tsp
+++ b/specification/cognitiveservices/data-plane/LanguageQuestionAnsweringAuthoring/client.tsp
@@ -83,4 +83,4 @@ interface QuestionAnsweringAuthoringClientOperations {
 @@clientName(ExportQueryParameters.format, "fileFormat", "python");
 @@clientName(ImportQueryParameters.format, "fileFormat", "python");
 @@clientName(AssestKind, "AssetKind");
-@@clientName(Error, "QuestionAnsweringError", "csharp");
+@@clientName(Error, "QuestionAnsweringError");


### PR DESCRIPTION
This type does not end up getting exposed in C#, but the fact that it conflicts with the Azure.Core.Foundations.Error type is causing errors in the generation due to changes to TCGC - https://github.com/Azure/typespec-azure/pull/3775

Hitting the same error in other languages so applying the rename across all languages