### PR TITLE
Add C# mgmt emitter config for RecoveryServicesSiteRecovery

### DIFF
--- a/specification/billingbenefits/BillingBenefits.Management/client.tsp
+++ b/specification/billingbenefits/BillingBenefits.Management/client.tsp
@@ -46,3 +46,37 @@ using Microsoft.BillingBenefits;
   "GetApplicableConditionalCredits",
   "csharp"
 );
+
+// csharp: Rename Request/Response models to comply with AZC0030 naming rules
+@@clientName(BenefitValidateRequest,
+  "BillingBenefitsBenefitValidateContent",
+  "csharp"
+);
+@@clientName(BenefitValidateResponse,
+  "BillingBenefitsBenefitValidateResult",
+  "csharp"
+);
+@@clientName(ChargeShortfallRequest,
+  "BillingBenefitsChargeShortfallContent",
+  "csharp"
+);
+@@clientName(PurchaseRequest,
+  "BillingBenefitsPurchaseContent",
+  "csharp"
+);
+@@clientName(ReservationOrderAliasRequest,
+  "BillingBenefitsReservationOrderAliasContent",
+  "csharp"
+);
+@@clientName(SavingsPlanUpdateValidateRequest,
+  "BillingBenefitsSavingsPlanUpdateValidateContent",
+  "csharp"
+);
+@@clientName(SavingsPlanValidateResponse,
+  "BillingBenefitsSavingsPlanValidateResult",
+  "csharp"
+);
+@@clientName(SellerResourceListRequest,
+  "BillingBenefitsSellerResourceListContent",
+  "csharp"
+);

--- a/specification/billingbenefits/BillingBenefits.Management/client.tsp
+++ b/specification/billingbenefits/BillingBenefits.Management/client.tsp
@@ -36,3 +36,13 @@ using Microsoft.BillingBenefits;
   "ServiceManagedIdentityType",
   "python"
 );
+
+// csharp
+@@clientName(DiscountsOperationGroup.scopeList,
+  "GetApplicableDiscounts",
+  "csharp"
+);
+@@clientName(ConditionalCreditsOperationGroup.scopeList,
+  "GetApplicableConditionalCredits",
+  "csharp"
+);

--- a/specification/billingbenefits/BillingBenefits.Management/tspconfig.yaml
+++ b/specification/billingbenefits/BillingBenefits.Management/tspconfig.yaml
@@ -42,6 +42,9 @@ options:
     head-as-boolean: true
     inject-spans: true
     factory-gather-all-params: false
+  "@azure-typespec/http-client-csharp-mgmt":
+    namespace: "Azure.ResourceManager.BillingBenefits"
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/resource-manager"

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/client.tsp
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/client.tsp
@@ -96,13 +96,93 @@ using Microsoft.NetApp;
 // ============================================================
 // C# backward compatibility: type renames
 // ============================================================
-@@clientName(Microsoft.NetApp.KeyVaultProperties, "NetAppKeyVaultProperties", "csharp");
-@@clientName(Microsoft.NetApp.ReplicationObject, "NetAppReplicationObject", "csharp");
+// Resource types - add NetApp prefix to match old SDK names
+@@clientName(Microsoft.NetApp.BackupPolicy, "NetAppBackupPolicy", "csharp");
+@@clientName(Microsoft.NetApp.BackupVault, "NetAppBackupVault", "csharp");
+@@clientName(Microsoft.NetApp.QuotaItem, "NetAppSubscriptionQuotaItem", "csharp");
+@@clientName(Microsoft.NetApp.SubvolumeInfo, "NetAppSubvolumeInfo", "csharp");
+@@clientName(Microsoft.NetApp.VolumeGroupDetails, "NetAppVolumeGroup", "csharp");
+@@clientName(Microsoft.NetApp.VolumeQuotaRule, "NetAppVolumeQuotaRule", "csharp");
+@@clientName(Microsoft.NetApp.Snapshot, "NetAppVolumeSnapshot", "csharp");
+
+// Model types - preserve old SDK names
+@@clientName(Microsoft.NetApp.AccountEncryption, "NetAppAccountEncryption", "csharp");
+@@clientName(Microsoft.NetApp.ActiveDirectoryStatus, "NetAppAccountActiveDirectoryStatus", "csharp");
+@@clientName(Microsoft.NetApp.AuthorizeRequest, "NetAppVolumeAuthorizeReplicationContent", "csharp");
+@@clientName(Microsoft.NetApp.AvsDataStore, "NetAppAvsDataStore", "csharp");
+@@clientName(Microsoft.NetApp.BackupPatch, "NetAppBackupVaultBackupPatch", "csharp");
+@@clientName(Microsoft.NetApp.BackupPolicyPatch, "NetAppBackupPolicyPatch", "csharp");
 @@clientName(Microsoft.NetApp.BackupRestoreFiles, "NetAppVolumeBackupBackupRestoreFilesContent", "csharp");
