### PR TITLE
Add C# mgmt emitter config and clientName decorators for Maps

### DIFF
--- a/specification/maps/resource-manager/Microsoft.Maps/Maps/back-compatible.tsp
+++ b/specification/maps/resource-manager/Microsoft.Maps/Maps/back-compatible.tsp
@@ -32,5 +32,5 @@ using Microsoft.Maps;
 
 @@clientLocation(OperationStatusOperationGroup.get, "OperationStatus");
 
-@@clientLocation(Operations.list, "MapsOperations");
+@@clientLocation(Operations.list, "Maps");
 @@clientName(Operations.list, "ListOperations");

--- a/specification/maps/resource-manager/Microsoft.Maps/Maps/back-compatible.tsp
+++ b/specification/maps/resource-manager/Microsoft.Maps/Maps/back-compatible.tsp
@@ -32,5 +32,5 @@ using Microsoft.Maps;
 
 @@clientLocation(OperationStatusOperationGroup.get, "OperationStatus");
 
-@@clientLocation(Operations.list, "Maps");
+@@clientLocation(Operations.list, "MapsOperations");
 @@clientName(Operations.list, "ListOperations");

--- a/specification/maps/resource-manager/Microsoft.Maps/Maps/client.tsp
+++ b/specification/maps/resource-manager/Microsoft.Maps/Maps/client.tsp
@@ -36,14 +36,26 @@ using Azure.ClientGenerator.Core;
 @@clientName(Microsoft.Maps.Creator, "MapsCreator", "csharp");
 
 // Model renames (prepend RP prefix "Maps")
-@@clientName(Microsoft.Maps.CreatorProperties, "MapsCreatorProperties", "csharp");
-@@clientName(Microsoft.Maps.CreatorUpdateParameters, "MapsCreatorPatch", "csharp");
+@@clientName(Microsoft.Maps.CreatorProperties,
+  "MapsCreatorProperties",
+  "csharp"
+);
+@@clientName(Microsoft.Maps.CreatorUpdateParameters,
+  "MapsCreatorPatch",
+  "csharp"
+);
 @@clientName(Microsoft.Maps.CreatorList, "MapsCreatorListResult", "csharp");
-@@clientName(Microsoft.Maps.AccountSasParameters, "MapsAccountSasContent", "csharp");
+@@clientName(Microsoft.Maps.AccountSasParameters,
+  "MapsAccountSasContent",
+  "csharp"
+);
 @@clientName(Microsoft.Maps.Kind, "MapsAccountKind", "csharp");
 @@clientName(Microsoft.Maps.Name, "MapsSkuName", "csharp");
 @@clientName(Microsoft.Maps.Sku, "MapsSku", "csharp");
-@@clientName(Microsoft.Maps.InfrastructureEncryption, "MapsInfrastructureEncryption", "csharp");
+@@clientName(Microsoft.Maps.InfrastructureEncryption,
+  "MapsInfrastructureEncryption",
+  "csharp"
+);
 @@clientName(Microsoft.Maps.SigningKey, "MapsSigningKey", "csharp");
 @@clientName(Microsoft.Maps.KeyType, "MapsKeyType", "csharp");
 @@clientName(Microsoft.Maps.LinkedResource, "MapsLinkedResource", "csharp");
@@ -51,7 +63,10 @@ using Azure.ClientGenerator.Core;
 @@clientName(Microsoft.Maps.CorsRules, "MapsCorsRules", "csharp");
 
 // Common type renames for C#
-@@clientName(Azure.ResourceManager.CommonTypes.Encryption, "MapsEncryption", "csharp");
+@@clientName(Azure.ResourceManager.CommonTypes.Encryption,
+  "MapsEncryption",
+  "csharp"
+);
 @@clientName(Azure.ResourceManager.CommonTypes.KeyEncryptionKeyIdentity,
   "CustomerManagedKeyEncryptionKeyIdentity",
   "csharp"
@@ -66,8 +81,14 @@ using Azure.ClientGenerator.Core;
 );
 
 // Suppress OperationResult/OperationStatus operations (not in previous GA SDK)
