### PR TITLE
[Search] Update TypeSpec config for Java SDK migration

### DIFF
--- a/specification/search/resource-manager/Microsoft.Search/Search/client.tsp
+++ b/specification/search/resource-manager/Microsoft.Search/Search/client.tsp
@@ -858,7 +858,7 @@ model AccessRulePropertiesSubscriptionsItem {
 }
 @@alternateType(Azure.ResourceManager.CommonTypes.AccessRuleProperties.subscriptions,
   AccessRulePropertiesSubscriptionsItem[],
-  "go,python,javascript"
+  "go,python,javascript,java"
 );
 
 @@clientName(SearchServiceProperties.eTag, "etag", "java");

--- a/specification/search/resource-manager/Microsoft.Search/Search/tspconfig.yaml
+++ b/specification/search/resource-manager/Microsoft.Search/Search/tspconfig.yaml
@@ -28,7 +28,9 @@ options:
     service-name: "Search"
     flavor: azure
     use-object-for-unknown: true
+    uuid-as-string: false
     premium: true
+    generate-tests: false
     enable-sync-stack: false
     remove-inner: CheckNameAvailabilityOutput
     client-side-validations: true


### PR DESCRIPTION
Update tspconfig.yaml and client.tsp for azure-resourcemanager-search Java SDK TypeSpec migration.