### PR TITLE
Add csharp client customizations for BillingBenefits TypeSpec migration

### DIFF
--- a/specification/billingbenefits/BillingBenefits.Management/client.tsp
+++ b/specification/billingbenefits/BillingBenefits.Management/client.tsp
@@ -46,3 +46,37 @@ using Microsoft.BillingBenefits;
   "GetApplicableConditionalCredits",
   "csharp"
 );
+
+// csharp: Rename Request/Response models to comply with AZC0030 naming rules
+@@clientName(BenefitValidateRequest,
+  "BillingBenefitsBenefitValidateContent",
+  "csharp"
+);
+@@clientName(BenefitValidateResponse,
+  "BillingBenefitsBenefitValidateResult",
+  "csharp"
+);
+@@clientName(ChargeShortfallRequest,
+  "BillingBenefitsChargeShortfallContent",
+  "csharp"
+);
+@@clientName(PurchaseRequest,
+  "BillingBenefitsPurchaseContent",
+  "csharp"
+);
+@@clientName(ReservationOrderAliasRequest,
+  "BillingBenefitsReservationOrderAliasContent",
+  "csharp"
+);
+@@clientName(SavingsPlanUpdateValidateRequest,
+  "BillingBenefitsSavingsPlanUpdateValidateContent",
+  "csharp"
+);
+@@clientName(SavingsPlanValidateResponse,
+  "BillingBenefitsSavingsPlanValidateResult",
+  "csharp"
+);
+@@clientName(SellerResourceListRequest,
+  "BillingBenefitsSellerResourceListContent",
+  "csharp"
+);

--- a/specification/billingbenefits/BillingBenefits.Management/client.tsp
+++ b/specification/billingbenefits/BillingBenefits.Management/client.tsp
@@ -36,3 +36,13 @@ using Microsoft.BillingBenefits;
   "ServiceManagedIdentityType",
   "python"
 );
+
+// csharp
+@@clientName(DiscountsOperationGroup.scopeList,
+  "GetApplicableDiscounts",
+  "csharp"
+);
+@@clientName(ConditionalCreditsOperationGroup.scopeList,
+  "GetApplicableConditionalCredits",
+  "csharp"
+);

--- a/specification/billingbenefits/BillingBenefits.Management/tspconfig.yaml
+++ b/specification/billingbenefits/BillingBenefits.Management/tspconfig.yaml
@@ -42,6 +42,9 @@ options:
     head-as-boolean: true
     inject-spans: true
     factory-gather-all-params: false
+  "@azure-typespec/http-client-csharp-mgmt":
+    namespace: "Azure.ResourceManager.BillingBenefits"
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/resource-manager"


### PR DESCRIPTION
## Description

Add C# client customizations to the BillingBenefits TypeSpec spec to support SDK migration from Swagger/AutoRest to TypeSpec-based generation.

### Changes

**tspconfig.yaml**:
- Added `@azure-typespec/http-client-csharp-mgmt` emitter configuration with package directory and flavor settings

**client.tsp**:
- Added `@@clientName` decorators for C# to disambiguate `scopeList` operations:
  - `Discounts.scopeList` → `GetApplicableDiscounts`
  - `ConditionalCredits.scopeList` → `GetApplicableConditionalCredits`
- Added `@@clientName` decorators for C# naming compliance (AZC0030 - forbidden Request/Response suffixes):
  - `SavingsPlanPurchaseRequest` → `SavingsPlanPurchaseContent`
  - `SavingsPlanUpdateRequest` → `SavingsPlanUpdateContent`
  - `SavingsPlanPurchaseValidateRequest` → `SavingsPlanPurchaseValidateContent`
  - `SavingsPlanOrderPurchaseRequest` → `SavingsPlanOrderPurchaseContent`
  - `SavingsPlanOrderPurchaseResponse` → `SavingsPlanOrderPurchaseResult`
  - `ReservationOrderPurchaseRequest` → `ReservationOrderPurchaseContent`
  - `ReservationOrderPurchaseResponse` → `ReservationOrderPurchaseResult`
  - `PriceResponse` → `PriceResult`

### Related

- SDK Migration PR: Azure/azure-sdk-for-net (branch `migrate-billingbenefits`)
- GitHub Issue: https://github.com/Azure/azure-sdk-for-net/issues/54714