-@@access(Microsoft.Maps.OperationResultOperationGroup.get, Access.internal, "csharp");
-@@access(Microsoft.Maps.OperationStatusOperationGroup.get, Access.internal, "csharp");
+@@access(Microsoft.Maps.OperationResultOperationGroup.get,
+  Access.internal,
+  "csharp"
+);
+@@access(Microsoft.Maps.OperationStatusOperationGroup.get,
+  Access.internal,
+  "csharp"
+);
 
 // Override clientLocation for Operations.list to avoid C# namespace conflict
 // (back-compatible.tsp sets it to "Maps" for all languages, which conflicts with
@@ -76,16 +97,37 @@ using Azure.ClientGenerator.Core;
 
 // Format: uniqueId should be uuid (Guid) for backward compatibility
 #suppress "@azure-tools/typespec-azure-core/no-format" "uuid format required for backward compat"
-@@alternateType(Microsoft.Maps.MapsAccountProperties.uniqueId, Azure.Core.uuid, "csharp");
+@@alternateType(Microsoft.Maps.MapsAccountProperties.uniqueId,
+  Azure.Core.uuid,
+  "csharp"
+);
 
 // Property renames for backward compatibility
-@@clientName(Microsoft.Maps.MapsAccountKeys.primaryKeyLastUpdated, "PrimaryKeyLastUpdatedOn", "csharp");
-@@clientName(Microsoft.Maps.MapsAccountKeys.secondaryKeyLastUpdated, "SecondaryKeyLastUpdatedOn", "csharp");
+@@clientName(Microsoft.Maps.MapsAccountKeys.primaryKeyLastUpdated,
+  "PrimaryKeyLastUpdatedOn",
+  "csharp"
+);
+@@clientName(Microsoft.Maps.MapsAccountKeys.secondaryKeyLastUpdated,
+  "SecondaryKeyLastUpdatedOn",
+  "csharp"
+);
 
 // DateTimeOffset format for key timestamps
-@@alternateType(Microsoft.Maps.MapsAccountKeys.primaryKeyLastUpdated, utcDateTime, "csharp");
-@@alternateType(Microsoft.Maps.MapsAccountKeys.secondaryKeyLastUpdated, utcDateTime, "csharp");
+@@alternateType(Microsoft.Maps.MapsAccountKeys.primaryKeyLastUpdated,
+  utcDateTime,
+  "csharp"
+);
+@@alternateType(Microsoft.Maps.MapsAccountKeys.secondaryKeyLastUpdated,
+  utcDateTime,
+  "csharp"
+);
 
 // URI format for key encryption key URL (target common type, not local model)
-@@alternateType(Azure.ResourceManager.CommonTypes.CustomerManagedKeyEncryption.keyEncryptionKeyUrl, url, "csharp");
-@@clientName(Azure.ResourceManager.CommonTypes.CustomerManagedKeyEncryption.keyEncryptionKeyUrl, "KeyEncryptionKeyUri", "csharp");
+@@alternateType(Azure.ResourceManager.CommonTypes.CustomerManagedKeyEncryption.keyEncryptionKeyUrl,
+  url,
+  "csharp"
+);
+@@clientName(Azure.ResourceManager.CommonTypes.CustomerManagedKeyEncryption.keyEncryptionKeyUrl,
+  "KeyEncryptionKeyUri",
+  "csharp"
+);

--- a/specification/maps/resource-manager/Microsoft.Maps/Maps/client.tsp
+++ b/specification/maps/resource-manager/Microsoft.Maps/Maps/client.tsp
@@ -60,6 +60,10 @@ using Azure.ClientGenerator.Core;
   "MapsIdentityType",
   "csharp"
 );
