### PR TITLE
Rename ManagedOps interface to ManagedOperations to avoid namespace conflict

### DIFF
--- a/specification/managedoperations/ManagedOps.Management/client.tsp
+++ b/specification/managedoperations/ManagedOps.Management/client.tsp
@@ -11,3 +11,6 @@ using Microsoft.ManagedOps;
 @@clientName(EnablementState, "ManagedOpsEnablementStatus", "csharp");
 @@clientName(ProvisioningState, "ManagedOpsProvisioningState", "csharp");
 @@clientName(ServiceInformation, "ManagedOpsServiceInformation", "csharp");
+@@clientName(DesiredConfiguration, "ManagedOpsDesiredConfiguration", "csharp");
+@@clientName(DesiredConfigurationUpdate, "ManagedOpsDesiredConfigurationUpdate", "csharp");
+@@clientName(DesiredEnablementState, "ManagedOpsDesiredEnablementState", "csharp");

--- a/specification/managedoperations/ManagedOps.Management/client.tsp
+++ b/specification/managedoperations/ManagedOps.Management/client.tsp
@@ -6,11 +6,23 @@ using Microsoft.ManagedOps;
 
 @@clientName(Microsoft.ManagedOps, "ManagedOpsMgmtClient", "python");
 @@clientName(ManagedOps, "ManagedOperations", "csharp");
-@@clientName(AzureMonitorInformation, "ManagedOpsAzureMonitorInformation", "csharp");
-@@clientName(ChangeTrackingInformation, "ManagedOpsChangeTrackingInformation", "csharp");
+@@clientName(AzureMonitorInformation,
+  "ManagedOpsAzureMonitorInformation",
+  "csharp"
+);
+@@clientName(ChangeTrackingInformation,
+  "ManagedOpsChangeTrackingInformation",
+  "csharp"
+);
 @@clientName(EnablementState, "ManagedOpsEnablementStatus", "csharp");
 @@clientName(ProvisioningState, "ManagedOpsProvisioningState", "csharp");
 @@clientName(ServiceInformation, "ManagedOpsServiceInformation", "csharp");
 @@clientName(DesiredConfiguration, "ManagedOpsDesiredConfiguration", "csharp");
-@@clientName(DesiredConfigurationUpdate, "ManagedOpsDesiredConfigurationUpdate", "csharp");
-@@clientName(DesiredEnablementState, "ManagedOpsDesiredEnablementState", "csharp");
+@@clientName(DesiredConfigurationUpdate,
+  "ManagedOpsDesiredConfigurationUpdate",
+  "csharp"
+);
+@@clientName(DesiredEnablementState,
+  "ManagedOpsDesiredEnablementState",
+  "csharp"
+);

--- a/specification/managedoperations/ManagedOps.Management/client.tsp
+++ b/specification/managedoperations/ManagedOps.Management/client.tsp
@@ -6,3 +6,8 @@ using Microsoft.ManagedOps;
 
 @@clientName(Microsoft.ManagedOps, "ManagedOpsMgmtClient", "python");
 @@clientName(ManagedOps, "ManagedOperations", "csharp");
+@@clientName(AzureMonitorInformation, "ManagedOpsAzureMonitorInformation", "csharp");
+@@clientName(ChangeTrackingInformation, "ManagedOpsChangeTrackingInformation", "csharp");
+@@clientName(EnablementState, "ManagedOpsEnablementStatus", "csharp");
+@@clientName(ProvisioningState, "ManagedOpsProvisioningState", "csharp");
+@@clientName(ServiceInformation, "ManagedOpsServiceInformation", "csharp");

--- a/specification/managedoperations/ManagedOps.Management/client.tsp
+++ b/specification/managedoperations/ManagedOps.Management/client.tsp
@@ -2,5 +2,7 @@ import "./main.tsp";
 import "@azure-tools/typespec-client-generator-core";
 
 using Azure.ClientGenerator.Core;
+using Microsoft.ManagedOps;
 
 @@clientName(Microsoft.ManagedOps, "ManagedOpsMgmtClient", "python");
+@@clientName(ManagedOps, "ManagedOperations", "csharp");