+@@clientName(Microsoft.NetApp.BackupVaultPatch, "NetAppBackupVaultPatch", "csharp");
+@@clientName(Microsoft.NetApp.BackupsMigrationRequest, "BackupsMigrationContent", "csharp");
+@@clientName(Microsoft.NetApp.BreakFileLocksRequest, "NetAppVolumeBreakFileLocksContent", "csharp");
+@@clientName(Microsoft.NetApp.BreakReplicationRequest, "NetAppVolumeBreakReplicationContent", "csharp");
+@@clientName(Microsoft.NetApp.ChangeKeyVault, "NetAppChangeKeyVault", "csharp");
+@@clientName(Microsoft.NetApp.CheckAvailabilityResponse, "NetAppCheckAvailabilityResult", "csharp");
+@@clientName(Microsoft.NetApp.CheckNameResourceTypes, "NetAppNameAvailabilityResourceType", "csharp");
+@@clientName(Microsoft.NetApp.CheckQuotaNameResourceTypes, "NetAppQuotaAvailabilityResourceType", "csharp");
+@@clientName(Microsoft.NetApp.ChownMode, "NetAppChownMode", "csharp");
+@@clientName(Microsoft.NetApp.ClusterPeerCommandResponse, "ClusterPeerCommandResult", "csharp");
+@@clientName(Microsoft.NetApp.DailySchedule, "SnapshotPolicyDailySchedule", "csharp");
+@@clientName(Microsoft.NetApp.DestinationReplication, "NetAppDestinationReplication", "csharp");
+@@clientName(Microsoft.NetApp.EnableSubvolumes, "EnableNetAppSubvolume", "csharp");
+@@clientName(Microsoft.NetApp.EncryptionIdentity, "NetAppEncryptionIdentity", "csharp");
+@@clientName(Microsoft.NetApp.EncryptionKeySource, "NetAppEncryptionKeySource", "csharp");
+@@clientName(Microsoft.NetApp.EncryptionTransitionRequest, "NetAppEncryptionTransitionContent", "csharp");
+@@clientName(Microsoft.NetApp.FileAccessLogs, "NetAppFileAccessLog", "csharp");
+@@clientName(Microsoft.NetApp.FilePathAvailabilityRequest, "NetAppFilePathAvailabilityContent", "csharp");
+@@clientName(Microsoft.NetApp.GetGroupIdListForLdapUserRequest, "GetGroupIdListForLdapUserContent", "csharp");
+@@clientName(Microsoft.NetApp.GetGroupIdListForLdapUserResponse, "GetGroupIdListForLdapUserResult", "csharp");
+@@clientName(Microsoft.NetApp.GetKeyVaultStatusResponse, "NetAppKeyVaultStatusResult", "csharp");
+@@clientName(Microsoft.NetApp.HourlySchedule, "SnapshotPolicyHourlySchedule", "csharp");
+@@clientName(Microsoft.NetApp.InAvailabilityReasonType, "NetAppNameUnavailableReason", "csharp");
+@@clientName(Microsoft.NetApp.KeySource, "NetAppKeySource", "csharp");
+@@clientName(Microsoft.NetApp.KeyVaultPrivateEndpoint, "NetAppKeyVaultPrivateEndpoint", "csharp");
+@@clientName(Microsoft.NetApp.KeyVaultProperties, "NetAppKeyVaultProperties", "csharp");
+@@clientName(Microsoft.NetApp.LdapSearchScopeOpt, "NetAppLdapSearchScopeConfiguration", "csharp");
+@@clientName(Microsoft.NetApp.ListReplicationsRequest, "ListReplicationsContent", "csharp");
+@@clientName(Microsoft.NetApp.MonthlySchedule, "SnapshotPolicyMonthlySchedule", "csharp");
+@@clientName(Microsoft.NetApp.MountTargetProperties, "NetAppVolumeMountTarget", "csharp");
+@@clientName(Microsoft.NetApp.NetworkFeatures, "NetAppNetworkFeature", "csharp");
+@@clientName(Microsoft.NetApp.PeerClusterForVolumeMigrationRequest, "PeerClusterForVolumeMigrationContent", "csharp");
+@@clientName(Microsoft.NetApp.PoolChangeRequest, "NetAppVolumePoolChangeContent", "csharp");
+@@clientName(Microsoft.NetApp.QosType, "CapacityPoolQosType", "csharp");
+@@clientName(Microsoft.NetApp.QueryNetworkSiblingSetRequest, "QueryNetworkSiblingSetContent", "csharp");
+@@clientName(Microsoft.NetApp.QuotaAvailabilityRequest, "NetAppQuotaAvailabilityContent", "csharp");
+@@clientName(Microsoft.NetApp.QuotaReportFilterRequest, "QuotaReportFilterContent", "csharp");
+@@clientName(Microsoft.NetApp.QuotaType, "NetAppVolumeQuotaType", "csharp");
+@@clientName(Microsoft.NetApp.RansomwareSuspectsClearRequest, "RansomwareSuspectsClearContent", "csharp");
+@@clientName(Microsoft.NetApp.ReestablishReplicationRequest, "NetAppVolumeReestablishReplicationContent", "csharp");
+@@clientName(Microsoft.NetApp.RegionInfo, "NetAppRegionInfo", "csharp");
+@@clientName(Microsoft.NetApp.RelocateVolumeRequest, "RelocateVolumeContent", "csharp");
+@@clientName(Microsoft.NetApp.Replication, "NetAppVolumeReplication", "csharp");
+@@clientName(Microsoft.NetApp.ReplicationObject, "NetAppReplicationObject", "csharp");
+@@clientName(Microsoft.NetApp.ReplicationSchedule, "NetAppReplicationSchedule", "csharp");
+@@clientName(Microsoft.NetApp.ReplicationType, "NetAppReplicationType", "csharp");
+@@clientName(Microsoft.NetApp.ResourceNameAvailabilityRequest, "NetAppNameAvailabilityContent", "csharp");
+@@clientName(Microsoft.NetApp.SecurityStyle, "NetAppVolumeSecurityStyle", "csharp");
+@@clientName(Microsoft.NetApp.SnapshotRestoreFiles, "NetAppVolumeSnapshotRestoreFilesContent", "csharp");
+@@clientName(Microsoft.NetApp.SubvolumeModel, "NetAppSubvolumeMetadata", "csharp");
+@@clientName(Microsoft.NetApp.SubvolumePatchRequest, "NetAppSubvolumeInfoPatch", "csharp");
+@@clientName(Microsoft.NetApp.SvmPeerCommandResponse, "SvmPeerCommandResult", "csharp");
+@@clientName(Microsoft.NetApp.UpdateNetworkSiblingSetRequest, "UpdateNetworkSiblingSetContent", "csharp");
+@@clientName(Microsoft.NetApp.UsageName, "NetAppUsageName", "csharp");
+@@clientName(Microsoft.NetApp.UsageResult, "NetAppUsageResult", "csharp");
 @@clientName(Microsoft.NetApp.VolumeBackupProperties, "NetAppVolumeBackupConfiguration", "csharp");
