### PR TITLE
machine properties: add localDNSProfile

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/Machine.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/Machine.tsp
@@ -451,6 +451,13 @@ model MachineProperties {
   @added(Versions.v2026_01_02_preview)
   @visibility(Lifecycle.Read)
   status?: MachineStatus;
+
+  /**
+   * Configures the per-node local DNS, with VnetDNS and KubeDNS overrides. LocalDNS helps improve performance and reliability of DNS resolution in an AKS cluster. For more details see aka.ms/aks/localdns.
+   */
+  #suppress "@azure-tools/typespec-azure-core/casing-style" "Property name maintained for backward compatibility with existing API versions"
+  @added(Versions.v2026_01_02_preview)
+  localDNSProfile?: LocalDNSProfile;
 }
 
 /**

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-01-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-01-02-preview/managedClusters.json
@@ -9623,6 +9623,10 @@
           "$ref": "#/definitions/MachineStatus",
           "description": "Contains read-only information about the machine.",
           "readOnly": true
+        },
+        "localDNSProfile": {
+          "$ref": "#/definitions/LocalDNSProfile",
+          "description": "Configures the per-node local DNS, with VnetDNS and KubeDNS overrides. LocalDNS helps improve performance and reliability of DNS resolution in an AKS cluster. For more details see aka.ms/aks/localdns."
         }
       }
     },


### PR DESCRIPTION
Add localDNSProfile to MachineProperties to enable per-node local DNS configuration with VnetDNS and KubeDNS overrides. This aligns with the existing localDNSProfile support in AgentPoolProfileProperties.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
