### PR TITLE
Add SKU support to HealthDataAIServices DeidService

### DIFF
--- a/specification/contosowidgetmanager/Contoso.WidgetManager/main.tsp
+++ b/specification/contosowidgetmanager/Contoso.WidgetManager/main.tsp
@@ -34,6 +34,9 @@ model WidgetSuite {
   @doc("The ID of the widget's manufacturer.")
   manufacturerId: string;
 
+  @doc("The service name.")
+  serviceName?: string;
+
   @doc("The faked shared model.")
   sharedModel?: FakedSharedModel;
 }

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/main.tsp
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/main.tsp
@@ -40,10 +40,6 @@ model DeidService is TrackedResource<DeidServiceProperties> {
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "Adding property for versioning"
   @doc("The managed service identities assigned to this resource.")
   identity?: Azure.ResourceManager.Foundations.ManagedIdentityProperties;
-
-  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "Adding SKU support using ARM common-types"
-  @doc("The SKU (Stock Keeping Unit) assigned to this resource.")
-  sku?: Azure.ResourceManager.CommonTypes.Sku;
 }
 
 /** Patch request body for DeidService */

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/main.tsp
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/main.tsp
@@ -51,9 +51,6 @@ model DeidUpdate {
 
   /** RP-specific properties */
   properties?: DeidPropertiesUpdate;
-
-  /** The SKU (Stock Keeping Unit) assigned to this resource. */
-  sku?: Azure.ResourceManager.CommonTypes.Sku;
 }
 
 model DeidPropertiesUpdate

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/main.tsp
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/main.tsp
@@ -40,6 +40,10 @@ model DeidService is TrackedResource<DeidServiceProperties> {
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "Adding property for versioning"
   @doc("The managed service identities assigned to this resource.")
   identity?: Azure.ResourceManager.Foundations.ManagedIdentityProperties;
+
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "Adding SKU support using ARM common-types"
+  @doc("The SKU (Stock Keeping Unit) assigned to this resource.")
+  sku?: Azure.ResourceManager.CommonTypes.Sku;
 }
 
 /** Patch request body for DeidService */
@@ -51,6 +55,9 @@ model DeidUpdate {
 
   /** RP-specific properties */
   properties?: DeidPropertiesUpdate;
+
+  /** The SKU (Stock Keeping Unit) assigned to this resource. */
+  sku?: Azure.ResourceManager.CommonTypes.Sku;
 }
 
 model DeidPropertiesUpdate


### PR DESCRIPTION
## Summary

Add optional SKU support to the HealthDataAIServices DeidService resource using ARM common-types `Sku` type.

### Changes
- Added `sku?: Sku` property to `DeidService` TrackedResource model
- Added `sku?: Sku` property to `DeidUpdate` patch model
- Uses standard ARM common-types SKU definition (no custom SKU models)

### Validation
- TypeSpec validation passed successfully