+@@clientName(Microsoft.NetApp.VolumeGroup, "NetAppVolumeGroupResult", "csharp");
 @@clientName(Microsoft.NetApp.VolumeGroupVolumeProperties, "NetAppVolumeGroupVolume", "csharp");
 @@clientName(Microsoft.NetApp.VolumePatch, "NetAppVolumePatch", "csharp");
+@@clientName(Microsoft.NetApp.VolumePatchPropertiesDataProtection, "NetAppVolumePatchDataProtection", "csharp");
+@@clientName(Microsoft.NetApp.VolumePropertiesDataProtection, "NetAppVolumeDataProtection", "csharp");
+@@clientName(Microsoft.NetApp.VolumeQuotaRulePatch, "NetAppVolumeQuotaRulePatch", "csharp");
+@@clientName(Microsoft.NetApp.VolumeRelocationProperties, "NetAppVolumeRelocationProperties", "csharp");
+@@clientName(Microsoft.NetApp.VolumeRevert, "NetAppVolumeRevertContent", "csharp");
+@@clientName(Microsoft.NetApp.VolumeStorageToNetworkProximity, "NetAppVolumeStorageToNetworkProximity", "csharp");
+@@clientName(Microsoft.NetApp.WeeklySchedule, "SnapshotPolicyWeeklySchedule", "csharp");
 @@clientName(Microsoft.NetApp.ReplicationStatus, "NetAppVolumeReplicationStatus", "csharp");