+@@clientName(Azure.ResourceManager.CommonTypes.InfrastructureEncryption,
+  "MapsInfrastructureEncryption",
+  "csharp"
+);
 
 // Suppress OperationResult/OperationStatus operations (not in previous GA SDK)
 @@access(Microsoft.Maps.OperationResultOperationGroup.get, Access.internal, "csharp");
@@ -77,6 +81,6 @@ using Azure.ClientGenerator.Core;
 @@alternateType(Microsoft.Maps.MapsAccountKeys.primaryKeyLastUpdated, utcDateTime, "csharp");
 @@alternateType(Microsoft.Maps.MapsAccountKeys.secondaryKeyLastUpdated, utcDateTime, "csharp");
 
-// URI format for key encryption key URL
-@@alternateType(Microsoft.Maps.EncryptionCustomerManagedKeyEncryption.keyEncryptionKeyUrl, url, "csharp");
-@@clientName(Microsoft.Maps.EncryptionCustomerManagedKeyEncryption.keyEncryptionKeyUrl, "KeyEncryptionKeyUri", "csharp");
+// URI format for key encryption key URL (target common type, not local model)
+@@alternateType(Azure.ResourceManager.CommonTypes.CustomerManagedKeyEncryption.keyEncryptionKeyUrl, url, "csharp");
+@@clientName(Azure.ResourceManager.CommonTypes.CustomerManagedKeyEncryption.keyEncryptionKeyUrl, "KeyEncryptionKeyUri", "csharp");

--- a/specification/maps/resource-manager/Microsoft.Maps/Maps/client.tsp
+++ b/specification/maps/resource-manager/Microsoft.Maps/Maps/client.tsp
@@ -69,6 +69,11 @@ using Azure.ClientGenerator.Core;
 @@access(Microsoft.Maps.OperationResultOperationGroup.get, Access.internal, "csharp");
 @@access(Microsoft.Maps.OperationStatusOperationGroup.get, Access.internal, "csharp");
 
+// Override clientLocation for Operations.list to avoid C# namespace conflict
+// (back-compatible.tsp sets it to "Maps" for all languages, which conflicts with
+// the C# namespace Azure.ResourceManager.Maps)
+@@clientLocation(Microsoft.Maps.Operations.list, "MapsOperations", "csharp");
+
 // Format: uniqueId should be uuid (Guid) for backward compatibility
 #suppress "@azure-tools/typespec-azure-core/no-format" "uuid format required for backward compat"
 @@alternateType(Microsoft.Maps.MapsAccountProperties.uniqueId, Azure.Core.uuid, "csharp");

--- a/specification/maps/resource-manager/Microsoft.Maps/Maps/client.tsp
+++ b/specification/maps/resource-manager/Microsoft.Maps/Maps/client.tsp
@@ -27,3 +27,56 @@ using Azure.ClientGenerator.Core;
   "EncryptionCustomerManagedKeyEncryptionKeyIdentityType",
   "python"
 );
