### PR TITLE
Mitigate Java SDK breaking changes for sqlvirtualmachine TypeSpec migration

### DIFF
--- a/specification/sqlvirtualmachine/resource-manager/Microsoft.SqlVirtualMachine/SqlVirtualMachine/client.tsp
+++ b/specification/sqlvirtualmachine/resource-manager/Microsoft.SqlVirtualMachine/SqlVirtualMachine/client.tsp
@@ -236,3 +236,14 @@ using Microsoft.SqlVirtualMachine;
 @@alternateType(AutoBackupSettings.storageAccountUrl, url, "csharp");
 @@alternateType(KeyVaultCredentialSettings.azureKeyVaultUrl, url, "csharp");
 @@alternateType(WsfcDomainProfile.storageAccountUrl, url, "csharp");
+
+// Java-specific client names to mitigate migration breaks
+@@clientName(SQLStorageSettings, "SqlStorageSettings", "java");
+@@clientName(SQLTempDbSettings, "SqlTempDbSettings", "java");
+@@clientName(AADAuthenticationSettings, "AadAuthenticationSettings", "java");
+@@clientName(SQLInstanceSettings, "SqlInstanceSettings", "java");
+@@clientName(PrivateIPAddress, "PrivateIpAddress", "java");
+@@clientName(SqlConnectivityUpdateSettings.sqlAuthUpdateUserName,
+  "sqlAuthUpdateUsername",
+  "java"
+);


### PR DESCRIPTION

Add @@clientName decorators in client.tsp to preserve backward-compatible Java SDK model and property names after TypeSpec migration:
- SQLStorageSettings -> SqlStorageSettings
- SQLTempDbSettings -> SqlTempDbSettings
- AADAuthenticationSettings -> AadAuthenticationSettings
- SQLInstanceSettings -> SqlInstanceSettings
- PrivateIPAddress -> PrivateIpAddress
- SqlConnectivityUpdateSettings.sqlAuthUpdateUserName -> sqlAuthUpdateUsername

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