+@@clientName(Microsoft.NetApp.VolumeBackups, "NetAppVolumeBackupDetail", "csharp");
+@@clientName(Microsoft.NetApp.QuotaReport, "NetAppVolumeQuotaReport", "csharp");
+@@clientName(Microsoft.NetApp.Exclude, "ExcludeReplicationsFilter", "csharp");
 
 // ============================================================
 // C# backward compatibility: @@alternateType for ResourceIdentifier
@@ -141,6 +221,9 @@ using Microsoft.NetApp;
 
 // VolumeGroupVolumeProperties
 @@alternateType(Microsoft.NetApp.VolumeGroupVolumeProperties.id, Azure.Core.armResourceIdentifier, "csharp");
+
+// VolumeBackups
+@@alternateType(Microsoft.NetApp.VolumeBackups.volumeResourceId, Azure.Core.armResourceIdentifier, "csharp");
 
 // ============================================================
 // C# backward compatibility: @@alternateType for ETag

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/client.tsp
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/client.tsp
@@ -92,3 +92,88 @@ using Microsoft.NetApp;
   "NetAppCachePropertiesExportPolicy",
   "csharp"
 );
+
+// ============================================================
+// C# backward compatibility: type renames
+// ============================================================
+@@clientName(Microsoft.NetApp.KeyVaultProperties, "NetAppKeyVaultProperties", "csharp");
+@@clientName(Microsoft.NetApp.ReplicationObject, "NetAppReplicationObject", "csharp");
+@@clientName(Microsoft.NetApp.BackupRestoreFiles, "NetAppVolumeBackupBackupRestoreFilesContent", "csharp");
+@@clientName(Microsoft.NetApp.VolumeBackupProperties, "NetAppVolumeBackupConfiguration", "csharp");
+@@clientName(Microsoft.NetApp.VolumeGroupVolumeProperties, "NetAppVolumeGroupVolume", "csharp");
+@@clientName(Microsoft.NetApp.VolumePatch, "NetAppVolumePatch", "csharp");
+@@clientName(Microsoft.NetApp.ReplicationStatus, "NetAppVolumeReplicationStatus", "csharp");
+
+// ============================================================
+// C# backward compatibility: @@alternateType for ResourceIdentifier
+// ============================================================
+// VolumeProperties
+@@alternateType(Microsoft.NetApp.VolumeProperties.subnetId, Azure.Core.armResourceIdentifier, "csharp");
+@@alternateType(Microsoft.NetApp.VolumeProperties.keyVaultPrivateEndpointResourceId, Azure.Core.armResourceIdentifier, "csharp");
+@@alternateType(Microsoft.NetApp.VolumeProperties.proximityPlacementGroup, Azure.Core.armResourceIdentifier, "csharp");
+@@alternateType(Microsoft.NetApp.VolumeProperties.originatingResourceId, Azure.Core.armResourceIdentifier, "csharp");
+@@alternateType(Microsoft.NetApp.VolumeProperties.capacityPoolResourceId, Azure.Core.armResourceIdentifier, "csharp");
+@@alternateType(Microsoft.NetApp.VolumeProperties.dataStoreResourceId, Azure.Core.armResourceIdentifier[], "csharp");
+
+// ReplicationObject
+@@alternateType(Microsoft.NetApp.ReplicationObject.remoteVolumeResourceId, Azure.Core.armResourceIdentifier, "csharp");
+
+// VolumeSnapshotProperties
+@@alternateType(Microsoft.NetApp.VolumeSnapshotProperties.snapshotPolicyId, Azure.Core.armResourceIdentifier, "csharp");
+
+// Replication
+@@alternateType(Microsoft.NetApp.Replication.remoteVolumeResourceId, Azure.Core.armResourceIdentifier, "csharp");
+
+// AuthorizeRequest
+@@alternateType(Microsoft.NetApp.AuthorizeRequest.remoteVolumeResourceId, Azure.Core.armResourceIdentifier, "csharp");
+
+// ReestablishReplicationRequest
+@@alternateType(Microsoft.NetApp.ReestablishReplicationRequest.sourceVolumeId, Azure.Core.armResourceIdentifier, "csharp");
+
+// PoolChangeRequest
+@@alternateType(Microsoft.NetApp.PoolChangeRequest.newPoolResourceId, Azure.Core.armResourceIdentifier, "csharp");
+
+// FilePathAvailabilityRequest
+@@alternateType(Microsoft.NetApp.FilePathAvailabilityRequest.subnetId, Azure.Core.armResourceIdentifier, "csharp");
+
+// BackupPolicyProperties
+@@alternateType(Microsoft.NetApp.BackupPolicyProperties.backupPolicyId, Azure.Core.armResourceIdentifier, "csharp");
+
+// VolumeGroupVolumeProperties
+@@alternateType(Microsoft.NetApp.VolumeGroupVolumeProperties.id, Azure.Core.armResourceIdentifier, "csharp");
+
+// ============================================================
+// C# backward compatibility: @@alternateType for ETag
+// ============================================================
+@@alternateType(Microsoft.NetApp.CapacityPool.etag, Azure.Core.eTag, "csharp");
+@@alternateType(Microsoft.NetApp.NetAppAccount.etag, Azure.Core.eTag, "csharp");
+@@alternateType(Microsoft.NetApp.BackupPolicy.etag, Azure.Core.eTag, "csharp");
+@@alternateType(Microsoft.NetApp.Volume.etag, Azure.Core.eTag, "csharp");
+@@alternateType(Microsoft.NetApp.SnapshotPolicy.etag, Azure.Core.eTag, "csharp");
+
+// ============================================================
+// C# backward compatibility: @@alternateType for AzureLocation
+// ============================================================
+@@alternateType(Microsoft.NetApp.VolumeGroupDetails.location, Azure.Core.azureLocation, "csharp");
+@@alternateType(Microsoft.NetApp.VolumeGroup.location, Azure.Core.azureLocation, "csharp");
+@@alternateType(Microsoft.NetApp.Snapshot.location, Azure.Core.azureLocation, "csharp");
+@@alternateType(Microsoft.NetApp.NetAppAccountPatch.location, Azure.Core.azureLocation, "csharp");
+@@alternateType(Microsoft.NetApp.BackupPolicyPatch.location, Azure.Core.azureLocation, "csharp");
+@@alternateType(Microsoft.NetApp.SnapshotPolicyPatch.location, Azure.Core.azureLocation, "csharp");
+@@alternateType(Microsoft.NetApp.CapacityPoolPatch.location, Azure.Core.azureLocation, "csharp");
+
+// ============================================================
+// C# backward compatibility: @@hierarchyBuilding for base types
+// ============================================================
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "C# backward compat: preserve TrackedResourceData base"
+@@Azure.ClientGenerator.Core.Legacy.hierarchyBuilding(Microsoft.NetApp.NetAppAccountPatch, Azure.ResourceManager.CommonTypes.TrackedResource, "csharp");
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "C# backward compat: preserve TrackedResourceData base"
+@@Azure.ClientGenerator.Core.Legacy.hierarchyBuilding(Microsoft.NetApp.BackupPolicyPatch, Azure.ResourceManager.CommonTypes.TrackedResource, "csharp");
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "C# backward compat: preserve TrackedResourceData base"
+@@Azure.ClientGenerator.Core.Legacy.hierarchyBuilding(Microsoft.NetApp.SnapshotPolicyPatch, Azure.ResourceManager.CommonTypes.TrackedResource, "csharp");
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "C# backward compat: preserve TrackedResourceData base"
+@@Azure.ClientGenerator.Core.Legacy.hierarchyBuilding(Microsoft.NetApp.CapacityPoolPatch, Azure.ResourceManager.CommonTypes.TrackedResource, "csharp");
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "C# backward compat: preserve ResourceData base"
+@@Azure.ClientGenerator.Core.Legacy.hierarchyBuilding(Microsoft.NetApp.SubvolumeModel, Azure.ResourceManager.CommonTypes.Resource, "csharp");
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "C# backward compat: preserve ResourceData base"
+@@Azure.ClientGenerator.Core.Legacy.hierarchyBuilding(Microsoft.NetApp.VolumeGroup, Azure.ResourceManager.CommonTypes.Resource, "csharp");

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/client.tsp
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/client.tsp
@@ -97,6 +97,8 @@ using Microsoft.NetApp;
 // C# backward compatibility: type renames
 // ============================================================
 // Resource types - add NetApp prefix to match old SDK names
