### PR TITLE
add go config to mitigate postgresqlflexibleservers breaking

### DIFF
--- a/specification/postgresql/DBforPostgreSQL.Management/client.tsp
+++ b/specification/postgresql/DBforPostgreSQL.Management/client.tsp
@@ -45,8 +45,13 @@ using Azure.ClientGenerator.Core;
   "java"
 );
 
-@@clientName(Microsoft.DBforPostgreSQL.PostgreSqlFlexibleServerHighAvailabilityMode,
-  "PostgreSqlFlexibleServersHighAvailabilityMode",
+@@alternateType(Microsoft.DBforPostgreSQL.HighAvailability.mode,
+  HighAvailabilityMode,
+  "go"
+);
+
+@@alternateType(Microsoft.DBforPostgreSQL.HighAvailabilityForPatch.mode,
+  HighAvailabilityMode,
   "go"
 );
 

--- a/specification/postgresql/DBforPostgreSQL.Management/client.tsp
+++ b/specification/postgresql/DBforPostgreSQL.Management/client.tsp
@@ -44,3 +44,22 @@ using Azure.ClientGenerator.Core;
   PostgreSqlFlexibleServerHighAvailabilityMode[],
   "java"
 );
+
+@@alternateType(Microsoft.DBforPostgreSQL.HighAvailability.mode,
+  HighAvailabilityMode,
+  "go"
+);
+
+@@alternateType(Microsoft.DBforPostgreSQL.HighAvailabilityForPatch.mode,
+  HighAvailabilityMode,
+  "go"
+);
+
+@@clientName(PostgresMajorVersion.`11`, "Eleven", "go");
+@@clientName(PostgresMajorVersion.`12`, "Twelve", "go");
+@@clientName(PostgresMajorVersion.`13`, "Thirteen", "go");
+@@clientName(PostgresMajorVersion.`14`, "Fourteen", "go");
+@@clientName(PostgresMajorVersion.`15`, "Fifteen", "go");
+@@clientName(PostgresMajorVersion.`16`, "Sixteen", "go");
+@@clientName(PostgresMajorVersion.`17`, "Seventeen", "go");
+@@clientName(PostgresMajorVersion.`18`, "Eighteen", "go");

--- a/specification/postgresql/DBforPostgreSQL.Management/client.tsp
+++ b/specification/postgresql/DBforPostgreSQL.Management/client.tsp
@@ -45,6 +45,11 @@ using Azure.ClientGenerator.Core;
   "java"
 );
 
+@@clientName(Microsoft.DBforPostgreSQL.PostgreSqlFlexibleServerHighAvailabilityMode,
+  "PostgreSqlFlexibleServersHighAvailabilityMode",
+  "go"
+);
+
 @@clientName(PostgresMajorVersion.`11`, "Eleven", "go");
 @@clientName(PostgresMajorVersion.`12`, "Twelve", "go");
 @@clientName(PostgresMajorVersion.`13`, "Thirteen", "go");

--- a/specification/postgresql/DBforPostgreSQL.Management/client.tsp
+++ b/specification/postgresql/DBforPostgreSQL.Management/client.tsp
@@ -42,7 +42,7 @@ using Azure.ClientGenerator.Core;
 );
 @@alternateType(Microsoft.DBforPostgreSQL.ServerSkuCapability.supportedHaMode,
   PostgreSqlFlexibleServerHighAvailabilityMode[],
-  "java"
+  "java,go"
 );
 
 @@clientName(PostgresMajorVersion.`11`, "Eleven", "go");

--- a/specification/postgresql/DBforPostgreSQL.Management/client.tsp
+++ b/specification/postgresql/DBforPostgreSQL.Management/client.tsp
@@ -34,25 +34,15 @@ using Azure.ClientGenerator.Core;
 
 @@clientName(Microsoft.DBforPostgreSQL.PostgreSqlFlexibleServerHighAvailabilityMode,
   "HighAvailabilityMode",
-  "java"
+  "java,go"
 );
 @@clientName(Microsoft.DBforPostgreSQL.HighAvailabilityMode,
   "SupportedHighAvailabilityMode",
-  "java"
+  "java,go"
 );
 @@alternateType(Microsoft.DBforPostgreSQL.ServerSkuCapability.supportedHaMode,
   PostgreSqlFlexibleServerHighAvailabilityMode[],
   "java"
-);
-
-@@alternateType(Microsoft.DBforPostgreSQL.HighAvailability.mode,
-  HighAvailabilityMode,
-  "go"
-);
-
-@@alternateType(Microsoft.DBforPostgreSQL.HighAvailabilityForPatch.mode,
-  HighAvailabilityMode,
-  "go"
 );
 
 @@clientName(PostgresMajorVersion.`11`, "Eleven", "go");

