### PR TITLE
Add enableOSDiskFullCaching field to 2026-01-02-preview

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
@@ -181,6 +181,13 @@ model ManagedClusterAgentPoolProfileProperties {
   upgradeStrategy?: UpgradeStrategy;
 
   /**
+   * Whether to enable the full-cache ephemeral OS disk feature. When this feature is enabled, the entire operating system will be locally cached on the ephemeral OS disk, preventing E17 events caused by network failures.
+   */
+  #suppress "@azure-tools/typespec-azure-core/casing-style" "Property name maintained for backward compatibility with existing API versions"
+  @added(Versions.v2026_01_02_preview)
+  enableOSDiskFullCaching?: boolean;
+
+  /**
    * Settings for upgrading the agentpool
    */
   upgradeSettings?: AgentPoolUpgradeSettings;

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-01-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-01-02-preview/managedClusters.json
@@ -10164,6 +10164,10 @@
           "$ref": "#/definitions/UpgradeStrategy",
           "description": "Defines the upgrade strategy for the agent pool. The default is Rolling."
         },
+        "enableOSDiskFullCaching": {
+          "type": "boolean",
+          "description": "Whether to enable the full-cache ephemeral OS disk feature. When this feature is enabled, the entire operating system will be locally cached on the ephemeral OS disk, preventing E17 events caused by network failures."
+        },
         "upgradeSettings": {
           "$ref": "#/definitions/AgentPoolUpgradeSettings",
           "description": "Settings for upgrading the agentpool"


### PR DESCRIPTION
# ARM (Control Plane) API Specification Update Pull Request 

> [!TIP]
> Overwhelmed by all this guidance? See the `Getting help` section at the bottom of this PR description.

## PR review workflow diagram

Please understand this diagram before proceeding. It explains how to get your PR approved & merged.

![spec_pr_review_workflow_diagram](https://github.com/Azure/azure-rest-api-specs/assets/4429827/5bb5e7ce-8aff-4dbb-a3f8-0d9b68fef5b1)

## Purpose of this PR

What's the purpose of this PR? Check the specific option that applies. This is **mandatory**!

  - [ ] New resource provider.
  - [ ] New API version for an existing resource provider. (If API spec is not defined in TypeSpec, the PR should have been created in adherence to [OpenAPI specs PR creation guidance](https://aka.ms/azsdkdocs/createopenapispec)).
  - [X] Update existing version for a new feature. (This is applicable only when you are revising a private preview API version.)
  - [ ] Update existing version to fix OpenAPI spec quality issues in S360.
  - [ ] Convert existing [OpenAPI spec to TypeSpec spec](https://aka.ms/typespec/conversion) (do not combine this with implementing changes for a new API version).
  - [ ] Other, please clarify:
    - _edit this with your clarification_

## Due diligence checklist

To merge this PR, you **must** go through the following checklist and confirm you understood 
and followed the instructions by checking all the boxes:

- [X] I confirm this PR is modifying Azure Resource Manager (ARM) related specifications, and not data plane related specifications.
- [X] I have reviewed following [Resource Provider guidelines](https://aka.ms/rpguidelines), including
  [ARM resource provider contract](https://aka.ms/azurerpc) and
  [REST guidelines](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md) (estimated time: 4 hours).  
  I understand this is required before I can proceed to the diagram Step 2, "ARM API changes review", for this PR.
- [X] A [release plan](https://aka.ms/azsdkdocs/release-plans) has been created. If not, please create one as it will help guide you through the REST API and SDK creation process. 

## Additional information

## Change Description
  Add `enableOSDiskFullCaching` boolean field to `ManagedClusterAgentPoolProfileProperties`
  in API version `2026-01-02-preview`.

  When this feature is enabled, the entire operating system will be locally cached on
  the ephemeral OS disk, preventing E17 events caused by network failures.

  ### Files changed
  - `AgentPoolModels.tsp` — Added new field definition
  - `preview/2026-01-02-preview/managedClusters.json` — Generated Swagger output

</details>

## Getting help

- First, please carefully read through this PR description, from top to bottom. Please fill out the `Purpose of this PR` and `Due diligence checklist`.
- If you don't have permissions to remove or add labels to the PR, request `write access` per [aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories](https://aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories)
- To understand what you must do next to merge this PR, see the `Next Steps to Merge` comment. It will appear within few minutes of submitting this PR and will continue to be up-to-date with current PR state.
- For guidance on fixing this PR CI check failures, see the hyperlinks provided in given failure 
  and https://aka.ms/ci-fix.
- For help with ARM review (PR workflow diagram Step 2), see https://aka.ms/azsdk/pr-arm-review.
- If the PR CI checks appear to be stuck in `queued` state, please add a comment with contents `/azp run`.
  This should result in a new comment denoting a `PR validation pipeline` has started and the checks should be updated after few minutes.
- If the help provided by the previous points is not enough, post to https://aka.ms/azsdk/support/specreview-channel and link to this PR.
- For guidance on SDK breaking change review, refer to https://aka.ms/ci-fix.
