### PR TITLE
Fix null parameters crash in OpenApiFunctionDefinition deserialization

### DIFF
--- a/specification/ai/Foundry/tools/models.tsp
+++ b/specification/ai/Foundry/tools/models.tsp
@@ -405,7 +405,7 @@ model OpenApiFunctionDefinition {
      * The parameters the functions accepts, described as a JSON Schema object.
      */
     #suppress "@azure-tools/typespec-azure-core/no-unknown" "External API shape takes an arbitrary json"
-    parameters: unknown;
+    parameters?: unknown;
   }[];
 }
 


### PR DESCRIPTION
## Problem
The `parameters` field in `OpenApiFunctionDefinition.functions[]` is typed as `unknown` (required, non-nullable). When agents stored in Cosmos DB have `"parameters": null`, the generated C# deserialization code calls `EnumerateObject()` without a null guard, causing:

```
InvalidOperationException: The requested operation requires an element of type 'Object', but the target element has type 'Null'.
```

**Impact**: ~100+ errors/day affecting GET /agents (ListAgents) across all 6 production regions.

## Root Cause
- TypeSpec: `parameters: unknown` (required, non-nullable)
- JSON Schema: `parameters` has no type constraint (because `unknown` = any type), so `null` passes schema validation
- C# codegen: `EnumerateObject()` is called directly without checking for `JsonValueKind.Null`

## Fix
Change `parameters: unknown` → `parameters?: unknown` (make optional).

This causes the C# emitter to generate a null guard before calling `EnumerateObject()`, matching the pattern already used for other optional `unknown` fields (e.g., `schema?: unknown` in `StructuredInputDefinition`).

## Verification
- TypeSpec compiles cleanly (warnings only, no errors)
- C# regeneration needed in the vienna agents repo after merge