### PR TITLE
[blobs] Fix parameter optionality on SignedIdentifier and AccessPolicy

### DIFF
--- a/specification/storage/Microsoft.BlobStorage/models.tsp
+++ b/specification/storage/Microsoft.BlobStorage/models.tsp
@@ -435,7 +435,7 @@ model SignedIdentifier {
   @Xml.name("Id") id: string;
 
   /** The access policy for the signed identifier. */
-  @Xml.name("AccessPolicy") accessPolicy: AccessPolicy;
+  @Xml.name("AccessPolicy") accessPolicy?: AccessPolicy;
 }
 
 /** The result of a Filter Blobs API call */
@@ -801,15 +801,15 @@ model AccessPolicy {
   /** The date-time the policy is active. */
   @Xml.name("Start")
   @encode("rfc3339-fixed-width")
-  start: utcDateTime;
+  start?: utcDateTime;
 
   /** The date-time the policy expires. */
   @Xml.name("Expiry")
   @encode("rfc3339-fixed-width")
-  expiry: utcDateTime;
+  expiry?: utcDateTime;
 
   /** The permissions for acl the policy. */
-  @Xml.name("Permission") permission: string;
+  @Xml.name("Permission") permission?: string;
 }
 
 /** The access tiers. */

--- a/specification/storage/data-plane/Microsoft.BlobStorage/stable/2025-11-05/generated_blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/stable/2025-11-05/generated_blob.json
@@ -13715,12 +13715,7 @@
           "description": "The permissions for acl the policy.",
           "x-ms-client-name": "permission"
         }
-      },
-      "required": [
-        "Start",
-        "Expiry",
-        "Permission"
-      ]
+      }
     },
     "AccessTier": {
       "type": "string",
@@ -14756,7 +14751,7 @@
           "description": "The date-time the container was last modified in RFC1123 format.",
           "x-ms-client-name": "lastModified"
         },
-        "ETag": {
+        "Etag": {
           "type": "string",
           "description": "The ETag of the container.",
           "x-ms-client-name": "eTag"
@@ -14821,7 +14816,7 @@
       },
       "required": [
         "Last-Modified",
-        "ETag"
+        "Etag"
       ]
     },
     "CopyStatus": {
@@ -16053,8 +16048,7 @@
         }
       },
       "required": [
-        "Id",
-        "AccessPolicy"
+        "Id"
       ]
     },
     "SignedIdentifiers": {

--- a/specification/storage/data-plane/Microsoft.BlobStorage/stable/2026-02-06/generated_blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/stable/2026-02-06/generated_blob.json
@@ -13797,12 +13797,7 @@
           "description": "The permissions for acl the policy.",
           "x-ms-client-name": "permission"
         }
-      },
-      "required": [
-        "Start",
-        "Expiry",
-        "Permission"
-      ]
+      }
     },
     "AccessTier": {
       "type": "string",
@@ -14838,7 +14833,7 @@
           "description": "The date-time the container was last modified in RFC1123 format.",
           "x-ms-client-name": "lastModified"
         },
-        "ETag": {
+        "Etag": {
           "type": "string",
           "description": "The ETag of the container.",
           "x-ms-client-name": "eTag"
@@ -14903,7 +14898,7 @@
       },
       "required": [
         "Last-Modified",
-        "ETag"
+        "Etag"
       ]
     },
     "CopyStatus": {
@@ -16135,8 +16130,7 @@
         }
       },
       "required": [
-        "Id",
-        "AccessPolicy"
+        "Id"
       ]
     },
     "SignedIdentifiers": {

--- a/specification/storage/data-plane/Microsoft.BlobStorage/stable/2026-04-06/generated_blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/stable/2026-04-06/generated_blob.json
@@ -14003,12 +14003,7 @@
           "description": "The permissions for acl the policy.",
           "x-ms-client-name": "permission"
         }
-      },
-      "required": [
-        "Start",
-        "Expiry",
-        "Permission"
-      ]
+      }
     },
     "AccessTier": {
       "type": "string",
@@ -15044,7 +15039,7 @@
           "description": "The date-time the container was last modified in RFC1123 format.",
           "x-ms-client-name": "lastModified"
         },
-        "ETag": {
+        "Etag": {
           "type": "string",
           "description": "The ETag of the container.",
           "x-ms-client-name": "eTag"
@@ -15109,7 +15104,7 @@
       },
       "required": [
         "Last-Modified",
-        "ETag"
+        "Etag"
       ]
     },
     "CopyStatus": {
@@ -16346,8 +16341,7 @@
         }
       },
       "required": [
-        "Id",
-        "AccessPolicy"
+        "Id"
       ]
     },
     "SignedIdentifiers": {


### PR DESCRIPTION
Improving accuracy of spec properties. Access policy is actually optionally returned by the service, likewise the AccessPolicy properties were also defined as optional before. This PR updated the typespec to reflect these behaviors. 

Fixes https://github.com/Azure/azure-rest-api-specs/issues/40597
