### PR TITLE
Keep version parameters optional for Rust

### DIFF
--- a/specification/keyvault/Security.KeyVault.Certificates/client.tsp
+++ b/specification/keyvault/Security.KeyVault.Certificates/client.tsp
@@ -76,8 +76,8 @@ op getCertificate is KeyVaultOperation<
   CertificateBundle
 >;
 
-@@override(KeyVault.updateCertificate, updateCertificate);
-@@override(KeyVault.getCertificate, getCertificate);
+@@override(KeyVault.updateCertificate, updateCertificate, "!rust");
+@@override(KeyVault.getCertificate, getCertificate, "!rust");
 
 // Java configuration
 @@usage(CertificateIssuerItem, Usage.input, "java");

--- a/specification/keyvault/Security.KeyVault.Keys/client.tsp
+++ b/specification/keyvault/Security.KeyVault.Keys/client.tsp
@@ -359,16 +359,18 @@ op getKeyAttestation is KeyVaultOperation<
   KeyBundle
 >;
 
-@@override(KeyVault.updateKey, updateKey);
-@@override(KeyVault.getKey, getKey);
+@@override(KeyVault.updateKey, updateKey, "!rust");
+@@override(KeyVault.getKey, getKey, "!rust");
+// Rust follows the service definition for optional versions but will consistently promote the version for crypto operation.
+// Not using (and storing) an explicit version for crypto operations is dangerous and can lock applications out of their data.
 @@override(KeyVault.encrypt, encrypt);
 @@override(KeyVault.decrypt, decrypt);
 @@override(KeyVault.sign, sign);
 @@override(KeyVault.verify, verify);
 @@override(KeyVault.wrapKey, wrapKey);
 @@override(KeyVault.unwrapKey, unwrapKey);
-@@override(KeyVault.release, release);
-@@override(KeyVault.getKeyAttestation, getKeyAttestation);
+@@override(KeyVault.release, release, "!rust");
+@@override(KeyVault.getKeyAttestation, getKeyAttestation, "!rust");
 
 // Java configuration
 @@clientName(KeyEncryptionAlgorithm, "KeyExportEncryptionAlgorithm", "java");

--- a/specification/keyvault/Security.KeyVault.Secrets/client.tsp
+++ b/specification/keyvault/Security.KeyVault.Secrets/client.tsp
@@ -83,8 +83,8 @@ op getSecret is KeyVaultOperation<
   SecretBundle
 >;
 
-@@override(KeyVault.updateSecret, updateSecret);
-@@override(KeyVault.getSecret, getSecret);
+@@override(KeyVault.updateSecret, updateSecret, "!rust");
+@@override(KeyVault.getSecret, getSecret, "!rust");
 
 // go renames
 


### PR DESCRIPTION
The Rust emitter had a bug that was ignoring the client.tsp overrides for making version parameters optional.
However, after discussing this with several people, I'm going to allow the client.tsp overrides to promote the versions as required for crypto operations,
because not using a versioned key ID is a really bad idea for crypto operations that can leave you locked out of your data.
The Rust SDK hasn't GA'd yet (soon) so now is the time to make DX improvements like this.

Rust will keep version optional and in its "client method options bucket" because passing an empty string to mean "optional" is not idimomatic to Rust.
