### PR TITLE
[Azure Search] Fix the missing x-ms-parameterized-host for REST docs

### DIFF
--- a/specification/search/data-plane/Search/main.tsp
+++ b/specification/search/data-plane/Search/main.tsp
@@ -26,6 +26,14 @@ using TypeSpec.Versioning;
     }
   ]>
 )
+@server(
+  "{endpoint}",
+  "The endpoint URL of the search service.",
+  {
+    @doc("The endpoint URL of the search service.")
+    endpoint: url,
+  }
+)
 @service(#{ title: "Azure AI Search" })
 @versioned(Versions)
 namespace Search;

--- a/specification/search/data-plane/Search/preview/2025-11-01-preview/search.json
+++ b/specification/search/data-plane/Search/preview/2025-11-01-preview/search.json
@@ -13,6 +13,21 @@
   "schemes": [
     "https"
   ],
+  "x-ms-parameterized-host": {
+    "hostTemplate": "{endpoint}",
+    "useSchemePrefix": false,
+    "parameters": [
+      {
+        "name": "endpoint",
+        "in": "path",
+        "description": "The endpoint URL of the search service.",
+        "required": true,
+        "type": "string",
+        "format": "uri",
+        "x-ms-skip-url-encoding": true
+      }
+    ]
+  },
   "produces": [
     "application/json"
   ],


### PR DESCRIPTION
Due to the missing of `x-ms-parameterized-host` in the tsp-compiled swagger, Search REST API docs showed `///` instead of `{endpoint}/`. This PR fixes this bug.

Example
[Indexes - Create - REST API (Azure Search Service) | Microsoft Learn](https://learn.microsoft.com/en-us/rest/api/searchservice/indexes/create?view=rest-searchservice-2025-11-01-preview&tabs=HTTP)

- Wrong url format:
`POST https:///indexes?api-version=2025-11-01-preview`

- Expected url format:
`POST {endpoint}/indexes?api-version=2025-09-01`