### PR TITLE
[SDK Validation]: handle rename scenario gracefully in findAllParentsWithFile to prevent crash

### DIFF
--- a/eng/tools/spec-gen-sdk-runner/src/index.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/index.ts
@@ -22,12 +22,18 @@ export async function main() {
     mkdirSync(logFolder, { recursive: true });
   }
   let statusCode: number;
-  if (batchType) {
-    statusCode = await generateSdkForBatchSpecs(batchType);
-  } else if (pullRequestNumber) {
-    statusCode = await generateSdkForSpecPr();
-  } else {
-    statusCode = await generateSdkForSingleSpec();
+  try {
+    if (batchType) {
+      statusCode = await generateSdkForBatchSpecs(batchType);
+    } else if (pullRequestNumber) {
+      statusCode = await generateSdkForSpecPr();
+    } else {
+      statusCode = await generateSdkForSingleSpec();
+    }
+  } catch (error) {
+    console.error("Unhandled exception in spec-gen-sdk-runner:", error);
+    console.log("##vso[task.complete result=Failed;]");
+    exit(1);
   }
   if (statusCode !== 0) {
     console.log("##vso[task.complete result=Failed;]");

--- a/eng/tools/spec-gen-sdk-runner/src/utils.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/utils.ts
@@ -249,13 +249,8 @@ export function findAllParentsWithFile(
         results.push(currentPath);
       }
     } catch (error) {
-      logMessage(
-        `Error reading directory: ${currentPath}. ` +
-          `If this is a transient IO error, please re-run the pipeline. ` +
-          `Error details: ${inspect(error)}`,
-        LogLevel.Error,
-      );
-      throw error;
+      logMessage(`Error reading directory: ${currentPath} with ${inspect(error)}`, LogLevel.Warn);
+      return results;
     }
     currentPath = path.dirname(currentPath);
     // Check if we've reached the root of the path (stopAtFolder) or

--- a/eng/tools/spec-gen-sdk-runner/test/utils/findAllParentsWithFile.test.ts
+++ b/eng/tools/spec-gen-sdk-runner/test/utils/findAllParentsWithFile.test.ts
@@ -66,10 +66,13 @@ describe("findAllParentsWithFile", () => {
     );
   });
 
-  test("throws error when directory does not exist", () => {
-    expect(() =>
-      findAllParentsWithFile("specification/nonexistent/path", typespecProjectRegex, repoRoot),
-    ).toThrow(/ENOENT/);
+  test("returns empty array when directory does not exist", () => {
+    const result = findAllParentsWithFile(
+      "specification/nonexistent/path",
+      typespecProjectRegex,
+      repoRoot,
+    );
+    expect(result).toHaveLength(0);
   });
 
   test("stops at specified boundary and finds files before it", () => {


### PR DESCRIPTION
## Problem

`FindAllParentsWithFile` in `\eng/tools/spec-gen-sdk-runner/src/utils.ts` re-throws ENOENT errors when scanning directories that no longer exist on disk. When a PR renames/restructures folder paths (e.g. [keyvault folder migration PR #38668](https://github.com/Azure/azure-rest-api-specs/pull/38668)), \git diff\ reports both old and new paths. The old paths don't exist after checkout, and for paths containing `data-plane` or `
resource-manager`, the code crashes the entire Node.js process with an uncaught exception — preventing any SDK generation from running.

## Fix

1. `FindAllParentsWithFile`: Changed to match `FindParentWithFile` behavior — catch errors, log a warning, and return early instead of re-throwing.
2. `main()` in `index.ts`: Added top-level try-catch so unexpected exceptions properly set the pipeline step result to `Failed`.