+
+// C# backward-compatible renames to match existing GA SDK surface.
+// Fix namespace conflict (client "Maps" vs namespace "Azure.ResourceManager.Maps").
+@@clientName(Microsoft.Maps, "AzureMapsManagement", "csharp");
+
+// Resource type rename: Creator -> MapsCreator
+@@clientName(Microsoft.Maps.Creator, "MapsCreator", "csharp");
+
+// Model renames (prepend RP prefix "Maps")
+@@clientName(Microsoft.Maps.CreatorProperties, "MapsCreatorProperties", "csharp");
+@@clientName(Microsoft.Maps.CreatorUpdateParameters, "MapsCreatorPatch", "csharp");
+@@clientName(Microsoft.Maps.CreatorList, "MapsCreatorListResult", "csharp");
+@@clientName(Microsoft.Maps.AccountSasParameters, "MapsAccountSasContent", "csharp");
+@@clientName(Microsoft.Maps.Kind, "MapsAccountKind", "csharp");
+@@clientName(Microsoft.Maps.Name, "MapsSkuName", "csharp");
+@@clientName(Microsoft.Maps.Sku, "MapsSku", "csharp");
+@@clientName(Microsoft.Maps.InfrastructureEncryption, "MapsInfrastructureEncryption", "csharp");
+@@clientName(Microsoft.Maps.SigningKey, "MapsSigningKey", "csharp");
+@@clientName(Microsoft.Maps.KeyType, "MapsKeyType", "csharp");
+@@clientName(Microsoft.Maps.LinkedResource, "MapsLinkedResource", "csharp");
+@@clientName(Microsoft.Maps.CorsRule, "MapsCorsRule", "csharp");
+@@clientName(Microsoft.Maps.CorsRules, "MapsCorsRules", "csharp");
+
+// Common type renames for C#
+@@clientName(Azure.ResourceManager.CommonTypes.Encryption, "MapsEncryption", "csharp");
+@@clientName(Azure.ResourceManager.CommonTypes.KeyEncryptionKeyIdentity,
+  "CustomerManagedKeyEncryptionKeyIdentity",
+  "csharp"
+);
+@@clientName(Azure.ResourceManager.CommonTypes.KeyEncryptionKeyIdentityType,
+  "MapsIdentityType",
+  "csharp"
+);
+
+// Suppress OperationResult/OperationStatus operations (not in previous GA SDK)
+@@access(Microsoft.Maps.OperationResultOperationGroup.get, Access.internal, "csharp");
+@@access(Microsoft.Maps.OperationStatusOperationGroup.get, Access.internal, "csharp");
+
+// Format: uniqueId should be uuid (Guid) for backward compatibility
+#suppress "@azure-tools/typespec-azure-core/no-format" "uuid format required for backward compat"
+@@alternateType(Microsoft.Maps.MapsAccountProperties.uniqueId, Azure.Core.uuid, "csharp");
+
+// Property renames for backward compatibility
+@@clientName(Microsoft.Maps.MapsAccountKeys.primaryKeyLastUpdated, "PrimaryKeyLastUpdatedOn", "csharp");
+@@clientName(Microsoft.Maps.MapsAccountKeys.secondaryKeyLastUpdated, "SecondaryKeyLastUpdatedOn", "csharp");
+
+// DateTimeOffset format for key timestamps
+@@alternateType(Microsoft.Maps.MapsAccountKeys.primaryKeyLastUpdated, utcDateTime, "csharp");
+@@alternateType(Microsoft.Maps.MapsAccountKeys.secondaryKeyLastUpdated, utcDateTime, "csharp");
+
+// URI format for key encryption key URL
+@@alternateType(Microsoft.Maps.EncryptionCustomerManagedKeyEncryption.keyEncryptionKeyUrl, url, "csharp");
+@@clientName(Microsoft.Maps.EncryptionCustomerManagedKeyEncryption.keyEncryptionKeyUrl, "KeyEncryptionKeyUri", "csharp");

--- a/specification/maps/resource-manager/Microsoft.Maps/Maps/tspconfig.yaml
+++ b/specification/maps/resource-manager/Microsoft.Maps/Maps/tspconfig.yaml
@@ -40,6 +40,9 @@ options:
     generate-fakes: true
     head-as-boolean: true
     inject-spans: true
+  "@azure-typespec/http-client-csharp-mgmt":
+    namespace: "Azure.ResourceManager.Maps"
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/resource-manager"


### PR DESCRIPTION
## Summary

This PR adds the C# management plane emitter configuration and backward-compatible clientName decorators for the Maps TypeSpec specification to support the .NET SDK migration from AutoRest to TypeSpec.

### Changes

**tspconfig.yaml:** Added `@azure-typespec/http-client-csharp-mgmt` emitter

**client.tsp:** Added `@@clientName` decorators for C# backward-compatible naming

**back-compatible.tsp:** Fixed namespace conflict for C#

Related to: https://github.com/Azure/azure-sdk-for-net/issues/56950