### PR TITLE
feat: Add session file operations TypeSpec for hosted agents

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/main.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/main.tsp
@@ -1,5 +1,6 @@
 import "./src/agents/routes.tsp";
 import "./src/agents-containers/routes.tsp";
+import "./src/agents-session-files/routes.tsp";
 import "./src/agents-invocations/routes.tsp";
 import "./src/common/custom-types.tsp";
 import "./src/common/service.tsp";

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-session-files/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-session-files/models.tsp
@@ -1,0 +1,52 @@
+using TypeSpec.Http;
+using TypeSpec.Versioning;
+
+namespace Azure.AI.Projects;
+
+// ---------------------------------------------------------------------------
+// Response models
+// ---------------------------------------------------------------------------
+
+@removed(Versions.v1)
+@doc("Response from uploading a file to a session sandbox.")
+model SessionFileWriteResponse {
+  @doc("The path where the file was written.")
+  path: string;
+
+  @doc("Number of bytes written.")
+  bytes_written: int64;
+}
+
+@removed(Versions.v1)
+@doc("A single entry in a directory listing.")
+model SessionDirectoryEntry {
+  @doc("The name of the file or directory.")
+  name: string;
+
+  @doc("The size in bytes (0 for directories).")
+  size: int64;
+
+  @doc("Whether this entry is a directory.")
+  is_dir: boolean;
+
+  @doc("The last modification time in UTC (ISO 8601).")
+  @encode(DateTimeKnownEncoding.rfc3339)
+  modified_time: utcDateTime;
+}
+
+@removed(Versions.v1)
+@doc("Response from listing a directory in a session sandbox.")
+model SessionDirectoryListResponse {
+  @doc("The path that was listed.")
+  path: string;
+
+  @doc("The directory entries.")
+  entries: SessionDirectoryEntry[];
+}
+
+@removed(Versions.v1)
+@doc("Generic response for session file operations (delete).")
+model SessionFileOperationResponse {
+  @doc("A human-readable message describing the result.")
+  message: string;
+}

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-session-files/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-session-files/routes.tsp
@@ -1,0 +1,145 @@
+import "../common/models.tsp";
+import "./models.tsp";
+
+using TypeSpec.Http;
+using TypeSpec.OpenAPI;
+using TypeSpec.Versioning;
+
+namespace Azure.AI.Projects;
+
+/**
+ * Session-scoped file operations for hosted agent sandboxes.
+ *
+ * These endpoints enable uploading, downloading, listing, and deleting
+ * files within a live ADC sandbox session. All file content is streamed
+ * end-to-end (no buffering in Agents service memory).
+ *
+ * Sessions are scoped to agents (not versions), giving optionality to
+ * mutate the associated agent version independently of the session lifecycle.
+ */
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" ""
+@tag("Agent Session Files")
+@removed(Versions.v1)
+interface AgentSessionFiles {
+
+  /**
+   * Upload a file to the session sandbox via binary stream.
+   */
+  @put
+  @route("/agents/{agent_name}/sessions/{session_id}/files")
+  @extension(
+    "x-ms-foundry-meta",
+    #{
+      required_previews: #[
+        AgentDefinitionOptInKeys.hosted_agents_v1_preview
+      ],
+    }
+  )
+  uploadSessionFile is FoundryDataPlanePreviewOperation<
+    AgentDefinitionOptInKeys.hosted_agents_v1_preview,
+    {
+      /** The name of the agent. */
+      @path agent_name: string;
+
+      /** The session ID. */
+      @path session_id: string;
+
+      /** The destination file path within the sandbox. */
+      @query path: string;
+
+      /** The binary file content to upload. */
+      @header contentType: "application/octet-stream";
+      @body content: bytes;
+    },
+    SessionFileWriteResponse
+  >;
+
+  /**
+   * Download a file from the session sandbox as a binary stream.
+   */
+  @get
+  @route("/agents/{agent_name}/sessions/{session_id}/files")
+  @extension(
+    "x-ms-foundry-meta",
+    #{
+      required_previews: #[
+        AgentDefinitionOptInKeys.hosted_agents_v1_preview
+      ],
+    }
+  )
+  downloadSessionFile is FoundryDataPlanePreviewOperation<
+    AgentDefinitionOptInKeys.hosted_agents_v1_preview,
+    {
+      /** The name of the agent. */
+      @path agent_name: string;
+
+      /** The session ID. */
+      @path session_id: string;
+
+      /** The file path to download from the sandbox. */
+      @query path: string;
+    },
+    bytes
+  >;
+
+  /**
+   * List files and directories at a given path in the session sandbox.
+   * Returns only the immediate children of the specified directory (non-recursive).
+   */
+  @get
+  @route("/agents/{agent_name}/sessions/{session_id}/files/list")
+  @extension(
+    "x-ms-foundry-meta",
+    #{
+      required_previews: #[
+        AgentDefinitionOptInKeys.hosted_agents_v1_preview
+      ],
+    }
+  )
+  listSessionFiles is FoundryDataPlanePreviewOperation<
+    AgentDefinitionOptInKeys.hosted_agents_v1_preview,
+    {
+      /** The name of the agent. */
+      @path agent_name: string;
+
+      /** The session ID. */
+      @path session_id: string;
+
+      /** The directory path to list. */
+      @query path: string;
+    },
+    SessionDirectoryListResponse
+  >;
+
+  /**
+   * Delete a file or directory from the session sandbox.
+   * If `recursive` is false (default) and the target is a non-empty directory, the API returns 409 Conflict.
+   */
+  @delete
+  @route("/agents/{agent_name}/sessions/{session_id}/files")
+  @extension(
+    "x-ms-foundry-meta",
+    #{
+      required_previews: #[
+        AgentDefinitionOptInKeys.hosted_agents_v1_preview
+      ],
+    }
+  )
+  deleteSessionFile is FoundryDataPlanePreviewOperation<
+    AgentDefinitionOptInKeys.hosted_agents_v1_preview,
+    {
+      /** The name of the agent. */
+      @path agent_name: string;
+
+      /** The session ID. */
+      @path session_id: string;
+
+      /** The file or directory path to delete. */
+      @query path: string;
+
+      /** Whether to recursively delete directory contents. Defaults to false. */
+      @query recursive?: boolean;
+    },
+    SessionFileOperationResponse
+  >;
+}


