### PR TITLE
Refactor SDK generation to call azsdk CLIs

### DIFF
--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -210,6 +210,8 @@ stages:
         inputs:
           versionSpec: $(PythonVersion)
 
+      - template: /eng/common/pipelines/templates/steps/install-azsdk-cli.yml
+
       - script: |
           set -euo pipefail  # Exit on error, undefined vars, and pipeline failures
           optional_params=""

--- a/eng/tools/spec-gen-sdk-runner/src/azsdk-adapter.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/azsdk-adapter.ts
@@ -1,0 +1,151 @@
+import { EmitterCheckResult } from "./emitter-check.js";
+import { ExecutionReport, ExecutionReportPackage, ExecutionResult } from "./types.js";
+
+/**
+ * Response shape from `azsdk pkg generate --output json`.
+ */
+export interface AzsdkGenerateResponse {
+  result: "succeeded" | "failed";
+  message?: string;
+  package_name: string;
+  language: string;
+  version: string;
+  package_type: string;
+  typespec_project: string;
+  sdk_repo: string;
+  operation_status: string;
+  next_steps?: string[];
+  response_error?: string;
+  response_errors?: string[];
+  duration?: number;
+}
+
+/**
+ * Response shape from `azsdk pkg build --output json`.
+ */
+export interface AzsdkBuildResponse {
+  result: "succeeded" | "failed";
+  message?: string;
+  package_name: string;
+  language: string;
+  response_error?: string;
+  response_errors?: string[];
+  duration?: number;
+}
+
+/**
+ * Response shape from `azsdk pkg pack --output json`.
+ */
+export interface AzsdkPackResponse {
+  result: "succeeded" | "failed";
+  message?: string;
+  package_name: string;
+  language: string;
+  version: string;
+  package_type: string;
+  response_error?: string;
+  response_errors?: string[];
+  duration?: number;
+}
+
+/**
+ * Parses JSON output from an azsdk-cli command.
+ * The CLI emits log lines before the JSON payload. The JSON object is always
+ * the last block in the output, so we search backwards for the opening brace.
+ */
+export function parseAzsdkResponse<T>(output: string): T {
+  // The JSON block is the last section — find the last top-level '{' that
+  // appears either at the start of a line or at the very beginning of output.
+  const jsonEnd = output.lastIndexOf("}");
+  if (jsonEnd === -1) {
+    throw new SyntaxError(`No JSON object found in azsdk output: ${output.slice(0, 200)}`);
+  }
+
+  // Walk backwards from jsonEnd to find the matching '{'
+  let depth = 0;
+  let jsonStart = -1;
+  for (let i = jsonEnd; i >= 0; i--) {
+    if (output[i] === "}") {
+      depth++;
+    } else if (output[i] === "{") {
+      depth--;
+      if (depth === 0) {
+        jsonStart = i;
+        break;
+      }
+    }
+  }
+
+  if (jsonStart === -1) {
+    throw new SyntaxError(`No matching opening brace found in azsdk output: ${output.slice(0, 200)}`);
+  }
+
+  return JSON.parse(output.slice(jsonStart, jsonEnd + 1)) as T;
+}
+
+/**
+ * Extracts the artifact path from an azsdk pkg pack response message.
+ * The message format is: "Pack completed successfully. Artifact: /path/to/artifact"
+ */
+function extractArtifactPath(packResponse: AzsdkPackResponse): string {
+  if (!packResponse.message) {
+    return "";
+  }
+  const artifactPrefix = "Artifact: ";
+  const artifactIndex = packResponse.message.indexOf(artifactPrefix);
+  if (artifactIndex === -1) {
+    return "";
+  }
+  return packResponse.message.slice(artifactIndex + artifactPrefix.length).trim();
+}
+
+/**
+ * Builds an ExecutionReport from azsdk-cli generate/pack responses and
+ * typespec-metadata emitter output.
+ *
+ * This adapter bridges the gap between azsdk-cli output and the ExecutionReport
+ * format expected by the spec-gen-sdk-runner orchestration logic.
+ *
+ * @param generateResponse - Response from `azsdk pkg generate`
+ * @param packResponse - Response from `azsdk pkg pack` (undefined if pack was skipped)
+ * @param emitterCheck - Result from typespec-metadata emitter check
+ * @returns ExecutionReport compatible with existing runner logic
+ */
+export function buildExecutionReport(
+  generateResponse: AzsdkGenerateResponse | undefined,
+  packResponse: AzsdkPackResponse | undefined,
+  emitterCheck: EmitterCheckResult,
+): ExecutionReport {
+  // If emitter is not enabled, return notEnabled result
+  if (!emitterCheck.enabled) {
+    return {
+      packages: [],
+      executionResult: "notEnabled",
+      generateFromTypeSpec: true,
+    };
+  }
+
+  // Map azsdk-cli result to ExecutionResult
+  let executionResult: ExecutionResult;
+  if (!generateResponse) {
+    executionResult = "failed";
+  } else {
+    executionResult = generateResponse.result === "succeeded" ? "succeeded" : "failed";
+  }
+
+  // Build package info from typespec-metadata and pack response
+  const artifactPath = packResponse ? extractArtifactPath(packResponse) : "";
+  const pkg: ExecutionReportPackage = {
+    packageName: emitterCheck.packageName ?? generateResponse?.package_name ?? "",
+    apiViewArtifact: artifactPath || undefined,
+    // Deferred fields:
+    // shouldLabelBreakingChange: undefined,
+  };
+
+  return {
+    packages: [pkg],
+    executionResult,
+    stagedArtifactsFolder: artifactPath || undefined,
+    generateFromTypeSpec: true,    
+  };
+}

