### PR TITLE
Add MCP API type contract to 2025-09-01-preview specification

### DIFF
--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/ApiManagement/models.tsp
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/ApiManagement/models.tsp
@@ -183,6 +183,11 @@ union ApiType {
   odata: "odata",
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
   grpc: "grpc",
+
+  /**
+   * Model Context Protocol API.
+   */
+  mcp: "mcp",
 }
 
 /**
@@ -307,6 +312,55 @@ union SoapApiType {
    * Imports the API having a gRPC front end.
    */
   gRPC: "grpc",
+
+  /**
+   * Imports the API having a Model Context Protocol (MCP) front end.
+   */
+  MCP: "mcp",
+}
+
+/**
+ * Transport type for Model Context Protocol API.
+ */
+union McpTransportType {
+  string,
+
+  /**
+   * This API uses HTTP+SSE transport type.
+   */
+  sse: "sse",
+
+  /**
+   * This API uses the Streamable HTTP transport type.
+   */
+  streamable: "streamable",
+}
+
+/**
+ * Endpoint definition for MCP API type.
+ */
+model McpEndpoint {
+  /**
+   * Relative URL path that must start with '/'.
+   */
+  @pattern("^/.*$")
+  uriTemplate?: string;
+}
+
+/**
+ * Properties specific to MCP API type.
+ */
+model McpProperties {
+  /**
+   * Transport type for Model Context Protocol API.
+   */
+  transportType?: McpTransportType;
+
+  /**
+   * Collection of MCP endpoint definitions with relative URLs.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "MCP endpoints are a dynamic map of endpoint names to endpoint definitions"
+  endpoints?: Record<McpEndpoint>;
 }
 
 /**
@@ -2194,6 +2248,11 @@ model ApiEntityBaseContract {
    * License information for the API.
    */
   license?: ApiLicenseInformation;
+
+  /**
+   * Properties specific to MCP API type.
+   */
+  mcpProperties?: McpProperties;
 }
 
 /**

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/ApiManagement/preview/2025-09-01-preview/openapi.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/ApiManagement/preview/2025-09-01-preview/openapi.json
@@ -52472,6 +52472,10 @@
         "license": {
           "$ref": "#/definitions/ApiLicenseInformation",
           "description": "License information for the API."
+        },
+        "mcpProperties": {
+          "$ref": "#/definitions/McpProperties",
+          "description": "Properties specific to MCP API type."
         }
       }
     },
@@ -53958,7 +53962,8 @@
         "websocket",
         "graphql",
         "odata",
-        "grpc"
+        "grpc",
+        "mcp"
       ],
       "x-ms-enum": {
         "name": "ApiType",
@@ -53987,6 +53992,11 @@
           {
             "name": "grpc",
             "value": "grpc"
+          },
+          {
+            "name": "mcp",
+            "value": "mcp",
+            "description": "Model Context Protocol API."
           }
         ]
       }
@@ -59596,6 +59606,58 @@
         }
       }
     },
+    "McpEndpoint": {
+      "type": "object",
+      "description": "Endpoint definition for MCP API type.",
+      "properties": {
+        "uriTemplate": {
+          "type": "string",
+          "description": "Relative URL path that must start with '/'.",
+          "pattern": "^/.*$"
+        }
+      }
+    },
+    "McpProperties": {
+      "type": "object",
+      "description": "Properties specific to MCP API type.",
+      "properties": {
+        "transportType": {
+          "$ref": "#/definitions/McpTransportType",
+          "description": "Transport type for Model Context Protocol API."
+        },
+        "endpoints": {
+          "type": "object",
+          "description": "Collection of MCP endpoint definitions with relative URLs.",
+          "additionalProperties": {
+            "$ref": "#/definitions/McpEndpoint"
+          }
+        }
+      }
+    },
+    "McpTransportType": {
+      "type": "string",
+      "description": "Transport type for Model Context Protocol API.",
+      "enum": [
+        "sse",
+        "streamable"
+      ],
+      "x-ms-enum": {
+        "name": "McpTransportType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "sse",
+            "value": "sse",
+            "description": "This API uses HTTP+SSE transport type."
+          },
+          {
+            "name": "streamable",
+            "value": "streamable",
+            "description": "This API uses the Streamable HTTP transport type."
+          }
+        ]
+      }
+    },
     "Method": {
       "type": "string",
       "description": "The HTTP method to be used.",
@@ -63655,7 +63717,8 @@
         "websocket",
         "graphql",
         "odata",
-        "grpc"
+        "grpc",
+        "mcp"
       ],
       "x-ms-enum": {
         "name": "SoapApiType",
@@ -63690,6 +63753,11 @@
             "name": "gRPC",
             "value": "grpc",
             "description": "Imports the API having a gRPC front end."
+          },
+          {
+            "name": "MCP",
+            "value": "mcp",
+            "description": "Imports the API having a Model Context Protocol (MCP) front end."
           }
         ]
       }


### PR DESCRIPTION
- Add 'mcp' value to ApiType union
- Add 'MCP' value to SoapApiType union for API creation
- Add McpTransportType union (sse, streamable)
- Add McpEndpoint model with uriTemplate pattern
- Add McpProperties model with transportType and endpoints
- Add mcpProperties field to ApiEntityBaseContract
- Regenerate openapi.json with new MCP types

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
