### PR TITLE
feat: Add Hosted Agents ADC integration API spec changes

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -159,6 +159,9 @@ union AgentVersionStatus {
 
   @doc("The agent version is being deleted.")
   deleting: "deleting",
+
+  @doc("The agent version has been deleted.")
+  deleted: "deleted",
 }
 
 @doc("Error details for agent version provisioning failure.")

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -126,6 +126,55 @@ model AgentVersionObject {
   created_at: utcDateTime;
 
   definition: AgentDefinition;
+
+  @doc("The provisioning status of the agent version. For hosted agents, reflects ADC snapshot readiness.")
+  @extension(
+    "x-ms-foundry-meta",
+    #{ required_previews: #[AgentDefinitionFeatureKeys.hosted_agents_v1_preview] }
+  )
+  status?: AgentVersionStatus;
+
+  @doc("Error details if the agent version provisioning failed.")
+  @extension(
+    "x-ms-foundry-meta",
+    #{ required_previews: #[AgentDefinitionFeatureKeys.hosted_agents_v1_preview] }
+  )
+  error?: AgentVersionError;
+}
+
+@doc("The provisioning status of an agent version.")
+@extension(
+  "x-ms-foundry-meta",
+  #{ required_previews: #[AgentDefinitionFeatureKeys.hosted_agents_v1_preview] }
+)
+union AgentVersionStatus {
+  @doc("The agent version is being provisioned (e.g., ADC snapshot creation in progress).")
+  creating: "creating",
+
+  @doc("The agent version is active and ready to serve requests.")
+  active: "active",
+
+  @doc("The agent version provisioning failed.")
+  failed: "failed",
+
+  @doc("The agent version is being deleted.")
+  deleting: "deleting",
+}
+
+@doc("Error details for agent version provisioning failure.")
+@extension(
+  "x-ms-foundry-meta",
+  #{ required_previews: #[AgentDefinitionFeatureKeys.hosted_agents_v1_preview] }
+)
+model AgentVersionError {
+  @doc("The error code.")
+  code: string;
+
+  @doc("A human-readable error message.")
+  message: string;
+
+  @doc("Additional error details.")
+  details?: string;
 }
 
 union AgentProtocol {

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -152,7 +152,6 @@ union AgentVersionStatus {
   deleted: "deleted",
 }
 
-
 union AgentProtocol {
   string,
   activity_protocol: "activity_protocol",

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -127,28 +127,16 @@ model AgentVersionObject {
 
   definition: AgentDefinition;
 
-  @doc("The provisioning status of the agent version. For hosted agents, reflects ADC snapshot readiness.")
-  @extension(
-    "x-ms-foundry-meta",
-    #{ required_previews: #[AgentDefinitionFeatureKeys.hosted_agents_v1_preview] }
-  )
-  status?: AgentVersionStatus;
+  @doc("The provisioning status of the agent version. Defaults to 'active' for non-hosted agents. For hosted agents, reflects infrastructure readiness.")
+  status: AgentVersionStatus = AgentVersionStatus.active;
 
   @doc("Error details if the agent version provisioning failed.")
-  @extension(
-    "x-ms-foundry-meta",
-    #{ required_previews: #[AgentDefinitionFeatureKeys.hosted_agents_v1_preview] }
-  )
-  error?: AgentVersionError;
+  error?: ApiError;
 }
 
 @doc("The provisioning status of an agent version.")
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionFeatureKeys.hosted_agents_v1_preview] }
-)
 union AgentVersionStatus {
-  @doc("The agent version is being provisioned (e.g., ADC snapshot creation in progress).")
+  @doc("The agent version is being provisioned.")
   creating: "creating",
 
   @doc("The agent version is active and ready to serve requests.")
@@ -164,21 +152,6 @@ union AgentVersionStatus {
   deleted: "deleted",
 }
 
-@doc("Error details for agent version provisioning failure.")
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionFeatureKeys.hosted_agents_v1_preview] }
-)
-model AgentVersionError {
-  @doc("The error code.")
-  code: string;
-
-  @doc("A human-readable error message.")
-  message: string;
-
-  @doc("Additional error details.")
-  details?: string;
-}
 
 union AgentProtocol {
   string,

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -127,13 +127,16 @@ model AgentVersionObject {
 
   definition: AgentDefinition;
 
+  @removed(Versions.v1)
   @doc("The provisioning status of the agent version. Defaults to 'active' for non-hosted agents. For hosted agents, reflects infrastructure readiness.")
   status: AgentVersionStatus = AgentVersionStatus.active;
 
+  @removed(Versions.v1)
   @doc("Error details if the agent version provisioning failed.")
   error?: ApiError;
 }
 
+@removed(Versions.v1)
 @doc("The provisioning status of an agent version.")
 union AgentVersionStatus {
   @doc("The agent version is being provisioned.")

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
@@ -184,9 +184,6 @@ interface Agents {
 
       /** The version of the agent to delete */
       @path agent_version: string;
-
-      /** When true, force-deletes the version even if active sessions exist. Defaults to false. */
-      @query force?: boolean = false;
     },
     DeleteAgentVersionResponse
   >;

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
@@ -184,6 +184,9 @@ interface Agents {
 
       /** The version of the agent to delete */
       @path agent_version: string;
+
+      /** When true, force-deletes the version even if active sessions exist. Defaults to false. */
+      @query force?: boolean = false;
     },
     DeleteAgentVersionResponse
   >;

--- a/specification/ai-foundry/data-plane/Foundry/src/openai-responses/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai-responses/models.tsp
@@ -34,6 +34,13 @@ namespace Azure.AI.Projects {
 
       /** The structured inputs to the response that can participate in prompt template substitution or tool argument bindings. */
       structured_inputs?: Record<unknown>,
+
+      /** Optional session identifier for sandbox affinity. When provided, the request is routed to the same ADC sandbox. When omitted, auto-derived from conversation_id/prev_response_id or a new UUID is generated. */
+      @extension(
+        "x-ms-foundry-meta",
+        #{ required_previews: #[AgentDefinitionFeatureKeys.hosted_agents_v1_preview] }
+      )
+      foundry_session_id?: string,
     }
   );
 
@@ -48,6 +55,13 @@ namespace Azure.AI.Projects {
 
       /** The agent used for this response */
       agent_reference: AgentReference | null,
+
+      /** The session identifier for this response. Always returned for hosted agents — either the caller-provided value, the auto-derived value, or an auto-generated UUID. Use for session-scoped operations (log streaming) and to maintain sandbox affinity in follow-up calls. */
+      @extension(
+        "x-ms-foundry-meta",
+        #{ required_previews: #[AgentDefinitionFeatureKeys.hosted_agents_v1_preview] }
+      )
+      foundry_session_id?: string,
     }
   );
 

