### PR TITLE
Add displayName, isDeprecated, defaultParanoiaLevel to Front Door WAF ManagedRuleSetDefinition

### DIFF
--- a/specification/frontdoor/resource-manager/Microsoft.Network/stable/2025-03-01/examples/WafListManagedRuleSets.json
+++ b/specification/frontdoor/resource-manager/Microsoft.Network/stable/2025-03-01/examples/WafListManagedRuleSets.json
@@ -16,6 +16,8 @@
               "ruleSetId": "8125d145-ddc5-4d90-9bc3-24c5f2de69a2",
               "ruleSetType": "DefaultRuleSet",
               "ruleSetVersion": "1.0",
+              "displayName": "Default Ruleset 1.0",
+              "isDeprecated": true,
               "ruleGroups": [
                 {
                   "ruleGroupName": "SQLI",
@@ -25,13 +27,15 @@
                       "ruleId": "942100",
                       "description": "SQL Injection Attack Detected via libinjection",
                       "defaultState": "Enabled",
-                      "defaultAction": "Block"
+                      "defaultAction": "Block",
+                      "defaultParanoiaLevel": 1
                     },
                     {
                       "ruleId": "942110",
                       "description": "SQL Injection Attack: Common Injection Testing Detected",
                       "defaultState": "Enabled",
-                      "defaultAction": "Block"
+                      "defaultAction": "Block",
+                      "defaultParanoiaLevel": 1
                     }
                   ]
                 },
@@ -43,19 +47,22 @@
                       "ruleId": "941100",
                       "description": "XSS Attack Detected via libinjection",
                       "defaultState": "Enabled",
-                      "defaultAction": "Block"
+                      "defaultAction": "Block",
+                      "defaultParanoiaLevel": 1
                     },
                     {
                       "ruleId": "941101",
                       "description": "XSS Attack Detected via libinjection",
                       "defaultState": "Enabled",
-                      "defaultAction": "Block"
+                      "defaultAction": "Block",
+                      "defaultParanoiaLevel": 1
                     },
                     {
                       "ruleId": "941110",
                       "description": "XSS Filter - Category 1: Script Tag Vector",
                       "defaultState": "Enabled",
-                      "defaultAction": "Block"
+                      "defaultAction": "Block",
+                      "defaultParanoiaLevel": 1
                     }
                   ]
                 }

--- a/specification/frontdoor/resource-manager/Microsoft.Network/stable/2025-03-01/webapplicationfirewall.json
+++ b/specification/frontdoor/resource-manager/Microsoft.Network/stable/2025-03-01/webapplicationfirewall.json
@@ -926,6 +926,16 @@
             "$ref": "#/definitions/ManagedRuleGroupDefinition"
           },
           "description": "Rule groups of the managed rule set."
+        },
+        "displayName": {
+          "type": "string",
+          "readOnly": true,
+          "description": "Display name of the managed rule set."
+        },
+        "isDeprecated": {
+          "type": "boolean",
+          "readOnly": true,
+          "description": "Indicates whether the managed rule set version is deprecated."
         }
       }
     },
@@ -974,6 +984,12 @@
           "description": "Describes the functionality of the managed rule.",
           "readOnly": true,
           "type": "string"
+        },
+        "defaultParanoiaLevel": {
+          "description": "Describes the default paranoia level of the managed rule. Only applicable to DRS rules.",
+          "readOnly": true,
+          "type": "integer",
+          "format": "int32"
         }
       }
     },


### PR DESCRIPTION
## Description

Add three new read-only properties to the Front Door WAF managed rule set definitions swagger (API version 2025-03-01):

### ManagedRuleSetDefinitionProperties (rule set level)
- **displayName** (string, readOnly): Human-readable display name of the managed rule set
- **isDeprecated** (boolean, readOnly): Indicates whether the managed rule set version is deprecated

### ManagedRuleDefinition (individual rule level)
- **defaultParanoiaLevel** (integer, readOnly): Default paranoia level of the managed rule. Only applicable to DRS rules (null/omitted for Bot, DDoS, AI rule sets)

### Files Changed
- `specification/frontdoor/resource-manager/Microsoft.Network/stable/2025-03-01/webapplicationfirewall.json` - Schema definitions
- `specification/frontdoor/resource-manager/Microsoft.Network/stable/2025-03-01/examples/WafListManagedRuleSets.json` - Updated example

### Related Work Items
- ADO #36901405: Swagger update - ParanoiaLevel + DisplayName properties
- ADO #36901404: Swagger update - IsDeprecated property
- ADO #36796512: PBI - Paranoia Level + Display Name Visibility for AFD
- ADO #36796510: PBI - Managed Rule Set Versions Deprecation for AFD