### PR TITLE
Add Ray distribution type to MachineLearningServices 2026-01-15-preview

### DIFF
--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2026-01-15-preview/openapi.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2026-01-15-preview/openapi.json
@@ -24869,7 +24869,7 @@
         },
         "distribution": {
           "$ref": "#/definitions/DistributionConfiguration",
-          "description": "Distribution configuration of the job. If set, this should be one of Mpi, Tensorflow, PyTorch, or null.",
+          "description": "Distribution configuration of the job. If set, this should be one of Mpi, Tensorflow, PyTorch, Ray, or null.",
           "x-nullable": true,
           "x-ms-mutability": [
             "read",
@@ -29060,7 +29060,8 @@
       "enum": [
         "PyTorch",
         "TensorFlow",
-        "Mpi"
+        "Mpi",
+        "Ray"
       ],
       "x-ms-enum": {
         "name": "DistributionType",
@@ -29077,6 +29078,10 @@
           {
             "name": "Mpi",
             "value": "Mpi"
+          },
+          {
+            "name": "Ray",
+            "value": "Ray"
           }
         ]
       }
@@ -45041,6 +45046,51 @@
           }
         }
       }
+    },
+    "Ray": {
+      "description": "Ray distribution configuration.",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/DistributionConfiguration"
+        }
+      ],
+      "properties": {
+        "address": {
+          "description": "The address of Ray head node.",
+          "type": "string",
+          "x-nullable": true
+        },
+        "dashboardPort": {
+          "format": "int32",
+          "description": "The port to bind the dashboard server to.",
+          "type": "integer",
+          "x-nullable": true
+        },
+        "headNodeAdditionalArgs": {
+          "description": "Additional arguments passed to ray start in head node.",
+          "type": "string",
+          "x-nullable": true
+        },
+        "includeDashboard": {
+          "description": "Provide this argument to start the Ray dashboard GUI.",
+          "type": "boolean",
+          "x-nullable": true
+        },
+        "port": {
+          "format": "int32",
+          "description": "The port of the head ray process.",
+          "type": "integer",
+          "x-nullable": true
+        },
+        "workerNodeAdditionalArgs": {
+          "description": "Additional arguments passed to ray start in worker node.",
+          "type": "string",
+          "x-nullable": true
+        }
+      },
+      "x-ms-discriminator-value": "Ray",
+      "additionalProperties": false
     }
   },
   "parameters": {


### PR DESCRIPTION
## Summary
Add Ray as a new DistributionType for command/sweep jobs in the \2026-01-15-preview\ API version.

Ray already exists in older MFE API versions (\2023-04-01-preview\ through \2024-04-01-preview\). This PR adds it to the latest preview version.

## Changes
- Added \Ray\ enum value to \DistributionType\
- Added \Ray\ definition extending \DistributionConfiguration\ with properties: \port\, \ddress\, \includeDashboard\, \dashboardPort\, \headNodeAdditionalArgs\, \workerNodeAdditionalArgs\
- Updated \CommandJob\ distribution description to include Ray

## Vienna PR
https://dev.azure.com/msdata/Vienna/_git/vienna/pullrequest/1971126

## API Version
\2026-01-15-preview\
