### PR TITLE
Fix TypeSpec migration breaks for cost-management Java SDK

### DIFF
--- a/specification/cost-management/resource-manager/Microsoft.CostManagement/CostManagement/client.tsp
+++ b/specification/cost-management/resource-manager/Microsoft.CostManagement/CostManagement/client.tsp
@@ -36,7 +36,7 @@ using Microsoft.CostManagement;
 @@clientName(Microsoft.CostManagement, "CostManagementClient", "python");
 @@clientName(Azure.ResourceManager.CommonTypes.ErrorResponse,
   "ArmErrorResponse",
-  "python,javascript"
+  "python,javascript,java"
 );
 @@clientName(Term.P1Y, "P1_Y", "python");
 @@clientName(Term.P3Y, "P3_Y", "python");


### PR DESCRIPTION
## Fix TypeSpec migration breaks for cost-management Java SDK

### Problem
Java SDK generation failed with a `duplicate-client-name` error: both `Microsoft.CostManagement.ErrorResponse` and `Azure.ResourceManager.CommonTypes.ErrorResponse` resolved to the same client name `ErrorResponse` in the Java scope.

### Fix
Added `java` to the `@@clientName` scope for `Azure.ResourceManager.CommonTypes.ErrorResponse` in `client.tsp`, renaming it to `ArmErrorResponse` for Java (matching the existing python/javascript scope).

### Validation
- TypeSpec compiles successfully
- Java SDK generates and builds successfully
- Changelog reviewed: remaining breaks are expected (ListResult removals, validate() removals, constructor privacy changes) or from real API evolution in the new api-version