### PR TITLE
DO NOT MERGE - Add SKU support to HealthDataAIServices DeidService

### DIFF
--- a/specification/healthdataaiservices/HealthDataAIServices.Management/client.tsp
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/client.tsp
@@ -28,6 +28,14 @@ namespace Microsoft.HealthDataAIServices {
     "HealthDataAIServicesPrivateLinkResourceData",
     "csharp"
   );
+  @@clientName(DeidServiceSkuTier,
+    "HealthDataAIServicesSkuTier",
+    "csharp"
+  );
+  @@clientName(DeidServiceSku,
+    "HealthDataAIServicesSku",
+    "csharp"
+  );
   @@clientName(PrivateLinks.listByDeidService, "GetPrivateLinks", "csharp");
 
   @@clientName(Versions.v2024_09_20,

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_Create_MaximumSet_Gen.json
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_Create_MaximumSet_Gen.json
@@ -14,6 +14,10 @@
         "type": "None",
         "userAssignedIdentities": {}
       },
+      "sku": {
+        "name": "Standard",
+        "tier": "Standard"
+      },
       "tags": {},
       "location": "qwyhvdwcsjulggagdqxlmazcl"
     }
@@ -60,6 +64,10 @@
           "userAssignedIdentities": {},
           "principalId": "a82361f4-5320-4a26-8d1b-45832d2164dd",
           "tenantId": "53a6a686-ae15-4a1d-badf-3e7947918893"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
         },
         "tags": {},
         "location": "qwyhvdwcsjulggagdqxlmazcl",
@@ -120,6 +128,10 @@
           "userAssignedIdentities": {},
           "principalId": "a82361f4-5320-4a26-8d1b-45832d2164dd",
           "tenantId": "53a6a686-ae15-4a1d-badf-3e7947918893"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
         },
         "tags": {},
         "location": "qwyhvdwcsjulggagdqxlmazcl",

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_Get_MaximumSet_Gen.json
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_Get_MaximumSet_Gen.json
@@ -50,6 +50,10 @@
           "principalId": "a82361f4-5320-4a26-8d1b-45832d2164dd",
           "tenantId": "53a6a686-ae15-4a1d-badf-3e7947918893"
         },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
+        },
         "tags": {},
         "location": "qwyhvdwcsjulggagdqxlmazcl",
         "id": "/subscriptions/F21BB31B-C214-42C0-ACF0-DACCA05D3011/resourceGroups/rgopenapi/providers/Microsoft.HealthDataAIServices/deidServices/nlrthrxaukih",

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_ListByResourceGroup_MaximumSet_Gen.json
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_ListByResourceGroup_MaximumSet_Gen.json
@@ -51,6 +51,10 @@
               "type": "None",
               "userAssignedIdentities": {}
             },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
             "tags": {},
             "location": "qwyhvdwcsjulggagdqxlmazcl",
             "id": "/subscriptions/F21BB31B-C214-42C0-ACF0-DACCA05D3011/resourceGroups/rgopenapi/providers/Microsoft.HealthDataAIServices/deidServices/nlrthrxaukih",

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_ListBySubscription_MaximumSet_Gen.json
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_ListBySubscription_MaximumSet_Gen.json
@@ -50,6 +50,10 @@
               "type": "None",
               "userAssignedIdentities": {}
             },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
             "tags": {},
             "location": "qwyhvdwcsjulggagdqxlmazcl",
             "id": "/subscriptions/F21BB31B-C214-42C0-ACF0-DACCA05D3011/resourceGroups/rgopenapi/providers/Microsoft.HealthDataAIServices/deidServices/nlrthrxaukih",

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_Update_MaximumSet_Gen.json
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_Update_MaximumSet_Gen.json
@@ -11,6 +11,10 @@
         "type": "None",
         "userAssignedIdentities": {}
       },
+      "sku": {
+        "name": "Standard",
+        "tier": "Standard"
+      },
       "tags": {},
       "properties": {
         "publicNetworkAccess": "Enabled"
@@ -59,6 +63,10 @@
           "userAssignedIdentities": {},
           "principalId": "a82361f4-5320-4a26-8d1b-45832d2164dd",
           "tenantId": "53a6a686-ae15-4a1d-badf-3e7947918893"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
         },
         "tags": {},
         "location": "qwyhvdwcsjulggagdqxlmazcl",

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/main.tsp
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/main.tsp
@@ -40,6 +40,10 @@ model DeidService is TrackedResource<DeidServiceProperties> {
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "Adding property for versioning"
   @doc("The managed service identities assigned to this resource.")
   identity?: Azure.ResourceManager.Foundations.ManagedIdentityProperties;
+
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "Adding SKU support"
+  /** The SKU of the deid service. */
+  sku?: DeidServiceSku;
 }
 
 /** Patch request body for DeidService */
