### PR TITLE
fix: use boolean type for includeExtendedLocations

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/LocationRoutes.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/LocationRoutes.tsp
@@ -89,7 +89,7 @@ interface VmSkusOperationGroup {
        * To Include Extended Locations information or not in the response.
        */
       @query
-      includeExtendedLocations?: string;
+      includeExtendedLocations?: boolean;
     }
   >;
 }

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-01-02-preview/ListAvailableContainerServiceVmSkusWithExtendedLocations.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-01-02-preview/ListAvailableContainerServiceVmSkusWithExtendedLocations.json
@@ -3,7 +3,7 @@
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "api-version": "2026-01-02-preview",
     "location": "westus",
-    "includeExtendedLocations": "true"
+    "includeExtendedLocations": true
   },
   "responses": {
     "200": {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-01-02-preview/examples/ListAvailableContainerServiceVmSkusWithExtendedLocations.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-01-02-preview/examples/ListAvailableContainerServiceVmSkusWithExtendedLocations.json
@@ -3,7 +3,7 @@
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "api-version": "2026-01-02-preview",
     "location": "westus",
-    "includeExtendedLocations": "true"
+    "includeExtendedLocations": true
   },
   "responses": {
     "200": {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-01-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-01-02-preview/managedClusters.json
@@ -553,7 +553,7 @@
             "in": "query",
             "description": "To Include Extended Locations information or not in the response.",
             "required": false,
-            "type": "string"
+            "type": "boolean"
           }
         ],
         "responses": {


### PR DESCRIPTION
This PR addresses some comments regarding query param types in the List VM Skus API.