### PR DESCRIPTION
## Summary

Add TypeSpec definitions for session-scoped file operations on hosted agent sandboxes (stream-only).

### Operations (4 CRUDL)

| Method | Route | Description |
|--------|-------|-------------|
| `PUT` | `/agents/{name}/sessions/{id}/files?path=` | Upload file (binary stream) |
| `GET` | `/agents/{name}/sessions/{id}/files?path=` | Download file (binary stream) |
| `GET` | `/agents/{name}/sessions/{id}/files/list?path=` | List directory (non-recursive, single level) |
| `DELETE` | `/agents/{name}/sessions/{id}/files?path=` | Delete file/directory |

### Models (4)
- `SessionFileWriteResponse` — path, bytes_written
- `SessionDirectoryEntry` — name, size, is_dir, modified_time
- `SessionDirectoryListResponse` — path, entries[]
- `SessionFileOperationResponse` — message

### Preview Gating
- `@removed(Versions.v1)` on interface and all models — hidden from GA SDK
- `x-ms-foundry-meta` with `required_previews: hosted_agents_v1_preview` on each operation
- `FoundryDataPlanePreviewOperation` requires `Foundry-Features: HostedAgents=V1Preview` header

### Key Design Decisions
- **Sessions under agents (not versions)** — `/agents/{name}/sessions/` gives optionality to mutate the associated agent version independently of the session lifecycle
- **Non-recursive list** — returns immediate children only (cost/performance)
- **No symlink fields** — users can't create symlinks via the API
- **No `success` boolean** — HTTP status code suffices
- **No `file_api_root_path`** — consolidating with `$HOME` semantics (follow-up)
- **409 Conflict** on non-recursive delete of non-empty directory

### Related
- Design doc: https://msdata.visualstudio.com/Vienna/_git/vienna/pullrequest/1970903
- API review doc: https://github.com/Azure/agent-first-sdk/pull/189
- ADC integration spec (merged): https://github.com/Azure/azure-rest-api-specs/pull/40739

### Note
`tsp compile .` produces 2 pre-existing errors in `openai-responses/models.tsp` (`OpenAI.AutoCodeInterpreterToolParam` missing) — not related to this PR.
