### PR TITLE
[discovery] Add Python client name for Discovery Management

### DIFF
--- a/specification/discovery/Discovery.Management/client.tsp
+++ b/specification/discovery/Discovery.Management/client.tsp
@@ -9,3 +9,5 @@ using Azure.ClientGenerator.Core;
   "DiscoveryManagedStorage",
   "go"
 );
+
+@@clientName(Microsoft.Discovery, "DiscoveryMgmtClient", "python");


### PR DESCRIPTION
update python tsp config to add client name for sdk release: https://github.com/Azure/azure-sdk-for-python/pull/45562
namespace review result: https://github.com/Azure/azure-sdk-pr/issues/2507