--- a/specification/ai-foundry/data-plane/Foundry/src/openai-responses/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai-responses/models.tsp
@@ -35,7 +35,11 @@ namespace Azure.AI.Projects {
       /** The structured inputs to the response that can participate in prompt template substitution or tool argument bindings. */
       structured_inputs?: Record<unknown>,
 
-      /** Optional session identifier for sandbox affinity. When provided, the request is routed to the same sandbox. When omitted, auto-derived from conversation_id/prev_response_id or a new UUID is generated. */
+      /**
+       * Optional session identifier for sandbox affinity. Currently only relevant for hosted agents.
+       * When provided, the request is routed to the same sandbox. When omitted, auto-derived from
+       * conversation_id/prev_response_id or a new UUID is generated.
+       */
       agent_session_id?: string,
     }
   );
@@ -52,7 +56,12 @@ namespace Azure.AI.Projects {
       /** The agent used for this response */
       agent_reference: AgentReference | null,
 
-      /** The session identifier for this response. Always returned for hosted agents — either the caller-provided value, the auto-derived value, or an auto-generated UUID. Use for session-scoped operations (log streaming) and to maintain sandbox affinity in follow-up calls. */
+      /**
+       * The session identifier for this response. Currently only relevant for hosted agents.
+       * Always returned for hosted agents — either the caller-provided value, the auto-derived value,
+       * or an auto-generated UUID. Use for session-scoped operations and to maintain sandbox
+       * affinity in follow-up calls.
+       */
       agent_session_id?: string,
     }
   );

