### PR TITLE
Remove api-version setting from keyvault resource-manager tspconfig.yaml

### DIFF
--- a/specification/keyvault/resource-manager/Microsoft.KeyVault/KeyVault/tspconfig.yaml
+++ b/specification/keyvault/resource-manager/Microsoft.KeyVault/KeyVault/tspconfig.yaml
@@ -17,7 +17,6 @@ options:
     namespace: "Azure.ResourceManager.KeyVault"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     enable-wire-path-attribute: true
-    api-version: "2025-05-01"
   "@azure-tools/typespec-python":
     emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-keyvault"
     namespace: "azure.mgmt.keyvault"


### PR DESCRIPTION
Remove the `api-version: "2025-05-01"` setting from the `@azure-typespec/http-client-csharp-mgmt` emitter in `specification/keyvault/resource-manager/Microsoft.KeyVault/KeyVault/tspconfig.yaml`.