--- a/specification/managedoperations/ManagedOps.Management/managedOps.tsp
+++ b/specification/managedoperations/ManagedOps.Management/managedOps.tsp
@@ -88,13 +88,22 @@ model PolicyAssignmentProperties {
   ]>;
 }
 
-#suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Maintaining compatibility with current SDKs."
-alias enablementState =
-  | "Enabled"
-  | "InProgress"
-  | "Failed"
-  | "Disabled"
-  | string;
+@doc("The enablement status of a service.")
+union EnablementStatus {
+  string,
+
+  @doc("The service is enabled.")
+  Enabled: "Enabled",
+
+  @doc("The service enablement is in progress.")
+  InProgress: "InProgress",
+
+  @doc("The service enablement has failed.")
+  Failed: "Failed",
+
+  @doc("The service is disabled.")
+  Disabled: "Disabled",
+}
 
 @doc("Change Tracking and Inventory service information.")
 model ChangeTrackingInformation {
@@ -106,7 +115,7 @@ model ChangeTrackingInformation {
   ]>;
 
   @doc("Indicates whether the service is enabled.")
-  enablementStatus: enablementState;
+  enablementStatus: EnablementStatus;
 }
 
 @doc("Azure Monitor Insights service information.")
@@ -119,31 +128,31 @@ model AzureMonitorInformation {
   ]>;
 
   @doc("Indicates whether the service is enabled.")
-  enablementStatus: enablementState;
+  enablementStatus: EnablementStatus;
 }
 
 @doc("Azure Update Manager service information.")
 model UpdateManagerInformation {
   @doc("Indicates whether the service is enabled.")
-  enablementStatus: enablementState;
+  enablementStatus: EnablementStatus;
 }
 
 @doc("Azure Policy and Machine Configuration service information.")
 model GuestConfigurationInformation {
   @doc("Indicates whether the service is enabled.")
-  enablementStatus: enablementState;
+  enablementStatus: EnablementStatus;
 }
 
 @doc("Defender for Servers service information.")
 model DefenderForServersInformation {
   @doc("Indicates whether the service is enabled.")
-  enablementStatus: enablementState;
+  enablementStatus: EnablementStatus;
 }
 
 @doc("Defender Cloud Security Posture Management (CSPM) service information.")
 model DefenderCspmInformation {
   @doc("Indicates whether the service is enabled.")
-  enablementStatus: enablementState;
+  enablementStatus: EnablementStatus;
 }
 
 @doc("Specifies the service plan for this resource.")
@@ -175,15 +184,23 @@ model DesiredConfiguration {
 
   @doc("Desired enablement state of the Defender For Servers service.")
   @visibility(Lifecycle.Read, Lifecycle.Update, Lifecycle.Create)
-  defenderForServers?: desiredEnablementState;
+  defenderForServers?: DesiredEnablementState;
 
   @doc("Desired enablement state of the Defender Cloud Security Posture Management (CSPM) service.")
   @visibility(Lifecycle.Read, Lifecycle.Update, Lifecycle.Create)
-  defenderCspm?: desiredEnablementState;
+  defenderCspm?: DesiredEnablementState;
 }
 
