### PR TITLE
fix(containerregistrytasks): update C# emitter configuration to align

### DIFF
--- a/specification/containerregistry/resource-manager/Microsoft.ContainerRegistry/RegistryTasks/tspconfig.yaml
+++ b/specification/containerregistry/resource-manager/Microsoft.ContainerRegistry/RegistryTasks/tspconfig.yaml
@@ -12,12 +12,9 @@ options:
 
     arm-types-dir: "{project-root}/../../../../common-types/resource-management"
     emit-lro-options: "all"
-  "@azure-tools/typespec-csharp":
-    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
-    flavor: azure
-    clear-output-folder: true
-    model-namespace: true
+  "@azure-typespec/http-client-csharp-mgmt":
     namespace: "Azure.ResourceManager.ContainerRegistryTasks"
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
   "@azure-tools/typespec-python":
     service-dir: "sdk/containerregistry"
     emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-containerregistrytasks"


### PR DESCRIPTION
This PR corrects the .NET emitter for ContainerRegistryTasks to align with the emitter used by other Azure management SDKs (@azure-typespec/http-client-csharp-mgmt)