### PR TITLE
Suppressing the emission of classes duplicated by `openai-java` package

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-agents/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-agents/client.tsp
@@ -136,6 +136,45 @@ using Azure.AI.Projects;
 // is already exposed by the Stainless library. Currently there aren't any azure-isms.
 @@changePropertyType(PromptAgentDefinition.tool_choice, string);
 
+// AI Tooling: openai-java de-dup
+// Suppress emission of models that are exact duplicates of openai-java classes.
+// Users should use the openai-java equivalents directly.
+//
+// Group A: Standalone models (no hierarchy) — fully suppressed.
+//   ComparisonFilter + ComparisonFilterType  → com.openai.models.ComparisonFilter
+//   CompoundFilter + CompoundFilterType      → com.openai.models.CompoundFilter
+//   Reasoning + ReasoningSummary/GenerateSummary/Effort → com.openai.models.Reasoning
+@@access(OpenAI.ComparisonFilter, Access.internal, "java");
+@@access(OpenAI.CompoundFilter, Access.internal, "java");
+@@access(OpenAI.Reasoning, Access.internal, "java");
+@@access(OpenAI.ReasoningEffort, Access.internal, "java");
+// Change reasoning property type to string so it maps to BinaryData in Java.
+// Manual getters/setters for com.openai.models.Reasoning will be added in customizations.
+@@changePropertyType(PromptAgentDefinition.reasoning, string);
+
+// Group B: Tool / ResponseFormat hierarchy members — suppressed.
+//   FunctionTool         → com.openai.models.responses.FunctionTool
+//   FileSearchTool       → com.openai.models.responses.FileSearchTool
+//   WebSearchPreviewTool → com.openai.models.responses.WebSearchPreviewTool
+//   ComputerUsePreviewTool → com.openai.models.responses.ComputerTool
+//   TextResponseFormatJsonSchema → com.openai.models.responses.ResponseFormatTextJsonSchemaConfig
+//   TextResponseFormatConfigurationResponseFormatText → com.openai.models.ResponseFormatText
+//   TextResponseFormatConfigurationResponseFormatJsonObject → com.openai.models.ResponseFormatJsonObject
+@@access(OpenAI.FunctionTool, Access.internal, "java");
+@@access(OpenAI.FileSearchTool, Access.internal, "java");
+@@access(OpenAI.WebSearchPreviewTool, Access.internal, "java");
+@@access(OpenAI.ComputerUsePreviewTool, Access.internal, "java");
+@@access(OpenAI.TextResponseFormatJsonSchema, Access.internal, "java");
+@@access(OpenAI.TextResponseFormatConfigurationResponseFormatText, Access.internal, "java");
+@@access(OpenAI.TextResponseFormatConfigurationResponseFormatJsonObject, Access.internal, "java");
+
+// Sub-types used only by the suppressed hierarchy members above.
+@@access(OpenAI.RankingOptions, Access.internal, "java");
+@@access(OpenAI.HybridSearchOptions, Access.internal, "java");
+@@access(OpenAI.ResponseFormatJsonSchemaSchema, Access.internal, "java");
+@@access(OpenAI.ComputerEnvironment, Access.internal, "java");
+@@access(OpenAI.SearchContextSize, Access.internal, "java");
+
 // TimeZone property override via model indirection
 @alternateType({
   identity: "java.util.TimeZone"

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-agents/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-agents/client.tsp
@@ -137,10 +137,8 @@ using Azure.AI.Projects;
 @@changePropertyType(PromptAgentDefinition.tool_choice, string);
 
 // AI Tooling: openai-java de-dup
-// Suppress emission of models that are exact duplicates of openai-java classes.
+// Suppress emission of standalone models that are exact duplicates of openai-java classes.
 // Users should use the openai-java equivalents directly.
-//
-// Group A: Standalone models (no hierarchy) — fully suppressed.
 //   ComparisonFilter + ComparisonFilterType  → com.openai.models.ComparisonFilter
 //   CompoundFilter + CompoundFilterType      → com.openai.models.CompoundFilter
 //   Reasoning + ReasoningSummary/GenerateSummary/Effort → com.openai.models.Reasoning
@@ -149,31 +147,8 @@ using Azure.AI.Projects;
 @@access(OpenAI.Reasoning, Access.internal, "java");
 @@access(OpenAI.ReasoningEffort, Access.internal, "java");
 // Change reasoning property type to string so it maps to BinaryData in Java.
-// Manual getters/setters for com.openai.models.Reasoning will be added in customizations.
+// Manual getters/setters for com.openai.models.Reasoning are added in customizations.
 @@changePropertyType(PromptAgentDefinition.reasoning, string);
-
-// Group B: Tool / ResponseFormat hierarchy members — suppressed.
-//   FunctionTool         → com.openai.models.responses.FunctionTool
-//   FileSearchTool       → com.openai.models.responses.FileSearchTool
-//   WebSearchPreviewTool → com.openai.models.responses.WebSearchPreviewTool
-//   ComputerUsePreviewTool → com.openai.models.responses.ComputerTool
-//   TextResponseFormatJsonSchema → com.openai.models.responses.ResponseFormatTextJsonSchemaConfig
-//   TextResponseFormatConfigurationResponseFormatText → com.openai.models.ResponseFormatText
-//   TextResponseFormatConfigurationResponseFormatJsonObject → com.openai.models.ResponseFormatJsonObject
-@@access(OpenAI.FunctionTool, Access.internal, "java");
-@@access(OpenAI.FileSearchTool, Access.internal, "java");
-@@access(OpenAI.WebSearchPreviewTool, Access.internal, "java");
-@@access(OpenAI.ComputerUsePreviewTool, Access.internal, "java");
-@@access(OpenAI.TextResponseFormatJsonSchema, Access.internal, "java");
-@@access(OpenAI.TextResponseFormatConfigurationResponseFormatText, Access.internal, "java");
-@@access(OpenAI.TextResponseFormatConfigurationResponseFormatJsonObject, Access.internal, "java");
-
-// Sub-types used only by the suppressed hierarchy members above.
-@@access(OpenAI.RankingOptions, Access.internal, "java");
-@@access(OpenAI.HybridSearchOptions, Access.internal, "java");
-@@access(OpenAI.ResponseFormatJsonSchemaSchema, Access.internal, "java");
-@@access(OpenAI.ComputerEnvironment, Access.internal, "java");
-@@access(OpenAI.SearchContextSize, Access.internal, "java");
 
 // TimeZone property override via model indirection
 @alternateType({

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-agents/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-agents/client.tsp
@@ -146,6 +146,10 @@ using Azure.AI.Projects;
 @@access(OpenAI.CompoundFilter, Access.internal, "java");
 @@access(OpenAI.Reasoning, Access.internal, "java");
 @@access(OpenAI.ReasoningEffort, Access.internal, "java");
+// Map ComparisonFilter and CompoundFilter to their openai-java equivalents so the
+// codegen does not emit its own versions.
+@@alternateType(OpenAI.ComparisonFilter, { identity: "com.openai.models.ComparisonFilter" }, "java");
+@@alternateType(OpenAI.CompoundFilter, { identity: "com.openai.models.CompoundFilter" }, "java");
 // Change reasoning property type to string so it maps to BinaryData in Java.
 // Manual getters/setters for com.openai.models.Reasoning are added in customizations.
 @@changePropertyType(PromptAgentDefinition.reasoning, string);

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-agents/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-agents/client.tsp
@@ -138,21 +138,13 @@ using Azure.AI.Projects;
 
 // AI Tooling: openai-java de-dup
 // Suppress emission of standalone models that are exact duplicates of openai-java classes.
-// Users should use the openai-java equivalents directly.
+// Map them to their openai-java equivalents so the codegen does not emit its own versions.
 //   ComparisonFilter + ComparisonFilterType  → com.openai.models.ComparisonFilter
 //   CompoundFilter + CompoundFilterType      → com.openai.models.CompoundFilter
 //   Reasoning + ReasoningSummary/GenerateSummary/Effort → com.openai.models.Reasoning
-@@access(OpenAI.ComparisonFilter, Access.internal, "java");
-@@access(OpenAI.CompoundFilter, Access.internal, "java");
-@@access(OpenAI.Reasoning, Access.internal, "java");
-@@access(OpenAI.ReasoningEffort, Access.internal, "java");
-// Map ComparisonFilter and CompoundFilter to their openai-java equivalents so the
-// codegen does not emit its own versions.
 @@alternateType(OpenAI.ComparisonFilter, { identity: "com.openai.models.ComparisonFilter" }, "java");
 @@alternateType(OpenAI.CompoundFilter, { identity: "com.openai.models.CompoundFilter" }, "java");
-// Change reasoning property type to string so it maps to BinaryData in Java.
-// Manual getters/setters for com.openai.models.Reasoning are added in customizations.
-@@changePropertyType(PromptAgentDefinition.reasoning, string);
+@@alternateType(OpenAI.Reasoning, { identity: "com.openai.models.Reasoning" }, "java");
 
 // TimeZone property override via model indirection
 @alternateType({


### PR DESCRIPTION
This pull request introduces changes to suppress the emission of duplicate models in the Azure AI Foundry SDK for Java, specifically those that are already provided by the `openai-java` library. The goal is to avoid redundancy and ensure users leverage the official `openai-java` classes directly. The suppression is organized into two main groups: standalone models and hierarchy members, with additional sub-types also suppressed.

Suppression of duplicate models:

* Standalone models (`ComparisonFilter`, `CompoundFilter`, `Reasoning`, etc.) are suppressed, and their access is set to internal for Java, directing users to use `com.openai.models` equivalents. The `reasoning` property type is changed to `string` for compatibility.
* Tool and response format hierarchy members (e.g., `FunctionTool`, `FileSearchTool`, `WebSearchPreviewTool`, `ComputerUsePreviewTool`, `TextResponseFormatJsonSchema`, etc.) are suppressed and marked as internal for Java, with references to corresponding `com.openai.models.responses` classes.
* Sub-types used only by the suppressed hierarchy members (such as `RankingOptions`, `HybridSearchOptions`, `ResponseFormatJsonSchemaSchema`, etc.) are also suppressed and marked as internal for Java.