### PR TITLE
[TrafficManager] Update tspconfig.yaml for Java SDK migration

### DIFF
--- a/specification/trafficmanager/resource-manager/Microsoft.Network/TrafficManager/client.tsp
+++ b/specification/trafficmanager/resource-manager/Microsoft.Network/TrafficManager/client.tsp
@@ -53,6 +53,8 @@ op getReplace(
 
 @@override(HeatMapModels.get, getReplace, "go");
 @@alternateType(getReplace::parameters.heatMapType, "default", "go");
+@@alternateType(getReplace::parameters.heatMapType, "default", "java");
+@@override(HeatMapModels.get, getReplace, "java");
 @@clientName(Microsoft.Network,
   "TrafficManagerManagementClient",
   "javascript, python"

--- a/specification/trafficmanager/resource-manager/Microsoft.Network/TrafficManager/tspconfig.yaml
+++ b/specification/trafficmanager/resource-manager/Microsoft.Network/TrafficManager/tspconfig.yaml
@@ -25,7 +25,8 @@ options:
     namespace: "com.azure.resourcemanager.trafficmanager"
     service-name: "TrafficManager"
     premium: true
-    enable-sync-stack: true
+    generate-tests: false
+    enable-sync-stack: false
     client-side-validations: true
     rename-model:
       EndpointType: EndpointTypes


### PR DESCRIPTION
Update tspconfig.yaml for TrafficManager Java SDK migration to TypeSpec.

### Changes
- Set enable-sync-stack: false (matching readme.java.md)
- Add generate-tests: false