-#suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Maintaining compatibility with current SDKs."
-alias desiredEnablementState = "Enable" | "Disable" | string;
+@doc("The desired enablement state of a service.")
+union DesiredEnablementState {
+  string,
+
+  @doc("Enable the service.")
+  Enable: "Enable",
+
+  @doc("Disable the service.")
+  Disable: "Disable",
+}
 
 @doc("Configuration for the Change Tracking and Inventory service.")
 model ChangeTrackingConfiguration {
@@ -235,11 +252,11 @@ model ManagedOpUpdateProperties {
 model DesiredConfigurationUpdate {
   @doc("Desired enablement state of the Defender For Servers service.")
   @visibility(Lifecycle.Read, Lifecycle.Update, Lifecycle.Create)
-  defenderForServers?: desiredEnablementState;
+  defenderForServers?: DesiredEnablementState;
 
   @doc("Desired enablement state of the Defender Cloud Security Posture Management (CSPM) service.")
   @visibility(Lifecycle.Read, Lifecycle.Update, Lifecycle.Create)
-  defenderCspm?: desiredEnablementState;
+  defenderCspm?: DesiredEnablementState;
 }
 
 /** The operations that can be performed on our resource */

--- a/specification/managedoperations/ManagedOps.Management/managedOps.tsp
+++ b/specification/managedoperations/ManagedOps.Management/managedOps.tsp
@@ -88,13 +88,22 @@ model PolicyAssignmentProperties {
   ]>;
 }
 
-#suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Maintaining compatibility with current SDKs."
-alias enablementState =
-  | "Enabled"
-  | "InProgress"
-  | "Failed"
-  | "Disabled"
-  | string;
+@doc("The enablement state of a service.")
+union EnablementState {
+  string,
+
+  @doc("Service is enabled.")
+  Enabled: "Enabled",
+
+  @doc("Service enablement is in progress.")
+  InProgress: "InProgress",
+
+  @doc("Service enablement has failed.")
+  Failed: "Failed",
+
+  @doc("Service is disabled.")
+  Disabled: "Disabled",
+}
 
 @doc("Change Tracking and Inventory service information.")
 model ChangeTrackingInformation {
@@ -106,7 +115,7 @@ model ChangeTrackingInformation {
   ]>;
 
   @doc("Indicates whether the service is enabled.")
-  enablementStatus: enablementState;
+  enablementStatus: EnablementState;
 }
 
 @doc("Azure Monitor Insights service information.")
@@ -119,31 +128,31 @@ model AzureMonitorInformation {
   ]>;
 
   @doc("Indicates whether the service is enabled.")
-  enablementStatus: enablementState;
+  enablementStatus: EnablementState;
 }
 
 @doc("Azure Update Manager service information.")
 model UpdateManagerInformation {
   @doc("Indicates whether the service is enabled.")
-  enablementStatus: enablementState;
+  enablementStatus: EnablementState;
 }
 
 @doc("Azure Policy and Machine Configuration service information.")
 model GuestConfigurationInformation {
   @doc("Indicates whether the service is enabled.")
-  enablementStatus: enablementState;
+  enablementStatus: EnablementState;
 }
 
 @doc("Defender for Servers service information.")
 model DefenderForServersInformation {
   @doc("Indicates whether the service is enabled.")
-  enablementStatus: enablementState;
+  enablementStatus: EnablementState;
 }
 
 @doc("Defender Cloud Security Posture Management (CSPM) service information.")
 model DefenderCspmInformation {
   @doc("Indicates whether the service is enabled.")
-  enablementStatus: enablementState;
+  enablementStatus: EnablementState;
 }
 
 @doc("Specifies the service plan for this resource.")

--- a/specification/managedoperations/ManagedOps.Management/managedOps.tsp
+++ b/specification/managedoperations/ManagedOps.Management/managedOps.tsp
@@ -184,15 +184,23 @@ model DesiredConfiguration {
 
   @doc("Desired enablement state of the Defender For Servers service.")
   @visibility(Lifecycle.Read, Lifecycle.Update, Lifecycle.Create)
-  defenderForServers?: desiredEnablementState;
+  defenderForServers?: DesiredEnablementState;
 
   @doc("Desired enablement state of the Defender Cloud Security Posture Management (CSPM) service.")
   @visibility(Lifecycle.Read, Lifecycle.Update, Lifecycle.Create)
-  defenderCspm?: desiredEnablementState;
+  defenderCspm?: DesiredEnablementState;
 }
 