--- a/eng/tools/spec-gen-sdk-runner/src/command-helpers.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/command-helpers.ts
@@ -391,3 +391,87 @@ export function getRequiredSettingValue(
     return SpecGenSdkRequiredSettings[sdkName].dataPlane;
   }
 }
+
+/**
+ * Indicates which generation tool should be used for a given spec.
+ */
+export type GenerationTool = "azsdk-cli" | "spec-gen-sdk";
+
+/**
+ * Determines whether to use azsdk-cli based on the feature flag and spec type.
+ * When USE_AZSDK_CLI=true and the spec is TypeSpec (has tspConfigPath), uses azsdk-cli.
+ * OpenAPI-only specs always fall back to spec-gen-sdk.
+ */
+export function selectGenerationTool(tspConfigPath?: string, _readmePath?: string): GenerationTool {
+  const useAzsdkCli = process.env.USE_AZSDK_CLI === "true";
+  if (useAzsdkCli && tspConfigPath) {
+    return "azsdk-cli";
+  }
+  return "spec-gen-sdk";
+}
+
+/**
+ * Prepare the azsdk pkg generate command arguments.
+ *
+ * @param commandInput - The spec-gen-sdk command input.
+ * @param tspConfigRelativePath - Relative path to tspconfig.yaml within the spec repo.
+ * @returns Array of arguments for the azsdk command.
+ */
+export function prepareAzsdkGenerateCommand(
+  commandInput: SpecGenSdkCmdInput,
+  tspConfigRelativePath: string,
+): string[] {
+  const tspConfigFullPath = path.join(commandInput.localSpecRepoPath, tspConfigRelativePath);
+  return [
+    "pkg",
+    "generate",
+    "-r",
+    commandInput.localSdkRepoPath,
+    "-t",
+    tspConfigFullPath,
+    "--output",
+    "json",
+  ];
+}
+
+/**
+ * Prepare the azsdk pkg build command arguments.
+ *
+ * @param packagePath - Absolute path to the generated SDK package directory.
+ * @returns Array of arguments for the azsdk build command.
+ */
+export function prepareAzsdkBuildCommand(packagePath: string): string[] {
+  return ["pkg", "build", "--package-path", packagePath, "--output", "json"];
+}
+
+/**
+ * Prepare the azsdk pkg pack command arguments.
+ *
+ * @param packagePath - Absolute path to the generated SDK package directory.
+ * @param outputPath - Optional output directory for artifacts.
+ * @returns Array of arguments for the azsdk pack command.
+ */
+export function prepareAzsdkPackCommand(
+  packagePath: string,
+  outputPath?: string,
+): string[] {
+  const args = ["pkg", "pack", "--package-path", packagePath, "--output", "json"];
+  if (outputPath) {
+    args.push("--output-path", outputPath);
+  }
+  return args;
+}
+
+/**
+ * Resolves the generated package directory path from typespec-metadata output.
+ * The outputDir in metadata uses `{output-dir}` placeholder which resolves to the SDK repo root.
+ *
+ * @param outputDir - The outputDir from typespec-metadata (e.g., "{output-dir}/sdk/keyvault/azure-keyvault-keys")
+ * @param sdkRepoPath - Absolute path to the SDK repository root.
+ * @returns Absolute path to the generated package directory.
+ */
+export function resolvePackagePath(outputDir: string, sdkRepoPath: string): string {
+  // Replace {output-dir} placeholder with the SDK repo path
+  const resolved = outputDir.replace("{output-dir}", sdkRepoPath);
+  return path.resolve(resolved);
+}

