### PR TITLE
[Storage] Move to all `client.tsp` transforms post `v0.35` emitter TypeSpec Changes

### DIFF
--- a/specification/storage/Microsoft.BlobStorage/client.tsp
+++ b/specification/storage/Microsoft.BlobStorage/client.tsp
@@ -108,6 +108,9 @@ interface PageBlobClient extends Storage.Blob.PageBlob {}
   "rust"
 );
 
+@@alternateType(BlobItem.name, string, "rust");
+@@alternateType(BlobPrefix.name, string, "rust");
+
 @@clientNamespace(Storage.Blob, "Azure.Storage.Blobs");
 @@clientNamespace(Storage.Blob.Container, "Azure.Storage.Blobs");
 @@clientNamespace(Storage.Blob.Blob, "Azure.Storage.Blobs");

--- a/specification/storage/Microsoft.BlobStorage/client.tsp
+++ b/specification/storage/Microsoft.BlobStorage/client.tsp
@@ -108,9 +108,6 @@ interface PageBlobClient extends Storage.Blob.PageBlob {}
   "rust"
 );
 
-@@alternateType(BlobItem.name, string, "rust");
-@@alternateType(BlobPrefix.name, string, "rust");
-
 @@clientNamespace(Storage.Blob, "Azure.Storage.Blobs");
 @@clientNamespace(Storage.Blob.Container, "Azure.Storage.Blobs");
 @@clientNamespace(Storage.Blob.Blob, "Azure.Storage.Blobs");

--- a/specification/storage/Microsoft.BlobStorage/client.tsp
+++ b/specification/storage/Microsoft.BlobStorage/client.tsp
@@ -98,6 +98,10 @@ interface PageBlobClient extends Storage.Blob.PageBlob {}
 );
 
 @@usage(BlobName, Usage.output, "rust");
+
+@@alternateType(BlobItem.name, string, "rust");
+@@alternateType(BlobPrefix.name, string, "rust");
+
 @@clientOption(BlobItem.name,
   "deserialize_with",
   "crate::models::deserialize_blob_name",

--- a/specification/storage/Microsoft.BlobStorage/client.tsp
+++ b/specification/storage/Microsoft.BlobStorage/client.tsp
@@ -61,6 +61,53 @@ interface BlockBlobClient extends Storage.Blob.BlockBlob {}
 )
 interface PageBlobClient extends Storage.Blob.PageBlob {}
 
+@@clientInitialization(BlobServiceClient,
+  {
+    initializedBy: InitializedBy.customizeCode,
+  }
+);
+
+@@clientInitialization(BlobContainerClient,
+  {
+    initializedBy: InitializedBy.customizeCode,
+  }
+);
+
+@@clientInitialization(BlobClient,
+  {
+    initializedBy: InitializedBy.customizeCode,
+  }
+);
+
+@@clientInitialization(AppendBlobClient,
+  {
+    initializedBy: InitializedBy.customizeCode,
+  }
+);
+
+@@clientInitialization(BlockBlobClient,
+  {
+    initializedBy: InitializedBy.customizeCode,
+  }
+);
+
+@@clientInitialization(PageBlobClient,
+  {
+    initializedBy: InitializedBy.customizeCode,
+  }
+);
+
+@@clientOption(BlobItem.name,
+  "deserialize_with",
+  "crate::models::deserialize_blob_name",
+  "rust"
+);
+@@clientOption(BlobPrefix.name,
+  "deserialize_with",
+  "crate::models::deserialize_blob_name",
+  "rust"
+);
+
 @@clientNamespace(Storage.Blob, "Azure.Storage.Blobs");
 @@clientNamespace(Storage.Blob.Container, "Azure.Storage.Blobs");
 @@clientNamespace(Storage.Blob.Blob, "Azure.Storage.Blobs");

--- a/specification/storage/Microsoft.BlobStorage/client.tsp
+++ b/specification/storage/Microsoft.BlobStorage/client.tsp
@@ -97,7 +97,13 @@ interface PageBlobClient extends Storage.Blob.PageBlob {}
   }
 );
 
+@@usage(BlobName, Usage.output, "rust");
 @@clientOption(BlobItem.name,
+  "deserialize_with",
+  "crate::models::deserialize_blob_name",
+  "rust"
+);
+@@clientOption(BlobPrefix.name,
   "deserialize_with",
   "crate::models::deserialize_blob_name",
   "rust"

--- a/specification/storage/Microsoft.BlobStorage/client.tsp
+++ b/specification/storage/Microsoft.BlobStorage/client.tsp
@@ -102,11 +102,6 @@ interface PageBlobClient extends Storage.Blob.PageBlob {}
   "crate::models::deserialize_blob_name",
   "rust"
 );
-@@clientOption(BlobPrefix.name,
-  "deserialize_with",
-  "crate::models::deserialize_blob_name",
-  "rust"
-);
 
 @@clientNamespace(Storage.Blob, "Azure.Storage.Blobs");
 @@clientNamespace(Storage.Blob.Container, "Azure.Storage.Blobs");

--- a/specification/storage/Microsoft.BlobStorage/tspconfig.yaml
+++ b/specification/storage/Microsoft.BlobStorage/tspconfig.yaml
@@ -41,8 +41,6 @@ options:
     crate-version: "0.1.0"
     flavor: azure
     temp-omit-doc-links: true
-  # TODO: Replace this with client.tsp solution once it lands (issue: https://github.com/Azure/typespec-rust/issues/806)
-    omit-constructors: true
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/data-plane"


### PR DESCRIPTION
- Adds in required customizations to utilize custom deserializer
- Moves to control constructor emitting from emitter-level flag to `client.tsp`