### PR TITLE
Fix xml tag for BlobTags property on BlobItem

### DIFF
--- a/specification/storage/Microsoft.BlobStorage/models.tsp
+++ b/specification/storage/Microsoft.BlobStorage/models.tsp
@@ -906,7 +906,7 @@ model BlobItem {
   @Xml.name("Metadata") metadata?: BlobMetadata;
 
   /** The tags of the blob. */
-  @Xml.name("BlobTags") blobTags?: BlobTags;
+  @Xml.name("Tags") blobTags?: BlobTags;
 
   /** The object replication metadata of the blob. */
   #suppress "@azure-tools/typespec-autorest/unsupported-param-type" "Existing API"

--- a/specification/storage/data-plane/Microsoft.BlobStorage/stable/2025-11-05/generated_blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/stable/2025-11-05/generated_blob.json
@@ -14132,7 +14132,7 @@
           "description": "The metadata of the blob.",
           "x-ms-client-name": "metadata"
         },
-        "BlobTags": {
+        "Tags": {
           "$ref": "#/definitions/BlobTags",
           "description": "The tags of the blob.",
           "x-ms-client-name": "blobTags"

--- a/specification/storage/data-plane/Microsoft.BlobStorage/stable/2026-02-06/generated_blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/stable/2026-02-06/generated_blob.json
@@ -14214,7 +14214,7 @@
           "description": "The metadata of the blob.",
           "x-ms-client-name": "metadata"
         },
-        "BlobTags": {
+        "Tags": {
           "$ref": "#/definitions/BlobTags",
           "description": "The tags of the blob.",
           "x-ms-client-name": "blobTags"

--- a/specification/storage/data-plane/Microsoft.BlobStorage/stable/2026-04-06/generated_blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/stable/2026-04-06/generated_blob.json
@@ -14420,7 +14420,7 @@
           "description": "The metadata of the blob.",
           "x-ms-client-name": "metadata"
         },
-        "BlobTags": {
+        "Tags": {
           "$ref": "#/definitions/BlobTags",
           "description": "The tags of the blob.",
           "x-ms-client-name": "blobTags"


### PR DESCRIPTION
Got information from folks testing the typespec generated client libraries that the actual xml tag returned from the service for this property is "Tags" not "BlobTags". 

Fixes #40601