### PR TITLE
mgmt, java, Mitigate CDN Java TypeSpec migration

### DIFF
--- a/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/back-compatible.tsp
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/back-compatible.tsp
@@ -289,12 +289,15 @@ using Microsoft.Cdn;
 @@clientLocation(Profiles.getWafLogAnalyticsMetrics, "LogAnalytics");
 @@clientLocation(Profiles.getWafLogAnalyticsRankings, "LogAnalytics");
 @@clientName(Profiles.profilesListResourceUsage, "ListResourceUsage");
-@@clientLocation(AFDDomains.get, "AFDCustomDomains");
-@@clientLocation(AFDDomains.create, "AFDCustomDomains");
-@@clientLocation(AFDDomains.update, "AFDCustomDomains");
-@@clientLocation(AFDDomains.delete, "AFDCustomDomains");
-@@clientLocation(AFDDomains.listByProfile, "AFDCustomDomains");
-@@clientLocation(AFDDomains.refreshValidationToken, "AFDCustomDomains");
+@@clientLocation(AFDDomains.get, "AFDCustomDomains", "!java");
+@@clientLocation(AFDDomains.create, "AFDCustomDomains", "!java");
+@@clientLocation(AFDDomains.update, "AFDCustomDomains", "!java");
+@@clientLocation(AFDDomains.delete, "AFDCustomDomains", "!java");
+@@clientLocation(AFDDomains.listByProfile, "AFDCustomDomains", "!java");
+@@clientLocation(AFDDomains.refreshValidationToken,
+  "AFDCustomDomains",
+  "!java"
+);
 @@clientLocation(CdnWebApplicationFirewallPolicies.get, "Policies");
 @@clientLocation(CdnWebApplicationFirewallPolicies.createOrUpdate, "Policies");
 @@clientLocation(CdnWebApplicationFirewallPolicies.update, "Policies");

--- a/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/back-compatible.tsp
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/back-compatible.tsp
@@ -277,11 +277,14 @@ using Microsoft.Cdn;
 @@clientName(CidrIpAddress, "cidrIpAddress");
 @@clientName(PolicySettings, "policySettings");
 
-@@clientLocation(Profiles.checkEndpointNameAvailability, "AFDProfiles");
-@@clientLocation(Profiles.listResourceUsage, "AFDProfiles");
-@@clientLocation(Profiles.checkHostNameAvailability, "AFDProfiles");
-@@clientLocation(Profiles.validateSecret, "AFDProfiles");
-@@clientLocation(Profiles.upgrade, "AFDProfiles");
+@@clientLocation(Profiles.checkEndpointNameAvailability,
+  "AFDProfiles",
+  "!java"
+);
+@@clientLocation(Profiles.listResourceUsage, "AFDProfiles", "!java");
+@@clientLocation(Profiles.checkHostNameAvailability, "AFDProfiles", "!java");
+@@clientLocation(Profiles.validateSecret, "AFDProfiles", "!java");
+@@clientLocation(Profiles.upgrade, "AFDProfiles", "!java");
 @@clientLocation(Profiles.getLogAnalyticsMetrics, "LogAnalytics");
 @@clientLocation(Profiles.getLogAnalyticsRankings, "LogAnalytics");
 @@clientLocation(Profiles.getLogAnalyticsLocations, "LogAnalytics");

--- a/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/client.tsp
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/client.tsp
@@ -14,13 +14,25 @@ using Microsoft.Cdn;
 @@clientName(ValidateProbeInput.probeURL, "probeUrl", "java");
 
 @@access(Certificate, Access.public, "java");
-@@usage(Certificate, Azure.ClientGenerator.Core.Usage.input | Azure.ClientGenerator.Core.Usage.output, "java");
+@@usage(Certificate,
+  Azure.ClientGenerator.Core.Usage.input | Azure.ClientGenerator.Core.Usage.output,
+  "java"
+);
 @@access(CustomerCertificate, Access.public, "java");
-@@usage(CustomerCertificate, Azure.ClientGenerator.Core.Usage.input | Azure.ClientGenerator.Core.Usage.output, "java");
+@@usage(CustomerCertificate,
+  Azure.ClientGenerator.Core.Usage.input | Azure.ClientGenerator.Core.Usage.output,
+  "java"
+);
 @@access(ManagedCertificate, Access.public, "java");
-@@usage(ManagedCertificate, Azure.ClientGenerator.Core.Usage.input | Azure.ClientGenerator.Core.Usage.output, "java");
+@@usage(ManagedCertificate,
+  Azure.ClientGenerator.Core.Usage.input | Azure.ClientGenerator.Core.Usage.output,
+  "java"
+);
 @@access(AzureFirstPartyManagedCertificate, Access.public, "java");
