### PR TITLE
Update tspconfig.yaml to remove generate-sample

### DIFF
--- a/specification/computebulkactions/ComputeBulkActions.Management/tspconfig.yaml
+++ b/specification/computebulkactions/ComputeBulkActions.Management/tspconfig.yaml
@@ -19,7 +19,6 @@ options:
     generate-test: true
     generate-sample: true
   "@azure-tools/typespec-ts":
-    generate-sample: false
     experimental-extensible-enums: true
     emitter-output-dir: "{output-dir}/{service-dir}/arm-computebulkactions"
     flavor: azure


### PR DESCRIPTION
Removed generate-sample option for @azure-tools/typespec-ts.

