### PR TITLE
Temporary local fix for "type" discriminator in OpenAI's WebSearchApproximateLocation

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -31761,16 +31761,10 @@
       },
       "OpenAI.WebSearchApproximateLocation": {
         "type": "object",
+        "required": [
+          "type"
+        ],
         "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "approximate"
-            ],
-            "description": "The type of location approximation. Always `approximate`.",
-            "x-stainless-const": true,
-            "default": "approximate"
-          },
           "country": {
             "type": "string",
             "nullable": true
@@ -31786,6 +31780,13 @@
           "timezone": {
             "type": "string",
             "nullable": true
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "approximate"
+            ],
+            "description": "The type of location approximation. Always `approximate`."
           }
         },
         "description": "The approximate location of the user.",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -32675,16 +32675,10 @@
       },
       "OpenAI.WebSearchApproximateLocation": {
         "type": "object",
+        "required": [
+          "type"
+        ],
         "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "approximate"
-            ],
-            "description": "The type of location approximation. Always `approximate`.",
-            "x-stainless-const": true,
-            "default": "approximate"
-          },
           "country": {
             "type": "string",
             "nullable": true
@@ -32700,6 +32694,13 @@
           "timezone": {
             "type": "string",
             "nullable": true
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "approximate"
+            ],
+            "description": "The type of location approximation. Always `approximate`."
           }
         },
         "description": "The approximate location of the user.",

--- a/specification/ai-foundry/data-plane/Foundry/src/openai-responses/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai-responses/models.tsp
@@ -61,6 +61,16 @@ namespace Azure.AI.Projects {
     }
   );
 
+  // TODO: Remove the below when importing latest verion of OpenAI TypeSpec package that already includes this fix.
+  @@withoutOmittedProperties(OpenAI.WebSearchApproximateLocation, "type");
+  @@copyProperties(OpenAI.WebSearchApproximateLocation,
+    {
+      /** The type of location approximation. Always `approximate`. */
+      #suppress "@azure-tools/typespec-azure-core/no-openapi" "Auto-suppressed warnings non-applicable rules during import."
+      type: "approximate";
+    }
+  );
+
   alias AgentNameQueryParam = {
     @query
     @doc("Filter by agent name. If provided, only items associated with the specified agent will be returned.")


### PR DESCRIPTION
Howie already committed a fix for this in the OpenAI TypeSpec repo. However, since the next Foundry SDK beta releases will still use version 1.8, we won't have this fix. Patch it locally in the Foundry TypeSpec, until we decide to pick a later version of OpenAI TypeSpec package which already has the fix.