--- a/specification/postgresql/DBforPostgreSQL.Management/client.tsp
+++ b/specification/postgresql/DBforPostgreSQL.Management/client.tsp
@@ -45,16 +45,6 @@ using Azure.ClientGenerator.Core;
   "java"
 );
 
-@@alternateType(Microsoft.DBforPostgreSQL.HighAvailability.mode,
-  HighAvailabilityMode,
-  "go"
-);
-
-@@alternateType(Microsoft.DBforPostgreSQL.HighAvailabilityForPatch.mode,
-  HighAvailabilityMode,
-  "go"
-);
-
 @@clientName(PostgresMajorVersion.`11`, "Eleven", "go");
 @@clientName(PostgresMajorVersion.`12`, "Twelve", "go");
 @@clientName(PostgresMajorVersion.`13`, "Thirteen", "go");

--- a/specification/postgresql/DBforPostgreSQL.Management/client.tsp
+++ b/specification/postgresql/DBforPostgreSQL.Management/client.tsp
@@ -30,7 +30,7 @@ using Azure.ClientGenerator.Core;
   "geoBackupKeyUri",
   "java"
 );
-@@clientName(RequestIdResponseHeader.requestId, "xMsRequestId", "java");
+@@clientName(RequestIdResponseHeader.requestId, "xMsRequestId", "java,go");
 
 @@clientName(Microsoft.DBforPostgreSQL.PostgreSqlFlexibleServerHighAvailabilityMode,
   "HighAvailabilityMode",

--- a/specification/postgresql/DBforPostgreSQL.Management/tspconfig.yaml
+++ b/specification/postgresql/DBforPostgreSQL.Management/tspconfig.yaml
@@ -37,7 +37,7 @@ options:
     service-dir: "sdk/resourcemanager/postgresql"
     emitter-output-dir: "{output-dir}/{service-dir}/armpostgresqlflexibleservers"
     module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armpostgresqlflexibleservers"
-    fix-const-stuttering: false
+    fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true
     generate-fakes: true

--- a/specification/postgresql/DBforPostgreSQL.Management/tspconfig.yaml
+++ b/specification/postgresql/DBforPostgreSQL.Management/tspconfig.yaml
@@ -37,7 +37,7 @@ options:
     service-dir: "sdk/resourcemanager/postgresql"
     emitter-output-dir: "{output-dir}/{service-dir}/armpostgresqlflexibleservers"
     module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armpostgresqlflexibleservers"
-    fix-const-stuttering: true
+    fix-const-stuttering: false
     flavor: "azure"
     generate-samples: true
     generate-fakes: true


### PR DESCRIPTION
# SDK configuration pull request

## Purpose of this PR

- [ ] Make changes to the SDK configuration only when there are no modifications to the API specification, eliminating the need for an ARM or Stewardship Board API review.

## Due diligence checklist

To merge this PR, you **must** go through the following checklist and confirm you understood
and followed the instructions by checking all the boxes:

- [ ] I confirm this PR is modifying only SDK configurations, and not API related specifications.
- [ ] I have reviewed and used the respective `tspconfig.yaml` templates:
  - [ARM tspconfig template](https://aka.ms/azsdk/tspconfig-sample-mpg)
  - [Data plane tspconfig template](https://aka.ms/azsdk/tspconfig-sample-dpg)

## Getting help

- First, carefully read through this PR description, from top to bottom. Fill out the `Purpose of this PR` and `Due diligence checklist`.
- If you don't have permissions to remove or add labels to the PR, request `write access` per [aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories](https://aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories)
- To understand what you must do next to merge this PR, see the `Next Steps to Merge` comment. It will appear within few minutes of submitting this PR and will continue to be up-to-date with current PR state.
- For guidance on fixing this PR CI check failures, see the hyperlinks provided in given failure and https://aka.ms/ci-fix.
- If the PR CI checks appear to be stuck in `queued` state, please add a comment with contents `/azp run`.
  This should result in a new comment denoting a `PR validation pipeline` has started and the checks should be updated after few minutes.
- If the help provided by the previous points is not enough, post to https://aka.ms/azsdk/support/specreview-channel and link to this PR.
