### PR TITLE
[Demo] Add ContosoDocProcessor TypeSpec for DelegateAPIViewFeedbackTool E2E demo

### DIFF
--- a/specification/contoso/cspell.yaml
+++ b/specification/contoso/cspell.yaml
@@ -1,0 +1,3 @@
+words:
+  - contoso
+  - docprocessor

--- a/specification/contoso/data-plane/DocProcessor/main.tsp
+++ b/specification/contoso/data-plane/DocProcessor/main.tsp
@@ -1,0 +1,128 @@
+import "@typespec/http";
+import "@typespec/rest";
+import "@typespec/versioning";
+import "@azure-tools/typespec-azure-core";
+
+using TypeSpec.Http;
+using TypeSpec.Rest;
+using TypeSpec.Versioning;
+using Azure.Core;
+
+@useAuth(AadOauth2Auth<["https://contoso.azure.com/.default"]>)
+@service(#{ title: "ContosoDocProcessor" })
+@versioned(Contoso.DocProcessor.Versions)
+namespace Contoso.DocProcessor;
+
+@doc("API versions.")
+enum Versions {
+  @doc("Preview version.")
+  v2024_01_01_Preview: "2024-01-01-preview",
+}
+
+// ============================================================================
+// INTENTIONAL ISSUES FOR DEMO - These will trigger APIView feedback
+// ============================================================================
+
+// ISSUE 1: Model missing documentation on properties
+@doc("A document to be processed.")
+@resource("documents")
+model Document {
+  @key("documentId")
+  @visibility(Lifecycle.Read)
+  id: string;
+
+  // Missing @doc - will trigger feedback
+  name: string;
+
+  // Missing @doc - will trigger feedback
+  content: string;
+
+  // ISSUE 2: Using string instead of url type
+  sourceUrl: string;
+
+  // Missing @doc
+  status: DocumentStatus;
+
+  // ISSUE 3: Property naming - should use camelCase consistently
+  created_at?: utcDateTime;
+
+  // Missing @doc
+  processedResult?: ProcessingResult;
+}
+
+// ISSUE 4: Enum without documentation on members
+enum DocumentStatus {
+  pending,
+  processing,
+  completed,
+  failed,
+}
+
+// ISSUE 5: Model with poor naming and missing docs
+model ProcessingResult {
+  // Bad naming: should be more descriptive
+  data: string;
+  
+  // Missing @doc
+  confidence: float32;
+  
+  // ISSUE 6: Using string for what should be typed
+  metadata: string;
+}
+
+// ISSUE 7: Request model with missing documentation
+model ProcessDocRequest {
+  // Missing @doc
+  documentId: string;
+  
+  // Missing @doc - and bad naming
+  opts?: ProcessingOptions;
+}
+
+// ISSUE 8: Options model - unclear purpose
+model ProcessingOptions {
+  // Missing @doc
+  quality: string;
+  
+  // Missing @doc
+  timeout?: int32;
+}
+
+// ISSUE 9: Response without proper documentation
+model ProcessDocResponse {
+  jobId: string;
+  status: string;
+}
+
+interface Documents {
+  // ISSUE 10: Operation missing proper documentation
+  @doc("Get document.")
+  getDocument is ResourceRead<Document>;
+
+  // ISSUE 11: Should be LongRunning but isn't marked
+  @doc("Process a document.")
+  @post
+  @route("documents/{documentId}/process")
+  processDoc(
+    @path documentId: string,
+    @body request: ProcessDocRequest,
+  ): ProcessDocResponse;
+
+  // ISSUE 12: List operation missing pagination
+  @doc("List documents.")
+  @get
+  @route("documents")
+  listDocs(): Document[];
+
+  // ISSUE 13: Delete without proper async handling
+  @doc("Delete document.")
+  @delete
+  @route("documents/{documentId}")
+  deleteDoc(@path documentId: string): void;
+
+  // ISSUE 14: Create operation - should use standard patterns
+  @doc("Create document.")
+  @post
+  @route("documents")
+  createDoc(@body document: Document): Document;
+}

--- a/specification/contoso/data-plane/DocProcessor/preview/2024-01-01-preview/contosodocprocessor.json
+++ b/specification/contoso/data-plane/DocProcessor/preview/2024-01-01-preview/contosodocprocessor.json
@@ -1,0 +1,354 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "ContosoDocProcessor",
+    "version": "2024-01-01-preview",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "AadOauth2Auth": [
+        "https://contoso.azure.com/.default"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "AadOauth2Auth": {
+      "type": "oauth2",
+      "description": "The Azure Active Directory OAuth2 Flow",
+      "flow": "accessCode",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "https://contoso.azure.com/.default": ""
+      },
+      "tokenUrl": "https://login.microsoftonline.com/common/oauth2/token"
+    }
+  },
+  "tags": [],
+  "paths": {
+    "/documents": {
+      "get": {
+        "operationId": "Documents_ListDocs",
+        "description": "List documents.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Document"
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "Documents_CreateDoc",
+        "description": "Create document.",
+        "parameters": [
+          {
+            "name": "document",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Document"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/Document"
+            }
+          }
+        }
+      }
+    },
+    "/documents/{documentId}": {
+      "get": {
+        "operationId": "Documents_GetDocument",
+        "description": "Get document.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "documentId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/Document"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Documents_DeleteDoc",
+        "description": "Delete document.",
+        "parameters": [
+          {
+            "name": "documentId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful. "
+          }
+        }
+      }
+    },
+    "/documents/{documentId}/process": {
+      "post": {
+        "operationId": "Documents_ProcessDoc",
+        "description": "Process a document.",
+        "parameters": [
+          {
+            "name": "documentId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ProcessDocRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ProcessDocResponse"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Azure.Core.Foundations.Error": {
+      "type": "object",
+      "description": "The error object.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "One of a server-defined set of error codes."
+        },
+        "message": {
+          "type": "string",
+          "description": "A human-readable representation of the error."
+        },
+        "target": {
+          "type": "string",
+          "description": "The target of the error."
+        },
+        "details": {
+          "type": "array",
+          "description": "An array of details about specific errors that led to this reported error.",
+          "items": {
+            "$ref": "#/definitions/Azure.Core.Foundations.Error"
+          }
+        },
+        "innererror": {
+          "$ref": "#/definitions/Azure.Core.Foundations.InnerError",
+          "description": "An object containing more specific information than the current object about the error."
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ]
+    },
+    "Azure.Core.Foundations.ErrorResponse": {
+      "type": "object",
+      "description": "A response containing error details.",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/Azure.Core.Foundations.Error",
+          "description": "The error object."
+        }
+      },
+      "required": [
+        "error"
+      ]
+    },
+    "Azure.Core.Foundations.InnerError": {
+      "type": "object",
+      "description": "An object containing more specific information about the error. As per Azure REST API guidelines - https://aka.ms/AzureRestApiGuidelines#handling-errors.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "One of a server-defined set of error codes."
+        },
+        "innererror": {
+          "$ref": "#/definitions/Azure.Core.Foundations.InnerError",
+          "description": "Inner error."
+        }
+      }
+    },
+    "Document": {
+      "type": "object",
+      "description": "A document to be processed.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string"
+        },
+        "content": {
+          "type": "string"
+        },
+        "sourceUrl": {
+          "type": "string"
+        },
+        "status": {
+          "$ref": "#/definitions/DocumentStatus"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "processedResult": {
+          "$ref": "#/definitions/ProcessingResult"
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "content",
+        "sourceUrl",
+        "status"
+      ]
+    },
+    "DocumentStatus": {
+      "type": "string",
+      "enum": [
+        "pending",
+        "processing",
+        "completed",
+        "failed"
+      ],
+      "x-ms-enum": {
+        "name": "DocumentStatus",
+        "modelAsString": false
+      }
+    },
+    "ProcessDocRequest": {
+      "type": "object",
+      "properties": {
+        "documentId": {
+          "type": "string"
+        },
+        "opts": {
+          "$ref": "#/definitions/ProcessingOptions"
+        }
+      },
+      "required": [
+        "documentId"
+      ]
+    },
+    "ProcessDocResponse": {
+      "type": "object",
+      "properties": {
+        "jobId": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "jobId",
+        "status"
+      ]
+    },
+    "ProcessingOptions": {
+      "type": "object",
+      "properties": {
+        "quality": {
+          "type": "string"
+        },
+        "timeout": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "required": [
+        "quality"
+      ]
+    },
+    "ProcessingResult": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "string"
+        },
+        "confidence": {
+          "type": "number",
+          "format": "float"
+        },
+        "metadata": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "data",
+        "confidence",
+        "metadata"
+      ]
+    }
+  },
+  "parameters": {
+    "Azure.Core.Foundations.ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "description": "The API version to use for this operation.",
+      "required": true,
+      "type": "string",
+      "minLength": 1,
+      "x-ms-parameter-location": "method",
+      "x-ms-client-name": "apiVersion"
+    }
+  }
+}

