### PR TITLE
Azure specific for `ResponseCreate` ops clustered for SDK convenience

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -31765,6 +31765,10 @@
             ],
             "description": "(Deprecated) Use agent_reference instead.\nThe agent used for this response"
           },
+          "agent_session_id": {
+            "type": "string",
+            "description": "The session identifier for this response. Currently only relevant for hosted agents.\nAlways returned for hosted agents — either the caller-provided value, the auto-derived value,\nor an auto-generated UUID. Use for session-scoped operations and to maintain sandbox\naffinity in follow-up calls."
+          },
           "agent_reference": {
             "type": "object",
             "allOf": [
@@ -31774,10 +31778,6 @@
             ],
             "nullable": true,
             "description": "The agent used for this response"
-          },
-          "agent_session_id": {
-            "type": "string",
-            "description": "The session identifier for this response. Currently only relevant for hosted agents.\nAlways returned for hosted agents — either the caller-provided value, the auto-derived value,\nor an auto-generated UUID. Use for session-scoped operations and to maintain sandbox\naffinity in follow-up calls."
           }
         },
         "title": "The response object"

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -7960,6 +7960,10 @@
                         ],
                         "description": "(Deprecated) Use agent_reference instead.\nThe agent to use for generating the response."
                       },
+                      "agent_session_id": {
+                        "type": "string",
+                        "description": "Optional session identifier for sandbox affinity. Currently only relevant for hosted agents.\nWhen provided, the request is routed to the same sandbox. When omitted, auto-derived from\nconversation_id/prev_response_id or a new UUID is generated."
+                      },
                       "agent_reference": {
                         "allOf": [
                           {
@@ -7972,10 +7976,6 @@
                         "type": "object",
                         "additionalProperties": {},
                         "description": "The structured inputs to the response that can participate in prompt template substitution or tool argument bindings."
-                      },
-                      "agent_session_id": {
-                        "type": "string",
-                        "description": "Optional session identifier for sandbox affinity. Currently only relevant for hosted agents.\nWhen provided, the request is routed to the same sandbox. When omitted, auto-derived from\nconversation_id/prev_response_id or a new UUID is generated."
                       }
                     }
                   },
@@ -8172,6 +8172,10 @@
                         ],
                         "description": "(Deprecated) Use agent_reference instead.\nThe agent to use for generating the response."
                       },
+                      "agent_session_id": {
+                        "type": "string",
+                        "description": "Optional session identifier for sandbox affinity. Currently only relevant for hosted agents.\nWhen provided, the request is routed to the same sandbox. When omitted, auto-derived from\nconversation_id/prev_response_id or a new UUID is generated."
+                      },
                       "agent_reference": {
                         "allOf": [
                           {
@@ -8184,10 +8188,6 @@
                         "type": "object",
                         "additionalProperties": {},
                         "description": "The structured inputs to the response that can participate in prompt template substitution or tool argument bindings."
-                      },
-                      "agent_session_id": {
-                        "type": "string",
-                        "description": "Optional session identifier for sandbox affinity. Currently only relevant for hosted agents.\nWhen provided, the request is routed to the same sandbox. When omitted, auto-derived from\nconversation_id/prev_response_id or a new UUID is generated."
                       }
                     }
                   }

--- a/specification/ai-foundry/data-plane/Foundry/src/openai-responses/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai-responses/models.tsp
@@ -41,6 +41,7 @@ namespace Azure.AI.Projects {
     }
   );
 
+  // Any fields marked with `@removed` need to be placed directly under `@@copyProperties`
   /** intermediate model */
   model AzureCreateResponse {
       /** The agent to use for generating the response. */
@@ -59,9 +60,6 @@ namespace Azure.AI.Projects {
       @removed(Versions.v1)
       agent?: AgentId,
 
-      /** The agent used for this response */
-      agent_reference: AgentReference | null,
-
       /**
        * The session identifier for this response. Currently only relevant for hosted agents.
        * Always returned for hosted agents — either the caller-provided value, the auto-derived value,
@@ -70,8 +68,18 @@ namespace Azure.AI.Projects {
        */
       @removed(Versions.v1)
       agent_session_id?: string,
+
+      ...AzureCreateResponseResult,
     }
   );
