### PR TITLE
Blob fix container item "deleted" property name

### DIFF
--- a/specification/storage/Microsoft.BlobStorage/client.tsp
+++ b/specification/storage/Microsoft.BlobStorage/client.tsp
@@ -135,6 +135,9 @@ interface PageBlobClient extends Storage.Blob.PageBlob {}
 @@clientName(BlobProperties.immutabilityPolicyUntilDate,
   "ImmutabilityPolicyExpiresOn"
 );
+
+@@clientName(Storage.Blob.ContainerItem.deleted, "delete", "rust");
+
 @@clientName(MetadataHeaders.metadata, "metadata", "rust");
 @@clientName(ObjectReplicationHeaders.objectReplicationRules,
   "objectReplicationRules",

--- a/specification/storage/Microsoft.BlobStorage/client.tsp
+++ b/specification/storage/Microsoft.BlobStorage/client.tsp
@@ -135,7 +135,6 @@ interface PageBlobClient extends Storage.Blob.PageBlob {}
 @@clientName(BlobProperties.immutabilityPolicyUntilDate,
   "ImmutabilityPolicyExpiresOn"
 );
-
 @@clientName(MetadataHeaders.metadata, "metadata", "rust");
 @@clientName(ObjectReplicationHeaders.objectReplicationRules,
   "objectReplicationRules",

--- a/specification/storage/Microsoft.BlobStorage/client.tsp
+++ b/specification/storage/Microsoft.BlobStorage/client.tsp
@@ -136,8 +136,6 @@ interface PageBlobClient extends Storage.Blob.PageBlob {}
   "ImmutabilityPolicyExpiresOn"
 );
 
-@@clientName(Storage.Blob.ContainerItem.deleted, "delete", "rust");
-
 @@clientName(MetadataHeaders.metadata, "metadata", "rust");
 @@clientName(ObjectReplicationHeaders.objectReplicationRules,
   "objectReplicationRules",

--- a/specification/storage/Microsoft.BlobStorage/models.tsp
+++ b/specification/storage/Microsoft.BlobStorage/models.tsp
@@ -604,7 +604,7 @@ model ContainerItem {
   @Xml.name("Name") name: string;
 
   /** Whether the container is deleted. */
-  @Xml.name("Deleted") delete?: boolean;
+  @Xml.name("Deleted") deleted?: boolean;
 
   /** The version of the container. */
   @Xml.name("Version") version?: string;

--- a/specification/storage/data-plane/Microsoft.BlobStorage/stable/2025-11-05/generated_blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/stable/2025-11-05/generated_blob.json
@@ -15717,7 +15717,7 @@
         "Deleted": {
           "type": "boolean",
           "description": "Whether the container is deleted.",
-          "x-ms-client-name": "delete"
+          "x-ms-client-name": "deleted"
         },
         "Version": {
           "type": "string",

--- a/specification/storage/data-plane/Microsoft.BlobStorage/stable/2026-02-06/generated_blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/stable/2026-02-06/generated_blob.json
@@ -15799,7 +15799,7 @@
         "Deleted": {
           "type": "boolean",
           "description": "Whether the container is deleted.",
-          "x-ms-client-name": "delete"
+          "x-ms-client-name": "deleted"
         },
         "Version": {
           "type": "string",

--- a/specification/storage/data-plane/Microsoft.BlobStorage/stable/2026-04-06/generated_blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/stable/2026-04-06/generated_blob.json
@@ -16005,7 +16005,7 @@
         "Deleted": {
           "type": "boolean",
           "description": "Whether the container is deleted.",
-          "x-ms-client-name": "delete"
+          "x-ms-client-name": "deleted"
         },
         "Version": {
           "type": "string",


### PR DESCRIPTION
All of the sdks except for rust use the "deleted" name for this property, using it for the majority and modifying for the sdks that differ. 
Fixes https://github.com/Azure/azure-rest-api-specs/issues/40980