### PR TITLE
Add @azure-tools/typespec-metadata dependency to package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@azure-tools/typespec-client-generator-cli": "0.31.0",
         "@azure-tools/typespec-client-generator-core": "0.65.3",
         "@azure-tools/typespec-liftr-base": "0.10.0",
+        "@azure-tools/typespec-metadata": "0.1.0",
         "@azure/avocado": "0.10.5",
         "@azure/oad": "0.12.3",
         "@microsoft.azure/openapi-validator": "2.2.4",
@@ -1175,6 +1176,22 @@
       "resolved": "https://registry.npmjs.org/@azure-tools/typespec-liftr-base/-/typespec-liftr-base-0.10.0.tgz",
       "integrity": "sha512-FcF8IusZcS2vvm1J+CzaeZkv15FgcFOSR+YoFdIusnnm+mlcLudM92NupdxZnuobPYcfZzq+rRvylxzzgWky7A==",
       "dev": true
+    },
+    "node_modules/@azure-tools/typespec-metadata": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-metadata/-/typespec-metadata-0.1.0.tgz",
+      "integrity": "sha512-74lagxmUZdg9j2yvuS9OUfaCGSHUdpTN4FEOT76oC6mVyZ1f/zllTdf349vL3TiqAPbnDCEJBMyVx462onZC5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "~2.8.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@typespec/compiler": "^1.8.0"
+      }
     },
     "node_modules/@azure-tools/typespec-migration-validation": {
       "resolved": "eng/tools/typespec-migration-validation",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@azure-tools/typespec-client-generator-cli": "0.31.0",
         "@azure-tools/typespec-client-generator-core": "0.65.3",
         "@azure-tools/typespec-liftr-base": "0.12.0",
+        "@azure-tools/typespec-metadata": "0.1.0",
         "@azure/avocado": "0.10.5",
         "@azure/oad": "0.12.3",
         "@microsoft.azure/openapi-validator": "2.2.4",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "@azure-tools/spec-gen-sdk": "~0.9.1",
     "@azure-tools/specs-shared": "file:.github/shared",
     "@azure-tools/typespec-apiview": "0.7.2",
+    "@azure-tools/typespec-metadata": "0.1.0",
     "@azure-tools/typespec-autorest": "0.65.0",
     "@azure-tools/typespec-azure-core": "0.65.0",
     "@azure-tools/typespec-azure-portal-core": "0.65.0",


### PR DESCRIPTION
Adds `@azure-tools/typespec-metadata` (v0.1.0) to `devDependencies` in the root `package.json`.

This package is required by `eng/scripts/Create-APIView.ps1`, which uses it as a TypeSpec emitter to generate metadata files for APIView during PR CI checks.

This follows the same pattern as the existing `@azure-tools/typespec-apiview` dependency, which is also used only by the APIView CI pipeline.
