### PR TITLE
fix(containerregistry): correct namespace for csharp sdk

### DIFF
--- a/specification/containerregistry/resource-manager/Microsoft.ContainerRegistry/RegistryTasks/tspconfig.yaml
+++ b/specification/containerregistry/resource-manager/Microsoft.ContainerRegistry/RegistryTasks/tspconfig.yaml
@@ -13,7 +13,7 @@ options:
     arm-types-dir: "{project-root}/../../../../common-types/resource-management"
     emit-lro-options: "all"
   "@azure-typespec/http-client-csharp-mgmt":
-    namespace: "Azure.ResourceManager.ContainerRegistryTasks"
+    namespace: "Azure.ResourceManager.ContainerRegistry.Tasks"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
   "@azure-tools/typespec-python":
     service-dir: "sdk/containerregistry"


### PR DESCRIPTION
This PR corrects the RegistryTasks namespace for dotnet SDK