-@@usage(AzureFirstPartyManagedCertificate, Azure.ClientGenerator.Core.Usage.input | Azure.ClientGenerator.Core.Usage.output, "java");
+@@usage(AzureFirstPartyManagedCertificate,
+  Azure.ClientGenerator.Core.Usage.input | Azure.ClientGenerator.Core.Usage.output,
+  "java"
+);
 
 // AfdCustomDomains client for Java
 @@clientLocation(AFDDomains.get, "AfdCustomDomains", "java");
@@ -37,6 +49,7 @@ using Microsoft.Cdn;
   "java"
 );
 @@clientName(AFDDomainHttpsParameters, "AfdDomainHttpsParameters", "java");
+@@clientName(AFDDomainMtlsParameters, "AfdDomainMtlsParameters", "java");
 @@clientName(AFDDomains, "AfdDomains", "java");
 @@clientName(AFDDomainUpdateParameters, "AfdDomainUpdateParameters", "java");
 @@clientName(AFDDomainUpdatePropertiesParameters,
@@ -59,6 +72,10 @@ using Microsoft.Cdn;
 @@clientName(AFDOrigin, "AfdOrigin", "java");
 @@clientName(AFDOriginProperties, "AfdOriginProperties", "java");
 @@clientName(AFDOrigins, "AfdOrigins", "java");
+@@clientName(AFDOriginUpdatePropertiesParameters,
+  "AfdOriginUpdatePropertiesParameters",
+  "java"
+);
 @@clientName(AFDOriginGroupUpdateParameters,
   "AfdOriginGroupUpdateParameters",
   "java"
@@ -98,6 +115,15 @@ using Microsoft.Cdn;
   "java"
 );
 @@clientName(AFDEndpointProtocols, "AfdEndpointProtocols", "java");
+@@clientName(AFDRouteGrpcState, "AfdRouteGrpcState", "java");
+@@clientName(DeploymentVersionAFDOriginChange,
+  "DeploymentVersionAfdOriginChange",
+  "java"
+);
+@@clientName(DeploymentVersionAFDOriginGroupChange,
+  "DeploymentVersionAfdOriginGroupChange",
+  "java"
+);
 @@clientName(CheckHostNameAvailabilityInput,
   "CheckHostnameAvailabilityInput",
   "java"

--- a/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/client.tsp
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/client.tsp
@@ -96,6 +96,15 @@ using Microsoft.Cdn;
 @@clientName(DeliveryRuleActionName, "DeliveryRuleActionValue", "java");
 @@clientName(AFDStateProperties, "AfdStateProperties", "java");
 @@clientName(HostNameOperator, "HostnameOperator", "java");
+@@clientName(RequestMethodMatchValue,
+  "RequestMethodMatchConditionParametersMatchValuesItem",
+  "java"
+);
+@@clientName(CheckHostNameAvailabilityInput.hostName, "hostname", "java");
+@@clientName(AFDDomainProperties.hostName, "hostname", "java");
+@@clientName(AFDEndpointProperties.hostName, "hostname", "java");
+@@clientName(AFDOriginUpdatePropertiesParameters.hostName, "hostname", "java");
+@@clientName(OriginProperties.hostName, "hostname", "java");
 @@clientName(Microsoft.Cdn, "CdnManagementClient", "javascript");
 @@clientName(PolicySettingsDefaultCustomBlockResponseStatusCode.`405`,
   "FourHundredFive",

--- a/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/client.tsp
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/client.tsp
@@ -34,6 +34,11 @@ using Microsoft.Cdn;
   "java"
 );
 
+@@alternateType(RequestSchemeMatchConditionParameters.operator,
+  "Equal",
+  "java"
+);
+
 // AfdCustomDomains client for Java
 @@clientLocation(AFDDomains.get, "AfdCustomDomains", "java");
 @@clientLocation(AFDDomains.create, "AfdCustomDomains", "java");
@@ -46,7 +51,10 @@ using Microsoft.Cdn;
 @@clientLocation(Profiles.checkEndpointNameAvailability, "AfdProfiles", "java");
 @@clientLocation(Profiles.listResourceUsage, "AfdProfiles", "java");
 @@clientLocation(Profiles.checkHostNameAvailability, "AfdProfiles", "java");
-@@clientName(Profiles.checkHostNameAvailability, "checkHostnameAvailability", "java");
+@@clientName(Profiles.checkHostNameAvailability,
+  "checkHostnameAvailability",
+  "java"
+);
 @@clientLocation(Profiles.validateSecret, "AfdProfiles", "java");
 @@clientLocation(Profiles.upgrade, "AfdProfiles", "java");
 

--- a/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/client.tsp
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/client.tsp
@@ -13,6 +13,13 @@ using Microsoft.Cdn;
 
 @@clientName(ValidateProbeInput.probeURL, "probeUrl", "java");
 
+@@clientLocation(AFDDomains.get, "AfdCustomDomains", "java");
+@@clientLocation(AFDDomains.create, "AfdCustomDomains", "java");
+@@clientLocation(AFDDomains.update, "AfdCustomDomains", "java");
+@@clientLocation(AFDDomains.delete, "AfdCustomDomains", "java");
+@@clientLocation(AFDDomains.listByProfile, "AfdCustomDomains", "java");
+@@clientLocation(AFDDomains.refreshValidationToken, "AfdCustomDomains", "java");
+
 @@clientName(AFDDomain, "AfdDomain", "java");
 @@clientName(AFDDomainProperties, "AfdDomainProperties", "java");
 @@clientName(AFDDomainHttpsCustomizedCipherSuiteSet,

--- a/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/client.tsp
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/client.tsp
@@ -42,6 +42,14 @@ using Microsoft.Cdn;
 @@clientLocation(AFDDomains.listByProfile, "AfdCustomDomains", "java");
 @@clientLocation(AFDDomains.refreshValidationToken, "AfdCustomDomains", "java");
 
+// AfdProfiles client for Java
+@@clientLocation(Profiles.checkEndpointNameAvailability, "AfdProfiles", "java");
+@@clientLocation(Profiles.listResourceUsage, "AfdProfiles", "java");
+@@clientLocation(Profiles.checkHostNameAvailability, "AfdProfiles", "java");
+@@clientName(Profiles.checkHostNameAvailability, "checkHostnameAvailability", "java");
+@@clientLocation(Profiles.validateSecret, "AfdProfiles", "java");
+@@clientLocation(Profiles.upgrade, "AfdProfiles", "java");
+
 @@clientName(AFDDomain, "AfdDomain", "java");
 @@clientName(AFDDomainProperties, "AfdDomainProperties", "java");
 @@clientName(AFDDomainHttpsCustomizedCipherSuiteSet,

--- a/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/client.tsp
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/client.tsp
@@ -13,6 +13,16 @@ using Microsoft.Cdn;
 
 @@clientName(ValidateProbeInput.probeURL, "probeUrl", "java");
 
+@@access(Certificate, Access.public, "java");
+@@usage(Certificate, Azure.ClientGenerator.Core.Usage.input | Azure.ClientGenerator.Core.Usage.output, "java");
+@@access(CustomerCertificate, Access.public, "java");
+@@usage(CustomerCertificate, Azure.ClientGenerator.Core.Usage.input | Azure.ClientGenerator.Core.Usage.output, "java");
+@@access(ManagedCertificate, Access.public, "java");
+@@usage(ManagedCertificate, Azure.ClientGenerator.Core.Usage.input | Azure.ClientGenerator.Core.Usage.output, "java");
+@@access(AzureFirstPartyManagedCertificate, Access.public, "java");
+@@usage(AzureFirstPartyManagedCertificate, Azure.ClientGenerator.Core.Usage.input | Azure.ClientGenerator.Core.Usage.output, "java");
+
+// AfdCustomDomains client for Java
 @@clientLocation(AFDDomains.get, "AfdCustomDomains", "java");
 @@clientLocation(AFDDomains.create, "AfdCustomDomains", "java");
 @@clientLocation(AFDDomains.update, "AfdCustomDomains", "java");
@@ -112,6 +122,7 @@ using Microsoft.Cdn;
 @@clientName(AFDEndpointProperties.hostName, "hostname", "java");
 @@clientName(AFDOriginUpdatePropertiesParameters.hostName, "hostname", "java");
 @@clientName(OriginProperties.hostName, "hostname", "java");
+
 @@clientName(Microsoft.Cdn, "CdnManagementClient", "javascript");
 @@clientName(PolicySettingsDefaultCustomBlockResponseStatusCode.`405`,
   "FourHundredFive",

--- a/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/tspconfig.yaml
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/tspconfig.yaml
@@ -23,8 +23,11 @@ options:
     namespace: "com.azure.resourcemanager.cdn"
     service-name: "Cdn" # human-readable service name, whitespace allowed
     premium: true
+    client-side-validations: true
     service-dir: "sdk/cdn"
     enable-sync-stack: false
+    float32-as-double: false
+    uuid-as-string: false
     flavor: azure
   "@azure-tools/typespec-ts":
     service-dir: sdk/cdn


### PR DESCRIPTION
Add Java-specific mitigations for CDN TypeSpec project to support SDK migration from autorest to TypeSpec emitter.

sdk pr https://github.com/Azure/azure-sdk-for-java/pull/48177

(PR via agent hence no full description -- this is change for java sdk only)