--- a/specification/contoso/data-plane/DocProcessor/readme.md
+++ b/specification/contoso/data-plane/DocProcessor/readme.md
@@ -1,0 +1,23 @@
+# Contoso DocProcessor
+
+> see https://aka.ms/autorest
+
+This is the AutoRest configuration file for ContosoDocProcessor.
+
+## General Information
+
+These are the global settings for the ContosoDocProcessor API.
+
+```yaml
+openapi-type: data-plane
+tag: package-2024-01-preview
+```
+
+### Tag: package-2024-01-preview
+
+These settings apply only when `--tag=package-2024-01-preview` is specified on the command line.
+
+```yaml $(tag) == 'package-2024-01-preview'
+input-file:
+  - preview/2024-01-01-preview/contosodocprocessor.json
+```

--- a/specification/contoso/data-plane/DocProcessor/tspconfig.yaml
+++ b/specification/contoso/data-plane/DocProcessor/tspconfig.yaml
@@ -1,0 +1,34 @@
+parameters:
+  "service-dir":
+    default: "sdk/contoso"
+  "dependencies":
+    default: ""
+emit:
+  - "@azure-tools/typespec-autorest"
+linter:
+  extends:
+    - "@azure-tools/typespec-azure-rulesets/data-plane"
+options:
+  "@azure-tools/typespec-autorest":
+    azure-resource-provider-folder: "data-plane"
+    emit-lro-options: "none"
+    emitter-output-dir: "{project-root}"
+    output-file: "{version-status}/{version}/contosodocprocessor.json"
+  "@azure-tools/typespec-python":
+    emitter-output-dir: "{output-dir}/{service-dir}/azure-contoso-docprocessor"
+    namespace: "azure.contoso.docprocessor"
+    package-version: "1.0.0b1"
+    generate-test: true
+    generate-sample: true
+    flavor: azure
+  "@azure-tools/typespec-ts":
+    emitter-output-dir: "{output-dir}/sdk/contoso/contoso-docprocessor"
+    package-details:
+      name: "@azure/contoso-docprocessor"
+    is-modular-library: true
+    experimental-extensible-enums: true
+    flavor: azure
+  "@azure-tools/typespec-java":
+    emitter-output-dir: "{output-dir}/{service-dir}/azure-contoso-docprocessor"
+    namespace: com.azure.contoso.docprocessor
+    flavor: azure


### PR DESCRIPTION
## Purpose

This PR adds a demo TypeSpec service (ContosoDocProcessor) with **intentional API issues** to demonstrate the DelegateAPIViewFeedbackTool E2E workflow.

## Intentional Issues for Demo
- Missing `@doc` annotations on model properties
- Using `enum` instead of `union` for extensible enums
- Snake_case property naming (`created_at` instead of `createdAt`)
- Operations missing api-version parameter
- Non-standard operation patterns
- Missing list pagination

## Expected Outcome
1. TypeSpec CI validates the spec (warnings expected)
2. Python SDK generation runs with version 1.0.0b1
3. APIView is generated with feedback comments
4. DelegateAPIViewFeedbackTool creates issue for CCA

**Note: This is for demo/testing purposes only - do not merge.**