+@@clientName(Microsoft.NetApp.Volume, "NetAppVolume", "csharp");
+@@clientName(Microsoft.NetApp.Backup, "NetAppBackupVaultBackup", "csharp");
 @@clientName(Microsoft.NetApp.BackupPolicy, "NetAppBackupPolicy", "csharp");
 @@clientName(Microsoft.NetApp.BackupVault, "NetAppBackupVault", "csharp");
 @@clientName(Microsoft.NetApp.QuotaItem, "NetAppSubscriptionQuotaItem", "csharp");
@@ -104,9 +106,13 @@ using Microsoft.NetApp;
 @@clientName(Microsoft.NetApp.VolumeGroupDetails, "NetAppVolumeGroup", "csharp");
 @@clientName(Microsoft.NetApp.VolumeQuotaRule, "NetAppVolumeQuotaRule", "csharp");
 @@clientName(Microsoft.NetApp.Snapshot, "NetAppVolumeSnapshot", "csharp");
+@@clientName(Microsoft.NetApp.CapacityPool, "CapacityPool", "csharp");
+@@clientName(Microsoft.NetApp.SnapshotPolicy, "SnapshotPolicy", "csharp");
+@@clientName(Microsoft.NetApp.NetAppAccount, "NetAppAccount", "csharp");
 
 // Model types - preserve old SDK names
 @@clientName(Microsoft.NetApp.AccountEncryption, "NetAppAccountEncryption", "csharp");
