### PR TITLE
Mitigate Java SDK TypeSpec migration breaks for Relay

### DIFF
--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/client.tsp
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/client.tsp
@@ -1,0 +1,8 @@
+import "./main.tsp";
+import "@azure-tools/typespec-client-generator-core";
+
+using Azure.ClientGenerator.Core;
+using Microsoft.Relay;
+
+// Preserve existing "WcfRelays" client name (was "WCFRelays" in TypeSpec)
+@@clientName(WCFRelays, "WcfRelays", "java");


### PR DESCRIPTION
## Mitigate Java SDK TypeSpec migration breaks for Relay

### Changes

**client.tsp:**
- Added clientName decorator to preserve existing WcfRelays client name