### PR TITLE
Mitigate Java SDK TypeSpec migration breaks for DevCenter

### DIFF
--- a/specification/devcenter/DevCenter.Management/back-compatible.tsp
+++ b/specification/devcenter/DevCenter.Management/back-compatible.tsp
@@ -170,85 +170,85 @@ using Microsoft.DevCenter;
 // Flatten properties for backward compatibility
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(AllowedEnvironmentType.properties,
-  "autorest"
+  "autorest,java"
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(AttachedNetworkConnection.properties,
-  "autorest"
+  "autorest,java"
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(Catalog.properties,
-  "autorest"
+  "autorest,java"
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(CustomizationTask.properties,
-  "autorest"
+  "autorest,java"
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(DevBoxDefinition.properties,
-  "autorest"
+  "autorest,java"
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(DevCenterEncryptionSet.properties,
-  "autorest"
+  "autorest,java"
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(DevCenter.properties,
-  "autorest"
+  "autorest,java"
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(EnvironmentDefinition.properties,
-  "autorest"
+  "autorest,java"
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(EnvironmentType.properties,
-  "autorest"
+  "autorest,java"
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(Gallery.properties,
-  "autorest"
+  "autorest,java"
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(HealthCheckStatusDetails.properties,
-  "autorest"
+  "autorest,java"
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(ImageDefinitionBuild.properties,
-  "autorest"
+  "autorest,java"
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(ImageDefinition.properties,
-  "autorest"
+  "autorest,java"
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(Image.properties,
-  "autorest"
+  "autorest,java"
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(ImageVersion.properties,
-  "autorest"
+  "autorest,java"
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(NetworkConnection.properties,
-  "autorest"
+  "autorest,java"
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(Pool.properties,
-  "autorest"
+  "autorest,java"
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(ProjectEnvironmentType.properties,
-  "autorest"
+  "autorest,java"
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(ProjectPolicy.properties,
-  "autorest"
+  "autorest,java"
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(Project.properties,
-  "autorest"
+  "autorest,java"
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(Schedule.properties,
-  "autorest"
+  "autorest,java"
 );

--- a/specification/devcenter/DevCenter.Management/client.tsp
+++ b/specification/devcenter/DevCenter.Management/client.tsp
@@ -13,3 +13,18 @@ using Azure.ClientGenerator.Core;
 @@clientName(Microsoft.DevCenter.DevCenterSku, "SkuInfo", "go");
 
 @@clientName(Microsoft.DevCenter.UserRoleAssignment, "UserRoleAssignmentValue");
+
+@@clientName(Azure.ResourceManager.CommonTypes.KeyEncryptionKeyIdentity,
+  "CustomerManagedKeyEncryptionKeyIdentity",
+  "java"
+);
+
+@@clientName(Azure.ResourceManager.CommonTypes.KeyEncryptionKeyIdentityType,
+  "IdentityType",
+  "java"
+);
+
+@@alternateType(Microsoft.DevCenter.OperationStatus.properties,
+  unknown,
+  "java"
+);

--- a/specification/devcenter/DevCenter.Management/client.tsp
+++ b/specification/devcenter/DevCenter.Management/client.tsp
@@ -14,6 +14,11 @@ using Azure.ClientGenerator.Core;
 
 @@clientName(Microsoft.DevCenter.UserRoleAssignment, "UserRoleAssignmentValue");
 
+@@clientName(Azure.ResourceManager.CommonTypes.KeyEncryptionKeyIdentity,
+  "CustomerManagedKeyEncryptionKeyIdentity",
+  "java"
+);
+
 @@clientName(Azure.ResourceManager.CommonTypes.KeyEncryptionKeyIdentityType,
   "IdentityType",
   "java"

--- a/specification/devcenter/DevCenter.Management/client.tsp
+++ b/specification/devcenter/DevCenter.Management/client.tsp
@@ -14,11 +14,6 @@ using Azure.ClientGenerator.Core;
 
 @@clientName(Microsoft.DevCenter.UserRoleAssignment, "UserRoleAssignmentValue");
 
-@@clientName(Azure.ResourceManager.CommonTypes.KeyEncryptionKeyIdentity,
-  "CustomerManagedKeyEncryptionKeyIdentity",
-  "java"
-);
-
 @@clientName(Azure.ResourceManager.CommonTypes.KeyEncryptionKeyIdentityType,
   "IdentityType",
   "java"

--- a/specification/devcenter/DevCenter.Management/tspconfig.yaml
+++ b/specification/devcenter/DevCenter.Management/tspconfig.yaml
@@ -30,6 +30,7 @@ options:
     namespace: "com.azure.resourcemanager.devcenter"
     service-name: "DevCenter" # human-readable service name, whitespace allowed
     flavor: azure
+    use-object-for-unknown: true
     resource-collection-associations:
       - resource: Catalog
         collection: ProjectCatalogs


### PR DESCRIPTION
## Mitigate Java SDK TypeSpec migration breaks for DevCenter

### Changes

**client.tsp:**
- `@@clientName(Azure.ResourceManager.CommonTypes.KeyEncryptionKeyIdentity, "CustomerManagedKeyEncryptionKeyIdentity", "java")` — resolved `duplicate-client-name` compile error
- `@@clientName(Azure.ResourceManager.CommonTypes.KeyEncryptionKeyIdentityType, "IdentityType", "java")` — preserved existing `IdentityType` model name
- `@@alternateType(Microsoft.DevCenter.OperationStatus.properties, unknown, "java")` — kept `properties()` as `Object` instead of `Map`

**tspconfig.yaml:**
- Added `use-object-for-unknown: true` under `@azure-tools/typespec-java` — maps `unknown` to `Object` instead of `BinaryData`