### PR TITLE
[AKS] Add ArtifactStreamingProfile to v2026-02-01 GA API

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
@@ -373,7 +373,7 @@ model ManagedClusterAgentPoolProfileProperties {
   /**
    * Configuration for using artifact streaming on AKS.
    */
-  @added(Versions.v2026_02_02_preview)
+  @added(Versions.v2026_02_01)
   artifactStreamingProfile?: AgentPoolArtifactStreamingProfile;
 
   /**
@@ -881,7 +881,7 @@ model AgentPoolGatewayProfile {
 }
 
 /** Artifact streaming profile for the agent pool. */
-@added(Versions.v2026_02_02_preview)
+@added(Versions.v2026_02_01)
 model AgentPoolArtifactStreamingProfile {
   /**
    * Artifact streaming speeds up the cold-start of containers on a node through on-demand image loading. To use this feature, container images must also enable artifact streaming on ACR. If not specified, the default is false.

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-02-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-02-01/managedClusters.json
@@ -4456,6 +4456,16 @@
         }
       ]
     },
+    "AgentPoolArtifactStreamingProfile": {
+      "type": "object",
+      "description": "Artifact streaming profile for the agent pool.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Artifact streaming speeds up the cold-start of containers on a node through on-demand image loading. To use this feature, container images must also enable artifact streaming on ACR. If not specified, the default is false."
+        }
+      }
+    },
     "AgentPoolAvailableVersions": {
       "type": "object",
       "description": "The list of available versions for an agent pool.",
@@ -6960,6 +6970,10 @@
         "gatewayProfile": {
           "$ref": "#/definitions/AgentPoolGatewayProfile",
           "description": "Profile specific to a managed agent pool in Gateway mode. This field cannot be set if agent pool mode is not Gateway."
+        },
+        "artifactStreamingProfile": {
+          "$ref": "#/definitions/AgentPoolArtifactStreamingProfile",
+          "description": "Configuration for using artifact streaming on AKS."
         },
         "virtualMachinesProfile": {
           "$ref": "#/definitions/VirtualMachinesProfile",


### PR DESCRIPTION
## Summary
Promote ArtifactStreamingProfile from preview-only to GA by adding it to the v2026-02-01 API version. This enables faster container cold-start through on-demand image loading from ACR.

## Changes
- Add `v2026_02_01: "2026-02-01"` to Versions enum in `main.tsp` (in chronological order after preview)
- Keep `@added(Versions.v2025_10_02_preview)` decorators in `AgentPoolModels.tsp` (TypeSpec's versioning system automatically includes preview features in subsequent versions)
- Generate `stable/2026-02-01/managedClusters.json` with full artifact streaming support

## How TypeSpec Versioning Works
When a feature is marked with `@added` in a preview version, it automatically becomes available in all subsequent versions (both preview and stable) that come after it in chronological order in the Versions enum.

Since `v2026_02_01` comes after `v2025_10_02_preview` in the enum, the `artifactStreamingProfile` feature is now available in both:
- The preview API (v2025-10-02-preview) where it was originally added
- The new GA API (v2026-02-01) 

This is the correct TypeSpec pattern for graduating features from preview to GA.

## Context
This aligns with the aks-rp changes in commit 7c9554db4501 which added ArtifactStreamingProfile to the v20260201 GA API.

Artifact streaming speeds up the cold-start of containers on a node through on-demand image loading. To use this feature, container images must also enable artifact streaming on ACR.

## Related Links
- TypeSpec Documentation: https://typespec.io/
- Azure TypeSpec Guide: https://eng.ms/docs/products/azure-developer-experience/design/api-specs/api-typespec
- TypeSpec Versioning: https://typespec.io/docs/libraries/versioning