@@ -51,6 +55,9 @@ model DeidUpdate {
 
   /** RP-specific properties */
   properties?: DeidPropertiesUpdate;
+
+  /** The SKU of the deid service. */
+  sku?: DeidServiceSku;
 }
 
 model DeidPropertiesUpdate
@@ -89,6 +96,29 @@ enum PublicNetworkAccess {
 
   @doc("The public network access is disabled")
   Disabled,
+}
+
+/** The SKU tier for the DeidService resource. */
+union DeidServiceSkuTier {
+  string,
+
+  /** Free tier */
+  Free: "Free",
+
+  /** Basic tier */
+  Basic: "Basic",
+
+  /** Standard tier */
+  Standard: "Standard",
+}
+
+/** The SKU of the DeidService resource. */
+model DeidServiceSku {
+  /** The name of the SKU, e.g. "Free", "Basic", "Standard". */
+  name: string;
+
+  /** The tier of the SKU. */
+  tier?: DeidServiceSkuTier;
 }
 
 @doc("Details of the HealthDataAIServices DeidService.")

--- a/specification/healthdataaiservices/resource-manager/Microsoft.HealthDataAIServices/stable/2024-09-20/examples/DeidServices_Create_MaximumSet_Gen.json
+++ b/specification/healthdataaiservices/resource-manager/Microsoft.HealthDataAIServices/stable/2024-09-20/examples/DeidServices_Create_MaximumSet_Gen.json
@@ -14,6 +14,10 @@
         "type": "None",
         "userAssignedIdentities": {}
       },
+      "sku": {
+        "name": "Standard",
+        "tier": "Standard"
+      },
       "tags": {},
       "location": "qwyhvdwcsjulggagdqxlmazcl"
     }
@@ -60,6 +64,10 @@
           "userAssignedIdentities": {},
           "principalId": "a82361f4-5320-4a26-8d1b-45832d2164dd",
           "tenantId": "53a6a686-ae15-4a1d-badf-3e7947918893"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
         },
         "tags": {},
         "location": "qwyhvdwcsjulggagdqxlmazcl",
@@ -120,6 +128,10 @@
           "userAssignedIdentities": {},
           "principalId": "a82361f4-5320-4a26-8d1b-45832d2164dd",
           "tenantId": "53a6a686-ae15-4a1d-badf-3e7947918893"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
         },
         "tags": {},
         "location": "qwyhvdwcsjulggagdqxlmazcl",

--- a/specification/healthdataaiservices/resource-manager/Microsoft.HealthDataAIServices/stable/2024-09-20/examples/DeidServices_Get_MaximumSet_Gen.json
+++ b/specification/healthdataaiservices/resource-manager/Microsoft.HealthDataAIServices/stable/2024-09-20/examples/DeidServices_Get_MaximumSet_Gen.json
@@ -50,6 +50,10 @@
           "principalId": "a82361f4-5320-4a26-8d1b-45832d2164dd",
           "tenantId": "53a6a686-ae15-4a1d-badf-3e7947918893"
         },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
+        },
         "tags": {},
         "location": "qwyhvdwcsjulggagdqxlmazcl",
         "id": "/subscriptions/F21BB31B-C214-42C0-ACF0-DACCA05D3011/resourceGroups/rgopenapi/providers/Microsoft.HealthDataAIServices/deidServices/nlrthrxaukih",

--- a/specification/healthdataaiservices/resource-manager/Microsoft.HealthDataAIServices/stable/2024-09-20/examples/DeidServices_ListByResourceGroup_MaximumSet_Gen.json
+++ b/specification/healthdataaiservices/resource-manager/Microsoft.HealthDataAIServices/stable/2024-09-20/examples/DeidServices_ListByResourceGroup_MaximumSet_Gen.json
@@ -51,6 +51,10 @@
               "type": "None",
               "userAssignedIdentities": {}
             },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
             "tags": {},
             "location": "qwyhvdwcsjulggagdqxlmazcl",
             "id": "/subscriptions/F21BB31B-C214-42C0-ACF0-DACCA05D3011/resourceGroups/rgopenapi/providers/Microsoft.HealthDataAIServices/deidServices/nlrthrxaukih",