--- a/eng/tools/spec-gen-sdk-runner/src/commands.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/commands.ts
@@ -3,6 +3,13 @@ import fs from "node:fs";
 import path from "node:path";
 import { inspect } from "node:util";
 import {
+  AzsdkBuildResponse,
+  AzsdkGenerateResponse,
+  AzsdkPackResponse,
+  buildExecutionReport,
+  parseAzsdkResponse,
+} from "./azsdk-adapter.js";
+import {
   generateArtifact,
   getBreakingChangeInfo,
   getExecutionReport,
@@ -10,13 +17,118 @@ import {
   getSpecPaths,
   logIssuesToPipeline,
   parseArguments,
+  prepareAzsdkBuildCommand,
+  prepareAzsdkGenerateCommand,
+  prepareAzsdkPackCommand,
   prepareSpecGenSdkCommand,
+  resolvePackagePath,
+  selectGenerationTool,
   setPipelineVariables,
 } from "./command-helpers.js";
+import { checkEmitterEnabled, EmitterCheckResult } from "./emitter-check.js";
 import { LogLevel, logMessage, vsoAddAttachment, vsoLogIssue } from "./log.js";
 import { detectChangedSpecConfigFiles } from "./spec-helpers.js";
 import { ExecutionReport, SpecGenSdkCmdInput } from "./types.js";
-import { resetGitRepo, runSpecGenSdkCommand, SpecConfigs } from "./utils.js";
+import { resetGitRepo, runCommandWithOutput, runSpecGenSdkCommand, SpecConfigs } from "./utils.js";
+
+/**
+ * Run the azsdk-cli generation flow for a single TypeSpec spec:
+ * 1. Check emitter enabled via typespec-metadata
+ * 2. Run azsdk pkg generate
+ * 3. On success, run azsdk pkg build (skip for Python)
+ * 4. On build success, run azsdk pkg pack
+ * 5. Build ExecutionReport via adapter
+ */
+async function runAzsdkGeneration(
+  commandInput: SpecGenSdkCmdInput,
+  tspConfigRelativePath: string,
+): Promise<{ executionReport: ExecutionReport; statusCode: number }> {
+  let statusCode = 0;
+  const tspConfigDir = path.resolve(
+    commandInput.localSpecRepoPath,
+    path.dirname(tspConfigRelativePath),
+  );
+
+  // Step 1: Check if the language emitter is enabled
+  logMessage(`Checking emitter configuration for ${commandInput.sdkRepoName}`, LogLevel.Info);
+  const emitterCheck: EmitterCheckResult = await checkEmitterEnabled(
+    tspConfigDir,
+    commandInput.sdkRepoName,
+  );
+
+  if (!emitterCheck.enabled) {
+    logMessage(
+      `Emitter not enabled for ${commandInput.sdkRepoName}, skipping generation`,
+      LogLevel.Info,
+    );
+    return {
+      executionReport: buildExecutionReport(undefined, undefined, emitterCheck),
+      statusCode: 0,
+    };
+  }
+
+  // Step 2: Run azsdk pkg generate
+  let generateResponse: AzsdkGenerateResponse | undefined;
+  try {
+    const generateArgs = prepareAzsdkGenerateCommand(commandInput, tspConfigRelativePath);
+    logMessage(`Running: azsdk ${generateArgs.join(" ")}`, LogLevel.Info);
+    const generateOutput = await runCommandWithOutput("azsdk", generateArgs);
+    generateResponse = parseAzsdkResponse<AzsdkGenerateResponse>(generateOutput);
+    logMessage(`azsdk pkg generate result: ${generateResponse.result}`, LogLevel.Info);
+  } catch (error) {
+    logMessage(`Error running azsdk pkg generate: ${inspect(error)}`, LogLevel.Error);
+    statusCode = 1;
+  }
+
+  // Step 3 & 4: On success, build (if not Python) then pack
+  let packResponse: AzsdkPackResponse | undefined;
+  if (generateResponse?.result === "succeeded" && emitterCheck.metadata && emitterCheck.languageKey) {
+    const langMeta = emitterCheck.metadata.languages[emitterCheck.languageKey];
+    if (langMeta?.outputDir) {
+      const packagePath = resolvePackagePath(langMeta.outputDir, commandInput.localSdkRepoPath);
+      const isPython = commandInput.sdkRepoName.replace("-pr", "") === "azure-sdk-for-python";
+      let buildSucceeded = true;
+
+      // Step 3: Build (skip for Python — interpreted language, no compilation needed)
+      if (!isPython) {
+        try {
+          const buildArgs = prepareAzsdkBuildCommand(packagePath);
+          logMessage(`Running: azsdk ${buildArgs.join(" ")}`, LogLevel.Info);
+          const buildOutput = await runCommandWithOutput("azsdk", buildArgs);
+          const buildResponse = parseAzsdkResponse<AzsdkBuildResponse>(buildOutput);
+          logMessage(`azsdk pkg build result: ${buildResponse.result}`, LogLevel.Info);
+          if (buildResponse.result !== "succeeded") {
+            logMessage(`Build failed, skipping pack step`, LogLevel.Error);
+            buildSucceeded = false;
+            statusCode = 1;
+          }
+        } catch (error) {
+          logMessage(`Error running azsdk pkg build: ${inspect(error)}`, LogLevel.Error);
+          buildSucceeded = false;
+          statusCode = 1;
+        }
+      }
+
+      // Step 4: Pack (only if build succeeded or was skipped)
+      if (buildSucceeded) {
+        try {
+          const packArgs = prepareAzsdkPackCommand(packagePath);
+          logMessage(`Running: azsdk ${packArgs.join(" ")}`, LogLevel.Info);
+          const packOutput = await runCommandWithOutput("azsdk", packArgs);
+          packResponse = parseAzsdkResponse<AzsdkPackResponse>(packOutput);
+          logMessage(`azsdk pkg pack result: ${packResponse.result}`, LogLevel.Info);
+        } catch (error) {
+          logMessage(`Error running azsdk pkg pack: ${inspect(error)}`, LogLevel.Error);
+          statusCode = 1;
+        }
+      }
+    }
+  }
+
+  // Step 5: Build ExecutionReport via adapter
+  const executionReport = buildExecutionReport(generateResponse, packResponse, emitterCheck);
+  return { executionReport, statusCode };
+}
 
 /**
  * Generate SDK for a single spec.
@@ -28,28 +140,38 @@ export async function generateSdkForSingleSpec(): Promise<number> {
   const commandInput: SpecGenSdkCmdInput = parseArguments();
   const specConfigPathText = `${commandInput.tspConfigPath} ${commandInput.readmePath}`;
 
-  // Construct the spec-gen-sdk command
-  const specGenSdkCommand = prepareSpecGenSdkCommand(commandInput);
-  logMessage(`Generating SDK from ${specConfigPathText}`, LogLevel.Group);
-  logMessage(`Runner command:${specGenSdkCommand.join(" ")}`);
+  const tool = selectGenerationTool(commandInput.tspConfigPath, commandInput.readmePath);
   let statusCode = 0;
-  try {
-    await runSpecGenSdkCommand(specGenSdkCommand);
-    logMessage("Runner command executed successfully");
-  } catch (error) {
-    logMessage(`Runner: error executing command:${inspect(error)}`, LogLevel.Error);
-    statusCode = 1;
-  }
+  let executionReport: ExecutionReport | undefined;
 
-  let executionReport;
-  try {
-    // Read the execution report to determine if the generation was successful
-    executionReport = getExecutionReport(commandInput);
-    const executionResult = executionReport.executionResult;
-    logMessage(`Runner command execution result:${executionResult}`);
-  } catch (error) {
-    logMessage(`Runner: error reading execution-report.json:${inspect(error)}`, LogLevel.Error);
-    statusCode = 1;
+  if (tool === "azsdk-cli" && commandInput.tspConfigPath) {
+    // azsdk-cli path for TypeSpec specs
+    logMessage(`Generating SDK (azsdk-cli) from ${specConfigPathText}`, LogLevel.Group);
+    const result = await runAzsdkGeneration(commandInput, commandInput.tspConfigPath);
+    executionReport = result.executionReport;
+    statusCode = result.statusCode;
+    logMessage(`Runner command execution result:${executionReport.executionResult}`);
+  } else {
+    // Existing spec-gen-sdk path
+    const specGenSdkCommand = prepareSpecGenSdkCommand(commandInput);
+    logMessage(`Generating SDK from ${specConfigPathText}`, LogLevel.Group);
+    logMessage(`Runner command:${specGenSdkCommand.join(" ")}`);
+    try {
+      await runSpecGenSdkCommand(specGenSdkCommand);
+      logMessage("Runner command executed successfully");
+    } catch (error) {
+      logMessage(`Runner: error executing command:${inspect(error)}`, LogLevel.Error);
+      statusCode = 1;
+    }
+
+    try {
+      executionReport = getExecutionReport(commandInput);
+      const executionResult = executionReport.executionResult;
+      logMessage(`Runner command execution result:${executionResult}`);
+    } catch (error) {
+      logMessage(`Runner: error reading execution-report.json:${inspect(error)}`, LogLevel.Error);
+      statusCode = 1;
+    }
   }
 
   // Always set the pipeline variables for the SDK pull request even if
@@ -88,7 +210,7 @@ export async function generateSdkForSingleSpec(): Promise<number> {
 export async function generateSdkForSpecPr(): Promise<number> {
   // Parse the arguments
   const commandInput: SpecGenSdkCmdInput = parseArguments();
-  // Construct the spec-gen-sdk command
+  // Construct the spec-gen-sdk command (used for OpenAPI fallback path)
   const specGenSdkCommand = prepareSpecGenSdkCommand(commandInput);
   // Get the spec paths from the changed files
   const changedSpecs = await detectChangedSpecConfigFiles(commandInput);
@@ -117,72 +239,107 @@ export async function generateSdkForSpecPr(): Promise<number> {
       logMessage("Runner: no spec config file found in the changed files", LogLevel.Warn);
       continue;
     }
-    pushedSpecConfigCount = 0;
+
+    const tool = selectGenerationTool(changedSpec.typespecProject, changedSpec.readmeMd);
     changedSpecPathText = "";
+
     if (changedSpec.typespecProject) {
-      specGenSdkCommand.push("--tsp-config-relative-path", changedSpec.typespecProject);
       changedSpecPathText = changedSpec.typespecProject;
-      pushedSpecConfigCount++;
       if (changedSpec.typespecProject.includes(".Management")) {
         hasManagementPlaneSpecs = true;
       }
     }
     if (changedSpec.readmeMd) {
-      specGenSdkCommand.push("--readme-relative-path", changedSpec.readmeMd);
       changedSpecPathText = changedSpec.readmeMd;
-      pushedSpecConfigCount++;
-      if (pushedSpecConfigCount === 2) {
-        // If both readme and tspconfig are provided, we need to use the service folder path for the log message
+      if (changedSpec.typespecProject) {
         changedSpecPathText = getServiceFolderPath(changedSpec.readmeMd);
       }
       if (changedSpec.readmeMd.includes("resource-manager")) {
         hasManagementPlaneSpecs = true;
       }
     }
+
     logMessage(`Generating SDK from ${changedSpecPathText}`, LogLevel.Group);
-    logMessage(`Runner command:${specGenSdkCommand.join(" ")}`);
 
-    try {
-      await resetGitRepo(commandInput.localSdkRepoPath);
-      await runSpecGenSdkCommand(specGenSdkCommand);
-      logMessage("Runner command executed successfully");
-    } catch (error) {
-      logMessage(`Runner: error executing command:${inspect(error)}`, LogLevel.Error);
-      statusCode = 1;
-    }
-    // Pop the spec config path from specGenSdkCommand
-    for (let index = 0; index < pushedSpecConfigCount * 2; index++) {
-      specGenSdkCommand.pop();
-    }
+    if (tool === "azsdk-cli" && changedSpec.typespecProject) {
+      // azsdk-cli path for TypeSpec specs
+      try {
+        await resetGitRepo(commandInput.localSdkRepoPath);
+        const result = await runAzsdkGeneration(commandInput, changedSpec.typespecProject);
+        executionReport = result.executionReport;
+        if (result.statusCode !== 0) {
+          statusCode = result.statusCode;
+        }
+      } catch (error) {
+        logMessage(`Runner: error in azsdk generation:${inspect(error)}`, LogLevel.Error);
+        statusCode = 1;
+      }
+    } else {
+      // Existing spec-gen-sdk path
+      pushedSpecConfigCount = 0;
+      if (changedSpec.typespecProject) {
+        specGenSdkCommand.push("--tsp-config-relative-path", changedSpec.typespecProject);
+        pushedSpecConfigCount++;
+      }
+      if (changedSpec.readmeMd) {
+        specGenSdkCommand.push("--readme-relative-path", changedSpec.readmeMd);
+        pushedSpecConfigCount++;
+      }
+      logMessage(`Runner command:${specGenSdkCommand.join(" ")}`);
 
-    try {
-      // Read the execution report to aggreate the generation results
-      executionReport = getExecutionReport(commandInput);
-      currentExecutionResult = executionReport.executionResult;
-      if (executionReport.generateFromTypeSpec) {
-        hasTypeSpecProjects = true;
+      try {
+        await resetGitRepo(commandInput.localSdkRepoPath);
+        await runSpecGenSdkCommand(specGenSdkCommand);
+        logMessage("Runner command executed successfully");
+      } catch (error) {
+        logMessage(`Runner: error executing command:${inspect(error)}`, LogLevel.Error);
+        statusCode = 1;
+      }
+      // Pop the spec config path from specGenSdkCommand
+      for (let index = 0; index < pushedSpecConfigCount * 2; index++) {
+        specGenSdkCommand.pop();
       }
 
-      if (executionReport.stagedArtifactsFolder) {
-        stagedArtifactsFolder = executionReport.stagedArtifactsFolder;
-        for (const pkg of executionReport.packages) {
-          if (pkg.apiViewArtifact && pkg.packageName) {
-            apiViewRequestData.push({
-              packageName: pkg.packageName,
-              filePath: path.relative(stagedArtifactsFolder, pkg.apiViewArtifact),
-            });
+      try {
+        executionReport = getExecutionReport(commandInput);
+      } catch (error) {
+        logMessage(`Runner: error reading execution-report.json:${inspect(error)}`, LogLevel.Error);
+        statusCode = 1;
+        executionReport = undefined;
+      }
+    }
+
+    // Process execution report (common path for both tools)
+    try {
+      if (executionReport) {
+        currentExecutionResult = executionReport.executionResult;
+        if (executionReport.generateFromTypeSpec) {
+          hasTypeSpecProjects = true;
+        }
+
+        if (executionReport.stagedArtifactsFolder) {
+          stagedArtifactsFolder = executionReport.stagedArtifactsFolder;
+          for (const pkg of executionReport.packages) {
+            if (pkg.apiViewArtifact && pkg.packageName) {
+              apiViewRequestData.push({
+                packageName: pkg.packageName,
+                filePath: path.relative(stagedArtifactsFolder, pkg.apiViewArtifact),
+              });
+            }
           }
         }
-      }
 
-      if (overallExecutionResult !== "failed") {
-        overallExecutionResult = currentExecutionResult;
+        if (overallExecutionResult !== "failed") {
+          overallExecutionResult = currentExecutionResult;
+        }
+        currentRunHasBreakingChange = getBreakingChangeInfo(executionReport);
+        overallRunHasBreakingChange = overallRunHasBreakingChange || currentRunHasBreakingChange;
+        logMessage(`Runner command execution result:${currentExecutionResult}`);
+      } else {
+        overallExecutionResult = "failed";
       }
-      currentRunHasBreakingChange = getBreakingChangeInfo(executionReport);
-      overallRunHasBreakingChange = overallRunHasBreakingChange || currentRunHasBreakingChange;
-      logMessage(`Runner command execution result:${currentExecutionResult}`);
     } catch (error) {
-      logMessage(`Runner: error reading execution-report.json:${inspect(error)}`, LogLevel.Error);
+      logMessage(`Runner: error processing execution report:${inspect(error)}`, LogLevel.Error);
       statusCode = 1;
       overallExecutionResult = "failed";
     }
@@ -254,69 +411,96 @@ export async function generateSdkForBatchSpecs(batchType: string): Promise<numbe
     } else if (specConfigs.readmePath) {
       logMessage(`Generating SDK from ${specConfigs.readmePath}`, LogLevel.Group);
     }
-    pushedSpecConfigCount = 0;
-    if (specConfigs.readmePath) {
-      specConfigPath = specConfigs.readmePath;
-      specGenSdkCommand.push("--readme-relative-path", specConfigs.readmePath);
-      pushedSpecConfigCount++;
-    }
 
-    if (specConfigs.tspconfigPath) {
-      // Override specConfigPath variable for reporting purposes
-      // as we only input both tspconfig and readme while selecting typespec options for batch runs
+    const tool = selectGenerationTool(specConfigs.tspconfigPath, specConfigs.readmePath);
+
+    if (tool === "azsdk-cli" && specConfigs.tspconfigPath) {
+      // azsdk-cli path for TypeSpec specs
       specConfigPath = specConfigs.tspconfigPath;
-      specGenSdkCommand.push("--tsp-config-relative-path", specConfigs.tspconfigPath);
-      pushedSpecConfigCount++;
+      logMessage(`Using azsdk-cli for ${specConfigPath}`, LogLevel.Info);
+      try {
+        await resetGitRepo(commandInput.localSdkRepoPath);
+        const result = await runAzsdkGeneration(commandInput, specConfigs.tspconfigPath);
+        executionReport = result.executionReport;
+        if (result.statusCode !== 0) {
+          statusCode = result.statusCode;
+        }
+      } catch (error) {
+        logMessage(`Runner: error in azsdk generation:${inspect(error)}`, LogLevel.Error);
+        statusCode = 1;
+        executionReport = undefined;
+      }
+    } else {
+      // Existing spec-gen-sdk path
+      pushedSpecConfigCount = 0;
+      if (specConfigs.readmePath) {
+        specConfigPath = specConfigs.readmePath;
+        specGenSdkCommand.push("--readme-relative-path", specConfigs.readmePath);
+        pushedSpecConfigCount++;
+      }
+
+      if (specConfigs.tspconfigPath) {
+        specConfigPath = specConfigs.tspconfigPath;
+        specGenSdkCommand.push("--tsp-config-relative-path", specConfigs.tspconfigPath);
+        pushedSpecConfigCount++;
+      }
+
+      logMessage(`Runner command:${specGenSdkCommand.join(" ")}`);
+      try {
+        await resetGitRepo(commandInput.localSdkRepoPath);
+        await runSpecGenSdkCommand(specGenSdkCommand);
+        logMessage("Runner command executed successfully");
+      } catch (error) {
+        logMessage(`Runner: error executing command:${inspect(error)}`, LogLevel.Error);
+        statusCode = 1;
+      }
+
+      // Pop the spec config path from specGenSdkCommand
+      for (let index = 0; index < pushedSpecConfigCount * 2; index++) {
+        specGenSdkCommand.pop();
+      }
+
+      try {
+        executionReport = getExecutionReport(commandInput);
+      } catch (error) {
+        logMessage(`Runner: error reading execution-report.json:${inspect(error)}`, LogLevel.Error);
+        statusCode = 1;
+        executionReport = undefined;
+      }
     }
 
-    logMessage(`Runner command:${specGenSdkCommand.join(" ")}`);
+    // Process execution report (common path for both tools)
     try {
-      await resetGitRepo(commandInput.localSdkRepoPath);
-      await runSpecGenSdkCommand(specGenSdkCommand);
-      logMessage("Runner command executed successfully");
+      if (executionReport) {
+        const executionResult = executionReport.executionResult;
+        if (executionReport.stagedArtifactsFolder) {
+          stagedArtifactsFolder = executionReport.stagedArtifactsFolder;
+        }
+        logMessage(`Runner: command execution result:${executionResult}`);
+
+        if (executionResult === "succeeded" || executionResult === "warning") {
+          succeededContent += `${specConfigPath},`;
+          succeededCount++;
+        } else if (executionResult === "notEnabled") {
+          notEnabledContent += `${specConfigPath},`;
+          notEnabledCount++;
+        } else {
+          failedContent += `${specConfigPath},`;
+          failedCount++;
+          const specIndex = specConfigPath.indexOf("specification/");
+          const relativePath = specIndex >= 0 ? specConfigPath.substring(specIndex) : specConfigPath;
+          failedSpecs.push(relativePath);
+        }
+        if (executionReport.isSdkConfigDuplicated) {
+          duplicatedConfigContent += `${specConfigPath},`;
+          duplicatedConfigCount++;
+        }
+      }
     } catch (error) {
-      logMessage(`Runner: error executing command:${inspect(error)}`, LogLevel.Error);
+      logMessage(`Runner: error processing execution report:${inspect(error)}`, LogLevel.Error);
       statusCode = 1;
     }
 
-    // Pop the spec config path from specGenSdkCommand
-    for (let index = 0; index < pushedSpecConfigCount * 2; index++) {
-      specGenSdkCommand.pop();
-    }
-
-    try {
-      // Read the execution report to determine if the generation was successful
-      executionReport = getExecutionReport(commandInput);
-      const executionResult = executionReport.executionResult;
-      if (executionReport.stagedArtifactsFolder) {
-        stagedArtifactsFolder = executionReport.stagedArtifactsFolder;
-      }
-      logMessage(`Runner: command execution result:${executionResult}`);
-
-      if (executionResult === "succeeded" || executionResult === "warning") {
-        succeededContent += `${specConfigPath},`;
-        succeededCount++;
-      } else if (executionResult === "notEnabled") {
-        notEnabledContent += `${specConfigPath},`;
-        notEnabledCount++;
-      } else {
-        failedContent += `${specConfigPath},`;
-        failedCount++;
-        // Extract relative path from 'specification/' for telemetry
-        const specIndex = specConfigPath.indexOf("specification/");
-        const relativePath = specIndex >= 0 ? specConfigPath.substring(specIndex) : specConfigPath;
-        failedSpecs.push(relativePath);
-      }
-      // Check for duplicated SDK configurations,
-      // the execution result can be "succeeded" or "warning"
-      if (executionReport.isSdkConfigDuplicated) {
-        duplicatedConfigContent += `${specConfigPath},`;
-        duplicatedConfigCount++;
-      }
-    } catch (error) {
-      logMessage(`Runner: error reading execution-report.json:${inspect(error)}`, LogLevel.Error);
-      statusCode = 1;
-    }
     logMessage("ending group logging", LogLevel.EndGroup);
     if (specConfigs.tspconfigPath && specConfigs.readmePath) {
       specConfigPath = serviceFolderPath;

--- a/eng/tools/spec-gen-sdk-runner/src/emitter-check.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/emitter-check.ts
@@ -1,0 +1,158 @@
+import fs from "node:fs";
+import path from "node:path";
+import { inspect } from "node:util";
+import yaml from "js-yaml";
+import { LogLevel, logMessage } from "./log.js";
+import { execAsync } from "./utils.js";
+
+/**
+ * Metadata output from the @azure-tools/typespec-metadata emitter.
+ */
+export interface TypeSpecMetadata {
+  emitterVersion: string;
+  generatedAt: string;
+  typespec: {
+    namespace: string;
+    documentation?: string;
+    type: "data" | "management";
+  };
+  languages: Record<string, LanguageMetadata>;
+  sourceConfigPath: string;
+}
+
+export interface LanguageMetadata {
+  emitterName: string;
+  packageName: string;
+  namespace?: string;
+  outputDir?: string;
+  flavor?: string;
+  serviceDir?: string;
+}
+
+export interface EmitterCheckResult {
+  enabled: boolean;
+  metadata?: TypeSpecMetadata;
+  languageKey?: string;
+  packageName?: string;
+}
+
+/**
+ * Maps an SDK repo name to the typespec-metadata language key.
+ */
+const SDK_REPO_TO_LANGUAGE_KEY: Record<string, string[]> = {
+  "azure-sdk-for-python": ["python"],
+  "azure-sdk-for-java": ["java"],
+  "azure-sdk-for-net": ["csharp", "http-client-csharp", "http-client-csharp-mgmt"],
+  "azure-sdk-for-js": ["typescript"],
+  "azure-sdk-for-go": ["go"],
+};
+
+/**
+ * Resolves the language key from the SDK repo name by checking which key
+ * exists in the typespec-metadata output.
+ */
+function resolveLanguageKey(
+  sdkRepoName: string,
+  languages: Record<string, LanguageMetadata>,
+): string | undefined {
+  const normalizedName = sdkRepoName.replace("-pr", "");
+  const candidates = SDK_REPO_TO_LANGUAGE_KEY[normalizedName];
+  if (!candidates) {
+    return undefined;
+  }
+  return candidates.find((key) => key in languages);
+}
+
+/**
+ * Runs the typespec-metadata emitter to check if the target language emitter
+ * is enabled in the tspconfig.yaml and extracts package metadata.
+ *
+ * @param tspConfigDir - Absolute path to the directory containing tspconfig.yaml
+ * @param sdkRepoName - SDK repository name (e.g., "azure-sdk-for-python")
+ * @returns EmitterCheckResult with enabled status, metadata, and packageName
+ */
+export async function checkEmitterEnabled(
+  tspConfigDir: string,
+  sdkRepoName: string,
+): Promise<EmitterCheckResult> {
+  const metadataOutputDir = path.join(tspConfigDir, "@azure-tools", "typespec-metadata");
+
+  try {
+    // Run tsp compile with the typespec-metadata emitter using default options.
+    // Override output-dir to tspConfigDir so the metadata file lands in a
+    // predictable location regardless of the tspconfig.yaml output-dir setting.
+    const tspCommand = [
+      "tsp compile",
+      `"${tspConfigDir}"`,
+      '--emit "@azure-tools/typespec-metadata"',
+      `--output-dir "${tspConfigDir}"`,
+    ].join(" ");
+
+    logMessage(`Running typespec-metadata emitter: ${tspCommand}`, LogLevel.Debug);
+    const { stderr } = await execAsync(tspCommand, { cwd: tspConfigDir });
+    if (stderr) {
+      logMessage(`typespec-metadata emitter warnings: ${stderr}`, LogLevel.Warn);
+    }
+
+    // Find the metadata file (emitter may produce .yaml or .json)
+    const yamlPath = path.join(metadataOutputDir, "typespec-metadata.yaml");
+    const jsonPath = path.join(metadataOutputDir, "typespec-metadata.json");
+    let metadataFilePath: string | undefined;
+    if (fs.existsSync(jsonPath)) {
+      metadataFilePath = jsonPath;
+    } else if (fs.existsSync(yamlPath)) {
+      metadataFilePath = yamlPath;
+    }
+
+    if (!metadataFilePath) {
+      logMessage(
+        `typespec-metadata output not found in ${metadataOutputDir}`,
+        LogLevel.Error,
+      );
+      return { enabled: false };
+    }
+
+    const raw = fs.readFileSync(metadataFilePath, "utf8");
+    const metadata = (
+      metadataFilePath.endsWith(".json") ? JSON.parse(raw) : yaml.load(raw)
+    ) as TypeSpecMetadata;
+
+    // Check if the target language is configured
+    const languageKey = resolveLanguageKey(sdkRepoName, metadata.languages);
+    if (!languageKey) {
+      logMessage(
+        `Language emitter not enabled for ${sdkRepoName} in tspconfig.yaml`,
+        LogLevel.Info,
+      );
+      return { enabled: false, metadata, languageKey: undefined };
+    }
+
+    const langMetadata = metadata.languages[languageKey];
+    logMessage(
+      `Language emitter enabled for ${sdkRepoName}: ${langMetadata.emitterName} (package: ${langMetadata.packageName})`,
+      LogLevel.Info,
+    );
+
+    return {
+      enabled: true,
+      metadata,
+      languageKey,
+      packageName: langMetadata.packageName,
+    };
+  } catch (error) {
+    logMessage(
+      `Error running typespec-metadata emitter: ${inspect(error)}`,
+      LogLevel.Error,
+    );
+    return { enabled: false };
+  } finally {
+    // Clean up the metadata output directory
+    try {
+      if (fs.existsSync(metadataOutputDir)) {
+        fs.rmSync(metadataOutputDir, { recursive: true });
+      }
+    } catch {
+      // Ignore cleanup errors
+    }
+  }
+}

--- a/eng/tools/spec-gen-sdk-runner/src/utils.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/utils.ts
@@ -91,6 +91,46 @@ export async function runSpecGenSdkCommand(specGenSdkCommand: string[]): Promise
   });
 }
 
