### PR TITLE
DO NOT MERGE: Add SKU support to HealthDataAIServices DeidService

### DIFF
--- a/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_Create_MaximumSet_Gen.json
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_Create_MaximumSet_Gen.json
@@ -14,6 +14,10 @@
         "type": "None",
         "userAssignedIdentities": {}
       },
+      "sku": {
+        "name": "Standard",
+        "tier": "Standard"
+      },
       "tags": {},
       "location": "qwyhvdwcsjulggagdqxlmazcl"
     }
@@ -60,6 +64,10 @@
           "userAssignedIdentities": {},
           "principalId": "a82361f4-5320-4a26-8d1b-45832d2164dd",
           "tenantId": "53a6a686-ae15-4a1d-badf-3e7947918893"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
         },
         "tags": {},
         "location": "qwyhvdwcsjulggagdqxlmazcl",
@@ -120,6 +128,10 @@
           "userAssignedIdentities": {},
           "principalId": "a82361f4-5320-4a26-8d1b-45832d2164dd",
           "tenantId": "53a6a686-ae15-4a1d-badf-3e7947918893"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
         },
         "tags": {},
         "location": "qwyhvdwcsjulggagdqxlmazcl",

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_Get_MaximumSet_Gen.json
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_Get_MaximumSet_Gen.json
@@ -50,6 +50,10 @@
           "principalId": "a82361f4-5320-4a26-8d1b-45832d2164dd",
           "tenantId": "53a6a686-ae15-4a1d-badf-3e7947918893"
         },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
+        },
         "tags": {},
         "location": "qwyhvdwcsjulggagdqxlmazcl",
         "id": "/subscriptions/F21BB31B-C214-42C0-ACF0-DACCA05D3011/resourceGroups/rgopenapi/providers/Microsoft.HealthDataAIServices/deidServices/nlrthrxaukih",

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_ListByResourceGroup_MaximumSet_Gen.json
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_ListByResourceGroup_MaximumSet_Gen.json
@@ -51,6 +51,10 @@
               "type": "None",
               "userAssignedIdentities": {}
             },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
             "tags": {},
             "location": "qwyhvdwcsjulggagdqxlmazcl",
             "id": "/subscriptions/F21BB31B-C214-42C0-ACF0-DACCA05D3011/resourceGroups/rgopenapi/providers/Microsoft.HealthDataAIServices/deidServices/nlrthrxaukih",

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_ListBySubscription_MaximumSet_Gen.json
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_ListBySubscription_MaximumSet_Gen.json
@@ -50,6 +50,10 @@
               "type": "None",
               "userAssignedIdentities": {}
             },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
             "tags": {},
             "location": "qwyhvdwcsjulggagdqxlmazcl",
             "id": "/subscriptions/F21BB31B-C214-42C0-ACF0-DACCA05D3011/resourceGroups/rgopenapi/providers/Microsoft.HealthDataAIServices/deidServices/nlrthrxaukih",

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_Update_MaximumSet_Gen.json
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/examples/2024-09-20/DeidServices_Update_MaximumSet_Gen.json
@@ -11,6 +11,10 @@
         "type": "None",
         "userAssignedIdentities": {}
       },
+      "sku": {
+        "name": "Standard",
+        "tier": "Standard"
+      },
       "tags": {},
       "properties": {
         "publicNetworkAccess": "Enabled"
@@ -59,6 +63,10 @@
           "userAssignedIdentities": {},
           "principalId": "a82361f4-5320-4a26-8d1b-45832d2164dd",
           "tenantId": "53a6a686-ae15-4a1d-badf-3e7947918893"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
         },
         "tags": {},
         "location": "qwyhvdwcsjulggagdqxlmazcl",

--- a/specification/healthdataaiservices/HealthDataAIServices.Management/main.tsp
+++ b/specification/healthdataaiservices/HealthDataAIServices.Management/main.tsp
@@ -40,6 +40,10 @@ model DeidService is TrackedResource<DeidServiceProperties> {
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "Adding property for versioning"
   @doc("The managed service identities assigned to this resource.")
   identity?: Azure.ResourceManager.Foundations.ManagedIdentityProperties;
+
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "SKU is a standard ARM resource envelope property"
+  @doc("The SKU (Stock Keeping Unit) assigned to this resource.")
+  sku?: Azure.ResourceManager.CommonTypes.Sku;
 }
 
 /** Patch request body for DeidService */
@@ -51,6 +55,9 @@ model DeidUpdate {
 
   /** RP-specific properties */
   properties?: DeidPropertiesUpdate;
+
+  /** The SKU (Stock Keeping Unit) assigned to this resource. */
+  sku?: Azure.ResourceManager.CommonTypes.Sku;
 }
 
 model DeidPropertiesUpdate

--- a/specification/healthdataaiservices/resource-manager/Microsoft.HealthDataAIServices/stable/2024-09-20/examples/DeidServices_Create_MaximumSet_Gen.json
+++ b/specification/healthdataaiservices/resource-manager/Microsoft.HealthDataAIServices/stable/2024-09-20/examples/DeidServices_Create_MaximumSet_Gen.json
@@ -14,6 +14,10 @@
         "type": "None",
         "userAssignedIdentities": {}
       },
+      "sku": {
+        "name": "Standard",
+        "tier": "Standard"
+      },
       "tags": {},
       "location": "qwyhvdwcsjulggagdqxlmazcl"
     }
@@ -60,6 +64,10 @@
           "userAssignedIdentities": {},
           "principalId": "a82361f4-5320-4a26-8d1b-45832d2164dd",
           "tenantId": "53a6a686-ae15-4a1d-badf-3e7947918893"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
         },
         "tags": {},
         "location": "qwyhvdwcsjulggagdqxlmazcl",