--- a/specification/healthdataaiservices/resource-manager/Microsoft.HealthDataAIServices/stable/2024-09-20/examples/DeidServices_ListBySubscription_MaximumSet_Gen.json
+++ b/specification/healthdataaiservices/resource-manager/Microsoft.HealthDataAIServices/stable/2024-09-20/examples/DeidServices_ListBySubscription_MaximumSet_Gen.json
@@ -50,6 +50,10 @@
               "type": "None",
               "userAssignedIdentities": {}
             },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
             "tags": {},
             "location": "qwyhvdwcsjulggagdqxlmazcl",
             "id": "/subscriptions/F21BB31B-C214-42C0-ACF0-DACCA05D3011/resourceGroups/rgopenapi/providers/Microsoft.HealthDataAIServices/deidServices/nlrthrxaukih",

--- a/specification/healthdataaiservices/resource-manager/Microsoft.HealthDataAIServices/stable/2024-09-20/examples/DeidServices_Update_MaximumSet_Gen.json
+++ b/specification/healthdataaiservices/resource-manager/Microsoft.HealthDataAIServices/stable/2024-09-20/examples/DeidServices_Update_MaximumSet_Gen.json
@@ -11,6 +11,10 @@
         "type": "None",
         "userAssignedIdentities": {}
       },
+      "sku": {
+        "name": "Standard",
+        "tier": "Standard"
+      },
       "tags": {},
       "properties": {
         "publicNetworkAccess": "Enabled"
@@ -59,6 +63,10 @@
           "userAssignedIdentities": {},
           "principalId": "a82361f4-5320-4a26-8d1b-45832d2164dd",
           "tenantId": "53a6a686-ae15-4a1d-badf-3e7947918893"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
         },
         "tags": {},
         "location": "qwyhvdwcsjulggagdqxlmazcl",

--- a/specification/healthdataaiservices/resource-manager/Microsoft.HealthDataAIServices/stable/2024-09-20/openapi.json
+++ b/specification/healthdataaiservices/resource-manager/Microsoft.HealthDataAIServices/stable/2024-09-20/openapi.json
@@ -740,6 +740,10 @@
         "identity": {
           "$ref": "../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/ManagedServiceIdentity",
           "description": "The managed service identities assigned to this resource."
+        },
+        "sku": {
+          "$ref": "#/definitions/DeidServiceSku",
+          "description": "The SKU of the deid service."
         }
       },
       "allOf": [
@@ -797,6 +801,53 @@
         }
       }
     },
+    "DeidServiceSku": {
+      "type": "object",
+      "description": "The SKU of the DeidService resource.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the SKU, e.g. \"Free\", \"Basic\", \"Standard\"."
+        },
+        "tier": {
+          "$ref": "#/definitions/DeidServiceSkuTier",
+          "description": "The tier of the SKU."
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "DeidServiceSkuTier": {
+      "type": "string",
+      "description": "The SKU tier for the DeidService resource.",
+      "enum": [
+        "Free",
+        "Basic",
+        "Standard"
+      ],
+      "x-ms-enum": {
+        "name": "DeidServiceSkuTier",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Free",
+            "value": "Free",
+            "description": "Free tier"
+          },
+          {
+            "name": "Basic",
+            "value": "Basic",
+            "description": "Basic tier"
+          },
+          {
+            "name": "Standard",
+            "value": "Standard",
+            "description": "Standard tier"
+          }
+        ]
+      }
+    },
     "DeidUpdate": {
       "type": "object",
       "description": "Patch request body for DeidService",
@@ -815,6 +866,10 @@
         "properties": {
           "$ref": "#/definitions/DeidPropertiesUpdate",
           "description": "RP-specific properties"
+        },
+        "sku": {
+          "$ref": "#/definitions/DeidServiceSku",
+          "description": "The SKU of the deid service."
         }
       }
     },


### PR DESCRIPTION
## Demo PR - DO NOT MERGE

This PR adds SKU support (Free, Basic, Standard) to the HealthDataAIServices DeidService resource.

### Changes:
- **DeidServiceSkuTier** union: Defines Free, Basic, and Standard tiers
- **DeidServiceSku** model: Contains `name` (required) and `tier` (optional) properties
- Added `sku` as an envelope property on the `DeidService` TrackedResource
- Added `sku` to the `DeidUpdate` patch model for updates
- Added C# client names for new SKU types in `client.tsp`
- Updated all example JSON files with SKU data
- Regenerated OpenAPI spec