### PR TITLE
Remove @Versioning.removed(Versions.v1) from credentials and startPendingUpload evaluator APIs

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/src/evaluators/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/evaluators/routes.tsp
@@ -126,7 +126,6 @@ interface Evaluators {
   // POST /evaluators/{evaluatorName}/versions/{version}/startPendingUpload
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations"
   @doc("Start a new or get an existing pending upload of an evaluator for a specific version.")
-  @Versioning.removed(Versions.v1)
   @Rest.action("startPendingUpload")
   startPendingUpload is Azure.Core.Foundations.ResourceOperation<
     EvaluatorVersion,
@@ -152,7 +151,6 @@ interface Evaluators {
   @Http.post
   @Rest.action("credentials")
   @Rest.actionSeparator("/")
-  @Versioning.removed(Versions.v1)
   getCredentials is Azure.Core.Foundations.ResourceOperation<
     EvaluatorVersion,
     {


### PR DESCRIPTION
This PR enables the `credentials()` and `startPendingUpload()` evaluator APIs for GA (v1) by removing the `@Versioning.removed(Versions.v1)` decorator from both operations in `specification/ai-foundry/data-plane/Foundry/src/evaluators/routes.tsp`.