### PR TITLE
[SDK Validation] replace spawnSync pwsh with simple-git in getChangedFiles to fix ENOBUFS on large PRs

### DIFF
--- a/eng/tools/spec-gen-sdk-runner/src/commands.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/commands.ts
@@ -91,7 +91,7 @@ export async function generateSdkForSpecPr(): Promise<number> {
   // Construct the spec-gen-sdk command
   const specGenSdkCommand = prepareSpecGenSdkCommand(commandInput);
   // Get the spec paths from the changed files
-  const changedSpecs = detectChangedSpecConfigFiles(commandInput);
+  const changedSpecs = await detectChangedSpecConfigFiles(commandInput);
 
   let statusCode = 0;
   let pushedSpecConfigCount: number;

--- a/eng/tools/spec-gen-sdk-runner/src/spec-helpers.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/spec-helpers.ts
@@ -133,8 +133,10 @@ export function processTypeSpecProjectsV2FolderStructure(
   return changedSpecs;
 }
 
-export function detectChangedSpecConfigFiles(commandInput: SpecGenSdkCmdInput): ChangedSpecs[] {
-  const prChangedFiles: string[] = getChangedFiles(commandInput.localSpecRepoPath) ?? [];
+export async function detectChangedSpecConfigFiles(
+  commandInput: SpecGenSdkCmdInput,
+): Promise<ChangedSpecs[]> {
+  const prChangedFiles: string[] = await getChangedFiles(commandInput.localSpecRepoPath);
   if (prChangedFiles.length === 0) {
     logMessage("No files changed in the PR");
   }

--- a/eng/tools/spec-gen-sdk-runner/src/utils.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/utils.ts
@@ -1,3 +1,4 @@
+import { getChangedFiles as getChangedFilesShared } from "@azure-tools/specs-shared/changed-files";
 import { exec, spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
@@ -172,28 +173,18 @@ function isCommandAvailable(command: string): boolean {
   }
 }
 
-// Function to call Get-ChangedFiles from PowerShell script
-export function getChangedFiles(
+// Function to get changed files using simple-git via shared library
+export async function getChangedFiles(
   specRepoPath: string,
   baseCommitish: string = "HEAD^",
   targetCommitish: string = "HEAD",
-): string[] | undefined {
-  // set diff filter to include added, copied, modified, deleted, renamed, and type changed files
-  const diffFilter = "ACMDRT";
-  const scriptPath = path.resolve(specRepoPath, "eng/scripts/ChangedFiles-Functions.ps1");
-  const args = [
-    "-Command",
-    `& { . '${scriptPath}'; Get-ChangedFiles '${baseCommitish}' '${targetCommitish}' '${diffFilter}' }`,
-  ];
-
-  const output = runPowerShellScript(args);
-  if (output) {
-    return output
-      .split("\n")
-      .map((line) => line.trim())
-      .filter((line) => line.length > 0);
-  }
-  return undefined;
+): Promise<string[]> {
+  return getChangedFilesShared({
+    baseCommitish,
+    headCommitish: targetCommitish,
+    cwd: specRepoPath,
+    gitOptions: ["--diff-filter=ACMDRT"],
+  });
 }
 
 /**

--- a/eng/tools/spec-gen-sdk-runner/test/commands.test.ts
+++ b/eng/tools/spec-gen-sdk-runner/test/commands.test.ts
@@ -211,7 +211,7 @@ describe("generateSdkForSpecPr", () => {
 
     vi.spyOn(commandHelpers, "parseArguments").mockReturnValue(mockCommandInput);
     vi.spyOn(commandHelpers, "prepareSpecGenSdkCommand").mockReturnValue(["mock-command"]);
-    vi.spyOn(changeFiles, "detectChangedSpecConfigFiles").mockReturnValue(mockChangedSpecs);
+    vi.spyOn(changeFiles, "detectChangedSpecConfigFiles").mockResolvedValue(mockChangedSpecs);
     vi.spyOn(utils, "resetGitRepo").mockResolvedValue(undefined);
     vi.spyOn(utils, "runSpecGenSdkCommand").mockResolvedValue(undefined);
     vi.spyOn(commandHelpers, "getExecutionReport").mockReturnValue(
@@ -270,7 +270,7 @@ describe("generateSdkForSpecPr", () => {
     };
 
     // Return empty array for changedSpecs
-    vi.spyOn(changeFiles, "detectChangedSpecConfigFiles").mockReturnValue([]);
+    vi.spyOn(changeFiles, "detectChangedSpecConfigFiles").mockResolvedValue([]);
     vi.spyOn(commandHelpers, "parseArguments").mockReturnValue(mockCommandInput);
     vi.spyOn(commandHelpers, "prepareSpecGenSdkCommand").mockReturnValue(["mock-command"]);
 
@@ -313,7 +313,7 @@ describe("generateSdkForSpecPr", () => {
     const mockChangedSpecs = [{ specs: [] }];
 
     vi.spyOn(commandHelpers, "parseArguments").mockReturnValue(mockCommandInput);
-    vi.spyOn(changeFiles, "detectChangedSpecConfigFiles").mockReturnValue(mockChangedSpecs);
+    vi.spyOn(changeFiles, "detectChangedSpecConfigFiles").mockResolvedValue(mockChangedSpecs);
     vi.spyOn(commandHelpers, "generateArtifact").mockReturnValue(0);
     vi.spyOn(log, "logMessage").mockImplementation(() => {
       // mock implementation intentionally left blank
@@ -365,7 +365,7 @@ describe("generateSdkForSpecPr", () => {
     };
     vi.spyOn(commandHelpers, "parseArguments").mockReturnValue(mockCommandInput);
     vi.spyOn(commandHelpers, "prepareSpecGenSdkCommand").mockReturnValue(["mock-command"]);
-    vi.spyOn(changeFiles, "detectChangedSpecConfigFiles").mockReturnValue(mockChangedSpecs);
+    vi.spyOn(changeFiles, "detectChangedSpecConfigFiles").mockResolvedValue(mockChangedSpecs);
     vi.spyOn(utils, "runSpecGenSdkCommand").mockRejectedValue(new Error("Command failed"));
     vi.spyOn(utils, "resetGitRepo").mockImplementation(() => Promise.resolve());
     vi.spyOn(commandHelpers, "getExecutionReport").mockReturnValue(
@@ -413,7 +413,7 @@ describe("generateSdkForSpecPr", () => {
     });
     vi.spyOn(commandHelpers, "parseArguments").mockReturnValue(mockCommandInput);
     vi.spyOn(commandHelpers, "prepareSpecGenSdkCommand").mockReturnValue(["mock-command"]);
-    vi.spyOn(changeFiles, "detectChangedSpecConfigFiles").mockReturnValue(mockChangedSpecs);
+    vi.spyOn(changeFiles, "detectChangedSpecConfigFiles").mockResolvedValue(mockChangedSpecs);
     vi.spyOn(utils, "runSpecGenSdkCommand").mockResolvedValue(undefined);
     vi.spyOn(utils, "resetGitRepo").mockImplementation(() => Promise.resolve());
     vi.spyOn(log, "logMessage").mockImplementation(() => {

--- a/eng/tools/spec-gen-sdk-runner/test/spec-helpers.test.ts
+++ b/eng/tools/spec-gen-sdk-runner/test/spec-helpers.test.ts
@@ -65,38 +65,38 @@ describe("detectChangedSpecConfigFiles", () => {
     vi.clearAllMocks();
   });
 
-  test("case with empty change files", () => {
-    vi.mocked(getChangedFiles).mockReturnValue([]);
-    const result = detectChangedSpecConfigFiles(mockCommandInput);
+  test("case with empty change files", async () => {
+    vi.mocked(getChangedFiles).mockResolvedValue([]);
+    const result = await detectChangedSpecConfigFiles(mockCommandInput);
     expect(result).toEqual([]);
   });
 
-  test("case with changed files but none under specification folder", () => {
-    vi.mocked(getChangedFiles).mockReturnValue([
+  test("case with changed files but none under specification folder", async () => {
+    vi.mocked(getChangedFiles).mockResolvedValue([
       "eng/tools/script1.js",
       "documentation/README.md",
       "profile/2020-09-01-hybrid.json",
     ]);
-    const result = detectChangedSpecConfigFiles(mockCommandInput);
+    const result = await detectChangedSpecConfigFiles(mockCommandInput);
     expect(result).toEqual([]);
   });
 
-  test("case with changed files only under scenarios folder", () => {
-    vi.mocked(getChangedFiles).mockReturnValue([
+  test("case with changed files only under scenarios folder", async () => {
+    vi.mocked(getChangedFiles).mockResolvedValue([
       "specification/storage/scenarios/test1.json",
       "specification/compute/scenarios/test2.json",
     ]);
-    const result = detectChangedSpecConfigFiles(mockCommandInput);
+    const result = await detectChangedSpecConfigFiles(mockCommandInput);
     expect(result).toEqual([]);
   });
 
-  test("case with readme files", () => {
-    vi.mocked(getChangedFiles).mockReturnValue([
+  test("case with readme files", async () => {
+    vi.mocked(getChangedFiles).mockResolvedValue([
       "specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/preview/2021-10-01-preview/examples/Employees_Get.json",
       "specification/contosowidgetmanager/data-plane/Azure.Contoso.WidgetManager/preview/2022-11-01-preview/widgets.json",
     ]);
 
-    const result = detectChangedSpecConfigFiles(mockCommandInput);
+    const result = await detectChangedSpecConfigFiles(mockCommandInput);
 
     expect(result).toHaveLength(2);
     expect(normalizeResultItem(result[0])).toEqual({
@@ -113,14 +113,14 @@ describe("detectChangedSpecConfigFiles", () => {
     });
   });
 
-  test("case with tsp files", () => {
-    vi.mocked(getChangedFiles).mockReturnValue([
+  test("case with tsp files", async () => {
+    vi.mocked(getChangedFiles).mockResolvedValue([
       "specification/contosowidgetmanager/Contoso.Management/main.tsp",
       "specification/contosowidgetmanager/Contoso.Management/client.tsp",
       "specification/contosowidgetmanager/Contoso.WidgetManager/tspconfig.yaml",
     ]);
 
-    const result = detectChangedSpecConfigFiles(mockCommandInput);
+    const result = await detectChangedSpecConfigFiles(mockCommandInput);
 
     expect(result).toHaveLength(2);
     expect(normalizeResultItem(result[0])).toEqual({
@@ -136,14 +136,14 @@ describe("detectChangedSpecConfigFiles", () => {
     });
   });
 
-  test("case with shared files", () => {
-    vi.mocked(getChangedFiles).mockReturnValue([
+  test("case with shared files", async () => {
+    vi.mocked(getChangedFiles).mockResolvedValue([
       "specification/contosowidgetmanager/Contoso.WidgetManager.Shared/main.tsp",
       "specification/contosowidgetmanager/Contoso.Management/client.tsp",
       "specification/contosowidgetmanager/Contoso.WidgetManager/tspconfig.yaml",
     ]);
 
-    const result = detectChangedSpecConfigFiles(mockCommandInput);
+    const result = await detectChangedSpecConfigFiles(mockCommandInput);
 
     expect(result).toHaveLength(2);
     expect(normalizeResultItem(result[0])).toEqual({
@@ -159,8 +159,8 @@ describe("detectChangedSpecConfigFiles", () => {
     });
   });
 
-  test("case with readme, tsp, shared files", () => {
-    vi.mocked(getChangedFiles).mockReturnValue([
+  test("case with readme, tsp, shared files", async () => {
+    vi.mocked(getChangedFiles).mockResolvedValue([
       "specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/preview/2021-10-01-preview/examples/Employees_Get.json",
       "specification/contosowidgetmanager/data-plane/Azure.Contoso.WidgetManager/preview/2022-11-01-preview/widgets.json",
       "specification/contosowidgetmanager/Contoso.WidgetManager.Shared/main.tsp",
@@ -168,7 +168,7 @@ describe("detectChangedSpecConfigFiles", () => {
       "specification/contosowidgetmanager/Contoso.WidgetManager/tspconfig.yaml",
     ]);
 
-    const result = detectChangedSpecConfigFiles(mockCommandInput);
+    const result = await detectChangedSpecConfigFiles(mockCommandInput);
 
     expect(result).toHaveLength(2);
     expect(normalizeResultItem(result[0])).toEqual({
@@ -190,14 +190,14 @@ describe("detectChangedSpecConfigFiles", () => {
     });
   });
 
-  test("case with V2 folder structure - resource-manager", () => {
-    vi.mocked(getChangedFiles).mockReturnValue([
+  test("case with V2 folder structure - resource-manager", async () => {
+    vi.mocked(getChangedFiles).mockResolvedValue([
       "specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/tspconfig.yaml",
       "specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/main.tsp",
       "specification/service1/resource-manager/readme.md",
     ]);
 
-    const result = detectChangedSpecConfigFiles(mockCommandInput);
+    const result = await detectChangedSpecConfigFiles(mockCommandInput);
 
     expect(result).toHaveLength(1);
     const normalizedResult = normalizeResultItem(result[0]);
@@ -215,14 +215,14 @@ describe("detectChangedSpecConfigFiles", () => {
     });
   });
 
-  test("case with V2 folder structure - data-plane", () => {
-    vi.mocked(getChangedFiles).mockReturnValue([
+  test("case with V2 folder structure - data-plane", async () => {
+    vi.mocked(getChangedFiles).mockResolvedValue([
       "specification/service1/data-plane/widget/tspconfig.yaml",
       "specification/service1/data-plane/widget/main.tsp",
       "specification/service1/data-plane/readme.md",
     ]);
 
-    const result = detectChangedSpecConfigFiles(mockCommandInput);
+    const result = await detectChangedSpecConfigFiles(mockCommandInput);
 
     expect(result).toHaveLength(1);
     const normalizedResult = normalizeResultItem(result[0]);
@@ -238,15 +238,15 @@ describe("detectChangedSpecConfigFiles", () => {
     });
   });
 
-  test("case with V2 folder structure - nested subfolders", () => {
-    vi.mocked(getChangedFiles).mockReturnValue([
+  test("case with V2 folder structure - nested subfolders", async () => {
+    vi.mocked(getChangedFiles).mockResolvedValue([
       "specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/examples/2021-11-01/create.json",
       "specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/stable/2021-11-01/servicecontrol.json",
       "specification/service1/resource-manager/Microsoft.Service1/readme.md",
       "specification/service1/resource-manager/readme.md",
     ]);
 
-    const result = detectChangedSpecConfigFiles(mockCommandInput);
+    const result = await detectChangedSpecConfigFiles(mockCommandInput);
 
     expect(result).toHaveLength(1);
     const normalizedResult = normalizeResultItem(result[0]);
@@ -264,8 +264,8 @@ describe("detectChangedSpecConfigFiles", () => {
     });
   });
 
-  test("case with V2 folder structure mixed with old structure", () => {
-    vi.mocked(getChangedFiles).mockReturnValue([
+  test("case with V2 folder structure mixed with old structure", async () => {
+    vi.mocked(getChangedFiles).mockResolvedValue([
       // V2 folder structure
       "specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/tspconfig.yaml",
       "specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/main.tsp",
@@ -276,7 +276,7 @@ describe("detectChangedSpecConfigFiles", () => {
       "specification/contosowidgetmanager/data-plane/readme.md",
     ]);
 
-    const result = detectChangedSpecConfigFiles(mockCommandInput);
+    const result = await detectChangedSpecConfigFiles(mockCommandInput);
 
     expect(result).toHaveLength(2);
 
@@ -306,8 +306,8 @@ describe("detectChangedSpecConfigFiles", () => {
     });
   });
 
-  test("case with multiple V2 folder structures", () => {
-    vi.mocked(getChangedFiles).mockReturnValue([
+  test("case with multiple V2 folder structures", async () => {
+    vi.mocked(getChangedFiles).mockResolvedValue([
       // First service
       "specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/tspconfig.yaml",
       "specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/main.tsp",
@@ -318,7 +318,7 @@ describe("detectChangedSpecConfigFiles", () => {
       "specification/service2/data-plane/readme.md",
     ]);
 
-    const result = detectChangedSpecConfigFiles(mockCommandInput);
+    const result = await detectChangedSpecConfigFiles(mockCommandInput);
 
     expect(result).toHaveLength(2);
 
@@ -347,15 +347,15 @@ describe("detectChangedSpecConfigFiles", () => {
     });
   });
 
-  test("case with V2 folder structure - cross-platform path separators", () => {
+  test("case with V2 folder structure - cross-platform path separators", async () => {
     // Mock getChangedFiles to return paths with both forward and backslashes
-    vi.mocked(getChangedFiles).mockReturnValue([
+    vi.mocked(getChangedFiles).mockResolvedValue([
       String.raw`specification\service1\resource-manager\Microsoft.Service1\WidgetManagement\tspconfig.yaml`,
       "specification/service1/resource-manager/Microsoft.Service1/WidgetManagement/main.tsp",
       String.raw`specification\service1\resource-manager\readme.md`,
     ]);
 
-    const result = detectChangedSpecConfigFiles(mockCommandInput);
+    const result = await detectChangedSpecConfigFiles(mockCommandInput);
 
     expect(result).toHaveLength(1);
     const normalizedResult = normalizeResultItem(result[0]);


### PR DESCRIPTION
## Problem

The `spec-gen-sdk-runner`'s `getChangedFiles` function uses `spawnSync` to invoke PowerShell (`pwsh`) for `git diff`, which has a default `maxBuffer` of 1MB. For PRs with thousands of changed files, the output exceeds this buffer limit, causing an `ENOBUFS` error.

When this happens, `runPowerShellScript` returns `undefined`, which gets coalesced to an empty array (`?? []`). The pipeline then sees **0 changed files** and skips SDK validation entirely — reporting a **false-positive success**.

### Pipeline log
```
Error executing PowerShell script: Error: spawnSync pwsh ENOBUFS
No files changed in the PR
Changed files in the PR: 0
No relevant files changed under 'specification' folder in the PR
```

## Fix

Replace the PowerShell-based `getChangedFiles` in `eng/tools/spec-gen-sdk-runner/src/utils.ts` with the existing `getChangedFiles` from `@azure-tools/specs-shared/changed-files`, which:

- Uses `simple-git` (streaming `spawn`) instead of `spawnSync` — **no buffer size limitation**

