### PR TITLE
add Istio CNI to AKS 2026-01-01 GA API

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
@@ -1292,7 +1292,6 @@ union IstioIngressGatewayMode {
 /**
  * Mode of traffic redirection.
  */
-@added(Versions.v2026_01_02_preview)
 @added(Versions.v2026_01_01)
 union ProxyRedirectionMechanism {
   string,
@@ -3658,7 +3657,6 @@ model IstioComponents {
   /**
    * Mode of traffic redirection.
    */
-  @added(Versions.v2026_01_02_preview)
   @added(Versions.v2026_01_01)
   proxyRedirectionMechanism?: ProxyRedirectionMechanism;
 }

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
@@ -1293,6 +1293,7 @@ union IstioIngressGatewayMode {
  * Mode of traffic redirection.
  */
 @added(Versions.v2026_01_02_preview)
+@added(Versions.v2026_01_01)
 union ProxyRedirectionMechanism {
   string,
 
@@ -3658,6 +3659,7 @@ model IstioComponents {
    * Mode of traffic redirection.
    */
   @added(Versions.v2026_01_02_preview)
+  @added(Versions.v2026_01_01)
   proxyRedirectionMechanism?: ProxyRedirectionMechanism;
 }
 

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-01-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-01-01/managedClusters.json
@@ -5513,6 +5513,10 @@
             "$ref": "#/definitions/IstioEgressGateway"
           },
           "x-ms-identifiers": []
+        },
+        "proxyRedirectionMechanism": {
+          "$ref": "#/definitions/ProxyRedirectionMechanism",
+          "description": "Mode of traffic redirection."
         }
       }
     },
@@ -9362,6 +9366,30 @@
             "name": "UDP",
             "value": "UDP",
             "description": "UDP protocol."
+          }
+        ]
+      }
+    },
+    "ProxyRedirectionMechanism": {
+      "type": "string",
+      "description": "Mode of traffic redirection.",
+      "enum": [
+        "InitContainers",
+        "CNIChaining"
+      ],
+      "x-ms-enum": {
+        "name": "ProxyRedirectionMechanism",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "InitContainers",
+            "value": "InitContainers",
+            "description": "Istio will inject an init container into each pod to redirect traffic (requires NET_ADMIN and NET_RAW)."
+          },
+          {
+            "name": "CNIChaining",
+            "value": "CNIChaining",
+            "description": "Istio will install a chained CNI plugin to redirect traffic (recommended)."
           }
         ]
       }


### PR DESCRIPTION
Adds Istio CNI swagger changes to 2026-01-01 API

[API design doc](https://dev.azure.com/msazure/CloudNativeCompute/_wiki/wikis/CloudNativeCompute.wiki/924239/-GA-Istio-AddOn-CNI)