### PR TITLE
Removed LRO from type names in C#

### DIFF
--- a/specification/cognitiveservices/data-plane/LanguageAnalyzeText/client.tsp
+++ b/specification/cognitiveservices/data-plane/LanguageAnalyzeText/client.tsp
@@ -562,3 +562,13 @@ namespace Language.AnalyzeTextClientCustomizations;
 
 @@clientName(AnalyzeTextJobState, "AnalyzeTextOperationState", "python");
 @@clientName(AnalyzeTextJobState.tasks, "Actions", "python");
+
+@@clientName(CustomEntitiesLROTask, "CustomEntitiesOperationAction", "csharp");
+@@clientName(EntitiesLROTask, "EntitiesOperationAction", "csharp");
+@@clientName(EntityLinkingLROTask, "EntityLinkingOperationAction", "csharp");
+@@clientName(HealthcareLROTask, "HealthcareOperationAction", "csharp");
+@@clientName(KeyPhraseLROTask, "KeyPhraseOperationAction", "csharp");
+@@clientName(PiiLROTask, "PiiOperationAction", "csharp");
+@@clientName(AnalyzeTextLROResult, "AnalyzeTextOperationResult", "csharp");
+@@clientName(HealthcareLROResult, "HealthcareOperationResult", "csharp");
+@@clientName(SentimentLROResult, "SentimentOperationResult", "csharp");


### PR DESCRIPTION
This pull request adds custom client name annotations for several types related to long-running operations (LRO) in the `LanguageAnalyzeText` client for C#. These annotations ensure that the generated C# SDK uses more descriptive and consistent class names for LRO-related tasks and results.

C# client name customizations for LRO types:

* Added `@@clientName` annotations to map internal LRO task types (such as `CustomEntitiesLROTask`, `EntitiesLROTask`, etc.) to more descriptive C# class names (e.g., `CustomEntitiesOperationAction`, `EntitiesOperationAction`).
* Added `@@clientName` annotations for LRO result types (such as `AnalyzeTextLROResult`, `HealthcareLROResult`, etc.) to use consistent C# class names (e.g., `AnalyzeTextOperationResult`, `HealthcareOperationResult`).