### PR TITLE
Azure Search: Restore Enum Types for categories and defaultLanguageCode in EntityRecognitionSkillV3 and SentimentSkillV3

### DIFF
--- a/specification/search/data-plane/Search/client.tsp
+++ b/specification/search/data-plane/Search/client.tsp
@@ -1003,6 +1003,20 @@ namespace KnowledgeBaseRetrievalClient {
   "com.azure.search.documents.indexes",
   "java"
 );
+@@clientNamespace(Search.EntityRecognitionSkillLanguage,
+  "Azure.Search.Documents.Indexes"
+);
+@@clientNamespace(Search.EntityRecognitionSkillLanguage,
+  "com.azure.search.documents.indexes",
+  "java"
+);
+@@clientNamespace(Search.SentimentSkillLanguage,
+  "Azure.Search.Documents.Indexes"
+);
+@@clientNamespace(Search.SentimentSkillLanguage,
+  "com.azure.search.documents.indexes",
+  "java"
+);
 @@clientNamespace(Search.SplitSkillLanguage, "Azure.Search.Documents.Indexes");
 @@clientNamespace(Search.SplitSkillLanguage,
   "com.azure.search.documents.indexes",

--- a/specification/search/data-plane/Search/models-service.tsp
+++ b/specification/search/data-plane/Search/models-service.tsp
@@ -1675,6 +1675,80 @@ union EntityCategory {
   Email: "email",
 }
 
+/** The language codes supported for input text by EntityRecognitionSkill. */
+union EntityRecognitionSkillLanguage {
+  string,
+
+  /** Arabic */
+  ar: "ar",
+
+  /** Czech */
+  cs: "cs",
+
+  /** Chinese-Simplified */
+  `zh-Hans`: "zh-Hans",
+
+  /** Chinese-Traditional */
+  `zh-Hant`: "zh-Hant",
+
+  /** Danish */
+  da: "da",
+
+  /** Dutch */
+  nl: "nl",
+
+  /** English */
+  en: "en",
+
+  /** Finnish */
+  fi: "fi",
+
+  /** French */
+  fr: "fr",
+
+  /** German */
+  de: "de",
+
+  /** Greek */
+  el: "el",
+
+  /** Hungarian */
+  hu: "hu",
+
+  /** Italian */
+  it: "it",
+
+  /** Japanese */
+  ja: "ja",
+
+  /** Korean */
+  ko: "ko",
+
+  /** Norwegian (Bokmaal) */
+  no: "no",
+
+  /** Polish */
+  pl: "pl",
+
+  /** Portuguese (Portugal) */
+  `pt-PT`: "pt-PT",
+
+  /** Portuguese (Brazil) */
+  `pt-BR`: "pt-BR",
+
+  /** Russian */
+  ru: "ru",
+
+  /** Spanish */
+  es: "es",
+
+  /** Swedish */
+  sv: "sv",
+
+  /** Turkish */
+  tr: "tr",
+}
+
 /** A string indicating what maskingMode to use to mask the personal information detected in the input text. */
 union PIIDetectionSkillMaskingMode {
   string,
@@ -1684,6 +1758,56 @@ union PIIDetectionSkillMaskingMode {
 
   /** Replaces the detected entities with the character given in the maskingCharacter parameter. The character will be repeated to the length of the detected entity so that the offsets will correctly correspond to both the input text as well as the output maskedText. */
   Replace: "replace",
+}
+
+/** The language codes supported for input text by SentimentSkill. */
+union SentimentSkillLanguage {
+  string,
+
+  /** Danish */
+  da: "da",
+
+  /** Dutch */
+  nl: "nl",
+
+  /** English */
+  en: "en",
+
+  /** Finnish */
+  fi: "fi",
+
+  /** French */
+  fr: "fr",
+
+  /** German */
+  de: "de",
+
+  /** Greek */
+  el: "el",
+
+  /** Italian */
+  it: "it",
+
+  /** Norwegian (Bokmaal) */
+  no: "no",
+
+  /** Polish */
+  pl: "pl",
+
+  /** Portuguese (Portugal) */
+  `pt-PT`: "pt-PT",
+
+  /** Russian */
+  ru: "ru",
+
+  /** Spanish */
+  es: "es",
+
+  /** Swedish */
+  sv: "sv",
+
+  /** Turkish */
+  tr: "tr",
 }
 
 /** The language codes supported for input text by SplitSkill. */
@@ -5967,7 +6091,7 @@ model MergeSkill extends SearchIndexerSkill {
 model SentimentSkillV3 extends SearchIndexerSkill {
   /** A value indicating which language code to use. Default is `en`. */
   #suppress "@azure-tools/typespec-azure-core/no-nullable" "Pre-existing API contract"
-  defaultLanguageCode?: string | null;
+  defaultLanguageCode?: SentimentSkillLanguage | null;
 
   /** If set to true, the skill output will include information from Text Analytics for opinion mining, namely targets (nouns or verbs) and their associated assessment (adjective) in the text. Default is false. */
   includeOpinionMining?: boolean = false;
@@ -6004,11 +6128,11 @@ model EntityLinkingSkill extends SearchIndexerSkill {
 /** Using the Text Analytics API, extracts entities of different types from text. */
 model EntityRecognitionSkillV3 extends SearchIndexerSkill {
   /** A list of entity categories that should be extracted. */
-  categories?: string[];
+  categories?: EntityCategory[];
 
   /** A value indicating which language code to use. Default is `en`. */
   #suppress "@azure-tools/typespec-azure-core/no-nullable" "Pre-existing API contract"
-  defaultLanguageCode?: string | null;
+  defaultLanguageCode?: EntityRecognitionSkillLanguage | null;
 
   /** A value between 0 and 1 that be used to only include entities whose confidence score is greater than the value specified. If not set (default), or if explicitly set to null, all entities will be included. */
   @minValue(0)

--- a/specification/search/data-plane/Search/preview/2025-11-01-preview/search.json
+++ b/specification/search/data-plane/Search/preview/2025-11-01-preview/search.json
@@ -7097,6 +7097,156 @@
       ],
       "x-ms-discriminator-value": "#Microsoft.Skills.Text.V3.EntityLinkingSkill"
     },
+    "EntityRecognitionSkillLanguage": {
+      "type": "string",
+      "description": "The language codes supported for input text by EntityRecognitionSkill.",
+      "enum": [
+        "ar",
+        "cs",
+        "zh-Hans",
+        "zh-Hant",
+        "da",
+        "nl",
+        "en",
+        "fi",
+        "fr",
+        "de",
+        "el",
+        "hu",
+        "it",
+        "ja",
+        "ko",
+        "no",
+        "pl",
+        "pt-PT",
+        "pt-BR",
+        "ru",
+        "es",
+        "sv",
+        "tr"
+      ],
+      "x-ms-enum": {
+        "name": "EntityRecognitionSkillLanguage",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ar",
+            "value": "ar",
+            "description": "Arabic"
+          },
+          {
+            "name": "cs",
+            "value": "cs",
+            "description": "Czech"
+          },
+          {
+            "name": "zh-Hans",
+            "value": "zh-Hans",
+            "description": "Chinese-Simplified"
+          },
+          {
+            "name": "zh-Hant",
+            "value": "zh-Hant",
+            "description": "Chinese-Traditional"
+          },
+          {
+            "name": "da",
+            "value": "da",
+            "description": "Danish"
+          },
+          {
+            "name": "nl",
+            "value": "nl",
+            "description": "Dutch"
+          },
+          {
+            "name": "en",
+            "value": "en",
+            "description": "English"
+          },
+          {
+            "name": "fi",
+            "value": "fi",
+            "description": "Finnish"
+          },
+          {
+            "name": "fr",
+            "value": "fr",
+            "description": "French"
+          },
+          {
+            "name": "de",
+            "value": "de",
+            "description": "German"
+          },
+          {
+            "name": "el",
+            "value": "el",
+            "description": "Greek"
+          },
+          {
+            "name": "hu",
+            "value": "hu",
+            "description": "Hungarian"
+          },
+          {
+            "name": "it",
+            "value": "it",
+            "description": "Italian"
+          },
+          {
+            "name": "ja",
+            "value": "ja",
+            "description": "Japanese"
+          },
+          {
+            "name": "ko",
+            "value": "ko",
+            "description": "Korean"
+          },
+          {
+            "name": "no",
+            "value": "no",
+            "description": "Norwegian (Bokmaal)"
+          },
+          {
+            "name": "pl",
+            "value": "pl",
+            "description": "Polish"
+          },
+          {
+            "name": "pt-PT",
+            "value": "pt-PT",
+            "description": "Portuguese (Portugal)"
+          },
+          {
+            "name": "pt-BR",
+            "value": "pt-BR",
+            "description": "Portuguese (Brazil)"
+          },
+          {
+            "name": "ru",
+            "value": "ru",
+            "description": "Russian"
+          },
+          {
+            "name": "es",
+            "value": "es",
+            "description": "Spanish"
+          },
+          {
+            "name": "sv",
+            "value": "sv",
+            "description": "Swedish"
+          },
+          {
+            "name": "tr",
+            "value": "tr",
+            "description": "Turkish"
+          }
+        ]
+      }
+    },
     "EntityRecognitionSkillV3": {
       "type": "object",
       "description": "Using the Text Analytics API, extracts entities of different types from text.",
@@ -7105,11 +7255,11 @@
           "type": "array",
           "description": "A list of entity categories that should be extracted.",
           "items": {
-            "type": "string"
+            "$ref": "#/definitions/EntityCategory"
           }
         },
         "defaultLanguageCode": {
-          "type": "string",
+          "$ref": "#/definitions/EntityRecognitionSkillLanguage",
           "description": "A value indicating which language code to use. Default is `en`.",
           "x-nullable": true
         },
@@ -17413,12 +17563,114 @@
         ]
       }
     },