@@ -120,6 +128,10 @@
           "userAssignedIdentities": {},
           "principalId": "a82361f4-5320-4a26-8d1b-45832d2164dd",
           "tenantId": "53a6a686-ae15-4a1d-badf-3e7947918893"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
         },
         "tags": {},
         "location": "qwyhvdwcsjulggagdqxlmazcl",

--- a/specification/healthdataaiservices/resource-manager/Microsoft.HealthDataAIServices/stable/2024-09-20/examples/DeidServices_Get_MaximumSet_Gen.json
+++ b/specification/healthdataaiservices/resource-manager/Microsoft.HealthDataAIServices/stable/2024-09-20/examples/DeidServices_Get_MaximumSet_Gen.json
@@ -50,6 +50,10 @@
           "principalId": "a82361f4-5320-4a26-8d1b-45832d2164dd",
           "tenantId": "53a6a686-ae15-4a1d-badf-3e7947918893"
         },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
+        },
         "tags": {},
         "location": "qwyhvdwcsjulggagdqxlmazcl",
         "id": "/subscriptions/F21BB31B-C214-42C0-ACF0-DACCA05D3011/resourceGroups/rgopenapi/providers/Microsoft.HealthDataAIServices/deidServices/nlrthrxaukih",

--- a/specification/healthdataaiservices/resource-manager/Microsoft.HealthDataAIServices/stable/2024-09-20/examples/DeidServices_ListByResourceGroup_MaximumSet_Gen.json
+++ b/specification/healthdataaiservices/resource-manager/Microsoft.HealthDataAIServices/stable/2024-09-20/examples/DeidServices_ListByResourceGroup_MaximumSet_Gen.json
@@ -51,6 +51,10 @@
               "type": "None",
               "userAssignedIdentities": {}
             },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
             "tags": {},
             "location": "qwyhvdwcsjulggagdqxlmazcl",
             "id": "/subscriptions/F21BB31B-C214-42C0-ACF0-DACCA05D3011/resourceGroups/rgopenapi/providers/Microsoft.HealthDataAIServices/deidServices/nlrthrxaukih",

--- a/specification/healthdataaiservices/resource-manager/Microsoft.HealthDataAIServices/stable/2024-09-20/examples/DeidServices_ListBySubscription_MaximumSet_Gen.json
+++ b/specification/healthdataaiservices/resource-manager/Microsoft.HealthDataAIServices/stable/2024-09-20/examples/DeidServices_ListBySubscription_MaximumSet_Gen.json
@@ -50,6 +50,10 @@
               "type": "None",
               "userAssignedIdentities": {}
             },
+            "sku": {
+              "name": "Standard",
+              "tier": "Standard"
+            },
             "tags": {},
             "location": "qwyhvdwcsjulggagdqxlmazcl",
             "id": "/subscriptions/F21BB31B-C214-42C0-ACF0-DACCA05D3011/resourceGroups/rgopenapi/providers/Microsoft.HealthDataAIServices/deidServices/nlrthrxaukih",

--- a/specification/healthdataaiservices/resource-manager/Microsoft.HealthDataAIServices/stable/2024-09-20/examples/DeidServices_Update_MaximumSet_Gen.json
+++ b/specification/healthdataaiservices/resource-manager/Microsoft.HealthDataAIServices/stable/2024-09-20/examples/DeidServices_Update_MaximumSet_Gen.json
@@ -11,6 +11,10 @@
         "type": "None",
         "userAssignedIdentities": {}
       },
+      "sku": {
+        "name": "Standard",
+        "tier": "Standard"
+      },
       "tags": {},
       "properties": {
         "publicNetworkAccess": "Enabled"
@@ -59,6 +63,10 @@
           "userAssignedIdentities": {},
           "principalId": "a82361f4-5320-4a26-8d1b-45832d2164dd",
           "tenantId": "53a6a686-ae15-4a1d-badf-3e7947918893"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
         },
         "tags": {},
         "location": "qwyhvdwcsjulggagdqxlmazcl",

--- a/specification/healthdataaiservices/resource-manager/Microsoft.HealthDataAIServices/stable/2024-09-20/openapi.json
+++ b/specification/healthdataaiservices/resource-manager/Microsoft.HealthDataAIServices/stable/2024-09-20/openapi.json
@@ -740,6 +740,10 @@
         "identity": {
           "$ref": "../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/ManagedServiceIdentity",
           "description": "The managed service identities assigned to this resource."
+        },
+        "sku": {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/Sku",
+          "description": "The SKU (Stock Keeping Unit) assigned to this resource."
         }
       },
       "allOf": [
@@ -815,6 +819,10 @@
         "properties": {
           "$ref": "#/definitions/DeidPropertiesUpdate",
           "description": "RP-specific properties"
+        },
+        "sku": {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/Sku",
+          "description": "The SKU (Stock Keeping Unit) assigned to this resource."
         }
       }
     },


### PR DESCRIPTION
## Summary

Adds optional SKU (Stock Keeping Unit) support to the HealthDataAIServices DeidService resource, enabling Free, Basic, and Standard tier selection.

## Changes

- **main.tsp**: Added `sku` property to `DeidService` model using ARM common-types `Sku` model. Added `sku` to `DeidUpdate` patch model for SKU updates.
- **examples/**: Updated all DeidService example JSON files to include Standard SKU data.
- **openapi.json**: Auto-generated OpenAPI spec updated to reflect the new SKU property.

## Demo Only
This PR is for demonstration purposes only and should not be merged.