### PR TITLE
fix(containerregistrytasks): rename RunRequest to RunContent in dotnet client

### DIFF
--- a/specification/containerregistry/resource-manager/Microsoft.ContainerRegistry/RegistryTasks/client.tsp
+++ b/specification/containerregistry/resource-manager/Microsoft.ContainerRegistry/RegistryTasks/client.tsp
@@ -39,6 +39,7 @@ using Microsoft.ContainerRegistry;
   "csharp"
 );
 @@clientName(PlatformUpdateParameters, "PlatformUpdateContent", "csharp");
+@@clientName(RunRequest, "RunContent", "csharp");
 @@clientName(SourceTriggerUpdateParameters,
   "SourceTriggerUpdateContent",
   "csharp"


### PR DESCRIPTION
The RunRequest base model is missing a @@clientName override for C#. The derived types were all correctly renamed. This PR adds the client naming for the RunRequest base class