--- a/specification/ai-foundry/data-plane/Foundry/src/openai-responses/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai-responses/models.tsp
@@ -35,11 +35,7 @@ namespace Azure.AI.Projects {
       /** The structured inputs to the response that can participate in prompt template substitution or tool argument bindings. */
       structured_inputs?: Record<unknown>,
 
-      /** Optional session identifier for sandbox affinity. When provided, the request is routed to the same ADC sandbox. When omitted, auto-derived from conversation_id/prev_response_id or a new UUID is generated. */
-      @extension(
-        "x-ms-foundry-meta",
-        #{ required_previews: #[AgentDefinitionFeatureKeys.hosted_agents_v1_preview] }
-      )
+      /** Optional session identifier for sandbox affinity. When provided, the request is routed to the same sandbox. When omitted, auto-derived from conversation_id/prev_response_id or a new UUID is generated. */
       agent_session_id?: string,
     }
   );
@@ -57,10 +53,6 @@ namespace Azure.AI.Projects {
       agent_reference: AgentReference | null,
 
       /** The session identifier for this response. Always returned for hosted agents — either the caller-provided value, the auto-derived value, or an auto-generated UUID. Use for session-scoped operations (log streaming) and to maintain sandbox affinity in follow-up calls. */
-      @extension(
-        "x-ms-foundry-meta",
-        #{ required_previews: #[AgentDefinitionFeatureKeys.hosted_agents_v1_preview] }
-      )
       agent_session_id?: string,
     }
   );

--- a/specification/ai-foundry/data-plane/Foundry/src/openai-responses/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai-responses/models.tsp
@@ -40,6 +40,7 @@ namespace Azure.AI.Projects {
        * When provided, the request is routed to the same sandbox. When omitted, auto-derived from
        * conversation_id/prev_response_id or a new UUID is generated.
        */
+      @removed(Versions.v1)
       agent_session_id?: string,
     }
   );
@@ -62,6 +63,7 @@ namespace Azure.AI.Projects {
        * or an auto-generated UUID. Use for session-scoped operations and to maintain sandbox
        * affinity in follow-up calls.
        */
+      @removed(Versions.v1)
       agent_session_id?: string,
     }
   );

--- a/specification/ai-foundry/data-plane/Foundry/src/openai-responses/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai-responses/models.tsp
@@ -40,7 +40,7 @@ namespace Azure.AI.Projects {
         "x-ms-foundry-meta",
         #{ required_previews: #[AgentDefinitionFeatureKeys.hosted_agents_v1_preview] }
       )
-      foundry_session_id?: string,
+      agent_session_id?: string,
     }
   );
 
@@ -61,7 +61,7 @@ namespace Azure.AI.Projects {
         "x-ms-foundry-meta",
         #{ required_previews: #[AgentDefinitionFeatureKeys.hosted_agents_v1_preview] }
       )
-      foundry_session_id?: string,
+      agent_session_id?: string,
     }
   );
 


### PR DESCRIPTION
## Problem
Implement the TypeSpec API spec changes to support Hosted Agents running on Azure Developer Compute (ADC).

## Changes

### 1. AgentVersionObject — Add `status` and `error` fields
**File**: `agents/models.tsp`
- Add `AgentVersionStatus` union (`creating`, `active`, `failed`, `deleting`, `deleted`)
- Add `AgentVersionError` model (`code`, `message`, `details?`)
- Add optional `status` and `error` fields to `AgentVersionObject`

### 2. CreateResponse / Response — Add `agent_session_id`
**File**: `openai-responses/models.tsp`
- Add `agent_session_id?: string` to the `@@copyProperties(OpenAI.CreateResponse, ...)` block
- Add `agent_session_id?: string` to the `@@copyProperties(OpenAI.Response, ...)` block