### PR TITLE
DO NOT MERGE - Add SKU support to HealthDataAIServices DeidService

### DIFF
--- a/specification/healthdataaiservices/HealthDataAIServices.Management/client.tsp
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/client.tsp
@@ -28,6 +28,10 @@ namespace Microsoft.HealthDataAIServices {
     "HealthDataAIServicesPrivateLinkResourceData",
     "csharp"
   );
+  @@clientName(DeidServiceSkuName,
+    "HealthDataAIServicesDeidServiceSkuName",
+    "csharp"
+  );
   @@clientName(PrivateLinks.listByDeidService, "GetPrivateLinks", "csharp");
 
   @@clientName(Versions.v2024_09_20,

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_Create_MaximumSet_Gen.json
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_Create_MaximumSet_Gen.json
@@ -14,6 +14,10 @@
         "type": "None",
         "userAssignedIdentities": {}
       },
+      "sku": {
+        "name": "Standard",
+        "tier": "Standard"
+      },
       "tags": {},
       "location": "qwyhvdwcsjulggagdqxlmazcl"
     }
@@ -60,6 +64,10 @@
           "userAssignedIdentities": {},
           "principalId": "a82361f4-5320-4a26-8d1b-45832d2164dd",
           "tenantId": "53a6a686-ae15-4a1d-badf-3e7947918893"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
         },
         "tags": {},
         "location": "qwyhvdwcsjulggagdqxlmazcl",
@@ -120,6 +128,10 @@
           "userAssignedIdentities": {},
           "principalId": "a82361f4-5320-4a26-8d1b-45832d2164dd",
           "tenantId": "53a6a686-ae15-4a1d-badf-3e7947918893"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
         },
         "tags": {},
         "location": "qwyhvdwcsjulggagdqxlmazcl",

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_Get_MaximumSet_Gen.json
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_Get_MaximumSet_Gen.json
@@ -50,6 +50,10 @@
           "principalId": "a82361f4-5320-4a26-8d1b-45832d2164dd",
           "tenantId": "53a6a686-ae15-4a1d-badf-3e7947918893"
         },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
+        },
         "tags": {},
         "location": "qwyhvdwcsjulggagdqxlmazcl",
         "id": "/subscriptions/F21BB31B-C214-42C0-ACF0-DACCA05D3011/resourceGroups/rgopenapi/providers/Microsoft.HealthDataAIServices/deidServices/nlrthrxaukih",

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_ListByResourceGroup_MaximumSet_Gen.json
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_ListByResourceGroup_MaximumSet_Gen.json
@@ -51,6 +51,10 @@
               "type": "None",
               "userAssignedIdentities": {}
             },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
             "tags": {},
             "location": "qwyhvdwcsjulggagdqxlmazcl",
             "id": "/subscriptions/F21BB31B-C214-42C0-ACF0-DACCA05D3011/resourceGroups/rgopenapi/providers/Microsoft.HealthDataAIServices/deidServices/nlrthrxaukih",

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_ListBySubscription_MaximumSet_Gen.json
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_ListBySubscription_MaximumSet_Gen.json
@@ -50,6 +50,10 @@
               "type": "None",
               "userAssignedIdentities": {}
             },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
             "tags": {},
             "location": "qwyhvdwcsjulggagdqxlmazcl",
             "id": "/subscriptions/F21BB31B-C214-42C0-ACF0-DACCA05D3011/resourceGroups/rgopenapi/providers/Microsoft.HealthDataAIServices/deidServices/nlrthrxaukih",

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_Update_MaximumSet_Gen.json
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_Update_MaximumSet_Gen.json
@@ -11,6 +11,10 @@
         "type": "None",
         "userAssignedIdentities": {}
       },
+      "sku": {
+        "name": "Standard",
+        "tier": "Standard"
+      },
       "tags": {},
       "properties": {
         "publicNetworkAccess": "Enabled"
@@ -59,6 +63,10 @@
           "userAssignedIdentities": {},
           "principalId": "a82361f4-5320-4a26-8d1b-45832d2164dd",
           "tenantId": "53a6a686-ae15-4a1d-badf-3e7947918893"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
         },
         "tags": {},
         "location": "qwyhvdwcsjulggagdqxlmazcl",

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/main.tsp
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/main.tsp
@@ -40,6 +40,9 @@ model DeidService is TrackedResource<DeidServiceProperties> {
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "Adding property for versioning"
   @doc("The managed service identities assigned to this resource.")
   identity?: Azure.ResourceManager.Foundations.ManagedIdentityProperties;
+
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "Adding SKU support"
+  ...ResourceSkuProperty;
 }
 
 /** Patch request body for DeidService */
@@ -51,6 +54,9 @@ model DeidUpdate {
 
   /** RP-specific properties */
   properties?: DeidPropertiesUpdate;
+
+  /** The SKU (Stock Keeping Unit) assigned to this resource. */
+  ...ResourceSkuProperty;
 }
 
 model DeidPropertiesUpdate
@@ -89,6 +95,20 @@ enum PublicNetworkAccess {
 
   @doc("The public network access is disabled")
   Disabled,
+}
+
+/** The available SKU names for the DeidService resource. */
+union DeidServiceSkuName {
+  string,
+
+  /** The Free SKU. */
+  Free: "Free",
+
+  /** The Basic SKU. */
+  Basic: "Basic",
+
+  /** The Standard SKU. */
+  Standard: "Standard",
 }
 
 @doc("Details of the HealthDataAIServices DeidService.")


### PR DESCRIPTION
## Summary

Adds SKU (Stock Keeping Unit) support to the HealthDataAIServices DeidService resource with Free, Basic, and Standard tiers.

## Changes

- Added `ResourceSkuProperty` spread to `DeidService` model for standard ARM SKU envelope property
- Defined `DeidServiceSkuName` union with `Free`, `Basic`, `Standard` values
- Added `sku` property to `DeidUpdate` model for PATCH operations
- Updated all DeidService example files with SKU data
- Added C# client name for `DeidServiceSkuName` in `client.tsp`

## API Version

`2024-09-20`

---

⚠️ **This is a demo PR - DO NOT MERGE**