+    "SentimentSkillLanguage": {
+      "type": "string",
+      "description": "The language codes supported for input text by SentimentSkill.",
+      "enum": [
+        "da",
+        "nl",
+        "en",
+        "fi",
+        "fr",
+        "de",
+        "el",
+        "it",
+        "no",
+        "pl",
+        "pt-PT",
+        "ru",
+        "es",
+        "sv",
+        "tr"
+      ],
+      "x-ms-enum": {
+        "name": "SentimentSkillLanguage",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "da",
+            "value": "da",
+            "description": "Danish"
+          },
+          {
+            "name": "nl",
+            "value": "nl",
+            "description": "Dutch"
+          },
+          {
+            "name": "en",
+            "value": "en",
+            "description": "English"
+          },
+          {
+            "name": "fi",
+            "value": "fi",
+            "description": "Finnish"
+          },
+          {
+            "name": "fr",
+            "value": "fr",
+            "description": "French"
+          },
+          {
+            "name": "de",
+            "value": "de",
+            "description": "German"
+          },
+          {
+            "name": "el",
+            "value": "el",
+            "description": "Greek"
+          },
+          {
+            "name": "it",
+            "value": "it",
+            "description": "Italian"
+          },
+          {
+            "name": "no",
+            "value": "no",
+            "description": "Norwegian (Bokmaal)"
+          },
+          {
+            "name": "pl",
+            "value": "pl",
+            "description": "Polish"
+          },
+          {
+            "name": "pt-PT",
+            "value": "pt-PT",
+            "description": "Portuguese (Portugal)"
+          },
+          {
+            "name": "ru",
+            "value": "ru",
+            "description": "Russian"
+          },
+          {
+            "name": "es",
+            "value": "es",
+            "description": "Spanish"
+          },
+          {
+            "name": "sv",
+            "value": "sv",
+            "description": "Swedish"
+          },
+          {
+            "name": "tr",
+            "value": "tr",
+            "description": "Turkish"
+          }
+        ]
+      }
+    },
     "SentimentSkillV3": {
       "type": "object",
       "description": "Using the Text Analytics API, evaluates unstructured text and for each record, provides sentiment labels (such as \"negative\", \"neutral\" and \"positive\") based on the highest confidence score found by the service at a sentence and document-level.",
       "properties": {
         "defaultLanguageCode": {
-          "type": "string",
+          "$ref": "#/definitions/SentimentSkillLanguage",
           "description": "A value indicating which language code to use. Default is `en`.",
           "x-nullable": true
         },


### PR DESCRIPTION
This PR is updating Search Data Plane TypeSpec code to fix the SDK issue: https://github.com/Azure/azure-sdk-for-net/issues/56671