### PR TITLE
DO NOT MERGE - Add SKU support to HealthDataAIServices DeidService

### DIFF
--- a/specification/healthdataaiservices/HealthDataAIServices.Management/client.tsp
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/client.tsp
@@ -29,6 +29,14 @@ namespace Microsoft.HealthDataAIServices {
     "csharp"
   );
   @@clientName(PrivateLinks.listByDeidService, "GetPrivateLinks", "csharp");
+  @@clientName(SkuName,
+    "HealthDataAIServicesSkuName",
+    "csharp"
+  );
+  @@clientName(SkuTier,
+    "HealthDataAIServicesSkuTier",
+    "csharp"
+  );
 
   @@clientName(Versions.v2024_09_20,
     "$DO_NOT_NORMALIZE$V2024_09_20",

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_Create_MaximumSet_Gen.json
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_Create_MaximumSet_Gen.json
@@ -14,6 +14,10 @@
         "type": "None",
         "userAssignedIdentities": {}
       },
+      "sku": {
+        "name": "Standard",
+        "tier": "Standard"
+      },
       "tags": {},
       "location": "qwyhvdwcsjulggagdqxlmazcl"
     }
@@ -60,6 +64,10 @@
           "userAssignedIdentities": {},
           "principalId": "a82361f4-5320-4a26-8d1b-45832d2164dd",
           "tenantId": "53a6a686-ae15-4a1d-badf-3e7947918893"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
         },
         "tags": {},
         "location": "qwyhvdwcsjulggagdqxlmazcl",
@@ -120,6 +128,10 @@
           "userAssignedIdentities": {},
           "principalId": "a82361f4-5320-4a26-8d1b-45832d2164dd",
           "tenantId": "53a6a686-ae15-4a1d-badf-3e7947918893"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
         },
         "tags": {},
         "location": "qwyhvdwcsjulggagdqxlmazcl",

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_Get_MaximumSet_Gen.json
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_Get_MaximumSet_Gen.json
@@ -50,6 +50,10 @@
           "principalId": "a82361f4-5320-4a26-8d1b-45832d2164dd",
           "tenantId": "53a6a686-ae15-4a1d-badf-3e7947918893"
         },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
+        },
         "tags": {},
         "location": "qwyhvdwcsjulggagdqxlmazcl",
         "id": "/subscriptions/F21BB31B-C214-42C0-ACF0-DACCA05D3011/resourceGroups/rgopenapi/providers/Microsoft.HealthDataAIServices/deidServices/nlrthrxaukih",

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_ListByResourceGroup_MaximumSet_Gen.json
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_ListByResourceGroup_MaximumSet_Gen.json
@@ -51,6 +51,10 @@
               "type": "None",
               "userAssignedIdentities": {}
             },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
             "tags": {},
             "location": "qwyhvdwcsjulggagdqxlmazcl",
             "id": "/subscriptions/F21BB31B-C214-42C0-ACF0-DACCA05D3011/resourceGroups/rgopenapi/providers/Microsoft.HealthDataAIServices/deidServices/nlrthrxaukih",

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_ListBySubscription_MaximumSet_Gen.json
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_ListBySubscription_MaximumSet_Gen.json
@@ -50,6 +50,10 @@
               "type": "None",
               "userAssignedIdentities": {}
             },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
             "tags": {},
             "location": "qwyhvdwcsjulggagdqxlmazcl",
             "id": "/subscriptions/F21BB31B-C214-42C0-ACF0-DACCA05D3011/resourceGroups/rgopenapi/providers/Microsoft.HealthDataAIServices/deidServices/nlrthrxaukih",

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_Update_MaximumSet_Gen.json
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_Update_MaximumSet_Gen.json
@@ -14,6 +14,10 @@
       "tags": {},
       "properties": {
         "publicNetworkAccess": "Enabled"
+      },
+      "sku": {
+        "name": "Standard",
+        "tier": "Standard"
       }
     }
   },
@@ -59,6 +63,10 @@
           "userAssignedIdentities": {},
           "principalId": "a82361f4-5320-4a26-8d1b-45832d2164dd",
           "tenantId": "53a6a686-ae15-4a1d-badf-3e7947918893"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
         },
         "tags": {},
         "location": "qwyhvdwcsjulggagdqxlmazcl",

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/main.tsp
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/main.tsp
@@ -40,6 +40,10 @@ model DeidService is TrackedResource<DeidServiceProperties> {
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "Adding property for versioning"
   @doc("The managed service identities assigned to this resource.")
   identity?: Azure.ResourceManager.Foundations.ManagedIdentityProperties;
+
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "Adding SKU property"
+  /** The SKU (Stock Keeping Unit) assigned to this resource. */
+  sku?: Sku;
 }
 
 /** Patch request body for DeidService */
@@ -51,6 +55,9 @@ model DeidUpdate {
 
   /** RP-specific properties */
   properties?: DeidPropertiesUpdate;
+
+  /** The SKU (Stock Keeping Unit) assigned to this resource. */
+  sku?: Sku;
 }
 
 model DeidPropertiesUpdate
@@ -89,6 +96,55 @@ enum PublicNetworkAccess {
 
   @doc("The public network access is disabled")
   Disabled,
+}
+
+/** The SKU tier based on the SKU name. */
+union SkuTier {
+  string,
+
+  /** The Free tier. */
+  Free: "Free",
+
+  /** The Basic tier. */
+  Basic: "Basic",
+
+  /** The Standard tier. */
+  Standard: "Standard",
+
+  /** The Premium tier. */
+  Premium: "Premium",
+}
+
+/** The name of the SKU. */
+union SkuName {
+  string,
+
+  /** The Free SKU. */
+  Free: "Free",
+
+  /** The Basic SKU. */
+  Basic: "Basic",
+
+  /** The Standard SKU. */
+  Standard: "Standard",
+}
+
+/** The resource model definition representing SKU. */
+model Sku {
+  /** The name of the SKU. Ex - Free, Basic, Standard. */
+  name: SkuName;
+
+  /** This field is required to be implemented by the resource provider if the service has more than one tier, but is not required on a PUT. */
+  tier?: SkuTier;
+
+  /** The SKU size. When the name field is the combination of tier and some other value, this would be the standalone code. */
+  size?: string;
+
+  /** If the service has different generations of hardware, for the same SKU, then that can be captured here. */
+  family?: string;
+
+  /** If the SKU supports scale out/in then the capacity integer should be included. If scale out/in is not possible for the resource this may be omitted. */
+  capacity?: int32;
 }
 
 @doc("Details of the HealthDataAIServices DeidService.")


### PR DESCRIPTION
## Summary

This PR adds SKU support (Free, Basic, Standard) to the HealthDataAIServices DeidService TypeSpec definition.

### Changes
- Added `SkuName` union with Free, Basic, and Standard members
- Added `SkuTier` union with Free, Basic, Standard, and Premium tiers
- Added `Sku` model with name, tier, size, family, and capacity properties
- Added optional `sku` property to `DeidService` resource model
- Added optional `sku` property to `DeidUpdate` patch model
- Added C# client name customizations for `SkuName` and `SkuTier`
- Updated all DeidService example JSON files with SKU data

**This is a demo PR. DO NOT MERGE.**