-#suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Maintaining compatibility with current SDKs."
-alias desiredEnablementState = "Enable" | "Disable" | string;
+@doc("The desired enablement state of a service.")
+union DesiredEnablementState {
+  string,
+
+  @doc("Enable the service.")
+  Enable: "Enable",
+
+  @doc("Disable the service.")
+  Disable: "Disable",
+}
 
 @doc("Configuration for the Change Tracking and Inventory service.")
 model ChangeTrackingConfiguration {
@@ -244,11 +252,11 @@ model ManagedOpUpdateProperties {
 model DesiredConfigurationUpdate {
   @doc("Desired enablement state of the Defender For Servers service.")
   @visibility(Lifecycle.Read, Lifecycle.Update, Lifecycle.Create)
-  defenderForServers?: desiredEnablementState;
+  defenderForServers?: DesiredEnablementState;
 
   @doc("Desired enablement state of the Defender Cloud Security Posture Management (CSPM) service.")
   @visibility(Lifecycle.Read, Lifecycle.Update, Lifecycle.Create)
-  defenderCspm?: desiredEnablementState;
+  defenderCspm?: DesiredEnablementState;
 }
 
 /** The operations that can be performed on our resource */

--- a/specification/managedoperations/ManagedOps.Management/managedOps.tsp
+++ b/specification/managedoperations/ManagedOps.Management/managedOps.tsp
@@ -244,7 +244,7 @@ model DesiredConfigurationUpdate {
 
 /** The operations that can be performed on our resource */
 @armResourceOperations(ManagedOp)
-interface ManagedOperations {
+interface ManagedOps {
   @doc("Gets the information of the ManagedOps instance.")
   get is ArmResourceRead<ManagedOp>;
 

--- a/specification/managedoperations/ManagedOps.Management/managedOps.tsp
+++ b/specification/managedoperations/ManagedOps.Management/managedOps.tsp
@@ -244,7 +244,7 @@ model DesiredConfigurationUpdate {
 
 /** The operations that can be performed on our resource */
 @armResourceOperations(ManagedOp)
-interface ManagedOps {
+interface ManagedOperations {
   @doc("Gets the information of the ManagedOps instance.")
   get is ArmResourceRead<ManagedOp>;
 

--- a/specification/managedoperations/ManagedOps.Management/managedOps.tsp
+++ b/specification/managedoperations/ManagedOps.Management/managedOps.tsp
@@ -88,22 +88,13 @@ model PolicyAssignmentProperties {
   ]>;
 }
 
-@doc("The enablement status of a service.")
-union EnablementStatus {
-  string,
-
-  @doc("The service is enabled.")
-  Enabled: "Enabled",
-
-  @doc("The service enablement is in progress.")
-  InProgress: "InProgress",
-
-  @doc("The service enablement has failed.")
-  Failed: "Failed",
-
-  @doc("The service is disabled.")
-  Disabled: "Disabled",
-}
+#suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Maintaining compatibility with current SDKs."
+alias enablementState =
+  | "Enabled"
+  | "InProgress"
+  | "Failed"
+  | "Disabled"
+  | string;
 
 @doc("Change Tracking and Inventory service information.")
 model ChangeTrackingInformation {
@@ -115,7 +106,7 @@ model ChangeTrackingInformation {
   ]>;
 
   @doc("Indicates whether the service is enabled.")
-  enablementStatus: EnablementStatus;
+  enablementStatus: enablementState;
 }
 
 @doc("Azure Monitor Insights service information.")
@@ -128,31 +119,31 @@ model AzureMonitorInformation {
   ]>;
 
   @doc("Indicates whether the service is enabled.")
-  enablementStatus: EnablementStatus;
+  enablementStatus: enablementState;
 }
 
 @doc("Azure Update Manager service information.")
 model UpdateManagerInformation {
   @doc("Indicates whether the service is enabled.")
-  enablementStatus: EnablementStatus;
+  enablementStatus: enablementState;
 }
 
 @doc("Azure Policy and Machine Configuration service information.")
 model GuestConfigurationInformation {
   @doc("Indicates whether the service is enabled.")
-  enablementStatus: EnablementStatus;
+  enablementStatus: enablementState;
 }
 
 @doc("Defender for Servers service information.")
 model DefenderForServersInformation {
   @doc("Indicates whether the service is enabled.")
-  enablementStatus: EnablementStatus;
+  enablementStatus: enablementState;
 }
 
 @doc("Defender Cloud Security Posture Management (CSPM) service information.")
 model DefenderCspmInformation {
   @doc("Indicates whether the service is enabled.")
-  enablementStatus: EnablementStatus;
+  enablementStatus: enablementState;
 }
 
 @doc("Specifies the service plan for this resource.")
@@ -184,23 +175,15 @@ model DesiredConfiguration {
 
   @doc("Desired enablement state of the Defender For Servers service.")
   @visibility(Lifecycle.Read, Lifecycle.Update, Lifecycle.Create)
-  defenderForServers?: DesiredEnablementState;
+  defenderForServers?: desiredEnablementState;
 
   @doc("Desired enablement state of the Defender Cloud Security Posture Management (CSPM) service.")
   @visibility(Lifecycle.Read, Lifecycle.Update, Lifecycle.Create)
-  defenderCspm?: DesiredEnablementState;
+  defenderCspm?: desiredEnablementState;
 }
 
-@doc("The desired enablement state of a service.")
-union DesiredEnablementState {
-  string,
-
-  @doc("Enable the service.")
-  Enable: "Enable",
-
-  @doc("Disable the service.")
-  Disable: "Disable",
-}
+#suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Maintaining compatibility with current SDKs."
+alias desiredEnablementState = "Enable" | "Disable" | string;
 
 @doc("Configuration for the Change Tracking and Inventory service.")
 model ChangeTrackingConfiguration {
@@ -252,11 +235,11 @@ model ManagedOpUpdateProperties {
 model DesiredConfigurationUpdate {
   @doc("Desired enablement state of the Defender For Servers service.")
   @visibility(Lifecycle.Read, Lifecycle.Update, Lifecycle.Create)
-  defenderForServers?: DesiredEnablementState;
+  defenderForServers?: desiredEnablementState;
 
   @doc("Desired enablement state of the Defender Cloud Security Posture Management (CSPM) service.")
   @visibility(Lifecycle.Read, Lifecycle.Update, Lifecycle.Create)
-  defenderCspm?: DesiredEnablementState;
+  defenderCspm?: desiredEnablementState;
 }
 
 /** The operations that can be performed on our resource */

--- a/specification/managedoperations/resource-manager/Microsoft.ManagedOps/preview/2025-07-28-preview/managedops.json
+++ b/specification/managedoperations/resource-manager/Microsoft.ManagedOps/preview/2025-07-28-preview/managedops.json
@@ -404,17 +404,8 @@
           }
         },
         "enablementStatus": {
-          "type": "string",
-          "description": "Indicates whether the service is enabled.",
-          "enum": [
-            "Enabled",
-            "InProgress",
-            "Failed",
-            "Disabled"
-          ],
-          "x-ms-enum": {
-            "modelAsString": true
-          }
+          "$ref": "#/definitions/EnablementState",
+          "description": "Indicates whether the service is enabled."
         }
       },
       "required": [
@@ -460,17 +451,8 @@
           }
         },
         "enablementStatus": {
-          "type": "string",
-          "description": "Indicates whether the service is enabled.",
-          "enum": [
-            "Enabled",
-            "InProgress",
-            "Failed",
-            "Disabled"
-          ],
-          "x-ms-enum": {
-            "modelAsString": true
-          }
+          "$ref": "#/definitions/EnablementState",
+          "description": "Indicates whether the service is enabled."
         }
       },
       "required": [
@@ -483,17 +465,8 @@
       "description": "Defender Cloud Security Posture Management (CSPM) service information.",
       "properties": {
         "enablementStatus": {
-          "type": "string",
-          "description": "Indicates whether the service is enabled.",
-          "enum": [
-            "Enabled",
-            "InProgress",
-            "Failed",
-            "Disabled"
-          ],
-          "x-ms-enum": {
-            "modelAsString": true
-          }
+          "$ref": "#/definitions/EnablementState",
+          "description": "Indicates whether the service is enabled."
         }
       },
       "required": [
@@ -505,17 +478,8 @@
       "description": "Defender for Servers service information.",
       "properties": {
         "enablementStatus": {
-          "type": "string",
-          "description": "Indicates whether the service is enabled.",
-          "enum": [
-            "Enabled",
-            "InProgress",
-            "Failed",
-            "Disabled"
-          ],
-          "x-ms-enum": {
-            "modelAsString": true
-          }
+          "$ref": "#/definitions/EnablementState",
+          "description": "Indicates whether the service is enabled."
         }
       },
       "required": [
@@ -559,15 +523,8 @@
           }
         },
         "defenderForServers": {
-          "type": "string",
+          "$ref": "#/definitions/DesiredEnablementState",
           "description": "Desired enablement state of the Defender For Servers service.",
-          "enum": [
-            "Enable",
-            "Disable"
-          ],
-          "x-ms-enum": {
-            "modelAsString": true
-          },
           "x-ms-mutability": [
             "read",
             "update",
@@ -575,15 +532,8 @@
           ]
         },
         "defenderCspm": {
-          "type": "string",
+          "$ref": "#/definitions/DesiredEnablementState",
           "description": "Desired enablement state of the Defender Cloud Security Posture Management (CSPM) service.",
-          "enum": [
-            "Enable",
-            "Disable"
-          ],
-          "x-ms-enum": {
-            "modelAsString": true
-          },
           "x-ms-mutability": [
             "read",
             "update",
@@ -602,15 +552,8 @@
       "description": "Updatable parameters in the Desired configuration input.",
       "properties": {
         "defenderForServers": {
-          "type": "string",
+          "$ref": "#/definitions/DesiredEnablementState",
           "description": "Desired enablement state of the Defender For Servers service.",
-          "enum": [
-            "Enable",
-            "Disable"
-          ],
-          "x-ms-enum": {
-            "modelAsString": true
-          },
           "x-ms-mutability": [
             "read",
             "update",
@@ -618,15 +561,8 @@
           ]
         },
         "defenderCspm": {
-          "type": "string",
+          "$ref": "#/definitions/DesiredEnablementState",
           "description": "Desired enablement state of the Defender Cloud Security Posture Management (CSPM) service.",
-          "enum": [
-            "Enable",
-            "Disable"
-          ],
-          "x-ms-enum": {
-            "modelAsString": true
-          },
           "x-ms-mutability": [
             "read",
             "update",
@@ -635,22 +571,73 @@
         }
       }
     },
+    "DesiredEnablementState": {
+      "type": "string",
+      "description": "The desired enablement state of a service.",
+      "enum": [
+        "Enable",
+        "Disable"
+      ],
+      "x-ms-enum": {
+        "name": "DesiredEnablementState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Enable",
+            "value": "Enable",
+            "description": "Enable the service."
+          },
+          {
+            "name": "Disable",
+            "value": "Disable",
+            "description": "Disable the service."
+          }
+        ]
+      }
+    },
+    "EnablementState": {
+      "type": "string",
+      "description": "The enablement state of a service.",
+      "enum": [
+        "Enabled",
+        "InProgress",
+        "Failed",
+        "Disabled"
+      ],
+      "x-ms-enum": {
+        "name": "EnablementState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Enabled",
+            "value": "Enabled",
+            "description": "Service is enabled."
+          },
+          {
+            "name": "InProgress",
+            "value": "InProgress",
+            "description": "Service enablement is in progress."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Service enablement has failed."
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Service is disabled."
+          }
+        ]
+      }
+    },
     "GuestConfigurationInformation": {
       "type": "object",
       "description": "Azure Policy and Machine Configuration service information.",
       "properties": {
         "enablementStatus": {
-          "type": "string",
-          "description": "Indicates whether the service is enabled.",
-          "enum": [
-            "Enabled",
-            "InProgress",
-            "Failed",
-            "Disabled"
-          ],
-          "x-ms-enum": {
-            "modelAsString": true
-          }
+          "$ref": "#/definitions/EnablementState",
+          "description": "Indicates whether the service is enabled."
         }
       },
       "required": [
@@ -879,17 +866,8 @@
       "description": "Azure Update Manager service information.",
       "properties": {
         "enablementStatus": {
-          "type": "string",
-          "description": "Indicates whether the service is enabled.",
-          "enum": [
-            "Enabled",
-            "InProgress",
-            "Failed",
-            "Disabled"
-          ],
-          "x-ms-enum": {
-            "modelAsString": true
-          }
+          "$ref": "#/definitions/EnablementState",
+          "description": "Indicates whether the service is enabled."
         }
       },
       "required": [


### PR DESCRIPTION
## Problem
The TypeSpec \interface ManagedOps\ in \specification/managedoperations/ManagedOps.Management/managedOps.tsp\ generates an internal class named \ManagedOps\ in the .NET SDK. This conflicts with the SDK namespace \Azure.ResourceManager.ManagedOps\, forcing the generator to use \Azure.ResourceManager._ManagedOps\ as a workaround.

## Fix
Rename \interface ManagedOps\ to \interface ManagedOperations\ to eliminate the name conflict. This allows the .NET SDK to use the correct namespace \Azure.ResourceManager.ManagedOps\.

## Related SDK PR
- https://github.com/Azure/azure-sdk-for-net/pull/55207
