### PR TITLE
[Storage] `set_metadata` @override attempt TypeSpec Changes

### DIFF
--- a/specification/storage/Microsoft.BlobStorage/client.tsp
+++ b/specification/storage/Microsoft.BlobStorage/client.tsp
@@ -172,12 +172,11 @@ interface PageBlobClient extends Storage.Blob.PageBlob {}
 
 // Override setMetadata operations to make metadata required for Rust
 op containerSetMetadataOverride(
-  ...ApiVersionHeader,
-  ...ClientRequestIdHeader,
   ...TimeoutParameter,
   ...LeaseIdOptionalParameter,
 
   /** The metadata headers. */
+  @alternateType(Record<string>, "rust")
   @header("x-ms-meta")
   metadata: string,
 
@@ -190,11 +189,10 @@ op containerSetMetadataOverride(
 );
 
 op blobSetMetadataOverride(
-  ...ApiVersionHeader,
-  ...ClientRequestIdHeader,
   ...TimeoutParameter,
 
   /** The metadata headers. */
+  @alternateType(Record<string>, "rust")
   @header("x-ms-meta")
   metadata: string,
 

--- a/specification/storage/Microsoft.BlobStorage/client.tsp
+++ b/specification/storage/Microsoft.BlobStorage/client.tsp
@@ -172,10 +172,16 @@ interface PageBlobClient extends Storage.Blob.PageBlob {}
 
 // Override setMetadata operations to make metadata required for Rust
 op containerSetMetadataOverride(
+  ...ApiVersionHeader,
+  ...ClientRequestIdHeader,
+  ...TimeoutParameter,
+  ...LeaseIdOptionalParameter,
+
   /** The metadata headers. */
-  @alternateType(Record<string>, "rust")
   @header("x-ms-meta")
   metadata: string,
+
+  ...IfModifiedSinceParameter,
 ): void;
 
 @@override(Storage.Blob.Container.setMetadata,
@@ -184,10 +190,24 @@ op containerSetMetadataOverride(
 );
 
 op blobSetMetadataOverride(
+  ...ApiVersionHeader,
+  ...ClientRequestIdHeader,
+  ...TimeoutParameter,
+
   /** The metadata headers. */
-  @alternateType(Record<string>, "rust")
   @header("x-ms-meta")
   metadata: string,
+
+  ...LeaseIdOptionalParameter,
+  ...EncryptionKeyParameter,
+  ...EncryptionKeySha256Parameter,
+  ...EncryptionAlgorithmParameter,
+  ...EncryptionScopeParameter,
+  ...IfModifiedSinceParameter,
+  ...IfUnmodifiedSinceParameter,
+  ...IfNoneMatchParameter,
+  ...IfMatchParameter,
+  ...IfTagsParameter,
 ): void;
 
 @@override(Storage.Blob.Blob.setMetadata, blobSetMetadataOverride, "rust");

--- a/specification/storage/Microsoft.BlobStorage/client.tsp
+++ b/specification/storage/Microsoft.BlobStorage/client.tsp
@@ -169,3 +169,25 @@ interface PageBlobClient extends Storage.Blob.PageBlob {}
 @@scope(Storage.Blob.BlockBlob.query, "!rust");
 @@scope(Storage.Blob.PageBlob.copyIncremental, "!rust");
 @@scope(Storage.Blob.PageBlob.getPageRangesDiff, "!rust");
+
+// Override setMetadata operations to make metadata required for Rust
+op containerSetMetadataOverride(
+  /** The metadata headers. */
+  @alternateType(Record<string>, "rust")
+  @header("x-ms-meta")
+  metadata: string,
+): void;
+
+@@override(Storage.Blob.Container.setMetadata,
+  containerSetMetadataOverride,
+  "rust"
+);
+
+op blobSetMetadataOverride(
+  /** The metadata headers. */
+  @alternateType(Record<string>, "rust")
+  @header("x-ms-meta")
+  metadata: string,
+): void;
+
+@@override(Storage.Blob.Blob.setMetadata, blobSetMetadataOverride, "rust");

--- a/specification/storage/Microsoft.BlobStorage/client.tsp
+++ b/specification/storage/Microsoft.BlobStorage/client.tsp
@@ -172,6 +172,8 @@ interface PageBlobClient extends Storage.Blob.PageBlob {}
 
 // Override setMetadata operations to make metadata required for Rust
 op containerSetMetadataOverride(
+  ...ApiVersionHeader,
+  ...ClientRequestIdHeader,
   ...TimeoutParameter,
   ...LeaseIdOptionalParameter,
 
@@ -189,6 +191,8 @@ op containerSetMetadataOverride(
 );
 
 op blobSetMetadataOverride(
+  ...ApiVersionHeader,
+  ...ClientRequestIdHeader,
   ...TimeoutParameter,
 
   /** The metadata headers. */

--- a/specification/storage/Microsoft.BlobStorage/models.tsp
+++ b/specification/storage/Microsoft.BlobStorage/models.tsp
@@ -2552,14 +2552,6 @@ alias LeaseDurationHeaderParameter = {
 };
 
 // NOTE: This does not explicitly let emitters know that this is a collection header for metadata. Logic should be handwritten to handle this.
-alias MetadataHeadersParameter = {
-  /** The metadata headers. */
-  @alternateType(Record<string>, "rust")
-  @header("x-ms-meta")
-  metadata: string;
-};
-
-// NOTE: This does not explicitly let emitters know that this is a collection header for metadata. Logic should be handwritten to handle this.
 alias MetadataHeaders = {
   /** The metadata headers. */
   @alternateType(Record<string>, "rust")

--- a/specification/storage/Microsoft.BlobStorage/routes.tsp
+++ b/specification/storage/Microsoft.BlobStorage/routes.tsp
@@ -331,7 +331,7 @@ interface Container {
     {
       ...TimeoutParameter;
       ...LeaseIdOptionalParameter;
-      ...MetadataHeadersParameter;
+      ...MetadataHeaders;
       ...IfModifiedSinceParameter;
     },
     {
@@ -1044,7 +1044,7 @@ interface Blob {
   setMetadata is StorageOperationNoBody<
     {
       ...TimeoutParameter;
-      ...MetadataHeadersParameter;
+      ...MetadataHeaders;
       ...LeaseIdOptionalParameter;
       ...EncryptionKeyParameter;
       ...EncryptionKeySha256Parameter;


### PR DESCRIPTION
First attempt was just a sparse override, ie. without re-defining all the parameters we wanted to carry over:

```typespec
// Override setMetadata operations to make metadata required for Rust
op containerSetMetadataOverride(
  /** The metadata headers. */
  @alternateType(Record<string>, "rust")
  @header("x-ms-meta")
  metadata: string,
): void;

@@override(Storage.Blob.Container.setMetadata,
  containerSetMetadataOverride,
  "rust"
);

op blobSetMetadataOverride(
  /** The metadata headers. */
  @alternateType(Record<string>, "rust")
  @header("x-ms-meta")
  metadata: string,
): void;

@@override(Storage.Blob.Blob.setMetadata, blobSetMetadataOverride, "rust");
```

But the compiler complained and code-gen exploded. So I went with the full definition, but even then, here you can see we explicitly define metadata as required:
```typespec
/** The metadata headers. */
  @header("x-ms-meta")
  metadata: string,
```

but still no dice.