+/**
+ * Run a command and capture its stdout output as a string.
+ * Used for azsdk-cli commands that return JSON on stdout.
+ *
+ * @param executable - The executable to run (e.g., "azsdk")
+ * @param args - Array of command arguments
+ * @returns The captured stdout output
+ */
+export async function runCommandWithOutput(
+  executable: string,
+  args: string[],
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    const childProcess = spawn(executable, args, {
+      shell: false,
+      stdio: ["inherit", "pipe", "inherit"],
+      env: process.env,
+    });
+    childProcess.stdout!.on("data", (data: Buffer) => {
+      chunks.push(data);
+    });
+    childProcess.on("error", (error) => {
+      reject(new Error(`Failed to start process '${executable}': ${error.message}`));
+    });
+    childProcess.on("exit", (code) => {
+      const output = Buffer.concat(chunks).toString("utf8");
+      if (code === 0) {
+        resolve(output);
+      } else {
+        reject(
+          new Error(
+            `Process '${executable}' exited with code ${code}. Output: ${output}`,
+          ),
+        );
+      }
+    });
+  });
+}
+
 /*
  * Get the list of all type spec project folder paths
  */


### PR DESCRIPTION
## Summary

Adds support for using **azsdk-cli** (`generate`, `build`, and `pack`) as an alternative to `spec-gen-sdk` for TypeSpec SDK generation in the spec-gen-sdk-runner.

