### PR TITLE
Include addOnPackages to MSDeploy definition

### DIFF
--- a/specification/web/resource-manager/Microsoft.Web/AppService/models.tsp
+++ b/specification/web/resource-manager/Microsoft.Web/AppService/models.tsp
@@ -11669,11 +11669,19 @@ model MSDeployStatusProperties {
 /**
  * MSDeploy ARM PUT information
  */
-#suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-#suppress "@azure-tools/typespec-azure-core/casing-style" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "MSDeploy is a type that inherits ProxyOnlyResource by design, not for code reuse"
+#suppress "@azure-tools/typespec-azure-core/casing-style" "MSDeploy is the intentional name matching the existing parameter name in the API"
 model MSDeploy extends ProxyOnlyResource {
   /** Core resource properties */
-  properties?: MSDeployCore;
+  properties?: {
+    ...MSDeployCore;
+
+    /**
+     * List of Add-On packages. Add-On packages implicitly enable the Do Not Delete MSDeploy rule.
+     */
+    @identifiers(#["packageUri"])
+    addOnPackages?: MSDeployCore[];
+  };
 }
 
 /**

--- a/specification/web/resource-manager/Microsoft.Web/AppService/stable/2025-03-01/openapi.json
+++ b/specification/web/resource-manager/Microsoft.Web/AppService/stable/2025-03-01/openapi.json
@@ -47400,8 +47400,51 @@
       "description": "MSDeploy ARM PUT information",
       "properties": {
         "properties": {
-          "$ref": "#/definitions/MSDeployCore",
+          "type": "object",
           "description": "Core resource properties",
+          "properties": {
+            "packageUri": {
+              "type": "string",
+              "description": "Package URI"
+            },
+            "connectionString": {
+              "type": "string",
+              "description": "SQL Connection String"
+            },
+            "dbType": {
+              "type": "string",
+              "description": "Database Type"
+            },
+            "setParametersXmlFileUri": {
+              "type": "string",
+              "description": "URI of MSDeploy Parameters file. Must not be set if SetParameters is used."
+            },
+            "setParameters": {
+              "type": "object",
+              "description": "MSDeploy Parameters. Must not be set if SetParametersXmlFileUri is used.",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "skipAppData": {
+              "type": "boolean",
+              "description": "Controls whether the MSDeploy operation skips the App_Data directory.\nIf set to <code>true</code>, the existing App_Data directory on the destination\nwill not be deleted, and any App_Data directory in the source will be ignored.\nSetting is <code>false</code> by default."
+            },
+            "appOffline": {
+              "type": "boolean",
+              "description": "Sets the AppOffline rule while the MSDeploy operation executes.\nSetting is <code>false</code> by default."
+            },
+            "addOnPackages": {
+              "type": "array",
+              "description": "List of Add-On packages. Add-On packages implicitly enable the Do Not Delete MSDeploy rule.",
+              "items": {
+                "$ref": "#/definitions/MSDeployCore"
+              },
+              "x-ms-identifiers": [
+                "packageUri"
+              ]
+            }
+          },
           "x-ms-client-flatten": true
         }
       },

--- a/specification/web/resource-manager/Microsoft.Web/AppService/stable/2025-05-01/openapi.json
+++ b/specification/web/resource-manager/Microsoft.Web/AppService/stable/2025-05-01/openapi.json
@@ -47414,8 +47414,51 @@
       "description": "MSDeploy ARM PUT information",
       "properties": {
         "properties": {
-          "$ref": "#/definitions/MSDeployCore",
+          "type": "object",
           "description": "Core resource properties",
+          "properties": {
+            "packageUri": {
+              "type": "string",
+              "description": "Package URI"
+            },
+            "connectionString": {
+              "type": "string",
+              "description": "SQL Connection String"
+            },
+            "dbType": {
+              "type": "string",
+              "description": "Database Type"
+            },
+            "setParametersXmlFileUri": {
+              "type": "string",
+              "description": "URI of MSDeploy Parameters file. Must not be set if SetParameters is used."
+            },
+            "setParameters": {
+              "type": "object",
+              "description": "MSDeploy Parameters. Must not be set if SetParametersXmlFileUri is used.",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "skipAppData": {
+              "type": "boolean",
+              "description": "Controls whether the MSDeploy operation skips the App_Data directory.\nIf set to <code>true</code>, the existing App_Data directory on the destination\nwill not be deleted, and any App_Data directory in the source will be ignored.\nSetting is <code>false</code> by default."
+            },
+            "appOffline": {
+              "type": "boolean",
+              "description": "Sets the AppOffline rule while the MSDeploy operation executes.\nSetting is <code>false</code> by default."
+            },
+            "addOnPackages": {
+              "type": "array",
+              "description": "List of Add-On packages. Add-On packages implicitly enable the Do Not Delete MSDeploy rule.",
+              "items": {
+                "$ref": "#/definitions/MSDeployCore"
+              },
+              "x-ms-identifiers": [
+                "packageUri"
+              ]
+            }
+          },
           "x-ms-client-flatten": true
         }
       },

--- a/specification/web/resource-manager/Microsoft.Web/AppService/suppressions.yaml
+++ b/specification/web/resource-manager/Microsoft.Web/AppService/suppressions.yaml
@@ -67,3 +67,9 @@
 - tool: TypeSpecRequirement
   path: ./stable/2024-11-01/*.json
   reason: "Suppressing TypeSpec requirement"
+
+- tool: AvoidAdditionalProperties
+  paths:
+    - stable/2025-03-01/openapi.json
+    - stable/2025-05-01/openapi.json
+  reason: "MSDeploy.setParameters is a legitimate string dictionary (Record<string>) that has been part of the MSDeploy API since its initial version. This pattern is preserved from the 2024-11-01 MSDeployCore definition."


### PR DESCRIPTION
This PR is to address the third bug described here: 
https://github.com/Azure/azure-rest-api-specs/issues/40347

There is no addOnPackages attribute in the MSDeploy definition