### PR TITLE
Fix tags property

### DIFF
--- a/specification/storage/Microsoft.BlobStorage/models.tsp
+++ b/specification/storage/Microsoft.BlobStorage/models.tsp
@@ -467,7 +467,7 @@ model FilterBlobItem {
   @Xml.name("ContainerName") containerName: string;
 
   /** The metadata of the blob. */
-  @Xml.unwrapped tags?: BlobTags;
+  @Xml.name("Tags") tags?: BlobTags;
 
   /** The version ID of the blob. */
   @Xml.name("VersionId") versionId?: string;

--- a/specification/storage/data-plane/Microsoft.BlobStorage/stable/2025-11-05/generated_blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/stable/2025-11-05/generated_blob.json
@@ -15019,9 +15019,10 @@
           "description": "The properties of the blob.",
           "x-ms-client-name": "containerName"
         },
-        "tags": {
+        "Tags": {
           "$ref": "#/definitions/BlobTags",
-          "description": "The metadata of the blob."
+          "description": "The metadata of the blob.",
+          "x-ms-client-name": "tags"
         },
         "VersionId": {
           "type": "string",

--- a/specification/storage/data-plane/Microsoft.BlobStorage/stable/2026-02-06/generated_blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/stable/2026-02-06/generated_blob.json
@@ -15101,9 +15101,10 @@
           "description": "The properties of the blob.",
           "x-ms-client-name": "containerName"
         },
-        "tags": {
+        "Tags": {
           "$ref": "#/definitions/BlobTags",
-          "description": "The metadata of the blob."
+          "description": "The metadata of the blob.",
+          "x-ms-client-name": "tags"
         },
         "VersionId": {
           "type": "string",

--- a/specification/storage/data-plane/Microsoft.BlobStorage/stable/2026-04-06/generated_blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/stable/2026-04-06/generated_blob.json
@@ -15307,9 +15307,10 @@
           "description": "The properties of the blob.",
           "x-ms-client-name": "containerName"
         },
-        "tags": {
+        "Tags": {
           "$ref": "#/definitions/BlobTags",
-          "description": "The metadata of the blob."
+          "description": "The metadata of the blob.",
+          "x-ms-client-name": "tags"
         },
         "VersionId": {
           "type": "string",


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-rest-api-specs/issues/40456

The unwrapped decorator wasn't needed here and the xml.name for the actual property was missing. 