## Changes

- **`emitter-check.ts`** — Runs `@azure-tools/typespec-metadata` emitter to check if a language emitter is enabled in tspconfig.yaml and extracts package metadata (packageName, outputDir)
- **`azsdk-adapter.ts`** — Builds `ExecutionReport` from azsdk-cli JSON output, bridging the gap between azsdk-cli's `PackageOperationResponse` and the existing runner contract

- **`utils.ts`** — Added `runCommandWithOutput()` for capturing azsdk-cli JSON stdout
- **`command-helpers.ts`** — Added methods to wrap the `azsdk-cli` commands call
- **`archetype-spec-gen-sdk.yml`** — Added `install-azsdk-cli.yml` template reference

## How it works

When `USE_AZSDK_CLI=true` and the spec is TypeSpec:

1. **Pre-check**: `tsp compile --emit @azure-tools/typespec-metadata` → check language enabled, extract packageName
2. **Generate**: `azsdk pkg generate -r {sdkRepo} -t {tspConfig}`
3. **Build**: `azsdk pkg build --package-path {packagePath}
4. **Pack**: `azsdk pkg pack --package-path {outputDir}`
5. **Adapt**: `buildExecutionReport()` constructs `ExecutionReport` for the existing runner orchestration

OpenAPI specs and `USE_AZSDK_CLI=false` (default) always use the existing `spec-gen-sdk` path — **no behavior change**.

