### PR TITLE
Add Managed HSM support to Application Gateway for API version 2025-07-01

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/applicationGateway.json
@@ -1339,6 +1339,20 @@
       },
       "description": "SKU of an application gateway."
     },
+    "ApplicationGatewayManagedHsm": {
+      "type": "object",
+      "properties": {
+        "keyId": {
+          "type": "string",
+          "description": "Key identifier of a key stored in Managed HSM.",
+          "format": "uri"
+        },
+        "publicCertData": {
+          "type": "string",
+          "description": "Base-64 encoded value of a base-64 public certificate."
+        }
+      }
+    },
     "ApplicationGatewaySslPolicy": {
       "properties": {
         "disabledSslProtocols": {
@@ -1617,6 +1631,10 @@
         "keyVaultSecretId": {
           "type": "string",
           "description": "Secret Id of (base-64 encoded unencrypted pfx) 'Secret' or 'Certificate' object stored in KeyVault."
+        },
+        "hsm": {
+          "$ref": "#/definitions/ApplicationGatewayManagedHsm",
+          "description": "Managed HSM properties of the Application Gateway resource."
         },
         "provisioningState": {
           "readOnly": true,


### PR DESCRIPTION
## Description

This PR adds Managed HSM (MHSM) support to the Application Gateway spec for API version 2025-07-01.

### Changes
- Added new type definition `ApplicationGatewayManagedHsm` with `keyId` (uri) and `publicCertData` properties
- Added `hsm` property to `ApplicationGatewaySslCertificatePropertiesFormat` referencing the new MHSM definition

## Original PR

Port of MHSM changes from:
https://github.com/Azure/azure-rest-api-specs-pr/pull/23831