+
+
+  // Any fields marked with `@removed` need to be placed directly under `@@copyProperties`
+  /** intermediate model */
+  model AzureCreateResponseResult {
+          /** The agent used for this response */
+      agent_reference: AgentReference | null,
+  }
 
   @@withoutOmittedProperties(OpenAI.CodeInterpreterTool, "container");
   @@copyProperties(OpenAI.CodeInterpreterTool,

--- a/specification/ai-foundry/data-plane/Foundry/src/openai-responses/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai-responses/models.tsp
@@ -22,6 +22,12 @@ namespace Azure.AI.Projects {
 
   @@copyProperties(OpenAI.CreateResponse,
     {
+      ...AzureCreateResponse;
+    }
+  );
+
+  /** intermediate model */
+  model AzureCreateResponse {
       /**
        * (Deprecated) Use agent_reference instead.
        *  The agent to use for generating the response.
@@ -42,8 +48,7 @@ namespace Azure.AI.Projects {
        */
       @removed(Versions.v1)
       agent_session_id?: string,
-    }
-  );
+  }
 
   @@copyProperties(OpenAI.Response,
     {

--- a/specification/ai-foundry/data-plane/Foundry/src/openai-responses/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai-responses/models.tsp
@@ -22,24 +22,12 @@ namespace Azure.AI.Projects {
 
   @@copyProperties(OpenAI.CreateResponse,
     {
-      ...AzureCreateResponse;
-    }
-  );
-
-  /** intermediate model */
-  model AzureCreateResponse {
       /**
        * (Deprecated) Use agent_reference instead.
        *  The agent to use for generating the response.
        */
       @removed(Versions.v1)
       agent?: AgentReference,
-
-      /** The agent to use for generating the response. */
-      agent_reference?: AgentReference,
-
-      /** The structured inputs to the response that can participate in prompt template substitution or tool argument bindings. */
-      structured_inputs?: Record<unknown>,
 
       /**
        * Optional session identifier for sandbox affinity. Currently only relevant for hosted agents.
@@ -48,6 +36,18 @@ namespace Azure.AI.Projects {
        */
       @removed(Versions.v1)
       agent_session_id?: string,
+
+      ...AzureCreateResponse;
+    }
+  );
+
+  /** intermediate model */
+  model AzureCreateResponse {
+      /** The agent to use for generating the response. */
+      agent_reference?: AgentReference,
+
+      /** The structured inputs to the response that can participate in prompt template substitution or tool argument bindings. */
+      structured_inputs?: Record<unknown>,
   }
 
   @@copyProperties(OpenAI.Response,

--- a/specification/ai-foundry/data-plane/Foundry/src/openai-responses/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai-responses/models.tsp
@@ -37,13 +37,13 @@ namespace Azure.AI.Projects {
       @removed(Versions.v1)
       agent_session_id?: string,
 
-      ...AzureCreateResponse;
+      ...AzureCreateResponseOptions;
     }
   );
 
   // Any fields marked with `@removed` need to be placed directly under `@@copyProperties`
   /** intermediate model */
-  model AzureCreateResponse {
+  model AzureCreateResponseOptions {
       /** The agent to use for generating the response. */
       agent_reference?: AgentReference,
 

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-agents/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-agents/client.tsp
@@ -130,6 +130,9 @@ using Azure.AI.Projects;
 @@usage(MemoryStoreUpdateResponse, Usage.output);
 @@access(MemoryStoreUpdateResponse, Access.public);
 
+@@usage(AzureCreateResponse, Usage.input);
+@@access(AzureCreateResponse, Access.public);
+
 // --------------------------------------------------------------------------------
 // Type overrides
 // --------------------------------------------------------------------------------

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-agents/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-agents/client.tsp
@@ -133,6 +133,9 @@ using Azure.AI.Projects;
 @@usage(AzureCreateResponse, Usage.input);
 @@access(AzureCreateResponse, Access.public);
 
+@@usage(AzureCreateResponseResult, Usage.output);
+@@access(AzureCreateResponseResult, Access.public);
+
 // --------------------------------------------------------------------------------
 // Type overrides
 // --------------------------------------------------------------------------------

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-agents/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-agents/client.tsp
@@ -130,8 +130,8 @@ using Azure.AI.Projects;
 @@usage(MemoryStoreUpdateResponse, Usage.output);
 @@access(MemoryStoreUpdateResponse, Access.public);
 
-@@usage(AzureCreateResponse, Usage.input);
-@@access(AzureCreateResponse, Access.public);
+@@usage(AzureCreateResponseOptions, Usage.input);
+@@access(AzureCreateResponseOptions, Access.public);
 
 @@usage(AzureCreateResponseResult, Usage.output);
 @@access(AzureCreateResponseResult, Access.public);

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-agents/main.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-agents/main.tsp
@@ -7,3 +7,5 @@ import "../memory-stores/routes.tsp";
 // so we can customize visibility where necessary.
 import "../openai-responses/models.tsp";
 import "../openai-conversations/routes.tsp";
+
+import "../openai-responses/models.tsp";


### PR DESCRIPTION
Grouping Azurisms for create `Response` operations under a model for better API in Java. Here is what this enables in Java: https://github.com/Azure/azure-sdk-for-java/pull/48443

Other languages shouldn't be affected unless they explicitly make these models visible like in `sdk-agents/client.tsp` in this PR. Also,  OpenAPI does not change at all (just field sorting order).