+@@clientName(Microsoft.NetApp.ActiveDirectory, "NetAppAccountActiveDirectory", "csharp");
 @@clientName(Microsoft.NetApp.ActiveDirectoryStatus, "NetAppAccountActiveDirectoryStatus", "csharp");
 @@clientName(Microsoft.NetApp.AuthorizeRequest, "NetAppVolumeAuthorizeReplicationContent", "csharp");
 @@clientName(Microsoft.NetApp.AvsDataStore, "NetAppAvsDataStore", "csharp");

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/tspconfig.yaml
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/tspconfig.yaml
@@ -45,6 +45,9 @@ options:
     generate-fakes: true
     head-as-boolean: true
     inject-spans: true
+  "@azure-typespec/http-client-csharp-mgmt":
+    emitter-output-dir: "{output-dir}/{service-dir}/Azure.ResourceManager.NetApp"
+    enable-wire-path-attribute: true
 
 linter:
   extends:

--- a/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/SiteRecovery/tspconfig.yaml
+++ b/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/SiteRecovery/tspconfig.yaml
@@ -11,6 +11,9 @@ options:
     arm-types-dir: "{project-root}/../../../../common-types/resource-management"
     emit-lro-options: "all"
     examples-dir: "{project-root}/examples"
+  "@azure-typespec/http-client-csharp-mgmt":
+    namespace: "Azure.ResourceManager.RecoveryServicesSiteRecovery"
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
   "@azure-tools/typespec-python":
     emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-recoveryservicessiterecovery"
     service-dir: "sdk/recoveryservices"


### PR DESCRIPTION
Adds `@azure-typespec/http-client-csharp-mgmt` emitter configuration to the RecoveryServicesSiteRecovery tspconfig.yaml to enable C# management SDK generation from TypeSpec.

Companion to SDK PR: https://github.com/Azure/azure-sdk-for-net/pull/57008