### PR TITLE
Mitigate Java SDK breaking changes for dynatrace and relay

### DIFF
--- a/specification/dynatrace/Dynatrace.Management/client.tsp
+++ b/specification/dynatrace/Dynatrace.Management/client.tsp
@@ -195,3 +195,11 @@ using Dynatrace.Observability;
 @@alternateType(ManageAgentList.id, armResourceIdentifier, "csharp");
 @@clientName(LiftrResourceCategories, "LiftrResourceCategory", "csharp");
 @@clientName(VMHostsListResponse, "VmHostsListResult", "csharp");
+
+// Java backward compatibility
+@@clientName(SSOStatus, "SsoStatus", "java");
+@@clientName(SSODetailsRequest, "SsoDetailsRequest", "java");
+@@clientName(SSODetailsResponse, "SsoDetailsResponse", "java");
+@@clientName(AppServiceInfo.hostName, "hostname", "java");
+@@clientName(VMInfo.hostName, "hostname", "java");
+@@clientName(MonitorResources.getSSODetails, "getSsoDetails", "java");

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/client.tsp
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/client.tsp
@@ -1,0 +1,8 @@
+import "./main.tsp";
+import "@azure-tools/typespec-client-generator-core";
+
+using Azure.ClientGenerator.Core;
+using Microsoft.Relay;
+
+// Preserve existing "WcfRelays" client name (was "WCFRelays" in TypeSpec)
+@@clientName(WCFRelays, "WcfRelays", "java");


### PR DESCRIPTION
This PR adds Java-specific \@@clientName\ entries to \client.tsp\ for the Dynatrace service to maintain backward compatibility during TypeSpec migration.

**Changes:**
- Rename \SSOStatus\ → \SsoStatus\ for Java
- Rename \SSODetailsRequest\ → \SsoDetailsRequest\ for Java
- Rename \SSODetailsResponse\ → \SsoDetailsResponse\ for Java
- Rename \AppServiceInfo.hostName\ → \hostname\ for Java
- Rename \VMInfo.hostName\ → \hostname\ for Java
- Rename \MonitorResources.getSSODetails\ → \getSsoDetails\ for Java