### PR TITLE
Add routing configuration for model router deployment

### DIFF
--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2025-10-01-preview/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2025-10-01-preview/cognitiveservices.json
@@ -12728,7 +12728,7 @@
         },
         "routing": {
           "$ref": "#/definitions/DeploymentRouting",
-          "description": "Routing configuration for the deployment. This property is only applicable when the deployment model is 'model-router' with version 2025-11-18 or onwards. Specifies how requests are routed across multiple models based on models subset and optimization criteria (e.g., cost, balanced, accuracy)."
+          "description": "Routing configuration for the deployment. This property is only applicable when the deployed model is 'model-router' version 2025-11-18 or later. Allows you to select the models subset for routing and the routing mode (balanced, accuracy, cost) for routing across all supported models or the model subset."
         }
       }
     },

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2025-10-01-preview/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2025-10-01-preview/cognitiveservices.json
@@ -12725,6 +12725,10 @@
           "$ref": "#/definitions/DeploymentState",
           "description": "The state of the deployment. Controls whether the deployment is accepting inference requests. Use 'Running' for active deployments that process requests, or 'Paused' to temporarily stop inference while preserving the deployment configuration.",
           "x-nullable": true
+        },
+        "routing": {
+          "$ref": "#/definitions/DeploymentRouting",
+          "description": "Routing configuration for the deployment. This property is only applicable when the deployment model is 'model-router' with version 2025-11-18 or onwards. Specifies how requests are routed across multiple models based on models subset and optimization criteria (e.g., cost, balanced, accuracy)."
         }
       }
     },
@@ -12864,6 +12868,58 @@
             "name": "Paused",
             "value": "Paused",
             "description": "The deployment is paused and not accepting inference requests."
+          }
+        ]
+      }
+    },
+    "DeploymentRouting": {
+      "type": "object",
+      "description": "Routing configuration for the deployment. Specifies how requests are routed across multiple models.",
+      "properties": {
+        "mode": {
+          "$ref": "#/definitions/RoutingMode",
+          "description": "The routing mode that determines how requests are distributed across models.",
+          "default": "balanced"
+        },
+        "models": {
+          "type": "array",
+          "description": "Optional. The list of models that the model router can use to route requests across. If not specified, the model router will route to all available models specified in the model-router version.",
+          "items": {
+            "$ref": "#/definitions/DeploymentModel"
+          },
+          "x-ms-identifiers": [
+            "name",
+            "version"
+          ]
+        }
+      }
+    },
+    "RoutingMode": {
+      "type": "string",
+      "description": "The routing mode that determines how requests are distributed across models.",
+      "enum": [
+        "cost",
+        "balanced",
+        "accuracy"
+      ],
+      "x-ms-enum": {
+        "name": "RoutingMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Cost",
+            "value": "cost",
+            "description": "Route requests to minimize cost while meeting performance requirements."
+          },
+          {
+            "name": "Balanced",
+            "value": "balanced",
+            "description": "Balance cost and accuracy when routing requests across models."
+          },
+          {
+            "name": "Accuracy",
+            "value": "accuracy",
+            "description": "Route requests to maximize accuracy regardless of cost."
           }
         ]
       }


### PR DESCRIPTION
Added routing configuration for deployment with options for routing mode and models.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
