### PR TITLE
Add Microsoft.Impact 2026-01-01-preview API version

### DIFF
--- a/specification/impact/Impact.Management/ImpactCategories.tsp
+++ b/specification/impact/Impact.Management/ImpactCategories.tsp
@@ -6,6 +6,8 @@ import "@azure-tools/typespec-azure-resource-manager";
 
 using TypeSpec.Http;
 using TypeSpec.Rest;
+using OpenAPI;
+using Azure.Core;
 using Azure.ResourceManager;
 using Azure.ResourceManager.Foundations;
 
@@ -38,7 +40,7 @@ model ImpactCategoryProperties is ResourceProperties {
   description?: string;
 
   @doc("The workloadImpact properties which are required when reporting with the impact category")
-  @identifiers(#[])
+  @Azure.ResourceManager.identifiers(#[])
   requiredImpactProperties?: RequiredImpactProperties[];
 }
 
@@ -75,5 +77,5 @@ model CustomParameters {
   @query
   @minLength(1)
   @doc("Filter by resource type")
-  resourceType: string;
+  resourceType?: string;
 }

--- a/specification/impact/Impact.Management/commonModels.tsp
+++ b/specification/impact/Impact.Management/commonModels.tsp
@@ -12,6 +12,7 @@ using OpenAPI;
 using Azure.ResourceManager;
 using Azure.ResourceManager.Foundations;
 using Azure.Core;
+using TypeSpec.Versioning;
 
 @doc("Details about impacted performance metrics. Applicable for performance related impact")
 model Performance {
@@ -233,9 +234,61 @@ union Protocol {
   Other: "Other",
 }
 
+@added(Versions.v2025_01_01_preview)
+@doc("List of detection types")
+union DetectionType {
+  string,
+
+  /** Use this when impact is alert based. */
+  BusinessAlert: "BusinessAlert",
+
+  /** Use this when impact is metrics or expectations based. */
+  MetricsThreshold: "MetricsThreshold",
+
+  /** Use this when impact is outlier based. */
+  MetricsAnomaly: "MetricsAnomaly",
+}
+
+@added(Versions.v2025_01_01_preview)
+@doc("List of severity of an impact.")
+union Severity {
+  string,
+
+  /** Use this when the issue is critical. Consider this to be similar to severity 1 incidents. */
+  Critical: "Critical",
+
+  /** Use this when the issue is high impact similar to severity 2 incidents. */
+  High: "High",
+
+  /** Use this when the issue is medium impact similar to severity 3 incidents. */
+  Medium: "Medium",
+
+  /** Use this for issues that are low impact similar to severity 4 and 5 incidents. */
+  Low: "Low",
+}
+
 @doc("Resource details")
 model SourceOrTarget {
   @doc("Azure resource id, example /subscription/{subscription}/resourceGroup/{rg}/Microsoft.compute/virtualMachine/{vmName}")
   @pattern("(\\/[0-9a-zA-Z]+)*")
   azureResourceId?: string;
+}
+
+@doc("Group of insights for a category")
+model InsightCategoryGroup {
+  @doc("Category name")
+  category: string;
+
+  @doc("Status of the insights in this category")
+  status?: string;
+
+  @doc("List of insight references in this category")
+  @Azure.ResourceManager.identifiers(#["id"])
+  insights?: InsightReference[];
+}
+
+@doc("Reference to an Insight resource")
+model InsightReference {
+  @doc("Azure resource ID of the insight")
+  id: string;
 }

--- a/specification/impact/Impact.Management/connectors.tsp
+++ b/specification/impact/Impact.Management/connectors.tsp
@@ -8,18 +8,53 @@ using TypeSpec.Http;
 using TypeSpec.Rest;
 using TypeSpec.Versioning;
 using Azure.ResourceManager;
+using Azure.ResourceManager.Foundations;
 
 namespace Microsoft.Impact;
 
 @doc("A connector is a resource that can be used to proactively report impacts against workloads in Azure to Microsoft.")
 @subscriptionResource
-model Connector is ProxyResource<ConnectorProperties> {
+model Connector is Azure.ResourceManager.ProxyResource<ConnectorProperties> {
   @doc("The name of the connector")
   @pattern("^[a-zA-Z0-9-]{3,24}$")
   @key("connectorName")
   @segment("connectors")
   @path
   name: string;
+
+  ...ConnectorManagedUserAssignedIdentityProperty;
+}
+
+@added(Versions.v2025_01_01_preview)
+@doc("The managed service identities envelope.")
+model ConnectorManagedUserAssignedIdentityProperty {
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "There is no built-in typespec support for MSI with only UserAssigned type; we must create custom models for this."
+  @added(Versions.v2025_01_01_preview)
+  @doc("The managed service identities assigned to this resource.")
+  identity?: ManagedServiceIdentityOnlyUserAssigned;
+}
+
+@added(Versions.v2025_01_01_preview)
+@doc("Managed service identity (system assigned and/or user assigned identities)")
+model ManagedServiceIdentityOnlyUserAssigned {
+  @doc("The type of managed identity assigned to this resource.")
+  type: ManagedServiceIdentityTypeOnlyUserAssigned;
+
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "There is no built-in typespec support for MSI wih only UserAssigned type; we must create custom models for this."
+  @doc("The identities assigned to this resource by the user.")
+  userAssignedIdentities?: Record<Foundations.UserAssignedIdentity | null>;
+}
+
+@added(Versions.v2025_01_01_preview)
+@doc("Type of managed service identity, where only UserAssigned type is allowed.")
+union ManagedServiceIdentityTypeOnlyUserAssigned {
+  @doc("User assigned managed identity.")
+  UserAssigned: "UserAssigned",
+
+  @doc("No identity.")
+  None: "None",
+
+  string,
 }
 
 @doc("Details of the Connector.")
@@ -38,6 +73,16 @@ model ConnectorProperties is ResourceProperties {
   @visibility(Lifecycle.Read)
   @doc("last run time stamp of this connector in UTC time zone")
   lastRunTimeStamp: utcDateTime;
+
+  @added(Versions.v2025_01_01_preview)
+  @visibility(Lifecycle.Read)
+  @doc("returns the processing state of a connector")
+  processingState: string;
+
+  @added(Versions.v2025_01_01_preview)
+  @visibility(Lifecycle.Read)
+  @doc("detailed description of the state and if any associated action that can be taken")
+  processingStateMessage: string;
 }
 
 @doc("Enum for connector types")
@@ -48,27 +93,11 @@ union Platform {
   AzureMonitor: "AzureMonitor",
 }
 
-@doc("The type used for update operations of the Connector.")
-model ConnectorUpdate
-  is OptionalProperties<UpdateableProperties<OmitProperties<
-    Connector,
-    "Name" | "name" | "properties"
-  >>> {
-  /** The resource-specific properties for this resource. */
-  properties?: ConnectorUpdateProperties;
-}
-
-model ConnectorUpdateProperties
-  is Azure.ResourceManager.Foundations.ResourceUpdateModelProperties<
-    Connector,
-    ConnectorProperties
-  >;
-
 @armResourceOperations(Connector)
 interface Connectors {
   get is ArmResourceRead<Connector>;
   createOrUpdate is ArmResourceCreateOrReplaceAsync<Connector>;
-  update is ArmCustomPatchSync<Connector, ConnectorUpdate>;
+  update is ArmResourcePatchSync<Connector, ConnectorProperties>;
   delete is ArmResourceDeleteSync<Connector>;
   listBySubscription is ArmListBySubscription<Connector>;
 }

--- a/specification/impact/Impact.Management/examples/2025-01-01-preview/Connectors_CreateOrUpdate.json
+++ b/specification/impact/Impact.Management/examples/2025-01-01-preview/Connectors_CreateOrUpdate.json
@@ -1,0 +1,91 @@
+{
+  "operationId": "Connectors_CreateOrUpdate",
+  "title": "CreateConnector",
+  "parameters": {
+    "api-version": "2025-01-01-preview",
+    "subscriptionId": "74f5e23f-d4d9-410a-bb4d-8f0608adb10d",
+    "connectorName": "testconnector1",
+    "resource": {
+      "properties": {
+        "connectorType": "AzureMonitor"
+      },
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/eu2cgroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1": {}
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "connectorId": "430a444e-6a84-4a6f-8c50-124843ca7cd4",
+          "tenantId": "23a8d1da-a7e9-4443-9797-4cd3e3aeb8f8",
+          "connectorType": "AzureMonitor",
+          "lastRunTimeStamp": "2024-03-19T06:23:56.238Z",
+          "processingState": "Initialized",
+          "processingStateMessage": ""
+        },
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/eu2cgroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1": {
+              "clientId": "fbe75b66-01c5-4f87-a220-233af3270436",
+              "principalId": "075a0ca6-43f6-4434-9abf-c9b1b79f9219"
+            }
+          }
+        },
+        "id": "/subscriptions/74f5e23f-d4d9-410a-bb4d-8f0608adb10d/providers/Microsoft.Impact/connectors/testconnector1",
+        "name": "testconnector1",
+        "type": "microsoft.impact/connectors",
+        "systemData": {
+          "createdBy": "testuser@hotmail.com",
+          "createdByType": "User",
+          "createdAt": "2024-03-07T06:19:01.6431721Z",
+          "lastModifiedBy": "testuser@hotmail.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-03-15T08:29:20.8549373Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+      },
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "connectorId": "430a444e-6a84-4a6f-8c50-124843ca7cd4",
+          "tenantId": "23a8d1da-a7e9-4443-9797-4cd3e3aeb8f8",
+          "connectorType": "AzureMonitor",
+          "lastRunTimeStamp": "2024-03-19T06:23:56.238Z",
+          "processingState": "Initialized",
+          "processingStateMessage": ""
+        },
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/eu2cgroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1": {
+              "clientId": "fbe75b66-01c5-4f87-a220-233af3270436",
+              "principalId": "075a0ca6-43f6-4434-9abf-c9b1b79f9219"
+            }
+          }
+        },
+        "id": "/subscriptions/74f5e23f-d4d9-410a-bb4d-8f0608adb10d/providers/Microsoft.Impact/connectors/testconnector1",
+        "name": "testconnector1",
+        "type": "microsoft.impact/connectors",
+        "systemData": {
+          "createdBy": "testuser@hotmail.com",
+          "createdByType": "User",
+          "createdAt": "2024-03-07T06:19:01.6431721Z",
+          "lastModifiedBy": "testuser@hotmail.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-03-15T08:29:20.8549373Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2025-01-01-preview/Connectors_Delete.json
+++ b/specification/impact/Impact.Management/examples/2025-01-01-preview/Connectors_Delete.json
@@ -1,0 +1,13 @@
+{
+  "title": "Connectors_Delete",
+  "operationId": "Connectors_Delete",
+  "parameters": {
+    "api-version": "2025-01-01-preview",
+    "subscriptionId": "8F74B371-8573-4773-9BDA-D546505BDB3A",
+    "connectorName": "testconnector1"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  }
+}

--- a/specification/impact/Impact.Management/examples/2025-01-01-preview/Connectors_Get.json
+++ b/specification/impact/Impact.Management/examples/2025-01-01-preview/Connectors_Get.json
@@ -1,0 +1,55 @@
+{
+  "operationId": "Connectors_Get",
+  "title": "GetConnector",
+  "parameters": {
+    "api-version": "2025-01-01-preview",
+    "subscriptionId": "74f5e23f-d4d9-410a-bb4d-8f0608adb10d",
+    "connectorName": "testconnector1",
+    "resource": {
+      "properties": {
+        "connectorType": "AzureMonitor"
+      },
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/eu2cgroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1": {}
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "connectorId": "430a444e-6a84-4a6f-8c50-124843ca7cd4",
+          "tenantId": "23a8d1da-a7e9-4443-9797-4cd3e3aeb8f8",
+          "connectorType": "AzureMonitor",
+          "lastRunTimeStamp": "2024-03-19T06:23:56.238Z",
+          "processingState": "Initialized",
+          "processingStateMessage": ""
+        },
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/eu2cgroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1": {
+              "clientId": "fbe75b66-01c5-4f87-a220-233af3270436",
+              "principalId": "075a0ca6-43f6-4434-9abf-c9b1b79f9219"
+            }
+          }
+        },
+        "id": "/subscriptions/74f5e23f-d4d9-410a-bb4d-8f0608adb10d/providers/Microsoft.Impact/connectors/testconnector1",
+        "name": "testconnector1",
+        "type": "microsoft.impact/connectors",
+        "systemData": {
+          "createdBy": "testuser@hotmail.com",
+          "createdByType": "User",
+          "createdAt": "2024-03-07T06:19:01.6431721Z",
+          "lastModifiedBy": "testuser@hotmail.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-03-15T08:29:20.8549373Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2025-01-01-preview/Connectors_ListBySubscription.json
+++ b/specification/impact/Impact.Management/examples/2025-01-01-preview/Connectors_ListBySubscription.json
@@ -1,0 +1,48 @@
+{
+  "title": "Connectors_ListBySubscription",
+  "operationId": "Connectors_ListBySubscription",
+  "parameters": {
+    "api-version": "2025-01-01-preview",
+    "subscriptionId": "74f5e23f-d4d9-410a-bb4d-8f0608adb10d"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "provisioningState": "Succeeded",
+              "connectorId": "430a444e-6a84-4a6f-8c50-124843ca7cd4",
+              "tenantId": "23a8d1da-a7e9-4443-9797-4cd3e3aeb8f8",
+              "connectorType": "AzureMonitor",
+              "lastRunTimeStamp": "2024-03-19T06:23:56.238Z",
+              "processingState": "Initialized",
+              "processingStateMessage": ""
+            },
+            "identity": {
+              "type": "UserAssigned",
+              "userAssignedIdentities": {
+                "/subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/eu2cgroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1": {
+                  "clientId": "fbe75b66-01c5-4f87-a220-233af3270436",
+                  "principalId": "075a0ca6-43f6-4434-9abf-c9b1b79f9219"
+                }
+              }
+            },
+            "id": "/subscriptions/74f5e23f-d4d9-410a-bb4d-8f0608adb10d/providers/Microsoft.Impact/connectors/testconnector1",
+            "name": "testconnector1",
+            "type": "microsoft.impact/connectors",
+            "systemData": {
+              "createdBy": "testuser@hotmail.com",
+              "createdByType": "User",
+              "createdAt": "2024-03-07T06:19:01.6431721Z",
+              "lastModifiedBy": "testuser@hotmail.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2024-03-15T08:29:20.8549373Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2025-01-01-preview/Connectors_Update.json
+++ b/specification/impact/Impact.Management/examples/2025-01-01-preview/Connectors_Update.json
@@ -1,0 +1,55 @@
+{
+  "title": "Connectors_Update",
+  "operationId": "Connectors_Update",
+  "parameters": {
+    "api-version": "2025-01-01-preview",
+    "subscriptionId": "74f5e23f-d4d9-410a-bb4d-8f0608adb10d",
+    "connectorName": "testconnector1",
+    "properties": {
+      "properties": {
+        "connectorType": "AzureMonitor"
+      },
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/eu2cgroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1": {}
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "connectorId": "430a444e-6a84-4a6f-8c50-124843ca7cd4",
+          "tenantId": "23a8d1da-a7e9-4443-9797-4cd3e3aeb8f8",
+          "connectorType": "AzureMonitor",
+          "lastRunTimeStamp": "2024-03-19T06:23:56.238Z",
+          "processingState": "Initialized",
+          "processingStateMessage": ""
+        },
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/eu2cgroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1": {
+              "clientId": "fbe75b66-01c5-4f87-a220-233af3270436",
+              "principalId": "075a0ca6-43f6-4434-9abf-c9b1b79f9219"
+            }
+          }
+        },
+        "id": "/subscriptions/74f5e23f-d4d9-410a-bb4d-8f0608adb10d/providers/Microsoft.Impact/connectors/testconnector1",
+        "name": "testconnector1",
+        "type": "microsoft.impact/connectors",
+        "systemData": {
+          "createdBy": "testuser@hotmail.com",
+          "createdByType": "User",
+          "createdAt": "2024-03-07T06:19:01.6431721Z",
+          "lastModifiedBy": "testuser@hotmail.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-03-15T08:29:20.8549373Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2025-01-01-preview/ImpactCategories_Get.json
+++ b/specification/impact/Impact.Management/examples/2025-01-01-preview/ImpactCategories_Get.json
@@ -1,0 +1,28 @@
+{
+  "operationId": "ImpactCategories_Get",
+  "title": "Get WorkloadImpact Resource by name",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2025-01-01-preview",
+    "impactCategoryName": "ARMOperation.Create"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/ImpactCategories/ARMOperation.Create",
+        "name": "ARMOperation.Create",
+        "type": "Microsoft.Impact/impactCategories",
+        "properties": {
+          "description": "Use this to report problems related to creating a new azure virtual machine such as provisioning or allocation failures.",
+          "categoryId": "778f815b-6576-4a36-bea9-bffb3d26d7f4",
+          "parentCategoryId": "36266d25-9c53-40b3-af41-27418b11851e",
+          "requiredImpactProperties": [
+            {
+              "name": "armCorrelations"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2025-01-01-preview/ImpactCategories_ListBySubscription.json
+++ b/specification/impact/Impact.Management/examples/2025-01-01-preview/ImpactCategories_ListBySubscription.json
@@ -1,0 +1,82 @@
+{
+  "operationId": "ImpactCategories_ListBySubscription",
+  "title": "Get ImpactCategories list by subscription",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceType": "microsoft.compute/virtualmachines",
+    "api-version": "2025-01-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/ImpactCategories/ARMOperation.Create",
+            "name": "ARMOperation.Create",
+            "type": "Microsoft.Impact/impactCategories",
+            "properties": {
+              "description": "Use this to report problems related to creating a new azure virtual machine such as provisioning or allocation failures.",
+              "categoryId": "778f815b-6576-4a36-bea9-bffb3d26d7f4",
+              "parentCategoryId": "36266d25-9c53-40b3-af41-27418b11851e",
+              "requiredImpactProperties": [
+                {
+                  "name": "armCorrelations"
+                }
+              ]
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/ImpactCategories/ARMOperation.Delete",
+            "name": "ARMOperation.Delete",
+            "type": "Microsoft.Impact/impactCategories",
+            "properties": {
+              "description": "Use this to report failures in deleting VMs.",
+              "categoryId": "a9a0c6e2-1208-406f-8f4f-1ccc13fb75d5",
+              "parentCategoryId": "36266d25-9c53-40b3-af41-27418b11851e",
+              "requiredImpactProperties": [
+                {
+                  "name": "armCorrelations"
+                }
+              ]
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/ImpactCategories/ARMOperation.Other",
+            "name": "ARMOperation.Other",
+            "type": "Microsoft.Impact/impactCategories",
+            "properties": {
+              "description": "Use this to report Control Plane operation failures that don't fall into other ARMOperation categories",
+              "categoryId": "7b71f937-9344-499c-bfbe-d86fb755d891",
+              "parentCategoryId": "36266d25-9c53-40b3-af41-27418b11851e",
+              "requiredImpactProperties": [
+                {
+                  "name": "armCorrelations"
+                }
+              ]
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/ImpactCategories/Resource.Connectivity",
+            "name": "Resource.Connectivity",
+            "type": "Microsoft.Impact/impactCategories",
+            "properties": {
+              "description": "Use this to report connectivity issues to or from a VM.",
+              "categoryId": "95903644-3a15-4e37-b4be-a2ae8651f27b",
+              "parentCategoryId": "a8d1c1ae-5fcb-4a8b-a647-fd0a911e8667"
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/ImpactCategories/Resource.Connectivity.Inbound",
+            "name": "Resource.Connectivity.Inbound",
+            "type": "Microsoft.Impact/impactCategories",
+            "properties": {
+              "description": "Use this to report inbound connectivity issues to a VM.",
+              "categoryId": "940fb706-8586-4a0e-bb18-2e2d0ef0708d",
+              "parentCategoryId": "95903644-3a15-4e37-b4be-a2ae8651f27b"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2025-01-01-preview/Insights_Create.json
+++ b/specification/impact/Impact.Management/examples/2025-01-01-preview/Insights_Create.json
@@ -1,0 +1,73 @@
+{
+  "operationId": "Insights_Create",
+  "title": "Creating an insight",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2025-01-01-preview",
+    "workloadImpactName": "impactid22",
+    "insightName": "insightId12",
+    "resource": {
+      "properties": {
+        "content": {
+          "title": "Impact Has been correlated to an outage",
+          "description": "At 2018-11-08T00:00:00Z UTC, your services dependent on these resources <link href=ΓÇ¥ΓÇªΓÇ¥>VM1</link> may have experienced an issue. <br/><div>We have identified an outage that affected these resources(s). You can look at outage information on <link href=\"https:// portal.azure.com/#view/Microsoft_Azure_Health/AzureHealthBrowseBlade/~/serviceIssues/trackingId/NL2W-VCZ\">NL2W-VCZ</link> link.<div>"
+        },
+        "category": "repair",
+        "status": "resolved",
+        "eventTime": "2023-06-15T04:00:00.009223Z",
+        "insightUniqueId": "00000000-0000-0000-0000-000000000000",
+        "impact": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+          "startTime": "2023-06-15T01:00:00.009223Z",
+          "impactId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/workloadImpacts/impactid22"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/workloadImpacts/impactid22/insights/insightId12",
+        "name": "insightId12",
+        "type": "Microsoft.Impact/insights",
+        "properties": {
+          "eventTime": "2023-06-15T04:00:00.009223Z",
+          "content": {
+            "title": "Impact Has been correlated to an outage",
+            "description": "At 2018-11-08T00:00:00Z UTC, your services dependent on these resources <link href=ΓÇ¥ΓÇªΓÇ¥>VM1</link> may have experienced an issue. <br/><div>We have identified an outage that affected these resources(s). You can look at outage information on <link href=\"https:// portal.azure.com/#view/Microsoft_Azure_Health/AzureHealthBrowseBlade/~/serviceIssues/trackingId/NL2W-VCZ\">NL2W-VCZ</link> link.<div>"
+          },
+          "category": "repair",
+          "status": "resolved",
+          "insightUniqueId": "00000000-0000-0000-0000-000000000000",
+          "impact": {
+            "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+            "startTime": "2023-06-15T01:00:00.009223Z",
+            "impactId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/workloadImpacts/impactid22"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/workloadImpacts/impactid22/insights/insightId12",
+        "name": "insightId12",
+        "type": "Microsoft.Impact/insights",
+        "properties": {
+          "eventTime": "2023-06-15T04:00:00.009223Z",
+          "content": {
+            "title": "Impact Has been correlated to an outage",
+            "description": "At 2018-11-08T00:00:00Z UTC, your services dependent on these resources <link href=ΓÇ¥ΓÇªΓÇ¥>VM1</link> may have experienced an issue. <br/><div>We have identified an outage that affected these resources(s). You can look at outage information on <link href=\"https:// portal.azure.com/#view/Microsoft_Azure_Health/AzureHealthBrowseBlade/~/serviceIssues/trackingId/NL2W-VCZ\">NL2W-VCZ</link> link.<div>"
+          },
+          "category": "repair",
+          "status": "resolved",
+          "insightUniqueId": "00000000-0000-0000-0000-000000000000",
+          "impact": {
+            "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+            "startTime": "2023-06-15T01:00:00.009223Z",
+            "impactId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/workloadImpacts/impactid22"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2025-01-01-preview/Insights_Delete.json
+++ b/specification/impact/Impact.Management/examples/2025-01-01-preview/Insights_Delete.json
@@ -1,0 +1,14 @@
+{
+  "operationId": "Insights_Delete",
+  "title": "Delete an Insight",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2025-01-01-preview",
+    "workloadImpactName": "impactid22",
+    "insightName": "insightId12"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  }
+}

--- a/specification/impact/Impact.Management/examples/2025-01-01-preview/Insights_Get_diagnostics.json
+++ b/specification/impact/Impact.Management/examples/2025-01-01-preview/Insights_Get_diagnostics.json
@@ -1,0 +1,33 @@
+{
+  "operationId": "Insights_Get",
+  "title": "Get Insight sample for Diagnostics category",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2025-01-01-preview",
+    "workloadImpactName": "impactid",
+    "insightName": "insight1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadimpacts/impactid/insights/insight1",
+        "name": "insight1",
+        "type": "Microsoft.impact/workloadimpacts/insights",
+        "properties": {
+          "category": "Diagnostics",
+          "impact": {
+            "impactId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadimpacts/impactid",
+            "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/virtualamchine/vm",
+            "startTime": "2018-11-08T00:00:00Z",
+            "endTime": "2018-11-08T00:00:00Z"
+          },
+          "insightUniqueId": "00000000-0000-0000-0000-000000000000",
+          "content": {
+            "title": "We ran diagnostics on your resource and found an issue",
+            "description": "<!--issueDescription-->\n<p>The physical host node where your VM is running had a networking stack update. This might result in a brief connectivity loss.</p>\n<br/><table><tr><th align=\"left\">Resource</th><th align=\"left\">Impact Start Time</th><th align=\"left\">Impact End Time</th><th align=\"left\">Impact Duration(Timespan)</th></tr><tr><td align=\"left\">west-eur-VM</td><td align=\"left\">2024-02-18 01:09:31 UTC</td><td align=\"left\">2024-02-18 01:09:35 UTC</td><td align=\"left\">00:00:04.2690000</td></tr></table>\n<!--/issueDescription-->\n<p>Azure performs updates to improve reliability, performance, and security of the VMs. Azure chooses the least impactful method, which might result in a brief connectivity loss. We are continuously working to improve and reduce impact of our updates, and we apologize for any inconvenience this may have caused you.</p>\n<!--recommendedActions-->\n<h2><strong>Recommended Documents</strong></h2>\n<ul>\n<li>To prepare for VM maintenance events and reduce its impact, try using <a href=\"https://docs.microsoft.com/azure/virtual-machines/windows/scheduled-events\">Scheduled Events for Windows</a> or <a href=\"https://docs.microsoft.com/azure/virtual-machines/linux/scheduled-events\">Linux</a></li>\n<li>Learn more about Azure maintenance and configuring for high availability:\n<ul>\n<li><a href=\"https://docs.microsoft.com/azure/virtual-machines/maintenance-and-updates\">Maintenance and updates for virtual machines in Azure</a></li>\n<li><a href=\"https://docs.microsoft.com/azure/virtual-machines/windows/tutorial-availability-sets\">Configure availability of virtual machines</a></li>\n</ul>\n</li>\n<li>To troubleshoot this scenario in the future, see <a href=\"https://docs.microsoft.com/azure/resource-health/resource-health-overview\">Resource Health Center</a></li>\n</ul>\n"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2025-01-01-preview/Insights_Get_mitigationAction.json
+++ b/specification/impact/Impact.Management/examples/2025-01-01-preview/Insights_Get_mitigationAction.json
@@ -1,0 +1,38 @@
+{
+  "operationId": "Insights_Get",
+  "title": "Get Insight sample for MitigationAction category",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2025-01-01-preview",
+    "workloadImpactName": "impactId",
+    "insightName": "HPCUASucceeded"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadimpacts/impactId/insights/HPCUASucceeded",
+        "name": "HPCUASucceeded",
+        "type": "Microsoft.impact/workloadimpacts/insights",
+        "properties": {
+          "category": "MitigationAction",
+          "eventTime": "2023-06-15T04:00:00.009223Z",
+          "insightUniqueId": "00000000-0000-0000-0000-000000000000",
+          "impact": {
+            "impactId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadimpacts/impactId",
+            "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/virtualMachine/vm",
+            "startTime": "2018-11-08T00:00:00Z",
+            "endTime": "2018-11-08T00:00:00Z"
+          },
+          "content": {
+            "title": "Node was flagged for inspection",
+            "description": "At 2024-02-16 21:05:07 (UTC) an impact was reported on west-eur-VM indicating a potential disruption from Azure platform. <strong>Action Taken</strong> The hardware your VM was running on was flagged for inspection. We will conduct our investigation and take corrective action to prevent further impact on your workloads. We apologize for any disruption. Microsoft Azure Team"
+          },
+          "additionalDetails": {
+            "statusCode": "Succeeded",
+            "terminalState": "true"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2025-01-01-preview/Insights_Get_servicehealth.json
+++ b/specification/impact/Impact.Management/examples/2025-01-01-preview/Insights_Get_servicehealth.json
@@ -1,0 +1,35 @@
+{
+  "operationId": "Insights_Get",
+  "title": "Get Insight sample for service health category",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2025-01-01-preview",
+    "workloadImpactName": "impactid",
+    "insightName": "insightname"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/workloadImpacts/impactname/insights/insightname",
+        "name": "insightname",
+        "type": "Microsoft.Impact/insights",
+        "properties": {
+          "category": "ServiceHealth",
+          "eventId": "ABC-123",
+          "eventTime": "2023-06-15T04:00:00.009223Z",
+          "impact": {
+            "impactId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadimpacts/impactid",
+            "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.compute/virtualmachines/vm1",
+            "startTime": "2018-11-08T00:00:00Z",
+            "endTime": "2018-11-08T00:00:00Z"
+          },
+          "insightUniqueId": "a3d91a07-698b-4044-a230-e918252c4c59",
+          "content": {
+            "title": "Impact Has been correlated to an outage",
+            "description": "On November 8, 2018, at 00:00 UTC, there may have been disruptions to your services linked to the resource <a href='...'>VM1<a>. We have pinpointed a service outage impacting these resources. For details on this outage, please refer to the service health information available at <a href='...'>service health</a>."
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2025-01-01-preview/Insights_ListBySubscription.json
+++ b/specification/impact/Impact.Management/examples/2025-01-01-preview/Insights_ListBySubscription.json
@@ -1,0 +1,37 @@
+{
+  "operationId": "Insights_ListBySubscription",
+  "title": "List Insight resources by workloadImpactName",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "workloadImpactName": "impactid22",
+    "api-version": "2025-01-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/workloadImpacts/impactid22/insights/insightId12",
+            "name": "insightId12",
+            "type": "Microsoft.Impact/insights",
+            "properties": {
+              "eventTime": "2023-06-15T04:00:00.009223Z",
+              "content": {
+                "title": "Impact Has been correlated to an outage",
+                "description": "At 2018-11-08T00:00:00Z UTC, your services dependent on these resources <link href=ΓÇ¥ΓÇªΓÇ¥>VM1</link> may have experienced an issue. <br/><div>We have identified an outage that affected these resources(s). You can look at outage information on <link href=\"https:// portal.azure.com/#view/Microsoft_Azure_Health/AzureHealthBrowseBlade/~/serviceIssues/trackingId/NL2W-VCZ\">NL2W-VCZ</link> link.<div>"
+              },
+              "category": "repair",
+              "status": "resolved",
+              "insightUniqueId": "00000000-0000-0000-0000-000000000000",
+              "impact": {
+                "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+                "startTime": "2023-06-15T01:00:00.009223Z",
+                "impactId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/workloadImpacts/impactid22"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2025-01-01-preview/Operations_List.json
+++ b/specification/impact/Impact.Management/examples/2025-01-01-preview/Operations_List.json
@@ -1,0 +1,52 @@
+{
+  "operationId": "Operations_List",
+  "title": "OperationsList",
+  "parameters": {
+    "api-version": "2025-01-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.Impact/workloadImpacts/write",
+            "display": {
+              "provider": "Microsoft.Impact",
+              "resource": "workloadImpacts",
+              "operation": "write",
+              "description": "Write workloadImpact resources"
+            }
+          },
+          {
+            "name": "Microsoft.Impact/workloadImpacts/read",
+            "display": {
+              "provider": "Microsoft.Impact",
+              "resource": "workloadimpacts",
+              "operation": "read",
+              "description": "Read workloadImpact resources"
+            }
+          },
+          {
+            "name": "Microsoft.Impact/impactCategories/read",
+            "display": {
+              "provider": "Microsoft.Impact",
+              "resource": "impactCategories",
+              "operation": "read",
+              "description": "Read impactCategory resources"
+            }
+          },
+          {
+            "name": "Microsoft.Impact/getUploadToken/action",
+            "display": {
+              "provider": "Microsoft.Impact",
+              "resource": "getUploadToken",
+              "operation": "Get Upload Token",
+              "description": "Get an upload token for the storage account and container to upload logs associated with impacts."
+            }
+          }
+        ],
+        "nextLink": null
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2025-01-01-preview/TopologyImpact_Delete.json
+++ b/specification/impact/Impact.Management/examples/2025-01-01-preview/TopologyImpact_Delete.json
@@ -1,0 +1,13 @@
+{
+  "operationId": "TopologyImpacts_Delete",
+  "title": "Delete topologyImpact Resource by name",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2025-01-01-preview",
+    "topologyImpactName": "impact-001"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  }
+}

--- a/specification/impact/Impact.Management/examples/2025-01-01-preview/TopologyImpact_Get.json
+++ b/specification/impact/Impact.Management/examples/2025-01-01-preview/TopologyImpact_Get.json
@@ -1,0 +1,39 @@
+{
+  "operationId": "TopologyImpacts_Get",
+  "title": "Get TopologyImpact Resource by name",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2025-01-01-preview",
+    "topologyImpactName": "impact-001"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/topologyImpacts/impact-001",
+        "name": "impact-001-",
+        "type": "Microsoft.Impact/topologyImpacts",
+        "properties": {
+          "impactedResources": [
+            {
+              "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm1"
+            }
+          ],
+          "topologyImpactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "one of the resources is unavailable",
+          "impactCategory": "Availability",
+          "additionalProperties": {
+            "errorCode": "504",
+            "errorMessage": "Gateway timeout error"
+          },
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2025-01-01-preview/TopologyImpact_ListBySubscription.json
+++ b/specification/impact/Impact.Management/examples/2025-01-01-preview/TopologyImpact_ListBySubscription.json
@@ -1,0 +1,42 @@
+{
+  "operationId": "TopologyImpacts_ListBySubscription",
+  "title": "List TopologyImpact resources by subscription",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2025-01-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Impacts-rg/providers/Microsoft.Impact/topologyImpacts/impact-001",
+            "name": "impact-001",
+            "type": "Microsoft.Impact/topologyImpacts",
+            "properties": {
+              "impactedResources": [
+                {
+                  "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm1"
+                }
+              ],
+              "topologyImpactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+              "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z",
+              "startDateTime": "2022-06-15T05:59:46.6517821Z",
+              "endDateTime": null,
+              "impactDescription": "one of the resources is unavailable",
+              "impactCategory": "Availability",
+              "additionalProperties": {
+                "errorCode": "504",
+                "errorMessage": "Gateway timeout error"
+              },
+              "workload": {
+                "context": "webapp/scenario1",
+                "toolset": "Other"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2025-01-01-preview/UploadService_GetUploadToken.json
+++ b/specification/impact/Impact.Management/examples/2025-01-01-preview/UploadService_GetUploadToken.json
@@ -1,0 +1,15 @@
+{
+  "operationId": "UploadService_GetUploadToken",
+  "title": "Get upload token to use for log upload",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2025-01-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "uploadUrl": "https://storageAccountHere.blob.core.windows.net/container-here/yyyyMMddHHmmss-12345678.zip?[SAS-token]"
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2025-01-01-preview/WorkloadArmOperation_create.json
+++ b/specification/impact/Impact.Management/examples/2025-01-01-preview/WorkloadArmOperation_create.json
@@ -1,0 +1,85 @@
+{
+  "operationId": "WorkloadImpacts_Create",
+  "title": "Reporting Arm operation failure",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2025-01-01-preview",
+    "workloadImpactName": "impact-002",
+    "resource": {
+      "properties": {
+        "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservercontext",
+        "startDateTime": "2022-06-15T05:59:46.6517821Z",
+        "endDateTime": null,
+        "impactDescription": "deletion of resource failed",
+        "impactCategory": "ArmOperation",
+        "armCorrelationIds": [
+          "00000000-0000-0000-0000-000000000000"
+        ],
+        "workload": {
+          "context": "webapp/scenario1",
+          "toolset": "Other"
+        },
+        "clientIncidentDetails": {
+          "clientIncidentId": "AA123",
+          "clientIncidentSource": "Jira"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadImpacts/impact-001",
+        "name": "impact-001",
+        "type": "Microsoft.Impact/workloadImpacts",
+        "properties": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "deletion of resource failed",
+          "impactCategory": "ArmOperation",
+          "armCorrelationIds": [
+            "00000000-0000-0000-0000-000000000000"
+          ],
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "clientIncidentDetails": {
+            "clientIncidentId": "AA123",
+            "clientIncidentSource": "Jira"
+          },
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadImpacts/impact-001",
+        "name": "impact-001",
+        "type": "Microsoft.Impact/workloadImpacts",
+        "properties": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "deletion of resource failed",
+          "impactCategory": "ArmOperation",
+          "armCorrelationIds": [
+            "00000000-0000-0000-0000-000000000000"
+          ],
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "clientIncidentDetails": {
+            "clientIncidentId": "AA123",
+            "clientIncidentSource": "Jira"
+          },
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2025-01-01-preview/WorkloadAvailability_Create.json
+++ b/specification/impact/Impact.Management/examples/2025-01-01-preview/WorkloadAvailability_Create.json
@@ -1,0 +1,76 @@
+{
+  "operationId": "WorkloadImpacts_Create",
+  "title": "Reporting availability related impact",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2025-01-01-preview",
+    "workloadImpactName": "impact-002",
+    "resource": {
+      "properties": {
+        "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservercontext",
+        "startDateTime": "2022-06-15T05:59:46.6517821Z",
+        "endDateTime": null,
+        "impactDescription": "read calls failed",
+        "impactCategory": "Availability",
+        "workload": {
+          "context": "webapp/scenario1",
+          "toolset": "Other"
+        },
+        "clientIncidentDetails": {
+          "clientIncidentId": "AA123",
+          "clientIncidentSource": "Jira"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadImpacts/impact-001",
+        "name": "impact-001",
+        "type": "Microsoft.Impact/workloadImpacts",
+        "properties": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "read calls failed",
+          "impactCategory": "Availability",
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "clientIncidentDetails": {
+            "clientIncidentId": "AA123",
+            "clientIncidentSource": "Jira"
+          },
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadImpacts/impact-001",
+        "name": "impact-001",
+        "type": "Microsoft.Impact/workloadImpacts",
+        "properties": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "read calls failed",
+          "impactCategory": "Availability",
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "clientIncidentDetails": {
+            "clientIncidentId": "AA123",
+            "clientIncidentSource": "Jira"
+          },
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2025-01-01-preview/WorkloadConnectivityImpact_Create.json
+++ b/specification/impact/Impact.Management/examples/2025-01-01-preview/WorkloadConnectivityImpact_Create.json
@@ -1,0 +1,106 @@
+{
+  "operationId": "WorkloadImpacts_Create",
+  "title": "Reporting a connectivity impact",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2025-01-01-preview",
+    "workloadImpactName": "impact-001",
+    "resource": {
+      "properties": {
+        "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservercontext",
+        "startDateTime": "2022-06-15T05:59:46.6517821Z",
+        "endDateTime": null,
+        "impactDescription": "conection failure",
+        "impactCategory": "Resource.Connectivity",
+        "connectivity": {
+          "protocol": "TCP",
+          "port": 1443,
+          "source": {
+            "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceSub/providers/Microsoft.compute/virtualmachines/vm1"
+          },
+          "target": {
+            "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceSub/providers/Microsoft.compute/virtualmachines/vm2"
+          }
+        },
+        "workload": {
+          "context": "webapp/scenario1",
+          "toolset": "Other"
+        },
+        "clientIncidentDetails": {
+          "clientIncidentId": "AA123",
+          "clientIncidentSource": "Jira"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Impacts-rg/providers/Microsoft.Impact/workloadImpacts/impact-001",
+        "name": "impact-001",
+        "type": "Microsoft.Impact/workloadImpacts",
+        "properties": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservercontext",
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "conection failure",
+          "impactCategory": "Resource.Connectivity",
+          "connectivity": {
+            "protocol": "TCP",
+            "port": 1443,
+            "source": {
+              "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceSub/providers/Microsoft.compute/virtualmachines/vm1"
+            },
+            "target": {
+              "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceSub/providers/Microsoft.compute/virtualmachines/vm2"
+            }
+          },
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "clientIncidentDetails": {
+            "clientIncidentId": "AA123",
+            "clientIncidentSource": "Jira"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Impacts-rg/providers/Microsoft.Impact/workloadImpacts/impact-001",
+        "name": "impact-001",
+        "type": "Microsoft.Impact/workloadImpacts",
+        "properties": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservercontext",
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "conection failure",
+          "impactCategory": "Resource.Connectivity",
+          "connectivity": {
+            "protocol": "TCP",
+            "port": 1443,
+            "source": {
+              "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceSub/providers/Microsoft.compute/virtualmachines/vm1"
+            },
+            "target": {
+              "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceSub/providers/Microsoft.compute/virtualmachines/vm2"
+            }
+          },
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "clientIncidentDetails": {
+            "clientIncidentId": "AA123",
+            "clientIncidentSource": "Jira"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2025-01-01-preview/WorkloadImpact_Delete.json
+++ b/specification/impact/Impact.Management/examples/2025-01-01-preview/WorkloadImpact_Delete.json
@@ -1,0 +1,13 @@
+{
+  "operationId": "WorkloadImpacts_Delete",
+  "title": "Delete WorkloadImpact Resource by name example",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2025-01-01-preview",
+    "workloadImpactName": "impact-001"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  }
+}

--- a/specification/impact/Impact.Management/examples/2025-01-01-preview/WorkloadImpact_Get.json
+++ b/specification/impact/Impact.Management/examples/2025-01-01-preview/WorkloadImpact_Get.json
@@ -1,0 +1,35 @@
+{
+  "operationId": "WorkloadImpacts_Get",
+  "title": "Get WorkloadImpact Resource by name example",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2025-01-01-preview",
+    "workloadImpactName": "impact-001"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadImpacts/impact-001",
+        "name": "impact-001",
+        "type": "Microsoft.Impact/workloadImpacts",
+        "properties": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "high cup utilization",
+          "impactCategory": "Performance",
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "clientIncidentDetails": {
+            "clientIncidentId": "AA123",
+            "clientIncidentSource": "Jira"
+          },
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2025-01-01-preview/WorkloadImpacts_Create_MaximumSet_Gen.json
+++ b/specification/impact/Impact.Management/examples/2025-01-01-preview/WorkloadImpacts_Create_MaximumSet_Gen.json
@@ -1,0 +1,211 @@
+{
+  "title": "WorkloadImpacts_Create_MaximumSet",
+  "operationId": "WorkloadImpacts_Create",
+  "parameters": {
+    "api-version": "2025-01-01-preview",
+    "subscriptionId": "0D045314-435A-41DA-B0A4-2CA7E9F87D12",
+    "workloadImpactName": "testWorkloadImpact",
+    "resource": {
+      "properties": {
+        "startDateTime": "2024-12-04T19:51:13.274Z",
+        "endDateTime": "2024-12-04T19:51:13.274Z",
+        "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+        "impactCategory": "Resource.Other",
+        "impactDescription": "test description",
+        "armCorrelationIds": [
+          "4D045314-435A-41DA-B0A4-2CA7E9F87D12"
+        ],
+        "performance": [
+          {
+            "metricName": "testMetric",
+            "expected": 23,
+            "actual": 20,
+            "expectedValueRange": {
+              "min": 1,
+              "max": 27
+            },
+            "unit": "ByteSeconds"
+          }
+        ],
+        "connectivity": {
+          "protocol": "TCP",
+          "port": 6,
+          "source": {
+            "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm1"
+          },
+          "target": {
+            "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm2"
+          }
+        },
+        "additionalProperties": {},
+        "errorDetails": {
+          "errorCode": "504",
+          "errorMessage": "Gateway timeout error"
+        },
+        "workload": {
+          "context": "webapp/scenario1",
+          "toolset": "Other"
+        },
+        "impactGroupId": "testGroup1",
+        "confidenceLevel": "Low",
+        "clientIncidentDetails": {
+          "clientIncidentId": "123456",
+          "clientIncidentSource": "AzureDevops"
+        },
+        "ongoingImpact": true,
+        "severity": "Critical",
+        "durationInSec": 26,
+        "detectionType": "BusinessAlert",
+        "durationMarginInSec": 28,
+        "hitCount": 21
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "startDateTime": "2024-12-04T19:51:13.274Z",
+          "endDateTime": "2024-12-04T19:51:13.274Z",
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm1",
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2024-12-04T19:51:13.274Z",
+          "impactCategory": "Resource.Other",
+          "impactDescription": "Test description",
+          "armCorrelationIds": [
+            "4D045314-435A-41DA-B0A4-2CA7E9F87D12"
+          ],
+          "performance": [
+            {
+              "metricName": "testMetric",
+              "expected": 23,
+              "actual": 20,
+              "expectedValueRange": {
+                "min": 1,
+                "max": 27
+              },
+              "unit": "ByteSeconds"
+            }
+          ],
+          "connectivity": {
+            "protocol": "TCP",
+            "port": 6,
+            "source": {
+              "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm1"
+            },
+            "target": {
+              "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm2"
+            }
+          },
+          "additionalProperties": {},
+          "errorDetails": {
+            "errorCode": "504",
+            "errorMessage": "Gateway timeout error"
+          },
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "impactGroupId": "testGroup1",
+          "confidenceLevel": "Low",
+          "clientIncidentDetails": {
+            "clientIncidentId": "123456",
+            "clientIncidentSource": "AzureDevops"
+          },
+          "ongoingImpact": true,
+          "severity": "Critical",
+          "durationInSec": 26,
+          "detectionType": "BusinessAlert",
+          "durationMarginInSec": 28,
+          "hitCount": 21
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Impacts-rg/providers/Microsoft.Impact/workloadImpacts/impact2",
+        "name": "testWorkloadImpact",
+        "type": "Microsoft.Impact/workloadImpacts",
+        "systemData": {
+          "createdBy": "testuser@hotmail.com",
+          "createdByType": "User",
+          "createdAt": "2024-03-07T06:19:01.6431721Z",
+          "lastModifiedBy": "testuser@hotmail.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-03-15T08:29:20.8549373Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+      },
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "startDateTime": "2024-12-04T19:51:13.274Z",
+          "endDateTime": "2024-12-04T19:51:13.274Z",
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm1",
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2024-12-04T19:51:13.274Z",
+          "impactCategory": "Resource.Other",
+          "impactDescription": "Test description",
+          "armCorrelationIds": [
+            "4D045314-435A-41DA-B0A4-2CA7E9F87D12"
+          ],
+          "performance": [
+            {
+              "metricName": "testMetric",
+              "expected": 23,
+              "actual": 20,
+              "expectedValueRange": {
+                "min": 1,
+                "max": 27
+              },
+              "unit": "ByteSeconds"
+            }
+          ],
+          "connectivity": {
+            "protocol": "TCP",
+            "port": 6,
+            "source": {
+              "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm1"
+            },
+            "target": {
+              "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm2"
+            }
+          },
+          "additionalProperties": {},
+          "errorDetails": {
+            "errorCode": "504",
+            "errorMessage": "Gateway timeout error"
+          },
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "impactGroupId": "testGroup1",
+          "confidenceLevel": "Low",
+          "clientIncidentDetails": {
+            "clientIncidentId": "123456",
+            "clientIncidentSource": "AzureDevops"
+          },
+          "ongoingImpact": true,
+          "severity": "Critical",
+          "durationInSec": 26,
+          "detectionType": "BusinessAlert",
+          "durationMarginInSec": 28,
+          "hitCount": 21
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Impacts-rg/providers/Microsoft.Impact/workloadImpacts/impact2",
+        "name": "testWorkloadImpact",
+        "type": "Microsoft.Impact/workloadImpacts",
+        "systemData": {
+          "createdBy": "testuser@hotmail.com",
+          "createdByType": "User",
+          "createdAt": "2024-03-07T06:19:01.6431721Z",
+          "lastModifiedBy": "testuser@hotmail.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-03-15T08:29:20.8549373Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2025-01-01-preview/WorkloadImpacts_ListBySubscription.json
+++ b/specification/impact/Impact.Management/examples/2025-01-01-preview/WorkloadImpacts_ListBySubscription.json
@@ -1,0 +1,38 @@
+{
+  "operationId": "WorkloadImpacts_ListBySubscription",
+  "title": "List WorkloadImpact resources by subscription",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2025-01-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Impacts-rg/providers/Microsoft.Impact/workloadImpacts/impact2",
+            "name": "impact2",
+            "type": "Microsoft.Impact/workloadImpacts",
+            "properties": {
+              "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm1",
+              "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+              "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z",
+              "startDateTime": "2022-06-15T05:59:46.6517821Z",
+              "endDateTime": null,
+              "impactDescription": "",
+              "impactCategory": "Resource.Other",
+              "additionalProperties": {
+                "errorCode": "504",
+                "errorMessage": "Gateway timeout error"
+              },
+              "workload": {
+                "context": "webapp/scenario1",
+                "toolset": "Other"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2025-01-01-preview/WorkloadPerformance_Create.json
+++ b/specification/impact/Impact.Management/examples/2025-01-01-preview/WorkloadPerformance_Create.json
@@ -1,0 +1,100 @@
+{
+  "operationId": "WorkloadImpacts_Create",
+  "title": "Reporting performance related impact",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2025-01-01-preview",
+    "workloadImpactName": "impact-002",
+    "resource": {
+      "properties": {
+        "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservercontext",
+        "startDateTime": "2022-06-15T05:59:46.6517821Z",
+        "endDateTime": null,
+        "impactDescription": "high cpu utilization",
+        "impactCategory": "Resource.Performance",
+        "workload": {
+          "context": "webapp/scenario1",
+          "toolset": "Other"
+        },
+        "performance": [
+          {
+            "metricName": "CPU",
+            "actual": 90,
+            "expected": 60,
+            "unit": "garbage"
+          }
+        ],
+        "clientIncidentDetails": {
+          "clientIncidentId": "AA123",
+          "clientIncidentSource": "Jira"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/PerformanceImpacts/impact-001",
+        "name": "impact-001",
+        "type": "Microsoft.Impact/PerformanceImpacts",
+        "properties": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "high cup utilization",
+          "impactCategory": "Resource.Performance",
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "performance": [
+            {
+              "metricName": "CPU",
+              "actual": 90,
+              "expected": 60,
+              "unit": "garbage"
+            }
+          ],
+          "clientIncidentDetails": {
+            "clientIncidentId": "AA123",
+            "clientIncidentSource": "Jira"
+          },
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/PerformanceImpacts/impact-001",
+        "name": "impact-001",
+        "type": "Microsoft.Impact/PerformanceImpacts",
+        "properties": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "high cup utilization",
+          "impactCategory": "Resource.Performance",
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "performance": [
+            {
+              "metricName": "CPU",
+              "actual": 90,
+              "expected": 60,
+              "unit": "garbage"
+            }
+          ],
+          "clientIncidentDetails": {
+            "clientIncidentId": "AA123",
+            "clientIncidentSource": "Jira"
+          },
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2025-01-01-preview/topologyImpact_Create.json
+++ b/specification/impact/Impact.Management/examples/2025-01-01-preview/topologyImpact_Create.json
@@ -1,0 +1,88 @@
+{
+  "operationId": "TopologyImpacts_Create",
+  "title": "Reporting a topology impact",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2025-01-01-preview",
+    "topologyImpactName": "impact-002",
+    "resource": {
+      "properties": {
+        "impactedResources": [
+          {
+            "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm1"
+          }
+        ],
+        "startDateTime": "2022-06-15T05:59:46.6517821Z",
+        "endDateTime": null,
+        "impactDescription": "one of the resources is unavailable",
+        "impactCategory": "Availability",
+        "additionalProperties": {
+          "errorCode": "504",
+          "errorMessage": "Gateway timeout error"
+        },
+        "workload": {
+          "context": "webapp/scenario1",
+          "toolset": "Other"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Impacts-rg/providers/Microsoft.Impact/topologyImpacts/impact-001",
+        "name": "impact-001",
+        "type": "Microsoft.Impact/topologyImpacts",
+        "properties": {
+          "impactedResources": [
+            {
+              "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm1"
+            }
+          ],
+          "topologyImpactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "one of the resources is unavailable",
+          "impactCategory": "Availability",
+          "additionalProperties": {
+            "errorCode": "504",
+            "errorMessage": "Gateway timeout error"
+          },
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Impacts-rg/providers/Microsoft.Impact/topologyImpacts/impact-001",
+        "name": "impact-001",
+        "type": "Microsoft.Impact/topologyImpacts",
+        "properties": {
+          "impactedResources": [
+            {
+              "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm1"
+            }
+          ],
+          "topologyImpactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "one of the resources is unavailable",
+          "impactCategory": "Availability",
+          "additionalProperties": {
+            "errorCode": "504",
+            "errorMessage": "Gateway timeout error"
+          },
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2026-01-01-preview/Connectors_CreateOrUpdate.json
+++ b/specification/impact/Impact.Management/examples/2026-01-01-preview/Connectors_CreateOrUpdate.json
@@ -1,0 +1,91 @@
+{
+  "operationId": "Connectors_CreateOrUpdate",
+  "title": "CreateConnector",
+  "parameters": {
+    "api-version": "2026-01-01-preview",
+    "subscriptionId": "74f5e23f-d4d9-410a-bb4d-8f0608adb10d",
+    "connectorName": "testconnector1",
+    "resource": {
+      "properties": {
+        "connectorType": "AzureMonitor"
+      },
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/eu2cgroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1": {}
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "connectorId": "430a444e-6a84-4a6f-8c50-124843ca7cd4",
+          "tenantId": "23a8d1da-a7e9-4443-9797-4cd3e3aeb8f8",
+          "connectorType": "AzureMonitor",
+          "lastRunTimeStamp": "2024-03-19T06:23:56.238Z",
+          "processingState": "Initialized",
+          "processingStateMessage": ""
+        },
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/eu2cgroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1": {
+              "clientId": "fbe75b66-01c5-4f87-a220-233af3270436",
+              "principalId": "075a0ca6-43f6-4434-9abf-c9b1b79f9219"
+            }
+          }
+        },
+        "id": "/subscriptions/74f5e23f-d4d9-410a-bb4d-8f0608adb10d/providers/Microsoft.Impact/connectors/testconnector1",
+        "name": "testconnector1",
+        "type": "microsoft.impact/connectors",
+        "systemData": {
+          "createdBy": "testuser@hotmail.com",
+          "createdByType": "User",
+          "createdAt": "2024-03-07T06:19:01.6431721Z",
+          "lastModifiedBy": "testuser@hotmail.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-03-15T08:29:20.8549373Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+      },
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "connectorId": "430a444e-6a84-4a6f-8c50-124843ca7cd4",
+          "tenantId": "23a8d1da-a7e9-4443-9797-4cd3e3aeb8f8",
+          "connectorType": "AzureMonitor",
+          "lastRunTimeStamp": "2024-03-19T06:23:56.238Z",
+          "processingState": "Initialized",
+          "processingStateMessage": ""
+        },
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/eu2cgroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1": {
+              "clientId": "fbe75b66-01c5-4f87-a220-233af3270436",
+              "principalId": "075a0ca6-43f6-4434-9abf-c9b1b79f9219"
+            }
+          }
+        },
+        "id": "/subscriptions/74f5e23f-d4d9-410a-bb4d-8f0608adb10d/providers/Microsoft.Impact/connectors/testconnector1",
+        "name": "testconnector1",
+        "type": "microsoft.impact/connectors",
+        "systemData": {
+          "createdBy": "testuser@hotmail.com",
+          "createdByType": "User",
+          "createdAt": "2024-03-07T06:19:01.6431721Z",
+          "lastModifiedBy": "testuser@hotmail.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-03-15T08:29:20.8549373Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2026-01-01-preview/Connectors_Delete.json
+++ b/specification/impact/Impact.Management/examples/2026-01-01-preview/Connectors_Delete.json
@@ -1,0 +1,13 @@
+{
+  "title": "Connectors_Delete",
+  "operationId": "Connectors_Delete",
+  "parameters": {
+    "api-version": "2026-01-01-preview",
+    "subscriptionId": "8F74B371-8573-4773-9BDA-D546505BDB3A",
+    "connectorName": "testconnector1"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  }
+}

--- a/specification/impact/Impact.Management/examples/2026-01-01-preview/Connectors_Get.json
+++ b/specification/impact/Impact.Management/examples/2026-01-01-preview/Connectors_Get.json
@@ -1,0 +1,55 @@
+{
+  "operationId": "Connectors_Get",
+  "title": "GetConnector",
+  "parameters": {
+    "api-version": "2026-01-01-preview",
+    "subscriptionId": "74f5e23f-d4d9-410a-bb4d-8f0608adb10d",
+    "connectorName": "testconnector1",
+    "resource": {
+      "properties": {
+        "connectorType": "AzureMonitor"
+      },
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/eu2cgroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1": {}
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "connectorId": "430a444e-6a84-4a6f-8c50-124843ca7cd4",
+          "tenantId": "23a8d1da-a7e9-4443-9797-4cd3e3aeb8f8",
+          "connectorType": "AzureMonitor",
+          "lastRunTimeStamp": "2024-03-19T06:23:56.238Z",
+          "processingState": "Initialized",
+          "processingStateMessage": ""
+        },
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/eu2cgroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1": {
+              "clientId": "fbe75b66-01c5-4f87-a220-233af3270436",
+              "principalId": "075a0ca6-43f6-4434-9abf-c9b1b79f9219"
+            }
+          }
+        },
+        "id": "/subscriptions/74f5e23f-d4d9-410a-bb4d-8f0608adb10d/providers/Microsoft.Impact/connectors/testconnector1",
+        "name": "testconnector1",
+        "type": "microsoft.impact/connectors",
+        "systemData": {
+          "createdBy": "testuser@hotmail.com",
+          "createdByType": "User",
+          "createdAt": "2024-03-07T06:19:01.6431721Z",
+          "lastModifiedBy": "testuser@hotmail.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-03-15T08:29:20.8549373Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2026-01-01-preview/Connectors_ListBySubscription.json
+++ b/specification/impact/Impact.Management/examples/2026-01-01-preview/Connectors_ListBySubscription.json
@@ -1,0 +1,48 @@
+{
+  "title": "Connectors_ListBySubscription",
+  "operationId": "Connectors_ListBySubscription",
+  "parameters": {
+    "api-version": "2026-01-01-preview",
+    "subscriptionId": "74f5e23f-d4d9-410a-bb4d-8f0608adb10d"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "provisioningState": "Succeeded",
+              "connectorId": "430a444e-6a84-4a6f-8c50-124843ca7cd4",
+              "tenantId": "23a8d1da-a7e9-4443-9797-4cd3e3aeb8f8",
+              "connectorType": "AzureMonitor",
+              "lastRunTimeStamp": "2024-03-19T06:23:56.238Z",
+              "processingState": "Initialized",
+              "processingStateMessage": ""
+            },
+            "identity": {
+              "type": "UserAssigned",
+              "userAssignedIdentities": {
+                "/subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/eu2cgroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1": {
+                  "clientId": "fbe75b66-01c5-4f87-a220-233af3270436",
+                  "principalId": "075a0ca6-43f6-4434-9abf-c9b1b79f9219"
+                }
+              }
+            },
+            "id": "/subscriptions/74f5e23f-d4d9-410a-bb4d-8f0608adb10d/providers/Microsoft.Impact/connectors/testconnector1",
+            "name": "testconnector1",
+            "type": "microsoft.impact/connectors",
+            "systemData": {
+              "createdBy": "testuser@hotmail.com",
+              "createdByType": "User",
+              "createdAt": "2024-03-07T06:19:01.6431721Z",
+              "lastModifiedBy": "testuser@hotmail.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2024-03-15T08:29:20.8549373Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2026-01-01-preview/Connectors_Update.json
+++ b/specification/impact/Impact.Management/examples/2026-01-01-preview/Connectors_Update.json
@@ -1,0 +1,55 @@
+{
+  "title": "Connectors_Update",
+  "operationId": "Connectors_Update",
+  "parameters": {
+    "api-version": "2026-01-01-preview",
+    "subscriptionId": "74f5e23f-d4d9-410a-bb4d-8f0608adb10d",
+    "connectorName": "testconnector1",
+    "properties": {
+      "properties": {
+        "connectorType": "AzureMonitor"
+      },
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/eu2cgroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1": {}
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "connectorId": "430a444e-6a84-4a6f-8c50-124843ca7cd4",
+          "tenantId": "23a8d1da-a7e9-4443-9797-4cd3e3aeb8f8",
+          "connectorType": "AzureMonitor",
+          "lastRunTimeStamp": "2024-03-19T06:23:56.238Z",
+          "processingState": "Initialized",
+          "processingStateMessage": ""
+        },
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/eu2cgroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1": {
+              "clientId": "fbe75b66-01c5-4f87-a220-233af3270436",
+              "principalId": "075a0ca6-43f6-4434-9abf-c9b1b79f9219"
+            }
+          }
+        },
+        "id": "/subscriptions/74f5e23f-d4d9-410a-bb4d-8f0608adb10d/providers/Microsoft.Impact/connectors/testconnector1",
+        "name": "testconnector1",
+        "type": "microsoft.impact/connectors",
+        "systemData": {
+          "createdBy": "testuser@hotmail.com",
+          "createdByType": "User",
+          "createdAt": "2024-03-07T06:19:01.6431721Z",
+          "lastModifiedBy": "testuser@hotmail.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-03-15T08:29:20.8549373Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2026-01-01-preview/ImpactCategories_Get.json
+++ b/specification/impact/Impact.Management/examples/2026-01-01-preview/ImpactCategories_Get.json
@@ -1,0 +1,28 @@
+{
+  "operationId": "ImpactCategories_Get",
+  "title": "Get WorkloadImpact Resource by name",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-01-01-preview",
+    "impactCategoryName": "ARMOperation.Create"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/ImpactCategories/ARMOperation.Create",
+        "name": "ARMOperation.Create",
+        "type": "Microsoft.Impact/impactCategories",
+        "properties": {
+          "description": "Use this to report problems related to creating a new azure virtual machine such as provisioning or allocation failures.",
+          "categoryId": "778f815b-6576-4a36-bea9-bffb3d26d7f4",
+          "parentCategoryId": "36266d25-9c53-40b3-af41-27418b11851e",
+          "requiredImpactProperties": [
+            {
+              "name": "armCorrelations"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2026-01-01-preview/ImpactCategories_ListBySubscription.json
+++ b/specification/impact/Impact.Management/examples/2026-01-01-preview/ImpactCategories_ListBySubscription.json
@@ -1,0 +1,82 @@
+{
+  "operationId": "ImpactCategories_ListBySubscription",
+  "title": "Get ImpactCategories list by subscription",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceType": "microsoft.compute/virtualmachines",
+    "api-version": "2026-01-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/ImpactCategories/ARMOperation.Create",
+            "name": "ARMOperation.Create",
+            "type": "Microsoft.Impact/impactCategories",
+            "properties": {
+              "description": "Use this to report problems related to creating a new azure virtual machine such as provisioning or allocation failures.",
+              "categoryId": "778f815b-6576-4a36-bea9-bffb3d26d7f4",
+              "parentCategoryId": "36266d25-9c53-40b3-af41-27418b11851e",
+              "requiredImpactProperties": [
+                {
+                  "name": "armCorrelations"
+                }
+              ]
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/ImpactCategories/ARMOperation.Delete",
+            "name": "ARMOperation.Delete",
+            "type": "Microsoft.Impact/impactCategories",
+            "properties": {
+              "description": "Use this to report failures in deleting VMs.",
+              "categoryId": "a9a0c6e2-1208-406f-8f4f-1ccc13fb75d5",
+              "parentCategoryId": "36266d25-9c53-40b3-af41-27418b11851e",
+              "requiredImpactProperties": [
+                {
+                  "name": "armCorrelations"
+                }
+              ]
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/ImpactCategories/ARMOperation.Other",
+            "name": "ARMOperation.Other",
+            "type": "Microsoft.Impact/impactCategories",
+            "properties": {
+              "description": "Use this to report Control Plane operation failures that don't fall into other ARMOperation categories",
+              "categoryId": "7b71f937-9344-499c-bfbe-d86fb755d891",
+              "parentCategoryId": "36266d25-9c53-40b3-af41-27418b11851e",
+              "requiredImpactProperties": [
+                {
+                  "name": "armCorrelations"
+                }
+              ]
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/ImpactCategories/Resource.Connectivity",
+            "name": "Resource.Connectivity",
+            "type": "Microsoft.Impact/impactCategories",
+            "properties": {
+              "description": "Use this to report connectivity issues to or from a VM.",
+              "categoryId": "95903644-3a15-4e37-b4be-a2ae8651f27b",
+              "parentCategoryId": "a8d1c1ae-5fcb-4a8b-a647-fd0a911e8667"
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/ImpactCategories/Resource.Connectivity.Inbound",
+            "name": "Resource.Connectivity.Inbound",
+            "type": "Microsoft.Impact/impactCategories",
+            "properties": {
+              "description": "Use this to report inbound connectivity issues to a VM.",
+              "categoryId": "940fb706-8586-4a0e-bb18-2e2d0ef0708d",
+              "parentCategoryId": "95903644-3a15-4e37-b4be-a2ae8651f27b"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2026-01-01-preview/Insights_Create.json
+++ b/specification/impact/Impact.Management/examples/2026-01-01-preview/Insights_Create.json
@@ -1,0 +1,73 @@
+{
+  "operationId": "Insights_Create",
+  "title": "Creating an insight",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-01-01-preview",
+    "workloadImpactName": "impactid22",
+    "insightName": "insightId12",
+    "resource": {
+      "properties": {
+        "content": {
+          "title": "Impact Has been correlated to an outage",
+          "description": "At 2018-11-08T00:00:00Z UTC, your services dependent on these resources <link href=”…”>VM1</link> may have experienced an issue. <br/><div>We have identified an outage that affected these resources(s). You can look at outage information on <link href=\"https:// portal.azure.com/#view/Microsoft_Azure_Health/AzureHealthBrowseBlade/~/serviceIssues/trackingId/NL2W-VCZ\">NL2W-VCZ</link> link.<div>"
+        },
+        "category": "repair",
+        "status": "resolved",
+        "eventTime": "2023-06-15T04:00:00.009223Z",
+        "insightUniqueId": "00000000-0000-0000-0000-000000000000",
+        "impact": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+          "startTime": "2023-06-15T01:00:00.009223Z",
+          "impactId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/workloadImpacts/impactid22"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/workloadImpacts/impactid22/insights/insightId12",
+        "name": "insightId12",
+        "type": "Microsoft.Impact/insights",
+        "properties": {
+          "eventTime": "2023-06-15T04:00:00.009223Z",
+          "content": {
+            "title": "Impact Has been correlated to an outage",
+            "description": "At 2018-11-08T00:00:00Z UTC, your services dependent on these resources <link href=”…”>VM1</link> may have experienced an issue. <br/><div>We have identified an outage that affected these resources(s). You can look at outage information on <link href=\"https:// portal.azure.com/#view/Microsoft_Azure_Health/AzureHealthBrowseBlade/~/serviceIssues/trackingId/NL2W-VCZ\">NL2W-VCZ</link> link.<div>"
+          },
+          "category": "repair",
+          "status": "resolved",
+          "insightUniqueId": "00000000-0000-0000-0000-000000000000",
+          "impact": {
+            "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+            "startTime": "2023-06-15T01:00:00.009223Z",
+            "impactId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/workloadImpacts/impactid22"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/workloadImpacts/impactid22/insights/insightId12",
+        "name": "insightId12",
+        "type": "Microsoft.Impact/insights",
+        "properties": {
+          "eventTime": "2023-06-15T04:00:00.009223Z",
+          "content": {
+            "title": "Impact Has been correlated to an outage",
+            "description": "At 2018-11-08T00:00:00Z UTC, your services dependent on these resources <link href=”…”>VM1</link> may have experienced an issue. <br/><div>We have identified an outage that affected these resources(s). You can look at outage information on <link href=\"https:// portal.azure.com/#view/Microsoft_Azure_Health/AzureHealthBrowseBlade/~/serviceIssues/trackingId/NL2W-VCZ\">NL2W-VCZ</link> link.<div>"
+          },
+          "category": "repair",
+          "status": "resolved",
+          "insightUniqueId": "00000000-0000-0000-0000-000000000000",
+          "impact": {
+            "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+            "startTime": "2023-06-15T01:00:00.009223Z",
+            "impactId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/workloadImpacts/impactid22"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2026-01-01-preview/Insights_Delete.json
+++ b/specification/impact/Impact.Management/examples/2026-01-01-preview/Insights_Delete.json
@@ -1,0 +1,14 @@
+{
+  "operationId": "Insights_Delete",
+  "title": "Delete an Insight",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-01-01-preview",
+    "workloadImpactName": "impactid22",
+    "insightName": "insightId12"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  }
+}

--- a/specification/impact/Impact.Management/examples/2026-01-01-preview/Insights_Get_diagnostics.json
+++ b/specification/impact/Impact.Management/examples/2026-01-01-preview/Insights_Get_diagnostics.json
@@ -1,0 +1,33 @@
+{
+  "operationId": "Insights_Get",
+  "title": "Get Insight sample for Diagnostics category",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-01-01-preview",
+    "workloadImpactName": "impactid",
+    "insightName": "insight1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadimpacts/impactid/insights/insight1",
+        "name": "insight1",
+        "type": "Microsoft.impact/workloadimpacts/insights",
+        "properties": {
+          "category": "Diagnostics",
+          "impact": {
+            "impactId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadimpacts/impactid",
+            "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/virtualamchine/vm",
+            "startTime": "2018-11-08T00:00:00Z",
+            "endTime": "2018-11-08T00:00:00Z"
+          },
+          "insightUniqueId": "00000000-0000-0000-0000-000000000000",
+          "content": {
+            "title": "We ran diagnostics on your resource and found an issue",
+            "description": "<!--issueDescription-->\n<p>The physical host node where your VM is running had a networking stack update. This might result in a brief connectivity loss.</p>\n<br/><table><tr><th align=\"left\">Resource</th><th align=\"left\">Impact Start Time</th><th align=\"left\">Impact End Time</th><th align=\"left\">Impact Duration(Timespan)</th></tr><tr><td align=\"left\">west-eur-VM</td><td align=\"left\">2024-02-18 01:09:31 UTC</td><td align=\"left\">2024-02-18 01:09:35 UTC</td><td align=\"left\">00:00:04.2690000</td></tr></table>\n<!--/issueDescription-->\n<p>Azure performs updates to improve reliability, performance, and security of the VMs. Azure chooses the least impactful method, which might result in a brief connectivity loss. We are continuously working to improve and reduce impact of our updates, and we apologize for any inconvenience this may have caused you.</p>\n<!--recommendedActions-->\n<h2><strong>Recommended Documents</strong></h2>\n<ul>\n<li>To prepare for VM maintenance events and reduce its impact, try using <a href=\"https://docs.microsoft.com/azure/virtual-machines/windows/scheduled-events\">Scheduled Events for Windows</a> or <a href=\"https://docs.microsoft.com/azure/virtual-machines/linux/scheduled-events\">Linux</a></li>\n<li>Learn more about Azure maintenance and configuring for high availability:\n<ul>\n<li><a href=\"https://docs.microsoft.com/azure/virtual-machines/maintenance-and-updates\">Maintenance and updates for virtual machines in Azure</a></li>\n<li><a href=\"https://docs.microsoft.com/azure/virtual-machines/windows/tutorial-availability-sets\">Configure availability of virtual machines</a></li>\n</ul>\n</li>\n<li>To troubleshoot this scenario in the future, see <a href=\"https://docs.microsoft.com/azure/resource-health/resource-health-overview\">Resource Health Center</a></li>\n</ul>\n"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2026-01-01-preview/Insights_Get_mitigationAction.json
+++ b/specification/impact/Impact.Management/examples/2026-01-01-preview/Insights_Get_mitigationAction.json
@@ -1,0 +1,38 @@
+{
+  "operationId": "Insights_Get",
+  "title": "Get Insight sample for MitigationAction category",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-01-01-preview",
+    "workloadImpactName": "impactId",
+    "insightName": "HPCUASucceeded"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadimpacts/impactId/insights/HPCUASucceeded",
+        "name": "HPCUASucceeded",
+        "type": "Microsoft.impact/workloadimpacts/insights",
+        "properties": {
+          "category": "MitigationAction",
+          "eventTime": "2023-06-15T04:00:00.009223Z",
+          "insightUniqueId": "00000000-0000-0000-0000-000000000000",
+          "impact": {
+            "impactId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadimpacts/impactId",
+            "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/virtualMachine/vm",
+            "startTime": "2018-11-08T00:00:00Z",
+            "endTime": "2018-11-08T00:00:00Z"
+          },
+          "content": {
+            "title": "Node was flagged for inspection",
+            "description": "At 2024-02-16 21:05:07 (UTC) an impact was reported on west-eur-VM indicating a potential disruption from Azure platform. <strong>Action Taken</strong> The hardware your VM was running on was flagged for inspection. We will conduct our investigation and take corrective action to prevent further impact on your workloads. We apologize for any disruption. Microsoft Azure Team"
+          },
+          "additionalDetails": {
+            "statusCode": "Succeeded",
+            "terminalState": "true"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2026-01-01-preview/Insights_Get_servicehealth.json
+++ b/specification/impact/Impact.Management/examples/2026-01-01-preview/Insights_Get_servicehealth.json
@@ -1,0 +1,35 @@
+{
+  "operationId": "Insights_Get",
+  "title": "Get Insight sample for service health category",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-01-01-preview",
+    "workloadImpactName": "impactid",
+    "insightName": "insightname"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/workloadImpacts/impactname/insights/insightname",
+        "name": "insightname",
+        "type": "Microsoft.Impact/insights",
+        "properties": {
+          "category": "ServiceHealth",
+          "eventId": "ABC-123",
+          "eventTime": "2023-06-15T04:00:00.009223Z",
+          "impact": {
+            "impactId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadimpacts/impactid",
+            "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.compute/virtualmachines/vm1",
+            "startTime": "2018-11-08T00:00:00Z",
+            "endTime": "2018-11-08T00:00:00Z"
+          },
+          "insightUniqueId": "a3d91a07-698b-4044-a230-e918252c4c59",
+          "content": {
+            "title": "Impact Has been correlated to an outage",
+            "description": "On November 8, 2018, at 00:00 UTC, there may have been disruptions to your services linked to the resource <a href='...'>VM1<a>. We have pinpointed a service outage impacting these resources. For details on this outage, please refer to the service health information available at <a href='...'>service health</a>."
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2026-01-01-preview/Insights_ListBySubscription.json
+++ b/specification/impact/Impact.Management/examples/2026-01-01-preview/Insights_ListBySubscription.json
@@ -1,0 +1,37 @@
+{
+  "operationId": "Insights_ListBySubscription",
+  "title": "List Insight resources by workloadImpactName",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "workloadImpactName": "impactid22",
+    "api-version": "2026-01-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/workloadImpacts/impactid22/insights/insightId12",
+            "name": "insightId12",
+            "type": "Microsoft.Impact/insights",
+            "properties": {
+              "eventTime": "2023-06-15T04:00:00.009223Z",
+              "content": {
+                "title": "Impact Has been correlated to an outage",
+                "description": "At 2018-11-08T00:00:00Z UTC, your services dependent on these resources <link href=”…”>VM1</link> may have experienced an issue. <br/><div>We have identified an outage that affected these resources(s). You can look at outage information on <link href=\"https:// portal.azure.com/#view/Microsoft_Azure_Health/AzureHealthBrowseBlade/~/serviceIssues/trackingId/NL2W-VCZ\">NL2W-VCZ</link> link.<div>"
+              },
+              "category": "repair",
+              "status": "resolved",
+              "insightUniqueId": "00000000-0000-0000-0000-000000000000",
+              "impact": {
+                "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+                "startTime": "2023-06-15T01:00:00.009223Z",
+                "impactId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/workloadImpacts/impactid22"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2026-01-01-preview/Operations_List.json
+++ b/specification/impact/Impact.Management/examples/2026-01-01-preview/Operations_List.json
@@ -1,0 +1,52 @@
+{
+  "operationId": "Operations_List",
+  "title": "OperationsList",
+  "parameters": {
+    "api-version": "2026-01-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.Impact/workloadImpacts/write",
+            "display": {
+              "provider": "Microsoft.Impact",
+              "resource": "workloadImpacts",
+              "operation": "write",
+              "description": "Write workloadImpact resources"
+            }
+          },
+          {
+            "name": "Microsoft.Impact/workloadImpacts/read",
+            "display": {
+              "provider": "Microsoft.Impact",
+              "resource": "workloadimpacts",
+              "operation": "read",
+              "description": "Read workloadImpact resources"
+            }
+          },
+          {
+            "name": "Microsoft.Impact/impactCategories/read",
+            "display": {
+              "provider": "Microsoft.Impact",
+              "resource": "impactCategories",
+              "operation": "read",
+              "description": "Read impactCategory resources"
+            }
+          },
+          {
+            "name": "Microsoft.Impact/getUploadToken/action",
+            "display": {
+              "provider": "Microsoft.Impact",
+              "resource": "getUploadToken",
+              "operation": "Get Upload Token",
+              "description": "Get an upload token for the storage account and container to upload logs associated with impacts."
+            }
+          }
+        ],
+        "nextLink": null
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2026-01-01-preview/TopologyImpact_Delete.json
+++ b/specification/impact/Impact.Management/examples/2026-01-01-preview/TopologyImpact_Delete.json
@@ -1,0 +1,13 @@
+{
+  "operationId": "TopologyImpacts_Delete",
+  "title": "Delete topologyImpact Resource by name",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-01-01-preview",
+    "topologyImpactName": "impact-001"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  }
+}

--- a/specification/impact/Impact.Management/examples/2026-01-01-preview/TopologyImpact_Get.json
+++ b/specification/impact/Impact.Management/examples/2026-01-01-preview/TopologyImpact_Get.json
@@ -1,0 +1,39 @@
+{
+  "operationId": "TopologyImpacts_Get",
+  "title": "Get TopologyImpact Resource by name",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-01-01-preview",
+    "topologyImpactName": "impact-001"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/topologyImpacts/impact-001",
+        "name": "impact-001-",
+        "type": "Microsoft.Impact/topologyImpacts",
+        "properties": {
+          "impactedResources": [
+            {
+              "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm1"
+            }
+          ],
+          "topologyImpactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "one of the resources is unavailable",
+          "impactCategory": "Availability",
+          "additionalProperties": {
+            "errorCode": "504",
+            "errorMessage": "Gateway timeout error"
+          },
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2026-01-01-preview/TopologyImpact_ListBySubscription.json
+++ b/specification/impact/Impact.Management/examples/2026-01-01-preview/TopologyImpact_ListBySubscription.json
@@ -1,0 +1,42 @@
+{
+  "operationId": "TopologyImpacts_ListBySubscription",
+  "title": "List TopologyImpact resources by subscription",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-01-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Impacts-rg/providers/Microsoft.Impact/topologyImpacts/impact-001",
+            "name": "impact-001",
+            "type": "Microsoft.Impact/topologyImpacts",
+            "properties": {
+              "impactedResources": [
+                {
+                  "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm1"
+                }
+              ],
+              "topologyImpactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+              "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z",
+              "startDateTime": "2022-06-15T05:59:46.6517821Z",
+              "endDateTime": null,
+              "impactDescription": "one of the resources is unavailable",
+              "impactCategory": "Availability",
+              "additionalProperties": {
+                "errorCode": "504",
+                "errorMessage": "Gateway timeout error"
+              },
+              "workload": {
+                "context": "webapp/scenario1",
+                "toolset": "Other"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2026-01-01-preview/UploadService_GetUploadToken.json
+++ b/specification/impact/Impact.Management/examples/2026-01-01-preview/UploadService_GetUploadToken.json
@@ -1,0 +1,15 @@
+{
+  "operationId": "UploadService_GetUploadToken",
+  "title": "Get upload token to use for log upload",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-01-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "uploadUrl": "https://storageAccountHere.blob.core.windows.net/container-here/yyyyMMddHHmmss-12345678.zip?[SAS-token]"
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2026-01-01-preview/WorkloadArmOperation_create.json
+++ b/specification/impact/Impact.Management/examples/2026-01-01-preview/WorkloadArmOperation_create.json
@@ -1,0 +1,99 @@
+{
+  "operationId": "WorkloadImpacts_Create",
+  "title": "Reporting Arm operation failure",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-01-01-preview",
+    "workloadImpactName": "impact-002",
+    "resource": {
+      "properties": {
+        "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservercontext",
+        "startDateTime": "2022-06-15T05:59:46.6517821Z",
+        "endDateTime": null,
+        "impactDescription": "deletion of resource failed",
+        "impactCategory": "ArmOperation",
+        "armCorrelationIds": [
+          "00000000-0000-0000-0000-000000000000"
+        ],
+        "workload": {
+          "context": "webapp/scenario1",
+          "toolset": "Other"
+        },
+        "clientIncidentDetails": {
+          "clientIncidentId": "AA123",
+          "clientIncidentSource": "Jira"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadImpacts/impact-001",
+        "name": "impact-001",
+        "type": "Microsoft.Impact/workloadImpacts",
+        "properties": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "deletion of resource failed",
+          "impactCategory": "ArmOperation",
+          "armCorrelationIds": [
+            "00000000-0000-0000-0000-000000000000"
+          ],
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "clientIncidentDetails": {
+            "clientIncidentId": "AA123",
+            "clientIncidentSource": "Jira"
+          },
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z",
+          "insightsByCategory": [
+            {
+              "category": "service health",
+              "status": "investigating",
+              "insights": []
+            }
+          ]
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadImpacts/impact-001",
+        "name": "impact-001",
+        "type": "Microsoft.Impact/workloadImpacts",
+        "properties": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "deletion of resource failed",
+          "impactCategory": "ArmOperation",
+          "armCorrelationIds": [
+            "00000000-0000-0000-0000-000000000000"
+          ],
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "clientIncidentDetails": {
+            "clientIncidentId": "AA123",
+            "clientIncidentSource": "Jira"
+          },
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z",
+          "insightsByCategory": [
+            {
+              "category": "service health",
+              "status": "investigating",
+              "insights": []
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2026-01-01-preview/WorkloadAvailability_Create.json
+++ b/specification/impact/Impact.Management/examples/2026-01-01-preview/WorkloadAvailability_Create.json
@@ -1,0 +1,90 @@
+{
+  "operationId": "WorkloadImpacts_Create",
+  "title": "Reporting availability related impact",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-01-01-preview",
+    "workloadImpactName": "impact-002",
+    "resource": {
+      "properties": {
+        "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservercontext",
+        "startDateTime": "2022-06-15T05:59:46.6517821Z",
+        "endDateTime": null,
+        "impactDescription": "read calls failed",
+        "impactCategory": "Availability",
+        "workload": {
+          "context": "webapp/scenario1",
+          "toolset": "Other"
+        },
+        "clientIncidentDetails": {
+          "clientIncidentId": "AA123",
+          "clientIncidentSource": "Jira"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadImpacts/impact-002",
+        "name": "impact-002",
+        "type": "Microsoft.Impact/workloadImpacts",
+        "properties": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "read calls failed",
+          "impactCategory": "Availability",
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "clientIncidentDetails": {
+            "clientIncidentId": "AA123",
+            "clientIncidentSource": "Jira"
+          },
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z",
+          "insightsByCategory": [
+            {
+              "category": "service health",
+              "status": "investigating",
+              "insights": []
+            }
+          ]
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadImpacts/impact-002",
+        "name": "impact-001",
+        "type": "Microsoft.Impact/workloadImpacts",
+        "properties": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "read calls failed",
+          "impactCategory": "Availability",
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "clientIncidentDetails": {
+            "clientIncidentId": "AA123",
+            "clientIncidentSource": "Jira"
+          },
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z",
+          "insightsByCategory": [
+            {
+              "category": "service health",
+              "status": "investigating",
+              "insights": []
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2026-01-01-preview/WorkloadConnectivityImpact_Create.json
+++ b/specification/impact/Impact.Management/examples/2026-01-01-preview/WorkloadConnectivityImpact_Create.json
@@ -1,0 +1,120 @@
+{
+  "operationId": "WorkloadImpacts_Create",
+  "title": "Reporting a connectivity impact",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-01-01-preview",
+    "workloadImpactName": "impact-001",
+    "resource": {
+      "properties": {
+        "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservercontext",
+        "startDateTime": "2022-06-15T05:59:46.6517821Z",
+        "endDateTime": null,
+        "impactDescription": "conection failure",
+        "impactCategory": "Resource.Connectivity",
+        "connectivity": {
+          "protocol": "TCP",
+          "port": 1443,
+          "source": {
+            "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceSub/providers/Microsoft.compute/virtualmachines/vm1"
+          },
+          "target": {
+            "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceSub/providers/Microsoft.compute/virtualmachines/vm2"
+          }
+        },
+        "workload": {
+          "context": "webapp/scenario1",
+          "toolset": "Other"
+        },
+        "clientIncidentDetails": {
+          "clientIncidentId": "AA123",
+          "clientIncidentSource": "Jira"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Impacts-rg/providers/Microsoft.Impact/workloadImpacts/impact-001",
+        "name": "impact-001",
+        "type": "Microsoft.Impact/workloadImpacts",
+        "properties": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservercontext",
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "conection failure",
+          "impactCategory": "Resource.Connectivity",
+          "connectivity": {
+            "protocol": "TCP",
+            "port": 1443,
+            "source": {
+              "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceSub/providers/Microsoft.compute/virtualmachines/vm1"
+            },
+            "target": {
+              "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceSub/providers/Microsoft.compute/virtualmachines/vm2"
+            }
+          },
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "clientIncidentDetails": {
+            "clientIncidentId": "AA123",
+            "clientIncidentSource": "Jira"
+          },
+          "insightsByCategory": [
+            {
+              "category": "service health",
+              "status": "investigating",
+              "insights": []
+            }
+          ]
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Impacts-rg/providers/Microsoft.Impact/workloadImpacts/impact-001",
+        "name": "impact-001",
+        "type": "Microsoft.Impact/workloadImpacts",
+        "properties": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservercontext",
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "conection failure",
+          "impactCategory": "Resource.Connectivity",
+          "connectivity": {
+            "protocol": "TCP",
+            "port": 1443,
+            "source": {
+              "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceSub/providers/Microsoft.compute/virtualmachines/vm1"
+            },
+            "target": {
+              "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceSub/providers/Microsoft.compute/virtualmachines/vm2"
+            }
+          },
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "clientIncidentDetails": {
+            "clientIncidentId": "AA123",
+            "clientIncidentSource": "Jira"
+          },
+          "insightsByCategory": [
+            {
+              "category": "service health",
+              "status": "investigating",
+              "insights": []
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2026-01-01-preview/WorkloadImpact_Delete.json
+++ b/specification/impact/Impact.Management/examples/2026-01-01-preview/WorkloadImpact_Delete.json
@@ -1,0 +1,13 @@
+{
+  "operationId": "WorkloadImpacts_Delete",
+  "title": "Delete WorkloadImpact Resource by name example",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-01-01-preview",
+    "workloadImpactName": "impact-001"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  }
+}

--- a/specification/impact/Impact.Management/examples/2026-01-01-preview/WorkloadImpact_Get.json
+++ b/specification/impact/Impact.Management/examples/2026-01-01-preview/WorkloadImpact_Get.json
@@ -1,0 +1,46 @@
+{
+  "operationId": "WorkloadImpacts_Get",
+  "title": "Get WorkloadImpact Resource by name example",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-01-01-preview",
+    "workloadImpactName": "impact-001"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadImpacts/impact-001",
+        "name": "impact-001",
+        "type": "Microsoft.Impact/workloadImpacts",
+        "properties": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "high cup utilization",
+          "impactCategory": "Performance",
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "clientIncidentDetails": {
+            "clientIncidentId": "AA123",
+            "clientIncidentSource": "Jira"
+          },
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z",
+          "insightsByCategory": [
+            {
+              "category": "service health",
+              "status": "Completed",
+              "insights": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadImpacts/impact-001/insight/insightId"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2026-01-01-preview/WorkloadImpacts_Create_MaximumSet_Gen.json
+++ b/specification/impact/Impact.Management/examples/2026-01-01-preview/WorkloadImpacts_Create_MaximumSet_Gen.json
@@ -1,0 +1,211 @@
+{
+  "title": "WorkloadImpacts_Create_MaximumSet",
+  "operationId": "WorkloadImpacts_Create",
+  "parameters": {
+    "api-version": "2026-01-01-preview",
+    "subscriptionId": "0D045314-435A-41DA-B0A4-2CA7E9F87D12",
+    "workloadImpactName": "testWorkloadImpact",
+    "resource": {
+      "properties": {
+        "startDateTime": "2024-12-04T19:51:13.274Z",
+        "endDateTime": "2024-12-04T19:51:13.274Z",
+        "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+        "impactCategory": "Resource.Other",
+        "impactDescription": "test description",
+        "armCorrelationIds": [
+          "4D045314-435A-41DA-B0A4-2CA7E9F87D12"
+        ],
+        "performance": [
+          {
+            "metricName": "testMetric",
+            "expected": 23,
+            "actual": 20,
+            "expectedValueRange": {
+              "min": 1,
+              "max": 27
+            },
+            "unit": "ByteSeconds"
+          }
+        ],
+        "connectivity": {
+          "protocol": "TCP",
+          "port": 6,
+          "source": {
+            "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm1"
+          },
+          "target": {
+            "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm2"
+          }
+        },
+        "additionalProperties": {},
+        "errorDetails": {
+          "errorCode": "504",
+          "errorMessage": "Gateway timeout error"
+        },
+        "workload": {
+          "context": "webapp/scenario1",
+          "toolset": "Other"
+        },
+        "impactGroupId": "testGroup1",
+        "confidenceLevel": "Low",
+        "clientIncidentDetails": {
+          "clientIncidentId": "123456",
+          "clientIncidentSource": "AzureDevops"
+        },
+        "ongoingImpact": true,
+        "severity": "Critical",
+        "durationInSec": 26,
+        "detectionType": "BusinessAlert",
+        "durationMarginInSec": 28,
+        "hitCount": 21
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "startDateTime": "2024-12-04T19:51:13.274Z",
+          "endDateTime": "2024-12-04T19:51:13.274Z",
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm1",
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2024-12-04T19:51:13.274Z",
+          "impactCategory": "Resource.Other",
+          "impactDescription": "Test description",
+          "armCorrelationIds": [
+            "4D045314-435A-41DA-B0A4-2CA7E9F87D12"
+          ],
+          "performance": [
+            {
+              "metricName": "testMetric",
+              "expected": 23,
+              "actual": 20,
+              "expectedValueRange": {
+                "min": 1,
+                "max": 27
+              },
+              "unit": "ByteSeconds"
+            }
+          ],
+          "connectivity": {
+            "protocol": "TCP",
+            "port": 6,
+            "source": {
+              "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm1"
+            },
+            "target": {
+              "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm2"
+            }
+          },
+          "additionalProperties": {},
+          "errorDetails": {
+            "errorCode": "504",
+            "errorMessage": "Gateway timeout error"
+          },
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "impactGroupId": "testGroup1",
+          "confidenceLevel": "Low",
+          "clientIncidentDetails": {
+            "clientIncidentId": "123456",
+            "clientIncidentSource": "AzureDevops"
+          },
+          "ongoingImpact": true,
+          "severity": "Critical",
+          "durationInSec": 26,
+          "detectionType": "BusinessAlert",
+          "durationMarginInSec": 28,
+          "hitCount": 21
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Impacts-rg/providers/Microsoft.Impact/workloadImpacts/impact2",
+        "name": "testWorkloadImpact",
+        "type": "Microsoft.Impact/workloadImpacts",
+        "systemData": {
+          "createdBy": "testuser@hotmail.com",
+          "createdByType": "User",
+          "createdAt": "2024-03-07T06:19:01.6431721Z",
+          "lastModifiedBy": "testuser@hotmail.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-03-15T08:29:20.8549373Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+      },
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "startDateTime": "2024-12-04T19:51:13.274Z",
+          "endDateTime": "2024-12-04T19:51:13.274Z",
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm1",
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2024-12-04T19:51:13.274Z",
+          "impactCategory": "Resource.Other",
+          "impactDescription": "Test description",
+          "armCorrelationIds": [
+            "4D045314-435A-41DA-B0A4-2CA7E9F87D12"
+          ],
+          "performance": [
+            {
+              "metricName": "testMetric",
+              "expected": 23,
+              "actual": 20,
+              "expectedValueRange": {
+                "min": 1,
+                "max": 27
+              },
+              "unit": "ByteSeconds"
+            }
+          ],
+          "connectivity": {
+            "protocol": "TCP",
+            "port": 6,
+            "source": {
+              "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm1"
+            },
+            "target": {
+              "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm2"
+            }
+          },
+          "additionalProperties": {},
+          "errorDetails": {
+            "errorCode": "504",
+            "errorMessage": "Gateway timeout error"
+          },
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "impactGroupId": "testGroup1",
+          "confidenceLevel": "Low",
+          "clientIncidentDetails": {
+            "clientIncidentId": "123456",
+            "clientIncidentSource": "AzureDevops"
+          },
+          "ongoingImpact": true,
+          "severity": "Critical",
+          "durationInSec": 26,
+          "detectionType": "BusinessAlert",
+          "durationMarginInSec": 28,
+          "hitCount": 21
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Impacts-rg/providers/Microsoft.Impact/workloadImpacts/impact2",
+        "name": "testWorkloadImpact",
+        "type": "Microsoft.Impact/workloadImpacts",
+        "systemData": {
+          "createdBy": "testuser@hotmail.com",
+          "createdByType": "User",
+          "createdAt": "2024-03-07T06:19:01.6431721Z",
+          "lastModifiedBy": "testuser@hotmail.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-03-15T08:29:20.8549373Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2026-01-01-preview/WorkloadImpacts_ListBySubscription.json
+++ b/specification/impact/Impact.Management/examples/2026-01-01-preview/WorkloadImpacts_ListBySubscription.json
@@ -1,0 +1,38 @@
+{
+  "operationId": "WorkloadImpacts_ListBySubscription",
+  "title": "List WorkloadImpact resources by subscription",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-01-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Impacts-rg/providers/Microsoft.Impact/workloadImpacts/impact2",
+            "name": "impact2",
+            "type": "Microsoft.Impact/workloadImpacts",
+            "properties": {
+              "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm1",
+              "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+              "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z",
+              "startDateTime": "2022-06-15T05:59:46.6517821Z",
+              "endDateTime": null,
+              "impactDescription": "",
+              "impactCategory": "Resource.Other",
+              "additionalProperties": {
+                "errorCode": "504",
+                "errorMessage": "Gateway timeout error"
+              },
+              "workload": {
+                "context": "webapp/scenario1",
+                "toolset": "Other"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2026-01-01-preview/WorkloadPerformance_Create.json
+++ b/specification/impact/Impact.Management/examples/2026-01-01-preview/WorkloadPerformance_Create.json
@@ -1,0 +1,114 @@
+{
+  "operationId": "WorkloadImpacts_Create",
+  "title": "Reporting performance related impact",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-01-01-preview",
+    "workloadImpactName": "impact-002",
+    "resource": {
+      "properties": {
+        "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservercontext",
+        "startDateTime": "2022-06-15T05:59:46.6517821Z",
+        "endDateTime": null,
+        "impactDescription": "high cpu utilization",
+        "impactCategory": "Resource.Performance",
+        "workload": {
+          "context": "webapp/scenario1",
+          "toolset": "Other"
+        },
+        "performance": [
+          {
+            "metricName": "CPU",
+            "actual": 90,
+            "expected": 60,
+            "unit": "garbage"
+          }
+        ],
+        "clientIncidentDetails": {
+          "clientIncidentId": "AA123",
+          "clientIncidentSource": "Jira"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/PerformanceImpacts/impact-001",
+        "name": "impact-001",
+        "type": "Microsoft.Impact/PerformanceImpacts",
+        "properties": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "high cup utilization",
+          "impactCategory": "Resource.Performance",
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "performance": [
+            {
+              "metricName": "CPU",
+              "actual": 90,
+              "expected": 60,
+              "unit": "garbage"
+            }
+          ],
+          "clientIncidentDetails": {
+            "clientIncidentId": "AA123",
+            "clientIncidentSource": "Jira"
+          },
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z",
+          "insightsByCategory": [
+            {
+              "category": "service health",
+              "status": "investigating",
+              "insights": []
+            }
+          ]
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/PerformanceImpacts/impact-001",
+        "name": "impact-001",
+        "type": "Microsoft.Impact/PerformanceImpacts",
+        "properties": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "high cup utilization",
+          "impactCategory": "Resource.Performance",
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "performance": [
+            {
+              "metricName": "CPU",
+              "actual": 90,
+              "expected": 60,
+              "unit": "garbage"
+            }
+          ],
+          "clientIncidentDetails": {
+            "clientIncidentId": "AA123",
+            "clientIncidentSource": "Jira"
+          },
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z",
+          "insightsByCategory": [
+            {
+              "category": "service health",
+              "status": "investigating",
+              "insights": []
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/examples/2026-01-01-preview/topologyImpact_Create.json
+++ b/specification/impact/Impact.Management/examples/2026-01-01-preview/topologyImpact_Create.json
@@ -1,0 +1,88 @@
+{
+  "operationId": "TopologyImpacts_Create",
+  "title": "Reporting a topology impact",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-01-01-preview",
+    "topologyImpactName": "impact-002",
+    "resource": {
+      "properties": {
+        "impactedResources": [
+          {
+            "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm1"
+          }
+        ],
+        "startDateTime": "2022-06-15T05:59:46.6517821Z",
+        "endDateTime": null,
+        "impactDescription": "one of the resources is unavailable",
+        "impactCategory": "Availability",
+        "additionalProperties": {
+          "errorCode": "504",
+          "errorMessage": "Gateway timeout error"
+        },
+        "workload": {
+          "context": "webapp/scenario1",
+          "toolset": "Other"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Impacts-rg/providers/Microsoft.Impact/topologyImpacts/impact-001",
+        "name": "impact-001",
+        "type": "Microsoft.Impact/topologyImpacts",
+        "properties": {
+          "impactedResources": [
+            {
+              "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm1"
+            }
+          ],
+          "topologyImpactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "one of the resources is unavailable",
+          "impactCategory": "Availability",
+          "additionalProperties": {
+            "errorCode": "504",
+            "errorMessage": "Gateway timeout error"
+          },
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Impacts-rg/providers/Microsoft.Impact/topologyImpacts/impact-001",
+        "name": "impact-001",
+        "type": "Microsoft.Impact/topologyImpacts",
+        "properties": {
+          "impactedResources": [
+            {
+              "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm1"
+            }
+          ],
+          "topologyImpactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "one of the resources is unavailable",
+          "impactCategory": "Availability",
+          "additionalProperties": {
+            "errorCode": "504",
+            "errorMessage": "Gateway timeout error"
+          },
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/Impact.Management/impact.tsp
+++ b/specification/impact/Impact.Management/impact.tsp
@@ -4,19 +4,39 @@ import "@azure-tools/typespec-azure-core";
 import "@azure-tools/typespec-azure-resource-manager";
 import "@typespec/versioning";
 
-using TypeSpec.Http;
-using TypeSpec.Rest;
 using TypeSpec.Versioning;
 using Azure.ResourceManager;
 
 @armProviderNamespace
 @service(#{ title: "Microsoft.Impact" })
 @versioned(Versions)
-@armCommonTypesVersion(CommonTypes.Versions.v3)
+@armCommonTypesVersion(CommonTypes.Versions.v5)
 namespace Microsoft.Impact;
 
 @doc("API Versions")
 enum Versions {
-  @doc("May 01, 2024 Preview API Version")
-  v2024_05_01_preview: "2024-05-01-preview",
+  @doc("January 01, 2025 Preview API Version")
+  v2025_01_01_preview: "2025-01-01-preview",
+
+  @doc("January 01, 2026 Preview API Version")
+  v2026_01_01_preview: "2026-01-01-preview",
+}
+
+@doc("A successful response from getUploadToken will contain an 'uploadUrl' field. This uploadUrl field's value should follow the format: https://[storage-account-name].blob.core.windows.net/[container-name]/[your-blob.extension]?[SAS-token]")
+@added(Versions.v2025_01_01_preview)
+model UploadTokenResult {
+  @doc("The SAS token URL for uploading")
+  @secret
+  uploadUrl: url;
+}
+
+@added(Versions.v2025_01_01_preview)
+@armResourceOperations
+interface UploadService {
+  @doc("Only for select HPC customers at this time, who can use this POST endpoint to trigger an action, where the UserRP/AzImpactRP service creates and returns a user-delegate SAS token for the storage account/container unique to the customer (identified by subscription ID).")
+  getUploadToken is ArmProviderActionSync<
+    void,
+    ArmResponse<UploadTokenResult>,
+    SubscriptionActionScope
+  >;
 }

--- a/specification/impact/Impact.Management/insights.tsp
+++ b/specification/impact/Impact.Management/insights.tsp
@@ -7,7 +7,9 @@ namespace Microsoft.Impact;
 
 using TypeSpec.Http;
 using TypeSpec.Rest;
+using OpenAPI;
 using Azure.ResourceManager;
+using TypeSpec.Versioning;
 
 @doc("Insight resource")
 @parentResource(WorkloadImpact)

--- a/specification/impact/Impact.Management/main.tsp
+++ b/specification/impact/Impact.Management/main.tsp
@@ -1,6 +1,4 @@
-// First, import the common Microsoft.Voiceservice definition
 import "./impact.tsp";
-//
 
 // Then import the resource API definitions
 import "./workloadImpacts.tsp";

--- a/specification/impact/Impact.Management/workloadImpacts.tsp
+++ b/specification/impact/Impact.Management/workloadImpacts.tsp
@@ -8,7 +8,9 @@ namespace Microsoft.Impact;
 
 using TypeSpec.Http;
 using TypeSpec.Rest;
+using OpenAPI;
 using Azure.ResourceManager;
+using TypeSpec.Versioning;
 
 @doc("Workload Impact properties")
 @subscriptionResource
@@ -52,7 +54,7 @@ model WorkloadImpactProperties is ResourceProperties {
   armCorrelationIds?: string[];
 
   @doc("Details about performance issue. Applicable for performance impacts.")
-  @identifiers(#[])
+  @Azure.ResourceManager.identifiers(#[])
   performance?: Performance[];
 
   @doc("Details about connectivity issue. Applicable when root resource causing the issue is not identified. For example, when a VM is impacted due to a network issue, the impacted resource is identified as the VM, but the root cause is the network. In such cases, the connectivity field will have the details about the network issue")
@@ -76,6 +78,39 @@ model WorkloadImpactProperties is ResourceProperties {
 
   @doc("Client incident details ex: incidentId , incident source")
   clientIncidentDetails?: ClientIncidentDetails;
+
+  @added(Versions.v2025_01_01_preview)
+  @doc("This field represents if an impact is ongoing or not. This is a boolean field.")
+  ongoingImpact?: boolean;
+
+  @added(Versions.v2025_01_01_preview)
+  @doc("This field represents the severity of an impact. Severity can be from critical to low severity impact. Severity ranges from 1 to 5 with 1 being critical, 2 is high, 3 is medium and 4,5 represents low severity impact.")
+  severity?: Severity;
+
+  @added(Versions.v2025_01_01_preview)
+  @doc("Captures the longest interruption duration within the specified start and end times. For example, it can be used to indicate network connectivity loss lasting longer than a specified number of seconds within the given time range.")
+  @minValue(0)
+  durationInSec?: float64;
+
+  @added(Versions.v2025_01_01_preview)
+  @doc("This field represents the type of impact. Possible values are MetricsThreshold, MetricsAnomaly, BusinessAlert.")
+  detectionType?: DetectionType;
+
+  @added(Versions.v2025_01_01_preview)
+  @doc("This field represents the duration margin in seconds that can be provided while providing endDateTime.")
+  @minValue(0)
+  durationMarginInSec?: float64;
+
+  @added(Versions.v2025_01_01_preview)
+  @doc("This field represents the number of times a particular issue was observed over a given time range.")
+  @minValue(0)
+  hitCount?: int32;
+
+  @added(Versions.v2026_01_01_preview)
+  @doc("Insights grouped by category. Each category contains status and a list of insight references.")
+  @visibility(Lifecycle.Read)
+  @Azure.ResourceManager.identifiers(#["category"])
+  insightsByCategory?: InsightCategoryGroup[];
 }
 
 interface Operations extends Azure.ResourceManager.Operations {}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/Connectors_CreateOrUpdate.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/Connectors_CreateOrUpdate.json
@@ -1,0 +1,91 @@
+{
+  "operationId": "Connectors_CreateOrUpdate",
+  "title": "CreateConnector",
+  "parameters": {
+    "api-version": "2025-01-01-preview",
+    "subscriptionId": "74f5e23f-d4d9-410a-bb4d-8f0608adb10d",
+    "connectorName": "testconnector1",
+    "resource": {
+      "properties": {
+        "connectorType": "AzureMonitor"
+      },
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/eu2cgroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1": {}
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "connectorId": "430a444e-6a84-4a6f-8c50-124843ca7cd4",
+          "tenantId": "23a8d1da-a7e9-4443-9797-4cd3e3aeb8f8",
+          "connectorType": "AzureMonitor",
+          "lastRunTimeStamp": "2024-03-19T06:23:56.238Z",
+          "processingState": "Initialized",
+          "processingStateMessage": ""
+        },
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/eu2cgroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1": {
+              "clientId": "fbe75b66-01c5-4f87-a220-233af3270436",
+              "principalId": "075a0ca6-43f6-4434-9abf-c9b1b79f9219"
+            }
+          }
+        },
+        "id": "/subscriptions/74f5e23f-d4d9-410a-bb4d-8f0608adb10d/providers/Microsoft.Impact/connectors/testconnector1",
+        "name": "testconnector1",
+        "type": "microsoft.impact/connectors",
+        "systemData": {
+          "createdBy": "testuser@hotmail.com",
+          "createdByType": "User",
+          "createdAt": "2024-03-07T06:19:01.6431721Z",
+          "lastModifiedBy": "testuser@hotmail.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-03-15T08:29:20.8549373Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+      },
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "connectorId": "430a444e-6a84-4a6f-8c50-124843ca7cd4",
+          "tenantId": "23a8d1da-a7e9-4443-9797-4cd3e3aeb8f8",
+          "connectorType": "AzureMonitor",
+          "lastRunTimeStamp": "2024-03-19T06:23:56.238Z",
+          "processingState": "Initialized",
+          "processingStateMessage": ""
+        },
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/eu2cgroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1": {
+              "clientId": "fbe75b66-01c5-4f87-a220-233af3270436",
+              "principalId": "075a0ca6-43f6-4434-9abf-c9b1b79f9219"
+            }
+          }
+        },
+        "id": "/subscriptions/74f5e23f-d4d9-410a-bb4d-8f0608adb10d/providers/Microsoft.Impact/connectors/testconnector1",
+        "name": "testconnector1",
+        "type": "microsoft.impact/connectors",
+        "systemData": {
+          "createdBy": "testuser@hotmail.com",
+          "createdByType": "User",
+          "createdAt": "2024-03-07T06:19:01.6431721Z",
+          "lastModifiedBy": "testuser@hotmail.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-03-15T08:29:20.8549373Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/Connectors_Delete.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/Connectors_Delete.json
@@ -1,0 +1,13 @@
+{
+  "title": "Connectors_Delete",
+  "operationId": "Connectors_Delete",
+  "parameters": {
+    "api-version": "2025-01-01-preview",
+    "subscriptionId": "8F74B371-8573-4773-9BDA-D546505BDB3A",
+    "connectorName": "testconnector1"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/Connectors_Get.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/Connectors_Get.json
@@ -1,0 +1,55 @@
+{
+  "operationId": "Connectors_Get",
+  "title": "GetConnector",
+  "parameters": {
+    "api-version": "2025-01-01-preview",
+    "subscriptionId": "74f5e23f-d4d9-410a-bb4d-8f0608adb10d",
+    "connectorName": "testconnector1",
+    "resource": {
+      "properties": {
+        "connectorType": "AzureMonitor"
+      },
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/eu2cgroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1": {}
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "connectorId": "430a444e-6a84-4a6f-8c50-124843ca7cd4",
+          "tenantId": "23a8d1da-a7e9-4443-9797-4cd3e3aeb8f8",
+          "connectorType": "AzureMonitor",
+          "lastRunTimeStamp": "2024-03-19T06:23:56.238Z",
+          "processingState": "Initialized",
+          "processingStateMessage": ""
+        },
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/eu2cgroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1": {
+              "clientId": "fbe75b66-01c5-4f87-a220-233af3270436",
+              "principalId": "075a0ca6-43f6-4434-9abf-c9b1b79f9219"
+            }
+          }
+        },
+        "id": "/subscriptions/74f5e23f-d4d9-410a-bb4d-8f0608adb10d/providers/Microsoft.Impact/connectors/testconnector1",
+        "name": "testconnector1",
+        "type": "microsoft.impact/connectors",
+        "systemData": {
+          "createdBy": "testuser@hotmail.com",
+          "createdByType": "User",
+          "createdAt": "2024-03-07T06:19:01.6431721Z",
+          "lastModifiedBy": "testuser@hotmail.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-03-15T08:29:20.8549373Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/Connectors_ListBySubscription.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/Connectors_ListBySubscription.json
@@ -1,0 +1,48 @@
+{
+  "title": "Connectors_ListBySubscription",
+  "operationId": "Connectors_ListBySubscription",
+  "parameters": {
+    "api-version": "2025-01-01-preview",
+    "subscriptionId": "74f5e23f-d4d9-410a-bb4d-8f0608adb10d"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "provisioningState": "Succeeded",
+              "connectorId": "430a444e-6a84-4a6f-8c50-124843ca7cd4",
+              "tenantId": "23a8d1da-a7e9-4443-9797-4cd3e3aeb8f8",
+              "connectorType": "AzureMonitor",
+              "lastRunTimeStamp": "2024-03-19T06:23:56.238Z",
+              "processingState": "Initialized",
+              "processingStateMessage": ""
+            },
+            "identity": {
+              "type": "UserAssigned",
+              "userAssignedIdentities": {
+                "/subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/eu2cgroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1": {
+                  "clientId": "fbe75b66-01c5-4f87-a220-233af3270436",
+                  "principalId": "075a0ca6-43f6-4434-9abf-c9b1b79f9219"
+                }
+              }
+            },
+            "id": "/subscriptions/74f5e23f-d4d9-410a-bb4d-8f0608adb10d/providers/Microsoft.Impact/connectors/testconnector1",
+            "name": "testconnector1",
+            "type": "microsoft.impact/connectors",
+            "systemData": {
+              "createdBy": "testuser@hotmail.com",
+              "createdByType": "User",
+              "createdAt": "2024-03-07T06:19:01.6431721Z",
+              "lastModifiedBy": "testuser@hotmail.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2024-03-15T08:29:20.8549373Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/Connectors_Update.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/Connectors_Update.json
@@ -1,0 +1,55 @@
+{
+  "title": "Connectors_Update",
+  "operationId": "Connectors_Update",
+  "parameters": {
+    "api-version": "2025-01-01-preview",
+    "subscriptionId": "74f5e23f-d4d9-410a-bb4d-8f0608adb10d",
+    "connectorName": "testconnector1",
+    "properties": {
+      "properties": {
+        "connectorType": "AzureMonitor"
+      },
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/eu2cgroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1": {}
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "connectorId": "430a444e-6a84-4a6f-8c50-124843ca7cd4",
+          "tenantId": "23a8d1da-a7e9-4443-9797-4cd3e3aeb8f8",
+          "connectorType": "AzureMonitor",
+          "lastRunTimeStamp": "2024-03-19T06:23:56.238Z",
+          "processingState": "Initialized",
+          "processingStateMessage": ""
+        },
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/eu2cgroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1": {
+              "clientId": "fbe75b66-01c5-4f87-a220-233af3270436",
+              "principalId": "075a0ca6-43f6-4434-9abf-c9b1b79f9219"
+            }
+          }
+        },
+        "id": "/subscriptions/74f5e23f-d4d9-410a-bb4d-8f0608adb10d/providers/Microsoft.Impact/connectors/testconnector1",
+        "name": "testconnector1",
+        "type": "microsoft.impact/connectors",
+        "systemData": {
+          "createdBy": "testuser@hotmail.com",
+          "createdByType": "User",
+          "createdAt": "2024-03-07T06:19:01.6431721Z",
+          "lastModifiedBy": "testuser@hotmail.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-03-15T08:29:20.8549373Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/ImpactCategories_Get.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/ImpactCategories_Get.json
@@ -1,0 +1,28 @@
+{
+  "operationId": "ImpactCategories_Get",
+  "title": "Get WorkloadImpact Resource by name",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2025-01-01-preview",
+    "impactCategoryName": "ARMOperation.Create"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/ImpactCategories/ARMOperation.Create",
+        "name": "ARMOperation.Create",
+        "type": "Microsoft.Impact/impactCategories",
+        "properties": {
+          "description": "Use this to report problems related to creating a new azure virtual machine such as provisioning or allocation failures.",
+          "categoryId": "778f815b-6576-4a36-bea9-bffb3d26d7f4",
+          "parentCategoryId": "36266d25-9c53-40b3-af41-27418b11851e",
+          "requiredImpactProperties": [
+            {
+              "name": "armCorrelations"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/ImpactCategories_ListBySubscription.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/ImpactCategories_ListBySubscription.json
@@ -1,0 +1,82 @@
+{
+  "operationId": "ImpactCategories_ListBySubscription",
+  "title": "Get ImpactCategories list by subscription",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceType": "microsoft.compute/virtualmachines",
+    "api-version": "2025-01-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/ImpactCategories/ARMOperation.Create",
+            "name": "ARMOperation.Create",
+            "type": "Microsoft.Impact/impactCategories",
+            "properties": {
+              "description": "Use this to report problems related to creating a new azure virtual machine such as provisioning or allocation failures.",
+              "categoryId": "778f815b-6576-4a36-bea9-bffb3d26d7f4",
+              "parentCategoryId": "36266d25-9c53-40b3-af41-27418b11851e",
+              "requiredImpactProperties": [
+                {
+                  "name": "armCorrelations"
+                }
+              ]
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/ImpactCategories/ARMOperation.Delete",
+            "name": "ARMOperation.Delete",
+            "type": "Microsoft.Impact/impactCategories",
+            "properties": {
+              "description": "Use this to report failures in deleting VMs.",
+              "categoryId": "a9a0c6e2-1208-406f-8f4f-1ccc13fb75d5",
+              "parentCategoryId": "36266d25-9c53-40b3-af41-27418b11851e",
+              "requiredImpactProperties": [
+                {
+                  "name": "armCorrelations"
+                }
+              ]
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/ImpactCategories/ARMOperation.Other",
+            "name": "ARMOperation.Other",
+            "type": "Microsoft.Impact/impactCategories",
+            "properties": {
+              "description": "Use this to report Control Plane operation failures that don't fall into other ARMOperation categories",
+              "categoryId": "7b71f937-9344-499c-bfbe-d86fb755d891",
+              "parentCategoryId": "36266d25-9c53-40b3-af41-27418b11851e",
+              "requiredImpactProperties": [
+                {
+                  "name": "armCorrelations"
+                }
+              ]
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/ImpactCategories/Resource.Connectivity",
+            "name": "Resource.Connectivity",
+            "type": "Microsoft.Impact/impactCategories",
+            "properties": {
+              "description": "Use this to report connectivity issues to or from a VM.",
+              "categoryId": "95903644-3a15-4e37-b4be-a2ae8651f27b",
+              "parentCategoryId": "a8d1c1ae-5fcb-4a8b-a647-fd0a911e8667"
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/ImpactCategories/Resource.Connectivity.Inbound",
+            "name": "Resource.Connectivity.Inbound",
+            "type": "Microsoft.Impact/impactCategories",
+            "properties": {
+              "description": "Use this to report inbound connectivity issues to a VM.",
+              "categoryId": "940fb706-8586-4a0e-bb18-2e2d0ef0708d",
+              "parentCategoryId": "95903644-3a15-4e37-b4be-a2ae8651f27b"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/Insights_Create.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/Insights_Create.json
@@ -1,0 +1,73 @@
+{
+  "operationId": "Insights_Create",
+  "title": "Creating an insight",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2025-01-01-preview",
+    "workloadImpactName": "impactid22",
+    "insightName": "insightId12",
+    "resource": {
+      "properties": {
+        "content": {
+          "title": "Impact Has been correlated to an outage",
+          "description": "At 2018-11-08T00:00:00Z UTC, your services dependent on these resources <link href=ΓÇ¥ΓÇªΓÇ¥>VM1</link> may have experienced an issue. <br/><div>We have identified an outage that affected these resources(s). You can look at outage information on <link href=\"https:// portal.azure.com/#view/Microsoft_Azure_Health/AzureHealthBrowseBlade/~/serviceIssues/trackingId/NL2W-VCZ\">NL2W-VCZ</link> link.<div>"
+        },
+        "category": "repair",
+        "status": "resolved",
+        "eventTime": "2023-06-15T04:00:00.009223Z",
+        "insightUniqueId": "00000000-0000-0000-0000-000000000000",
+        "impact": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+          "startTime": "2023-06-15T01:00:00.009223Z",
+          "impactId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/workloadImpacts/impactid22"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/workloadImpacts/impactid22/insights/insightId12",
+        "name": "insightId12",
+        "type": "Microsoft.Impact/insights",
+        "properties": {
+          "eventTime": "2023-06-15T04:00:00.009223Z",
+          "content": {
+            "title": "Impact Has been correlated to an outage",
+            "description": "At 2018-11-08T00:00:00Z UTC, your services dependent on these resources <link href=ΓÇ¥ΓÇªΓÇ¥>VM1</link> may have experienced an issue. <br/><div>We have identified an outage that affected these resources(s). You can look at outage information on <link href=\"https:// portal.azure.com/#view/Microsoft_Azure_Health/AzureHealthBrowseBlade/~/serviceIssues/trackingId/NL2W-VCZ\">NL2W-VCZ</link> link.<div>"
+          },
+          "category": "repair",
+          "status": "resolved",
+          "insightUniqueId": "00000000-0000-0000-0000-000000000000",
+          "impact": {
+            "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+            "startTime": "2023-06-15T01:00:00.009223Z",
+            "impactId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/workloadImpacts/impactid22"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/workloadImpacts/impactid22/insights/insightId12",
+        "name": "insightId12",
+        "type": "Microsoft.Impact/insights",
+        "properties": {
+          "eventTime": "2023-06-15T04:00:00.009223Z",
+          "content": {
+            "title": "Impact Has been correlated to an outage",
+            "description": "At 2018-11-08T00:00:00Z UTC, your services dependent on these resources <link href=ΓÇ¥ΓÇªΓÇ¥>VM1</link> may have experienced an issue. <br/><div>We have identified an outage that affected these resources(s). You can look at outage information on <link href=\"https:// portal.azure.com/#view/Microsoft_Azure_Health/AzureHealthBrowseBlade/~/serviceIssues/trackingId/NL2W-VCZ\">NL2W-VCZ</link> link.<div>"
+          },
+          "category": "repair",
+          "status": "resolved",
+          "insightUniqueId": "00000000-0000-0000-0000-000000000000",
+          "impact": {
+            "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+            "startTime": "2023-06-15T01:00:00.009223Z",
+            "impactId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/workloadImpacts/impactid22"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/Insights_Delete.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/Insights_Delete.json
@@ -1,0 +1,14 @@
+{
+  "operationId": "Insights_Delete",
+  "title": "Delete an Insight",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2025-01-01-preview",
+    "workloadImpactName": "impactid22",
+    "insightName": "insightId12"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/Insights_Get_diagnostics.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/Insights_Get_diagnostics.json
@@ -1,0 +1,33 @@
+{
+  "operationId": "Insights_Get",
+  "title": "Get Insight sample for Diagnostics category",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2025-01-01-preview",
+    "workloadImpactName": "impactid",
+    "insightName": "insight1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadimpacts/impactid/insights/insight1",
+        "name": "insight1",
+        "type": "Microsoft.impact/workloadimpacts/insights",
+        "properties": {
+          "category": "Diagnostics",
+          "impact": {
+            "impactId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadimpacts/impactid",
+            "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/virtualamchine/vm",
+            "startTime": "2018-11-08T00:00:00Z",
+            "endTime": "2018-11-08T00:00:00Z"
+          },
+          "insightUniqueId": "00000000-0000-0000-0000-000000000000",
+          "content": {
+            "title": "We ran diagnostics on your resource and found an issue",
+            "description": "<!--issueDescription-->\n<p>The physical host node where your VM is running had a networking stack update. This might result in a brief connectivity loss.</p>\n<br/><table><tr><th align=\"left\">Resource</th><th align=\"left\">Impact Start Time</th><th align=\"left\">Impact End Time</th><th align=\"left\">Impact Duration(Timespan)</th></tr><tr><td align=\"left\">west-eur-VM</td><td align=\"left\">2024-02-18 01:09:31 UTC</td><td align=\"left\">2024-02-18 01:09:35 UTC</td><td align=\"left\">00:00:04.2690000</td></tr></table>\n<!--/issueDescription-->\n<p>Azure performs updates to improve reliability, performance, and security of the VMs. Azure chooses the least impactful method, which might result in a brief connectivity loss. We are continuously working to improve and reduce impact of our updates, and we apologize for any inconvenience this may have caused you.</p>\n<!--recommendedActions-->\n<h2><strong>Recommended Documents</strong></h2>\n<ul>\n<li>To prepare for VM maintenance events and reduce its impact, try using <a href=\"https://docs.microsoft.com/azure/virtual-machines/windows/scheduled-events\">Scheduled Events for Windows</a> or <a href=\"https://docs.microsoft.com/azure/virtual-machines/linux/scheduled-events\">Linux</a></li>\n<li>Learn more about Azure maintenance and configuring for high availability:\n<ul>\n<li><a href=\"https://docs.microsoft.com/azure/virtual-machines/maintenance-and-updates\">Maintenance and updates for virtual machines in Azure</a></li>\n<li><a href=\"https://docs.microsoft.com/azure/virtual-machines/windows/tutorial-availability-sets\">Configure availability of virtual machines</a></li>\n</ul>\n</li>\n<li>To troubleshoot this scenario in the future, see <a href=\"https://docs.microsoft.com/azure/resource-health/resource-health-overview\">Resource Health Center</a></li>\n</ul>\n"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/Insights_Get_mitigationAction.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/Insights_Get_mitigationAction.json
@@ -1,0 +1,38 @@
+{
+  "operationId": "Insights_Get",
+  "title": "Get Insight sample for MitigationAction category",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2025-01-01-preview",
+    "workloadImpactName": "impactId",
+    "insightName": "HPCUASucceeded"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadimpacts/impactId/insights/HPCUASucceeded",
+        "name": "HPCUASucceeded",
+        "type": "Microsoft.impact/workloadimpacts/insights",
+        "properties": {
+          "category": "MitigationAction",
+          "eventTime": "2023-06-15T04:00:00.009223Z",
+          "insightUniqueId": "00000000-0000-0000-0000-000000000000",
+          "impact": {
+            "impactId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadimpacts/impactId",
+            "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/virtualMachine/vm",
+            "startTime": "2018-11-08T00:00:00Z",
+            "endTime": "2018-11-08T00:00:00Z"
+          },
+          "content": {
+            "title": "Node was flagged for inspection",
+            "description": "At 2024-02-16 21:05:07 (UTC) an impact was reported on west-eur-VM indicating a potential disruption from Azure platform. <strong>Action Taken</strong> The hardware your VM was running on was flagged for inspection. We will conduct our investigation and take corrective action to prevent further impact on your workloads. We apologize for any disruption. Microsoft Azure Team"
+          },
+          "additionalDetails": {
+            "statusCode": "Succeeded",
+            "terminalState": "true"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/Insights_Get_servicehealth.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/Insights_Get_servicehealth.json
@@ -1,0 +1,35 @@
+{
+  "operationId": "Insights_Get",
+  "title": "Get Insight sample for service health category",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2025-01-01-preview",
+    "workloadImpactName": "impactid",
+    "insightName": "insightname"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/workloadImpacts/impactname/insights/insightname",
+        "name": "insightname",
+        "type": "Microsoft.Impact/insights",
+        "properties": {
+          "category": "ServiceHealth",
+          "eventId": "ABC-123",
+          "eventTime": "2023-06-15T04:00:00.009223Z",
+          "impact": {
+            "impactId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadimpacts/impactid",
+            "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.compute/virtualmachines/vm1",
+            "startTime": "2018-11-08T00:00:00Z",
+            "endTime": "2018-11-08T00:00:00Z"
+          },
+          "insightUniqueId": "a3d91a07-698b-4044-a230-e918252c4c59",
+          "content": {
+            "title": "Impact Has been correlated to an outage",
+            "description": "On November 8, 2018, at 00:00 UTC, there may have been disruptions to your services linked to the resource <a href='...'>VM1<a>. We have pinpointed a service outage impacting these resources. For details on this outage, please refer to the service health information available at <a href='...'>service health</a>."
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/Insights_ListBySubscription.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/Insights_ListBySubscription.json
@@ -1,0 +1,37 @@
+{
+  "operationId": "Insights_ListBySubscription",
+  "title": "List Insight resources by workloadImpactName",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "workloadImpactName": "impactid22",
+    "api-version": "2025-01-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/workloadImpacts/impactid22/insights/insightId12",
+            "name": "insightId12",
+            "type": "Microsoft.Impact/insights",
+            "properties": {
+              "eventTime": "2023-06-15T04:00:00.009223Z",
+              "content": {
+                "title": "Impact Has been correlated to an outage",
+                "description": "At 2018-11-08T00:00:00Z UTC, your services dependent on these resources <link href=ΓÇ¥ΓÇªΓÇ¥>VM1</link> may have experienced an issue. <br/><div>We have identified an outage that affected these resources(s). You can look at outage information on <link href=\"https:// portal.azure.com/#view/Microsoft_Azure_Health/AzureHealthBrowseBlade/~/serviceIssues/trackingId/NL2W-VCZ\">NL2W-VCZ</link> link.<div>"
+              },
+              "category": "repair",
+              "status": "resolved",
+              "insightUniqueId": "00000000-0000-0000-0000-000000000000",
+              "impact": {
+                "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+                "startTime": "2023-06-15T01:00:00.009223Z",
+                "impactId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/workloadImpacts/impactid22"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/Operations_List.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/Operations_List.json
@@ -1,0 +1,52 @@
+{
+  "operationId": "Operations_List",
+  "title": "OperationsList",
+  "parameters": {
+    "api-version": "2025-01-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.Impact/workloadImpacts/write",
+            "display": {
+              "provider": "Microsoft.Impact",
+              "resource": "workloadImpacts",
+              "operation": "write",
+              "description": "Write workloadImpact resources"
+            }
+          },
+          {
+            "name": "Microsoft.Impact/workloadImpacts/read",
+            "display": {
+              "provider": "Microsoft.Impact",
+              "resource": "workloadimpacts",
+              "operation": "read",
+              "description": "Read workloadImpact resources"
+            }
+          },
+          {
+            "name": "Microsoft.Impact/impactCategories/read",
+            "display": {
+              "provider": "Microsoft.Impact",
+              "resource": "impactCategories",
+              "operation": "read",
+              "description": "Read impactCategory resources"
+            }
+          },
+          {
+            "name": "Microsoft.Impact/getUploadToken/action",
+            "display": {
+              "provider": "Microsoft.Impact",
+              "resource": "getUploadToken",
+              "operation": "Get Upload Token",
+              "description": "Get an upload token for the storage account and container to upload logs associated with impacts."
+            }
+          }
+        ],
+        "nextLink": null
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/UploadService_GetUploadToken.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/UploadService_GetUploadToken.json
@@ -1,0 +1,15 @@
+{
+  "operationId": "UploadService_GetUploadToken",
+  "title": "Get upload token to use for log upload",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2025-01-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "uploadUrl": "https://storageAccountHere.blob.core.windows.net/container-here/yyyyMMddHHmmss-12345678.zip?[SAS-token]"
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/WorkloadArmOperation_create.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/WorkloadArmOperation_create.json
@@ -1,0 +1,85 @@
+{
+  "operationId": "WorkloadImpacts_Create",
+  "title": "Reporting Arm operation failure",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2025-01-01-preview",
+    "workloadImpactName": "impact-002",
+    "resource": {
+      "properties": {
+        "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservercontext",
+        "startDateTime": "2022-06-15T05:59:46.6517821Z",
+        "endDateTime": null,
+        "impactDescription": "deletion of resource failed",
+        "impactCategory": "ArmOperation",
+        "armCorrelationIds": [
+          "00000000-0000-0000-0000-000000000000"
+        ],
+        "workload": {
+          "context": "webapp/scenario1",
+          "toolset": "Other"
+        },
+        "clientIncidentDetails": {
+          "clientIncidentId": "AA123",
+          "clientIncidentSource": "Jira"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadImpacts/impact-001",
+        "name": "impact-001",
+        "type": "Microsoft.Impact/workloadImpacts",
+        "properties": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "deletion of resource failed",
+          "impactCategory": "ArmOperation",
+          "armCorrelationIds": [
+            "00000000-0000-0000-0000-000000000000"
+          ],
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "clientIncidentDetails": {
+            "clientIncidentId": "AA123",
+            "clientIncidentSource": "Jira"
+          },
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadImpacts/impact-001",
+        "name": "impact-001",
+        "type": "Microsoft.Impact/workloadImpacts",
+        "properties": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "deletion of resource failed",
+          "impactCategory": "ArmOperation",
+          "armCorrelationIds": [
+            "00000000-0000-0000-0000-000000000000"
+          ],
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "clientIncidentDetails": {
+            "clientIncidentId": "AA123",
+            "clientIncidentSource": "Jira"
+          },
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/WorkloadAvailability_Create.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/WorkloadAvailability_Create.json
@@ -1,0 +1,76 @@
+{
+  "operationId": "WorkloadImpacts_Create",
+  "title": "Reporting availability related impact",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2025-01-01-preview",
+    "workloadImpactName": "impact-002",
+    "resource": {
+      "properties": {
+        "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservercontext",
+        "startDateTime": "2022-06-15T05:59:46.6517821Z",
+        "endDateTime": null,
+        "impactDescription": "read calls failed",
+        "impactCategory": "Availability",
+        "workload": {
+          "context": "webapp/scenario1",
+          "toolset": "Other"
+        },
+        "clientIncidentDetails": {
+          "clientIncidentId": "AA123",
+          "clientIncidentSource": "Jira"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadImpacts/impact-001",
+        "name": "impact-001",
+        "type": "Microsoft.Impact/workloadImpacts",
+        "properties": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "read calls failed",
+          "impactCategory": "Availability",
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "clientIncidentDetails": {
+            "clientIncidentId": "AA123",
+            "clientIncidentSource": "Jira"
+          },
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadImpacts/impact-001",
+        "name": "impact-001",
+        "type": "Microsoft.Impact/workloadImpacts",
+        "properties": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "read calls failed",
+          "impactCategory": "Availability",
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "clientIncidentDetails": {
+            "clientIncidentId": "AA123",
+            "clientIncidentSource": "Jira"
+          },
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/WorkloadConnectivityImpact_Create.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/WorkloadConnectivityImpact_Create.json
@@ -1,0 +1,106 @@
+{
+  "operationId": "WorkloadImpacts_Create",
+  "title": "Reporting a connectivity impact",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2025-01-01-preview",
+    "workloadImpactName": "impact-001",
+    "resource": {
+      "properties": {
+        "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservercontext",
+        "startDateTime": "2022-06-15T05:59:46.6517821Z",
+        "endDateTime": null,
+        "impactDescription": "conection failure",
+        "impactCategory": "Resource.Connectivity",
+        "connectivity": {
+          "protocol": "TCP",
+          "port": 1443,
+          "source": {
+            "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceSub/providers/Microsoft.compute/virtualmachines/vm1"
+          },
+          "target": {
+            "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceSub/providers/Microsoft.compute/virtualmachines/vm2"
+          }
+        },
+        "workload": {
+          "context": "webapp/scenario1",
+          "toolset": "Other"
+        },
+        "clientIncidentDetails": {
+          "clientIncidentId": "AA123",
+          "clientIncidentSource": "Jira"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Impacts-rg/providers/Microsoft.Impact/workloadImpacts/impact-001",
+        "name": "impact-001",
+        "type": "Microsoft.Impact/workloadImpacts",
+        "properties": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservercontext",
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "conection failure",
+          "impactCategory": "Resource.Connectivity",
+          "connectivity": {
+            "protocol": "TCP",
+            "port": 1443,
+            "source": {
+              "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceSub/providers/Microsoft.compute/virtualmachines/vm1"
+            },
+            "target": {
+              "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceSub/providers/Microsoft.compute/virtualmachines/vm2"
+            }
+          },
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "clientIncidentDetails": {
+            "clientIncidentId": "AA123",
+            "clientIncidentSource": "Jira"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Impacts-rg/providers/Microsoft.Impact/workloadImpacts/impact-001",
+        "name": "impact-001",
+        "type": "Microsoft.Impact/workloadImpacts",
+        "properties": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservercontext",
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "conection failure",
+          "impactCategory": "Resource.Connectivity",
+          "connectivity": {
+            "protocol": "TCP",
+            "port": 1443,
+            "source": {
+              "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceSub/providers/Microsoft.compute/virtualmachines/vm1"
+            },
+            "target": {
+              "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceSub/providers/Microsoft.compute/virtualmachines/vm2"
+            }
+          },
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "clientIncidentDetails": {
+            "clientIncidentId": "AA123",
+            "clientIncidentSource": "Jira"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/WorkloadImpact_Delete.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/WorkloadImpact_Delete.json
@@ -1,0 +1,13 @@
+{
+  "operationId": "WorkloadImpacts_Delete",
+  "title": "Delete WorkloadImpact Resource by name example",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2025-01-01-preview",
+    "workloadImpactName": "impact-001"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/WorkloadImpact_Get.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/WorkloadImpact_Get.json
@@ -1,0 +1,35 @@
+{
+  "operationId": "WorkloadImpacts_Get",
+  "title": "Get WorkloadImpact Resource by name example",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2025-01-01-preview",
+    "workloadImpactName": "impact-001"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadImpacts/impact-001",
+        "name": "impact-001",
+        "type": "Microsoft.Impact/workloadImpacts",
+        "properties": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "high cup utilization",
+          "impactCategory": "Performance",
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "clientIncidentDetails": {
+            "clientIncidentId": "AA123",
+            "clientIncidentSource": "Jira"
+          },
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/WorkloadImpacts_Create_MaximumSet_Gen.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/WorkloadImpacts_Create_MaximumSet_Gen.json
@@ -1,0 +1,211 @@
+{
+  "title": "WorkloadImpacts_Create_MaximumSet",
+  "operationId": "WorkloadImpacts_Create",
+  "parameters": {
+    "api-version": "2025-01-01-preview",
+    "subscriptionId": "0D045314-435A-41DA-B0A4-2CA7E9F87D12",
+    "workloadImpactName": "testWorkloadImpact",
+    "resource": {
+      "properties": {
+        "startDateTime": "2024-12-04T19:51:13.274Z",
+        "endDateTime": "2024-12-04T19:51:13.274Z",
+        "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+        "impactCategory": "Resource.Other",
+        "impactDescription": "test description",
+        "armCorrelationIds": [
+          "4D045314-435A-41DA-B0A4-2CA7E9F87D12"
+        ],
+        "performance": [
+          {
+            "metricName": "testMetric",
+            "expected": 23,
+            "actual": 20,
+            "expectedValueRange": {
+              "min": 1,
+              "max": 27
+            },
+            "unit": "ByteSeconds"
+          }
+        ],
+        "connectivity": {
+          "protocol": "TCP",
+          "port": 6,
+          "source": {
+            "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm1"
+          },
+          "target": {
+            "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm2"
+          }
+        },
+        "additionalProperties": {},
+        "errorDetails": {
+          "errorCode": "504",
+          "errorMessage": "Gateway timeout error"
+        },
+        "workload": {
+          "context": "webapp/scenario1",
+          "toolset": "Other"
+        },
+        "impactGroupId": "testGroup1",
+        "confidenceLevel": "Low",
+        "clientIncidentDetails": {
+          "clientIncidentId": "123456",
+          "clientIncidentSource": "AzureDevops"
+        },
+        "ongoingImpact": true,
+        "severity": "Critical",
+        "durationInSec": 26,
+        "detectionType": "BusinessAlert",
+        "durationMarginInSec": 28,
+        "hitCount": 21
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "startDateTime": "2024-12-04T19:51:13.274Z",
+          "endDateTime": "2024-12-04T19:51:13.274Z",
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm1",
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2024-12-04T19:51:13.274Z",
+          "impactCategory": "Resource.Other",
+          "impactDescription": "Test description",
+          "armCorrelationIds": [
+            "4D045314-435A-41DA-B0A4-2CA7E9F87D12"
+          ],
+          "performance": [
+            {
+              "metricName": "testMetric",
+              "expected": 23,
+              "actual": 20,
+              "expectedValueRange": {
+                "min": 1,
+                "max": 27
+              },
+              "unit": "ByteSeconds"
+            }
+          ],
+          "connectivity": {
+            "protocol": "TCP",
+            "port": 6,
+            "source": {
+              "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm1"
+            },
+            "target": {
+              "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm2"
+            }
+          },
+          "additionalProperties": {},
+          "errorDetails": {
+            "errorCode": "504",
+            "errorMessage": "Gateway timeout error"
+          },
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "impactGroupId": "testGroup1",
+          "confidenceLevel": "Low",
+          "clientIncidentDetails": {
+            "clientIncidentId": "123456",
+            "clientIncidentSource": "AzureDevops"
+          },
+          "ongoingImpact": true,
+          "severity": "Critical",
+          "durationInSec": 26,
+          "detectionType": "BusinessAlert",
+          "durationMarginInSec": 28,
+          "hitCount": 21
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Impacts-rg/providers/Microsoft.Impact/workloadImpacts/impact2",
+        "name": "testWorkloadImpact",
+        "type": "Microsoft.Impact/workloadImpacts",
+        "systemData": {
+          "createdBy": "testuser@hotmail.com",
+          "createdByType": "User",
+          "createdAt": "2024-03-07T06:19:01.6431721Z",
+          "lastModifiedBy": "testuser@hotmail.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-03-15T08:29:20.8549373Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+      },
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "startDateTime": "2024-12-04T19:51:13.274Z",
+          "endDateTime": "2024-12-04T19:51:13.274Z",
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm1",
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2024-12-04T19:51:13.274Z",
+          "impactCategory": "Resource.Other",
+          "impactDescription": "Test description",
+          "armCorrelationIds": [
+            "4D045314-435A-41DA-B0A4-2CA7E9F87D12"
+          ],
+          "performance": [
+            {
+              "metricName": "testMetric",
+              "expected": 23,
+              "actual": 20,
+              "expectedValueRange": {
+                "min": 1,
+                "max": 27
+              },
+              "unit": "ByteSeconds"
+            }
+          ],
+          "connectivity": {
+            "protocol": "TCP",
+            "port": 6,
+            "source": {
+              "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm1"
+            },
+            "target": {
+              "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm2"
+            }
+          },
+          "additionalProperties": {},
+          "errorDetails": {
+            "errorCode": "504",
+            "errorMessage": "Gateway timeout error"
+          },
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "impactGroupId": "testGroup1",
+          "confidenceLevel": "Low",
+          "clientIncidentDetails": {
+            "clientIncidentId": "123456",
+            "clientIncidentSource": "AzureDevops"
+          },
+          "ongoingImpact": true,
+          "severity": "Critical",
+          "durationInSec": 26,
+          "detectionType": "BusinessAlert",
+          "durationMarginInSec": 28,
+          "hitCount": 21
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Impacts-rg/providers/Microsoft.Impact/workloadImpacts/impact2",
+        "name": "testWorkloadImpact",
+        "type": "Microsoft.Impact/workloadImpacts",
+        "systemData": {
+          "createdBy": "testuser@hotmail.com",
+          "createdByType": "User",
+          "createdAt": "2024-03-07T06:19:01.6431721Z",
+          "lastModifiedBy": "testuser@hotmail.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-03-15T08:29:20.8549373Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/WorkloadImpacts_ListBySubscription.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/WorkloadImpacts_ListBySubscription.json
@@ -1,0 +1,38 @@
+{
+  "operationId": "WorkloadImpacts_ListBySubscription",
+  "title": "List WorkloadImpact resources by subscription",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2025-01-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Impacts-rg/providers/Microsoft.Impact/workloadImpacts/impact2",
+            "name": "impact2",
+            "type": "Microsoft.Impact/workloadImpacts",
+            "properties": {
+              "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm1",
+              "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+              "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z",
+              "startDateTime": "2022-06-15T05:59:46.6517821Z",
+              "endDateTime": null,
+              "impactDescription": "",
+              "impactCategory": "Resource.Other",
+              "additionalProperties": {
+                "errorCode": "504",
+                "errorMessage": "Gateway timeout error"
+              },
+              "workload": {
+                "context": "webapp/scenario1",
+                "toolset": "Other"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/WorkloadPerformance_Create.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/examples/WorkloadPerformance_Create.json
@@ -1,0 +1,100 @@
+{
+  "operationId": "WorkloadImpacts_Create",
+  "title": "Reporting performance related impact",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2025-01-01-preview",
+    "workloadImpactName": "impact-002",
+    "resource": {
+      "properties": {
+        "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservercontext",
+        "startDateTime": "2022-06-15T05:59:46.6517821Z",
+        "endDateTime": null,
+        "impactDescription": "high cpu utilization",
+        "impactCategory": "Resource.Performance",
+        "workload": {
+          "context": "webapp/scenario1",
+          "toolset": "Other"
+        },
+        "performance": [
+          {
+            "metricName": "CPU",
+            "actual": 90,
+            "expected": 60,
+            "unit": "garbage"
+          }
+        ],
+        "clientIncidentDetails": {
+          "clientIncidentId": "AA123",
+          "clientIncidentSource": "Jira"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/PerformanceImpacts/impact-001",
+        "name": "impact-001",
+        "type": "Microsoft.Impact/PerformanceImpacts",
+        "properties": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "high cup utilization",
+          "impactCategory": "Resource.Performance",
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "performance": [
+            {
+              "metricName": "CPU",
+              "actual": 90,
+              "expected": 60,
+              "unit": "garbage"
+            }
+          ],
+          "clientIncidentDetails": {
+            "clientIncidentId": "AA123",
+            "clientIncidentSource": "Jira"
+          },
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/PerformanceImpacts/impact-001",
+        "name": "impact-001",
+        "type": "Microsoft.Impact/PerformanceImpacts",
+        "properties": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "high cup utilization",
+          "impactCategory": "Resource.Performance",
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "performance": [
+            {
+              "metricName": "CPU",
+              "actual": 90,
+              "expected": 60,
+              "unit": "garbage"
+            }
+          ],
+          "clientIncidentDetails": {
+            "clientIncidentId": "AA123",
+            "clientIncidentSource": "Jira"
+          },
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/impact.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2025-01-01-preview/impact.json
@@ -1,0 +1,2206 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Microsoft.Impact",
+    "version": "2025-01-01-preview",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "UploadService"
+    },
+    {
+      "name": "Operations"
+    },
+    {
+      "name": "WorkloadImpacts"
+    },
+    {
+      "name": "ImpactCategories"
+    },
+    {
+      "name": "Insights"
+    },
+    {
+      "name": "Connectors"
+    }
+  ],
+  "paths": {
+    "/providers/Microsoft.Impact/operations": {
+      "get": {
+        "operationId": "Operations_List",
+        "tags": [
+          "Operations"
+        ],
+        "description": "List the operations for the provider",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/OperationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "OperationsList": {
+            "$ref": "./examples/Operations_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Impact/connectors": {
+      "get": {
+        "operationId": "Connectors_ListBySubscription",
+        "tags": [
+          "Connectors"
+        ],
+        "description": "List Connector resources by subscription ID",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectorListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Connectors_ListBySubscription": {
+            "$ref": "./examples/Connectors_ListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Impact/connectors/{connectorName}": {
+      "get": {
+        "operationId": "Connectors_Get",
+        "tags": [
+          "Connectors"
+        ],
+        "description": "Get a Connector",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "connectorName",
+            "in": "path",
+            "description": "The name of the connector",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Connector"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetConnector": {
+            "$ref": "./examples/Connectors_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Connectors_CreateOrUpdate",
+        "tags": [
+          "Connectors"
+        ],
+        "description": "Create a Connector",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "connectorName",
+            "in": "path",
+            "description": "The name of the connector",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Connector"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Connector' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Connector"
+            }
+          },
+          "201": {
+            "description": "Resource 'Connector' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Connector"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "CreateConnector": {
+            "$ref": "./examples/Connectors_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "Connectors_Update",
+        "tags": [
+          "Connectors"
+        ],
+        "description": "Update a Connector",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "connectorName",
+            "in": "path",
+            "description": "The name of the connector",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ConnectorUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Connector"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Connectors_Update": {
+            "$ref": "./examples/Connectors_Update.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Connectors_Delete",
+        "tags": [
+          "Connectors"
+        ],
+        "description": "Delete a Connector",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "connectorName",
+            "in": "path",
+            "description": "The name of the connector",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Connectors_Delete": {
+            "$ref": "./examples/Connectors_Delete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Impact/getUploadToken": {
+      "post": {
+        "operationId": "UploadService_GetUploadToken",
+        "tags": [
+          "UploadService"
+        ],
+        "description": "Only for select HPC customers at this time, who can use this POST endpoint to trigger an action, where the UserRP/AzImpactRP service creates and returns a user-delegate SAS token for the storage account/container unique to the customer (identified by subscription ID).",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/UploadTokenResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get upload token to use for log upload": {
+            "$ref": "./examples/UploadService_GetUploadToken.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Impact/impactCategories": {
+      "get": {
+        "operationId": "ImpactCategories_ListBySubscription",
+        "tags": [
+          "ImpactCategories"
+        ],
+        "description": "List ImpactCategory resources by subscription",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/CustomParameters.categoryName"
+          },
+          {
+            "$ref": "#/parameters/CustomParameters.resourceType"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ImpactCategoryListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get ImpactCategories list by subscription": {
+            "$ref": "./examples/ImpactCategories_ListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Impact/impactCategories/{impactCategoryName}": {
+      "get": {
+        "operationId": "ImpactCategories_Get",
+        "tags": [
+          "ImpactCategories"
+        ],
+        "description": "Get a ImpactCategory",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "impactCategoryName",
+            "in": "path",
+            "description": "Name of the impact category",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9.]*[a-zA-Z0-9]{3,180}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ImpactCategory"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get WorkloadImpact Resource by name": {
+            "$ref": "./examples/ImpactCategories_Get.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Impact/workloadImpacts": {
+      "get": {
+        "operationId": "WorkloadImpacts_ListBySubscription",
+        "tags": [
+          "WorkloadImpacts"
+        ],
+        "description": "List WorkloadImpact resources by subscription ID",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/WorkloadImpactListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List WorkloadImpact resources by subscription": {
+            "$ref": "./examples/WorkloadImpacts_ListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Impact/workloadImpacts/{workloadImpactName}": {
+      "get": {
+        "operationId": "WorkloadImpacts_Get",
+        "tags": [
+          "WorkloadImpacts"
+        ],
+        "description": "Get a WorkloadImpact",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "workloadImpactName",
+            "in": "path",
+            "description": "workloadImpact resource ",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-:]*[a-zA-Z0-9]{3,120}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/WorkloadImpact"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get WorkloadImpact Resource by name example": {
+            "$ref": "./examples/WorkloadImpact_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "WorkloadImpacts_Create",
+        "tags": [
+          "WorkloadImpacts"
+        ],
+        "description": "Create a WorkloadImpact",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "workloadImpactName",
+            "in": "path",
+            "description": "workloadImpact resource ",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-:]*[a-zA-Z0-9]{3,120}$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkloadImpact"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'WorkloadImpact' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/WorkloadImpact"
+            }
+          },
+          "201": {
+            "description": "Resource 'WorkloadImpact' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/WorkloadImpact"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Reporting Arm operation failure": {
+            "$ref": "./examples/WorkloadArmOperation_create.json"
+          },
+          "Reporting a connectivity impact": {
+            "$ref": "./examples/WorkloadConnectivityImpact_Create.json"
+          },
+          "Reporting availability related impact": {
+            "$ref": "./examples/WorkloadAvailability_Create.json"
+          },
+          "Reporting performance related impact": {
+            "$ref": "./examples/WorkloadPerformance_Create.json"
+          },
+          "WorkloadImpacts_Create_MaximumSet": {
+            "$ref": "./examples/WorkloadImpacts_Create_MaximumSet_Gen.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "WorkloadImpacts_Delete",
+        "tags": [
+          "WorkloadImpacts"
+        ],
+        "description": "Delete a WorkloadImpact",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "workloadImpactName",
+            "in": "path",
+            "description": "workloadImpact resource ",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-:]*[a-zA-Z0-9]{3,120}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete WorkloadImpact Resource by name example": {
+            "$ref": "./examples/WorkloadImpact_Delete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Impact/workloadImpacts/{workloadImpactName}/insights": {
+      "get": {
+        "operationId": "Insights_ListBySubscription",
+        "tags": [
+          "Insights"
+        ],
+        "description": "List Insight resources by workloadImpactName",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "workloadImpactName",
+            "in": "path",
+            "description": "workloadImpact resource ",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-:]*[a-zA-Z0-9]{3,120}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/InsightListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Insight resources by workloadImpactName": {
+            "$ref": "./examples/Insights_ListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Impact/workloadImpacts/{workloadImpactName}/insights/{insightName}": {
+      "get": {
+        "operationId": "Insights_Get",
+        "tags": [
+          "Insights"
+        ],
+        "description": "Get Insight resources by workloadImpactName and insightName",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "workloadImpactName",
+            "in": "path",
+            "description": "workloadImpact resource ",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-:]*[a-zA-Z0-9]{3,120}$"
+          },
+          {
+            "name": "insightName",
+            "in": "path",
+            "description": "Name of the insight",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9.]*[a-zA-Z0-9]{3,180}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Insight"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Insight sample for Diagnostics category": {
+            "$ref": "./examples/Insights_Get_diagnostics.json"
+          },
+          "Get Insight sample for MitigationAction category": {
+            "$ref": "./examples/Insights_Get_mitigationAction.json"
+          },
+          "Get Insight sample for service health category": {
+            "$ref": "./examples/Insights_Get_servicehealth.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Insights_Create",
+        "tags": [
+          "Insights"
+        ],
+        "description": "Create Insight resource, This is Admin only operation",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "workloadImpactName",
+            "in": "path",
+            "description": "workloadImpact resource ",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-:]*[a-zA-Z0-9]{3,120}$"
+          },
+          {
+            "name": "insightName",
+            "in": "path",
+            "description": "Name of the insight",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9.]*[a-zA-Z0-9]{3,180}$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Insight"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Insight' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Insight"
+            }
+          },
+          "201": {
+            "description": "Resource 'Insight' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Insight"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Creating an insight": {
+            "$ref": "./examples/Insights_Create.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Insights_Delete",
+        "tags": [
+          "Insights"
+        ],
+        "description": "Delete Insight resource, This is Admin only operation",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "workloadImpactName",
+            "in": "path",
+            "description": "workloadImpact resource ",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-:]*[a-zA-Z0-9]{3,120}$"
+          },
+          {
+            "name": "insightName",
+            "in": "path",
+            "description": "Name of the insight",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9.]*[a-zA-Z0-9]{3,180}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete an Insight": {
+            "$ref": "./examples/Insights_Delete.json"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "AdditionalField": {
+      "type": "object",
+      "description": "additional user defined field.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "name of the field."
+        },
+        "value": {
+          "type": "string",
+          "description": "value of the field."
+        }
+      },
+      "required": [
+        "name",
+        "value"
+      ]
+    },
+    "Azure.Core.uuid": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Universally Unique Identifier"
+    },
+    "ClientIncidentDetails": {
+      "type": "object",
+      "description": "Client incident details ex: incidentId , incident source",
+      "properties": {
+        "clientIncidentId": {
+          "type": "string",
+          "description": "Client incident id. ex : id of the incident created to investigate and address the impact if any."
+        },
+        "clientIncidentSource": {
+          "$ref": "#/definitions/IncidentSource",
+          "description": "Client incident source. ex : source system name where the incident is created"
+        }
+      }
+    },
+    "ConfidenceLevel": {
+      "type": "string",
+      "description": "Degree of confidence on the impact being a platform issue.",
+      "enum": [
+        "Low",
+        "Medium",
+        "High"
+      ],
+      "x-ms-enum": {
+        "name": "ConfidenceLevel",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Low",
+            "value": "Low",
+            "description": "Low confidence on azure being the source of impact"
+          },
+          {
+            "name": "Medium",
+            "value": "Medium",
+            "description": "Medium confidence on azure being the source of impact"
+          },
+          {
+            "name": "High",
+            "value": "High",
+            "description": "High confidence on azure being the source of impact"
+          }
+        ]
+      }
+    },
+    "Connectivity": {
+      "type": "object",
+      "description": "Details about connectivity issue. Applicable when root resource causing the issue is not identified. For example, when a VM is impacted due to a network issue, the impacted resource could be VM or the network. In such cases, the connectivity field will have the details about both VM and network.",
+      "properties": {
+        "protocol": {
+          "$ref": "#/definitions/Protocol",
+          "description": "Protocol used for the connection"
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Port number for the connection"
+        },
+        "source": {
+          "$ref": "#/definitions/SourceOrTarget",
+          "description": "Source from which the connection was attempted"
+        },
+        "target": {
+          "$ref": "#/definitions/SourceOrTarget",
+          "description": "target which connection was attempted"
+        }
+      }
+    },
+    "Connector": {
+      "type": "object",
+      "description": "A connector is a resource that can be used to proactively report impacts against workloads in Azure to Microsoft.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ConnectorProperties",
+          "description": "The resource-specific properties for this resource."
+        },
+        "identity": {
+          "$ref": "#/definitions/ManagedServiceIdentityOnlyUserAssigned",
+          "description": "The managed service identities assigned to this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ConnectorListResult": {
+      "type": "object",
+      "description": "The response of a Connector list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Connector items on this page",
+          "items": {
+            "$ref": "#/definitions/Connector"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ConnectorManagedUserAssignedIdentityProperty": {
+      "type": "object",
+      "description": "The managed service identities envelope.",
+      "properties": {
+        "identity": {
+          "$ref": "#/definitions/ManagedServiceIdentityOnlyUserAssigned",
+          "description": "The managed service identities assigned to this resource."
+        }
+      }
+    },
+    "ConnectorProperties": {
+      "type": "object",
+      "description": "Details of the Connector.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "Resource provisioning state.",
+          "readOnly": true
+        },
+        "connectorId": {
+          "type": "string",
+          "description": "unique id of the connector.",
+          "readOnly": true
+        },
+        "tenantId": {
+          "type": "string",
+          "description": "tenant id of this connector",
+          "readOnly": true
+        },
+        "connectorType": {
+          "$ref": "#/definitions/Platform",
+          "description": "connector type"
+        },
+        "lastRunTimeStamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "last run time stamp of this connector in UTC time zone",
+          "readOnly": true
+        },
+        "processingState": {
+          "type": "string",
+          "description": "returns the processing state of a connector",
+          "readOnly": true
+        },
+        "processingStateMessage": {
+          "type": "string",
+          "description": "detailed description of the state and if any associated action that can be taken",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "connectorId",
+        "tenantId",
+        "connectorType",
+        "lastRunTimeStamp",
+        "processingState",
+        "processingStateMessage"
+      ]
+    },
+    "ConnectorPropertiesUpdate": {
+      "type": "object",
+      "description": "Details of the Connector.",
+      "properties": {
+        "connectorType": {
+          "$ref": "#/definitions/Platform",
+          "description": "connector type"
+        }
+      }
+    },
+    "ConnectorUpdate": {
+      "type": "object",
+      "description": "A connector is a resource that can be used to proactively report impacts against workloads in Azure to Microsoft.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ConnectorPropertiesUpdate",
+          "description": "The resource-specific properties for this resource."
+        },
+        "identity": {
+          "$ref": "#/definitions/ManagedServiceIdentityOnlyUserAssignedUpdate",
+          "description": "The managed service identities assigned to this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "Content": {
+      "type": "object",
+      "description": "Article details of the insight like title, description etc",
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Title of the insight"
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the insight"
+        }
+      },
+      "required": [
+        "title",
+        "description"
+      ]
+    },
+    "DetectionType": {
+      "type": "string",
+      "description": "List of detection types",
+      "enum": [
+        "BusinessAlert",
+        "MetricsThreshold",
+        "MetricsAnomaly"
+      ],
+      "x-ms-enum": {
+        "name": "DetectionType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "BusinessAlert",
+            "value": "BusinessAlert",
+            "description": "Use this when impact is alert based."
+          },
+          {
+            "name": "MetricsThreshold",
+            "value": "MetricsThreshold",
+            "description": "Use this when impact is metrics or expectations based."
+          },
+          {
+            "name": "MetricsAnomaly",
+            "value": "MetricsAnomaly",
+            "description": "Use this when impact is outlier based."
+          }
+        ]
+      }
+    },
+    "ErrorDetailProperties": {
+      "type": "object",
+      "description": "ARM error code and error message associated with the impact",
+      "properties": {
+        "errorCode": {
+          "type": "string",
+          "description": "ARM Error code associated with the impact."
+        },
+        "errorMessage": {
+          "type": "string",
+          "description": "ARM Error Message associated with the impact"
+        }
+      }
+    },
+    "ExpectedValueRange": {
+      "type": "object",
+      "description": "Max and Min Threshold values for the metric",
+      "properties": {
+        "min": {
+          "type": "number",
+          "format": "double",
+          "description": "Min threshold value for the metric"
+        },
+        "max": {
+          "type": "number",
+          "format": "double",
+          "description": "Max threshold value for the metric"
+        }
+      },
+      "required": [
+        "min",
+        "max"
+      ]
+    },
+    "ImpactCategory": {
+      "type": "object",
+      "description": "ImpactCategory resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ImpactCategoryProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ImpactCategoryEnum": {
+      "type": "string",
+      "description": "List of impact categories.",
+      "enum": [
+        "Availability",
+        "Performance",
+        "Other"
+      ],
+      "x-ms-enum": {
+        "name": "ImpactCategoryEnum",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Availability",
+            "value": "Availability",
+            "description": "Availability category"
+          },
+          {
+            "name": "Performance",
+            "value": "Performance",
+            "description": "Performance category"
+          },
+          {
+            "name": "Other",
+            "value": "Other",
+            "description": "Other category"
+          }
+        ]
+      }
+    },
+    "ImpactCategoryListResult": {
+      "type": "object",
+      "description": "The response of a ImpactCategory list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ImpactCategory items on this page",
+          "items": {
+            "$ref": "#/definitions/ImpactCategory"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ImpactCategoryProperties": {
+      "type": "object",
+      "description": "Impact category properties.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "Resource provisioning state.",
+          "readOnly": true
+        },
+        "categoryId": {
+          "type": "string",
+          "description": "Unique ID of the category",
+          "pattern": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+        },
+        "parentCategoryId": {
+          "type": "string",
+          "description": "Unique ID of the parent category",
+          "pattern": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the category"
+        },
+        "requiredImpactProperties": {
+          "type": "array",
+          "description": "The workloadImpact properties which are required when reporting with the impact category",
+          "items": {
+            "$ref": "#/definitions/RequiredImpactProperties"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "required": [
+        "categoryId"
+      ]
+    },
+    "ImpactDetails": {
+      "type": "object",
+      "description": "details of of the impact for which insight has been generated.",
+      "properties": {
+        "impactedResourceId": {
+          "type": "string",
+          "description": "List of impacted Azure resources."
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Time at which impact was started according to reported impact."
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Time at which impact was ended according to reported impact."
+        },
+        "impactId": {
+          "type": "string",
+          "description": "Azure Id of the impact."
+        }
+      },
+      "required": [
+        "impactedResourceId",
+        "startTime",
+        "impactId"
+      ]
+    },
+    "ImpactedResource": {
+      "type": "object",
+      "description": "impacted azure resource id.",
+      "properties": {
+        "impactedResourceId": {
+          "type": "string",
+          "description": "impacted azure resource id"
+        }
+      },
+      "required": [
+        "impactedResourceId"
+      ]
+    },
+    "IncidentSource": {
+      "type": "string",
+      "description": "List of incident interfaces.",
+      "enum": [
+        "AzureDevops",
+        "ICM",
+        "Jira",
+        "ServiceNow",
+        "Other"
+      ],
+      "x-ms-enum": {
+        "name": "IncidentSource",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "AzureDevops",
+            "value": "AzureDevops",
+            "description": "When source of Incident is AzureDevops"
+          },
+          {
+            "name": "ICM",
+            "value": "ICM",
+            "description": "When source of Incident is Microsoft ICM"
+          },
+          {
+            "name": "Jira",
+            "value": "Jira",
+            "description": "When source of Incident is Jira"
+          },
+          {
+            "name": "ServiceNow",
+            "value": "ServiceNow",
+            "description": "When source of Incident is ServiceNow"
+          },
+          {
+            "name": "Other",
+            "value": "Other",
+            "description": "When source of Incident is Other"
+          }
+        ]
+      }
+    },
+    "Insight": {
+      "type": "object",
+      "description": "Insight resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/InsightProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "InsightCategoryGroup": {
+      "type": "object",
+      "description": "Group of insights for a category",
+      "properties": {
+        "category": {
+          "type": "string",
+          "description": "Category name"
+        },
+        "status": {
+          "type": "string",
+          "description": "Status of the insights in this category"
+        },
+        "insights": {
+          "type": "array",
+          "description": "List of insight references in this category",
+          "items": {
+            "$ref": "#/definitions/InsightReference"
+          },
+          "x-ms-identifiers": [
+            "id"
+          ]
+        }
+      },
+      "required": [
+        "category"
+      ]
+    },
+    "InsightCustomResourceCommonParameters": {
+      "type": "object",
+      "description": "context of post call for insight",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "The API version to use for this operation.",
+          "minLength": 1
+        },
+        "subscriptionId": {
+          "$ref": "#/definitions/Azure.Core.uuid",
+          "description": "The ID of the target subscription. The value must be an UUID.",
+          "minLength": 1
+        },
+        "provider": {
+          "type": "string",
+          "description": "The provider namespace for the resource.",
+          "enum": [
+            "Microsoft.Impact"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        },
+        "azureResourceId": {
+          "type": "string",
+          "description": "Filter by resource type",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "apiVersion",
+        "subscriptionId",
+        "provider"
+      ]
+    },
+    "InsightDetails": {
+      "type": "object",
+      "description": "Body of the get all insights",
+      "properties": {
+        "azureResourceId": {
+          "type": "string",
+          "description": "The ID of the azure resource."
+        }
+      }
+    },
+    "InsightListResult": {
+      "type": "object",
+      "description": "The response of a Insight list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Insight items on this page",
+          "items": {
+            "$ref": "#/definitions/Insight"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "InsightProperties": {
+      "type": "object",
+      "description": "Impact category properties.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "Resource provisioning state.",
+          "readOnly": true
+        },
+        "category": {
+          "type": "string",
+          "description": "category of the insight."
+        },
+        "status": {
+          "type": "string",
+          "description": "status of the insight. example resolved, repaired, other."
+        },
+        "eventId": {
+          "type": "string",
+          "description": "Identifier of the event that has been correlated with this insight. This can be used to aggregate insights for the same event."
+        },
+        "groupId": {
+          "type": "string",
+          "description": "Identifier that can be used to group similar insights."
+        },
+        "content": {
+          "$ref": "#/definitions/Content",
+          "description": "Contains title & description for the insight"
+        },
+        "eventTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Time of the event, which has been correlated the impact."
+        },
+        "insightUniqueId": {
+          "type": "string",
+          "description": "unique id of the insight."
+        },
+        "impact": {
+          "$ref": "#/definitions/ImpactDetails",
+          "description": "details of of the impact for which insight has been generated."
+        },
+        "additionalDetails": {
+          "type": "object",
+          "description": "additional details of the insight."
+        }
+      },
+      "required": [
+        "category",
+        "content",
+        "insightUniqueId",
+        "impact"
+      ]
+    },
+    "InsightReference": {
+      "type": "object",
+      "description": "Reference to an Insight resource",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Azure resource ID of the insight"
+        }
+      },
+      "required": [
+        "id"
+      ]
+    },
+    "InsightUnderSubscription": {
+      "type": "object",
+      "description": "Insight resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/InsightProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ManagedServiceIdentityOnlyUserAssigned": {
+      "type": "object",
+      "description": "Managed service identity (system assigned and/or user assigned identities)",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/ManagedServiceIdentityTypeOnlyUserAssigned",
+          "description": "The type of managed identity assigned to this resource."
+        },
+        "userAssignedIdentities": {
+          "type": "object",
+          "description": "The identities assigned to this resource by the user.",
+          "additionalProperties": {
+            "$ref": "../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/UserAssignedIdentity",
+            "x-nullable": true
+          }
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "ManagedServiceIdentityOnlyUserAssignedUpdate": {
+      "type": "object",
+      "description": "Managed service identity (system assigned and/or user assigned identities)",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/ManagedServiceIdentityTypeOnlyUserAssigned",
+          "description": "The type of managed identity assigned to this resource."
+        },
+        "userAssignedIdentities": {
+          "type": "object",
+          "description": "The identities assigned to this resource by the user.",
+          "additionalProperties": {
+            "$ref": "../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/UserAssignedIdentity",
+            "x-nullable": true
+          }
+        }
+      }
+    },
+    "ManagedServiceIdentityTypeOnlyUserAssigned": {
+      "type": "string",
+      "description": "Type of managed service identity, where only UserAssigned type is allowed.",
+      "enum": [
+        "UserAssigned",
+        "None"
+      ],
+      "x-ms-enum": {
+        "name": "ManagedServiceIdentityTypeOnlyUserAssigned",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "UserAssigned",
+            "value": "UserAssigned",
+            "description": "User assigned managed identity."
+          },
+          {
+            "name": "None",
+            "value": "None",
+            "description": "No identity."
+          }
+        ]
+      }
+    },
+    "MetricUnit": {
+      "type": "string",
+      "description": "List of unit of the metric.",
+      "enum": [
+        "ByteSeconds",
+        "Bytes",
+        "BytesPerSecond",
+        "Cores",
+        "Count",
+        "CountPerSecond",
+        "MilliCores",
+        "MilliSeconds",
+        "NanoCores",
+        "Percent",
+        "Seconds",
+        "Other"
+      ],
+      "x-ms-enum": {
+        "name": "MetricUnit",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ByteSeconds",
+            "value": "ByteSeconds",
+            "description": "When measurement is in ByteSeconds"
+          },
+          {
+            "name": "Bytes",
+            "value": "Bytes",
+            "description": "When measurement is in Bytes"
+          },
+          {
+            "name": "BytesPerSecond",
+            "value": "BytesPerSecond",
+            "description": "When measurement is in BytesPerSecond"
+          },
+          {
+            "name": "Cores",
+            "value": "Cores",
+            "description": "When measurement is in Cores"
+          },
+          {
+            "name": "Count",
+            "value": "Count",
+            "description": "When measurement is in Count"
+          },
+          {
+            "name": "CountPerSecond",
+            "value": "CountPerSecond",
+            "description": "When measurement is in CountPerSecond"
+          },
+          {
+            "name": "MilliCores",
+            "value": "MilliCores",
+            "description": "When measurement is in MilliCores"
+          },
+          {
+            "name": "MilliSeconds",
+            "value": "MilliSeconds",
+            "description": "When measurement is in MilliSeconds"
+          },
+          {
+            "name": "NanoCores",
+            "value": "NanoCores",
+            "description": "When measurement is in NanoCores"
+          },
+          {
+            "name": "Percent",
+            "value": "Percent",
+            "description": "When measurement is in Percent"
+          },
+          {
+            "name": "Seconds",
+            "value": "Seconds",
+            "description": "When measurement is in Seconds"
+          },
+          {
+            "name": "Other",
+            "value": "Other",
+            "description": "When measurement is in Other than listed"
+          }
+        ]
+      }
+    },
+    "Performance": {
+      "type": "object",
+      "description": "Details about impacted performance metrics. Applicable for performance related impact",
+      "properties": {
+        "metricName": {
+          "type": "string",
+          "description": "Name of the Metric examples:  Disk, IOPs, CPU, GPU, Memory, details can be found from /impactCategories API"
+        },
+        "expected": {
+          "type": "number",
+          "format": "double",
+          "description": "Threshold value for the metric"
+        },
+        "actual": {
+          "type": "number",
+          "format": "double",
+          "description": "Observed value for the metric"
+        },
+        "expectedValueRange": {
+          "$ref": "#/definitions/ExpectedValueRange",
+          "description": "Max and Min Threshold values for the metric"
+        },
+        "unit": {
+          "$ref": "#/definitions/MetricUnit",
+          "description": "Unit of the metric ex: Bytes, Percentage, Count, Seconds, Milliseconds, Bytes/Second, Count/Second, etc.., Other"
+        }
+      }
+    },
+    "Platform": {
+      "type": "string",
+      "description": "Enum for connector types",
+      "enum": [
+        "AzureMonitor"
+      ],
+      "x-ms-enum": {
+        "name": "Platform",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "AzureMonitor",
+            "value": "AzureMonitor",
+            "description": "Type of Azure Monitor"
+          }
+        ]
+      }
+    },
+    "Protocol": {
+      "type": "string",
+      "description": "List of protocols",
+      "enum": [
+        "TCP",
+        "UDP",
+        "HTTP",
+        "HTTPS",
+        "RDP",
+        "FTP",
+        "SSH",
+        "Other"
+      ],
+      "x-ms-enum": {
+        "name": "Protocol",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "TCP",
+            "value": "TCP",
+            "description": "When communication protocol is TCP"
+          },
+          {
+            "name": "UDP",
+            "value": "UDP",
+            "description": "When communication protocol is UDP"
+          },
+          {
+            "name": "HTTP",
+            "value": "HTTP",
+            "description": "When communication protocol is HTTP"
+          },
+          {
+            "name": "HTTPS",
+            "value": "HTTPS",
+            "description": "When communication protocol is HTTPS"
+          },
+          {
+            "name": "RDP",
+            "value": "RDP",
+            "description": "When communication protocol is RDP"
+          },
+          {
+            "name": "FTP",
+            "value": "FTP",
+            "description": "When communication protocol is FTP"
+          },
+          {
+            "name": "SSH",
+            "value": "SSH",
+            "description": "When communication protocol is SSH"
+          },
+          {
+            "name": "Other",
+            "value": "Other",
+            "description": "When communication protocol is Other"
+          }
+        ]
+      }
+    },
+    "ProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of the resource.",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled"
+      ],
+      "x-ms-enum": {
+        "name": "ProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Provisioning Succeeded"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Provisioning Failed"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Provisioning Canceled"
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "RequiredImpactProperties": {
+      "type": "object",
+      "description": "Required impact properties",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the property"
+        },
+        "allowedValues": {
+          "type": "array",
+          "description": "Allowed values values for the property",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "Severity": {
+      "type": "string",
+      "description": "List of severity of an impact.",
+      "enum": [
+        "Critical",
+        "High",
+        "Medium",
+        "Low"
+      ],
+      "x-ms-enum": {
+        "name": "Severity",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Critical",
+            "value": "Critical",
+            "description": "Use this when the issue is critical. Consider this to be similar to severity 1 incidents."
+          },
+          {
+            "name": "High",
+            "value": "High",
+            "description": "Use this when the issue is high impact similar to severity 2 incidents."
+          },
+          {
+            "name": "Medium",
+            "value": "Medium",
+            "description": "Use this when the issue is medium impact similar to severity 3 incidents."
+          },
+          {
+            "name": "Low",
+            "value": "Low",
+            "description": "Use this for issues that are low impact similar to severity 4 and 5 incidents."
+          }
+        ]
+      }
+    },
+    "SourceOrTarget": {
+      "type": "object",
+      "description": "Resource details",
+      "properties": {
+        "azureResourceId": {
+          "type": "string",
+          "description": "Azure resource id, example /subscription/{subscription}/resourceGroup/{rg}/Microsoft.compute/virtualMachine/{vmName}",
+          "pattern": "(\\/[0-9a-zA-Z]+)*"
+        }
+      }
+    },
+    "Toolset": {
+      "type": "string",
+      "description": "List of azure interfaces.",
+      "enum": [
+        "Terraform",
+        "Puppet",
+        "Chef",
+        "SDK",
+        "Ansible",
+        "ARM",
+        "Portal",
+        "Shell",
+        "Other"
+      ],
+      "x-ms-enum": {
+        "name": "Toolset",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Terraform",
+            "value": "Terraform",
+            "description": "If communication toolset is Terraform"
+          },
+          {
+            "name": "Puppet",
+            "value": "Puppet",
+            "description": "If communication toolset is Puppet"
+          },
+          {
+            "name": "Chef",
+            "value": "Chef",
+            "description": "If communication toolset is Chef"
+          },
+          {
+            "name": "SDK",
+            "value": "SDK",
+            "description": "If communication toolset is SDK"
+          },
+          {
+            "name": "Ansible",
+            "value": "Ansible",
+            "description": "If communication toolset is Ansible"
+          },
+          {
+            "name": "ARM",
+            "value": "ARM",
+            "description": "If communication toolset is ARM"
+          },
+          {
+            "name": "Portal",
+            "value": "Portal",
+            "description": "If communication toolset is Portal"
+          },
+          {
+            "name": "Shell",
+            "value": "Shell",
+            "description": "If communication toolset is Shell"
+          },
+          {
+            "name": "Other",
+            "value": "Other",
+            "description": "If communication toolset is Other"
+          }
+        ]
+      }
+    },
+    "UploadTokenResult": {
+      "type": "object",
+      "description": "A successful response from getUploadToken will contain an 'uploadUrl' field. This uploadUrl field's value should follow the format: https://[storage-account-name].blob.core.windows.net/[container-name]/[your-blob.extension]?[SAS-token]",
+      "properties": {
+        "uploadUrl": {
+          "type": "string",
+          "format": "password",
+          "description": "The SAS token URL for uploading",
+          "x-ms-secret": true
+        }
+      },
+      "required": [
+        "uploadUrl"
+      ]
+    },
+    "Workload": {
+      "type": "object",
+      "description": "Information about the impacted workload",
+      "properties": {
+        "context": {
+          "type": "string",
+          "description": "the scenario for the workload"
+        },
+        "toolset": {
+          "$ref": "#/definitions/Toolset",
+          "description": "Tool used to interact with Azure. SDK, AzPortal, etc.., Other"
+        }
+      }
+    },
+    "WorkloadImpact": {
+      "type": "object",
+      "description": "Workload Impact properties",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/WorkloadImpactProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "WorkloadImpactListResult": {
+      "type": "object",
+      "description": "The response of a WorkloadImpact list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The WorkloadImpact items on this page",
+          "items": {
+            "$ref": "#/definitions/WorkloadImpact"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "WorkloadImpactProperties": {
+      "type": "object",
+      "description": "Workload impact properties",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "Resource provisioning state.",
+          "readOnly": true
+        },
+        "startDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Time at which impact was observed "
+        },
+        "endDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Time at which impact has ended "
+        },
+        "impactedResourceId": {
+          "type": "string",
+          "description": "Azure resource id of the impacted resource"
+        },
+        "impactUniqueId": {
+          "type": "string",
+          "description": "Unique ID of the impact (UUID)",
+          "pattern": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
+          "readOnly": true
+        },
+        "reportedTimeUtc": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Time at which impact is reported",
+          "readOnly": true
+        },
+        "impactCategory": {
+          "type": "string",
+          "description": "Category of the impact,  details can found from /impactCategories API"
+        },
+        "impactDescription": {
+          "type": "string",
+          "description": "A detailed description of the impact"
+        },
+        "armCorrelationIds": {
+          "type": "array",
+          "description": "The ARM correlation ids, this is important field for control plane related impacts",
+          "items": {
+            "type": "string"
+          }
+        },
+        "performance": {
+          "type": "array",
+          "description": "Details about performance issue. Applicable for performance impacts.",
+          "items": {
+            "$ref": "#/definitions/Performance"
+          },
+          "x-ms-identifiers": []
+        },
+        "connectivity": {
+          "$ref": "#/definitions/Connectivity",
+          "description": "Details about connectivity issue. Applicable when root resource causing the issue is not identified. For example, when a VM is impacted due to a network issue, the impacted resource is identified as the VM, but the root cause is the network. In such cases, the connectivity field will have the details about the network issue"
+        },
+        "additionalProperties": {
+          "type": "object",
+          "description": "Additional fields related to impact, applicable fields per resource type are list under /impactCategories API",
+          "additionalProperties": {}
+        },
+        "errorDetails": {
+          "$ref": "#/definitions/ErrorDetailProperties",
+          "description": "ARM error code and error message associated with the impact"
+        },
+        "workload": {
+          "$ref": "#/definitions/Workload",
+          "description": "Information about the impacted workload"
+        },
+        "impactGroupId": {
+          "type": "string",
+          "description": "Use this field to group impacts"
+        },
+        "confidenceLevel": {
+          "$ref": "#/definitions/ConfidenceLevel",
+          "description": "Degree of confidence on the impact being a platform issue"
+        },
+        "clientIncidentDetails": {
+          "$ref": "#/definitions/ClientIncidentDetails",
+          "description": "Client incident details ex: incidentId , incident source"
+        },
+        "ongoingImpact": {
+          "type": "boolean",
+          "description": "This field represents if an impact is ongoing or not. This is a boolean field."
+        },
+        "severity": {
+          "$ref": "#/definitions/Severity",
+          "description": "This field represents the severity of an impact. Severity can be from critical to low severity impact. Severity ranges from 1 to 5 with 1 being critical, 2 is high, 3 is medium and 4,5 represents low severity impact."
+        },
+        "durationInSec": {
+          "type": "number",
+          "format": "double",
+          "description": "Captures the longest interruption duration within the specified start and end times. For example, it can be used to indicate network connectivity loss lasting longer than a specified number of seconds within the given time range.",
+          "minimum": 0
+        },
+        "detectionType": {
+          "$ref": "#/definitions/DetectionType",
+          "description": "This field represents the type of impact. Possible values are MetricsThreshold, MetricsAnomaly, BusinessAlert."
+        },
+        "durationMarginInSec": {
+          "type": "number",
+          "format": "double",
+          "description": "This field represents the duration margin in seconds that can be provided while providing endDateTime.",
+          "minimum": 0
+        },
+        "hitCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "This field represents the number of times a particular issue was observed over a given time range.",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "startDateTime",
+        "impactedResourceId",
+        "impactCategory"
+      ]
+    }
+  },
+  "parameters": {
+    "CustomParameters.categoryName": {
+      "name": "categoryName",
+      "in": "query",
+      "description": "Filter by category name ",
+      "required": false,
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[a-zA-Z0-9][a-zA-Z0-9.]*[a-zA-Z0-9]{3,180}$",
+      "x-ms-parameter-location": "method"
+    },
+    "CustomParameters.resourceType": {
+      "name": "resourceType",
+      "in": "query",
+      "description": "Filter by resource type",
+      "required": false,
+      "type": "string",
+      "minLength": 1,
+      "x-ms-parameter-location": "method"
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/Connectors_CreateOrUpdate.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/Connectors_CreateOrUpdate.json
@@ -1,0 +1,91 @@
+{
+  "operationId": "Connectors_CreateOrUpdate",
+  "title": "CreateConnector",
+  "parameters": {
+    "api-version": "2026-01-01-preview",
+    "subscriptionId": "74f5e23f-d4d9-410a-bb4d-8f0608adb10d",
+    "connectorName": "testconnector1",
+    "resource": {
+      "properties": {
+        "connectorType": "AzureMonitor"
+      },
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/eu2cgroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1": {}
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "connectorId": "430a444e-6a84-4a6f-8c50-124843ca7cd4",
+          "tenantId": "23a8d1da-a7e9-4443-9797-4cd3e3aeb8f8",
+          "connectorType": "AzureMonitor",
+          "lastRunTimeStamp": "2024-03-19T06:23:56.238Z",
+          "processingState": "Initialized",
+          "processingStateMessage": ""
+        },
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/eu2cgroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1": {
+              "clientId": "fbe75b66-01c5-4f87-a220-233af3270436",
+              "principalId": "075a0ca6-43f6-4434-9abf-c9b1b79f9219"
+            }
+          }
+        },
+        "id": "/subscriptions/74f5e23f-d4d9-410a-bb4d-8f0608adb10d/providers/Microsoft.Impact/connectors/testconnector1",
+        "name": "testconnector1",
+        "type": "microsoft.impact/connectors",
+        "systemData": {
+          "createdBy": "testuser@hotmail.com",
+          "createdByType": "User",
+          "createdAt": "2024-03-07T06:19:01.6431721Z",
+          "lastModifiedBy": "testuser@hotmail.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-03-15T08:29:20.8549373Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+      },
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "connectorId": "430a444e-6a84-4a6f-8c50-124843ca7cd4",
+          "tenantId": "23a8d1da-a7e9-4443-9797-4cd3e3aeb8f8",
+          "connectorType": "AzureMonitor",
+          "lastRunTimeStamp": "2024-03-19T06:23:56.238Z",
+          "processingState": "Initialized",
+          "processingStateMessage": ""
+        },
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/eu2cgroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1": {
+              "clientId": "fbe75b66-01c5-4f87-a220-233af3270436",
+              "principalId": "075a0ca6-43f6-4434-9abf-c9b1b79f9219"
+            }
+          }
+        },
+        "id": "/subscriptions/74f5e23f-d4d9-410a-bb4d-8f0608adb10d/providers/Microsoft.Impact/connectors/testconnector1",
+        "name": "testconnector1",
+        "type": "microsoft.impact/connectors",
+        "systemData": {
+          "createdBy": "testuser@hotmail.com",
+          "createdByType": "User",
+          "createdAt": "2024-03-07T06:19:01.6431721Z",
+          "lastModifiedBy": "testuser@hotmail.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-03-15T08:29:20.8549373Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/Connectors_Delete.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/Connectors_Delete.json
@@ -1,0 +1,13 @@
+{
+  "title": "Connectors_Delete",
+  "operationId": "Connectors_Delete",
+  "parameters": {
+    "api-version": "2026-01-01-preview",
+    "subscriptionId": "8F74B371-8573-4773-9BDA-D546505BDB3A",
+    "connectorName": "testconnector1"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/Connectors_Get.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/Connectors_Get.json
@@ -1,0 +1,55 @@
+{
+  "operationId": "Connectors_Get",
+  "title": "GetConnector",
+  "parameters": {
+    "api-version": "2026-01-01-preview",
+    "subscriptionId": "74f5e23f-d4d9-410a-bb4d-8f0608adb10d",
+    "connectorName": "testconnector1",
+    "resource": {
+      "properties": {
+        "connectorType": "AzureMonitor"
+      },
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/eu2cgroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1": {}
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "connectorId": "430a444e-6a84-4a6f-8c50-124843ca7cd4",
+          "tenantId": "23a8d1da-a7e9-4443-9797-4cd3e3aeb8f8",
+          "connectorType": "AzureMonitor",
+          "lastRunTimeStamp": "2024-03-19T06:23:56.238Z",
+          "processingState": "Initialized",
+          "processingStateMessage": ""
+        },
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/eu2cgroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1": {
+              "clientId": "fbe75b66-01c5-4f87-a220-233af3270436",
+              "principalId": "075a0ca6-43f6-4434-9abf-c9b1b79f9219"
+            }
+          }
+        },
+        "id": "/subscriptions/74f5e23f-d4d9-410a-bb4d-8f0608adb10d/providers/Microsoft.Impact/connectors/testconnector1",
+        "name": "testconnector1",
+        "type": "microsoft.impact/connectors",
+        "systemData": {
+          "createdBy": "testuser@hotmail.com",
+          "createdByType": "User",
+          "createdAt": "2024-03-07T06:19:01.6431721Z",
+          "lastModifiedBy": "testuser@hotmail.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-03-15T08:29:20.8549373Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/Connectors_ListBySubscription.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/Connectors_ListBySubscription.json
@@ -1,0 +1,48 @@
+{
+  "title": "Connectors_ListBySubscription",
+  "operationId": "Connectors_ListBySubscription",
+  "parameters": {
+    "api-version": "2026-01-01-preview",
+    "subscriptionId": "74f5e23f-d4d9-410a-bb4d-8f0608adb10d"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "provisioningState": "Succeeded",
+              "connectorId": "430a444e-6a84-4a6f-8c50-124843ca7cd4",
+              "tenantId": "23a8d1da-a7e9-4443-9797-4cd3e3aeb8f8",
+              "connectorType": "AzureMonitor",
+              "lastRunTimeStamp": "2024-03-19T06:23:56.238Z",
+              "processingState": "Initialized",
+              "processingStateMessage": ""
+            },
+            "identity": {
+              "type": "UserAssigned",
+              "userAssignedIdentities": {
+                "/subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/eu2cgroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1": {
+                  "clientId": "fbe75b66-01c5-4f87-a220-233af3270436",
+                  "principalId": "075a0ca6-43f6-4434-9abf-c9b1b79f9219"
+                }
+              }
+            },
+            "id": "/subscriptions/74f5e23f-d4d9-410a-bb4d-8f0608adb10d/providers/Microsoft.Impact/connectors/testconnector1",
+            "name": "testconnector1",
+            "type": "microsoft.impact/connectors",
+            "systemData": {
+              "createdBy": "testuser@hotmail.com",
+              "createdByType": "User",
+              "createdAt": "2024-03-07T06:19:01.6431721Z",
+              "lastModifiedBy": "testuser@hotmail.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2024-03-15T08:29:20.8549373Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/Connectors_Update.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/Connectors_Update.json
@@ -1,0 +1,55 @@
+{
+  "title": "Connectors_Update",
+  "operationId": "Connectors_Update",
+  "parameters": {
+    "api-version": "2026-01-01-preview",
+    "subscriptionId": "74f5e23f-d4d9-410a-bb4d-8f0608adb10d",
+    "connectorName": "testconnector1",
+    "properties": {
+      "properties": {
+        "connectorType": "AzureMonitor"
+      },
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/eu2cgroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1": {}
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "connectorId": "430a444e-6a84-4a6f-8c50-124843ca7cd4",
+          "tenantId": "23a8d1da-a7e9-4443-9797-4cd3e3aeb8f8",
+          "connectorType": "AzureMonitor",
+          "lastRunTimeStamp": "2024-03-19T06:23:56.238Z",
+          "processingState": "Initialized",
+          "processingStateMessage": ""
+        },
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/eu2cgroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1": {
+              "clientId": "fbe75b66-01c5-4f87-a220-233af3270436",
+              "principalId": "075a0ca6-43f6-4434-9abf-c9b1b79f9219"
+            }
+          }
+        },
+        "id": "/subscriptions/74f5e23f-d4d9-410a-bb4d-8f0608adb10d/providers/Microsoft.Impact/connectors/testconnector1",
+        "name": "testconnector1",
+        "type": "microsoft.impact/connectors",
+        "systemData": {
+          "createdBy": "testuser@hotmail.com",
+          "createdByType": "User",
+          "createdAt": "2024-03-07T06:19:01.6431721Z",
+          "lastModifiedBy": "testuser@hotmail.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-03-15T08:29:20.8549373Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/ImpactCategories_Get.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/ImpactCategories_Get.json
@@ -1,0 +1,28 @@
+{
+  "operationId": "ImpactCategories_Get",
+  "title": "Get WorkloadImpact Resource by name",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-01-01-preview",
+    "impactCategoryName": "ARMOperation.Create"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/ImpactCategories/ARMOperation.Create",
+        "name": "ARMOperation.Create",
+        "type": "Microsoft.Impact/impactCategories",
+        "properties": {
+          "description": "Use this to report problems related to creating a new azure virtual machine such as provisioning or allocation failures.",
+          "categoryId": "778f815b-6576-4a36-bea9-bffb3d26d7f4",
+          "parentCategoryId": "36266d25-9c53-40b3-af41-27418b11851e",
+          "requiredImpactProperties": [
+            {
+              "name": "armCorrelations"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/ImpactCategories_ListBySubscription.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/ImpactCategories_ListBySubscription.json
@@ -1,0 +1,82 @@
+{
+  "operationId": "ImpactCategories_ListBySubscription",
+  "title": "Get ImpactCategories list by subscription",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceType": "microsoft.compute/virtualmachines",
+    "api-version": "2026-01-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/ImpactCategories/ARMOperation.Create",
+            "name": "ARMOperation.Create",
+            "type": "Microsoft.Impact/impactCategories",
+            "properties": {
+              "description": "Use this to report problems related to creating a new azure virtual machine such as provisioning or allocation failures.",
+              "categoryId": "778f815b-6576-4a36-bea9-bffb3d26d7f4",
+              "parentCategoryId": "36266d25-9c53-40b3-af41-27418b11851e",
+              "requiredImpactProperties": [
+                {
+                  "name": "armCorrelations"
+                }
+              ]
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/ImpactCategories/ARMOperation.Delete",
+            "name": "ARMOperation.Delete",
+            "type": "Microsoft.Impact/impactCategories",
+            "properties": {
+              "description": "Use this to report failures in deleting VMs.",
+              "categoryId": "a9a0c6e2-1208-406f-8f4f-1ccc13fb75d5",
+              "parentCategoryId": "36266d25-9c53-40b3-af41-27418b11851e",
+              "requiredImpactProperties": [
+                {
+                  "name": "armCorrelations"
+                }
+              ]
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/ImpactCategories/ARMOperation.Other",
+            "name": "ARMOperation.Other",
+            "type": "Microsoft.Impact/impactCategories",
+            "properties": {
+              "description": "Use this to report Control Plane operation failures that don't fall into other ARMOperation categories",
+              "categoryId": "7b71f937-9344-499c-bfbe-d86fb755d891",
+              "parentCategoryId": "36266d25-9c53-40b3-af41-27418b11851e",
+              "requiredImpactProperties": [
+                {
+                  "name": "armCorrelations"
+                }
+              ]
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/ImpactCategories/Resource.Connectivity",
+            "name": "Resource.Connectivity",
+            "type": "Microsoft.Impact/impactCategories",
+            "properties": {
+              "description": "Use this to report connectivity issues to or from a VM.",
+              "categoryId": "95903644-3a15-4e37-b4be-a2ae8651f27b",
+              "parentCategoryId": "a8d1c1ae-5fcb-4a8b-a647-fd0a911e8667"
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/ImpactCategories/Resource.Connectivity.Inbound",
+            "name": "Resource.Connectivity.Inbound",
+            "type": "Microsoft.Impact/impactCategories",
+            "properties": {
+              "description": "Use this to report inbound connectivity issues to a VM.",
+              "categoryId": "940fb706-8586-4a0e-bb18-2e2d0ef0708d",
+              "parentCategoryId": "95903644-3a15-4e37-b4be-a2ae8651f27b"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/Insights_Create.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/Insights_Create.json
@@ -1,0 +1,73 @@
+{
+  "operationId": "Insights_Create",
+  "title": "Creating an insight",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-01-01-preview",
+    "workloadImpactName": "impactid22",
+    "insightName": "insightId12",
+    "resource": {
+      "properties": {
+        "content": {
+          "title": "Impact Has been correlated to an outage",
+          "description": "At 2018-11-08T00:00:00Z UTC, your services dependent on these resources <link href=”…”>VM1</link> may have experienced an issue. <br/><div>We have identified an outage that affected these resources(s). You can look at outage information on <link href=\"https:// portal.azure.com/#view/Microsoft_Azure_Health/AzureHealthBrowseBlade/~/serviceIssues/trackingId/NL2W-VCZ\">NL2W-VCZ</link> link.<div>"
+        },
+        "category": "repair",
+        "status": "resolved",
+        "eventTime": "2023-06-15T04:00:00.009223Z",
+        "insightUniqueId": "00000000-0000-0000-0000-000000000000",
+        "impact": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+          "startTime": "2023-06-15T01:00:00.009223Z",
+          "impactId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/workloadImpacts/impactid22"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/workloadImpacts/impactid22/insights/insightId12",
+        "name": "insightId12",
+        "type": "Microsoft.Impact/insights",
+        "properties": {
+          "eventTime": "2023-06-15T04:00:00.009223Z",
+          "content": {
+            "title": "Impact Has been correlated to an outage",
+            "description": "At 2018-11-08T00:00:00Z UTC, your services dependent on these resources <link href=”…”>VM1</link> may have experienced an issue. <br/><div>We have identified an outage that affected these resources(s). You can look at outage information on <link href=\"https:// portal.azure.com/#view/Microsoft_Azure_Health/AzureHealthBrowseBlade/~/serviceIssues/trackingId/NL2W-VCZ\">NL2W-VCZ</link> link.<div>"
+          },
+          "category": "repair",
+          "status": "resolved",
+          "insightUniqueId": "00000000-0000-0000-0000-000000000000",
+          "impact": {
+            "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+            "startTime": "2023-06-15T01:00:00.009223Z",
+            "impactId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/workloadImpacts/impactid22"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/workloadImpacts/impactid22/insights/insightId12",
+        "name": "insightId12",
+        "type": "Microsoft.Impact/insights",
+        "properties": {
+          "eventTime": "2023-06-15T04:00:00.009223Z",
+          "content": {
+            "title": "Impact Has been correlated to an outage",
+            "description": "At 2018-11-08T00:00:00Z UTC, your services dependent on these resources <link href=”…”>VM1</link> may have experienced an issue. <br/><div>We have identified an outage that affected these resources(s). You can look at outage information on <link href=\"https:// portal.azure.com/#view/Microsoft_Azure_Health/AzureHealthBrowseBlade/~/serviceIssues/trackingId/NL2W-VCZ\">NL2W-VCZ</link> link.<div>"
+          },
+          "category": "repair",
+          "status": "resolved",
+          "insightUniqueId": "00000000-0000-0000-0000-000000000000",
+          "impact": {
+            "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+            "startTime": "2023-06-15T01:00:00.009223Z",
+            "impactId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/workloadImpacts/impactid22"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/Insights_Delete.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/Insights_Delete.json
@@ -1,0 +1,14 @@
+{
+  "operationId": "Insights_Delete",
+  "title": "Delete an Insight",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-01-01-preview",
+    "workloadImpactName": "impactid22",
+    "insightName": "insightId12"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/Insights_Get_diagnostics.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/Insights_Get_diagnostics.json
@@ -1,0 +1,33 @@
+{
+  "operationId": "Insights_Get",
+  "title": "Get Insight sample for Diagnostics category",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-01-01-preview",
+    "workloadImpactName": "impactid",
+    "insightName": "insight1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadimpacts/impactid/insights/insight1",
+        "name": "insight1",
+        "type": "Microsoft.impact/workloadimpacts/insights",
+        "properties": {
+          "category": "Diagnostics",
+          "impact": {
+            "impactId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadimpacts/impactid",
+            "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/virtualamchine/vm",
+            "startTime": "2018-11-08T00:00:00Z",
+            "endTime": "2018-11-08T00:00:00Z"
+          },
+          "insightUniqueId": "00000000-0000-0000-0000-000000000000",
+          "content": {
+            "title": "We ran diagnostics on your resource and found an issue",
+            "description": "<!--issueDescription-->\n<p>The physical host node where your VM is running had a networking stack update. This might result in a brief connectivity loss.</p>\n<br/><table><tr><th align=\"left\">Resource</th><th align=\"left\">Impact Start Time</th><th align=\"left\">Impact End Time</th><th align=\"left\">Impact Duration(Timespan)</th></tr><tr><td align=\"left\">west-eur-VM</td><td align=\"left\">2024-02-18 01:09:31 UTC</td><td align=\"left\">2024-02-18 01:09:35 UTC</td><td align=\"left\">00:00:04.2690000</td></tr></table>\n<!--/issueDescription-->\n<p>Azure performs updates to improve reliability, performance, and security of the VMs. Azure chooses the least impactful method, which might result in a brief connectivity loss. We are continuously working to improve and reduce impact of our updates, and we apologize for any inconvenience this may have caused you.</p>\n<!--recommendedActions-->\n<h2><strong>Recommended Documents</strong></h2>\n<ul>\n<li>To prepare for VM maintenance events and reduce its impact, try using <a href=\"https://docs.microsoft.com/azure/virtual-machines/windows/scheduled-events\">Scheduled Events for Windows</a> or <a href=\"https://docs.microsoft.com/azure/virtual-machines/linux/scheduled-events\">Linux</a></li>\n<li>Learn more about Azure maintenance and configuring for high availability:\n<ul>\n<li><a href=\"https://docs.microsoft.com/azure/virtual-machines/maintenance-and-updates\">Maintenance and updates for virtual machines in Azure</a></li>\n<li><a href=\"https://docs.microsoft.com/azure/virtual-machines/windows/tutorial-availability-sets\">Configure availability of virtual machines</a></li>\n</ul>\n</li>\n<li>To troubleshoot this scenario in the future, see <a href=\"https://docs.microsoft.com/azure/resource-health/resource-health-overview\">Resource Health Center</a></li>\n</ul>\n"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/Insights_Get_mitigationAction.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/Insights_Get_mitigationAction.json
@@ -1,0 +1,38 @@
+{
+  "operationId": "Insights_Get",
+  "title": "Get Insight sample for MitigationAction category",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-01-01-preview",
+    "workloadImpactName": "impactId",
+    "insightName": "HPCUASucceeded"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadimpacts/impactId/insights/HPCUASucceeded",
+        "name": "HPCUASucceeded",
+        "type": "Microsoft.impact/workloadimpacts/insights",
+        "properties": {
+          "category": "MitigationAction",
+          "eventTime": "2023-06-15T04:00:00.009223Z",
+          "insightUniqueId": "00000000-0000-0000-0000-000000000000",
+          "impact": {
+            "impactId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadimpacts/impactId",
+            "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/virtualMachine/vm",
+            "startTime": "2018-11-08T00:00:00Z",
+            "endTime": "2018-11-08T00:00:00Z"
+          },
+          "content": {
+            "title": "Node was flagged for inspection",
+            "description": "At 2024-02-16 21:05:07 (UTC) an impact was reported on west-eur-VM indicating a potential disruption from Azure platform. <strong>Action Taken</strong> The hardware your VM was running on was flagged for inspection. We will conduct our investigation and take corrective action to prevent further impact on your workloads. We apologize for any disruption. Microsoft Azure Team"
+          },
+          "additionalDetails": {
+            "statusCode": "Succeeded",
+            "terminalState": "true"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/Insights_Get_servicehealth.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/Insights_Get_servicehealth.json
@@ -1,0 +1,35 @@
+{
+  "operationId": "Insights_Get",
+  "title": "Get Insight sample for service health category",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-01-01-preview",
+    "workloadImpactName": "impactid",
+    "insightName": "insightname"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/workloadImpacts/impactname/insights/insightname",
+        "name": "insightname",
+        "type": "Microsoft.Impact/insights",
+        "properties": {
+          "category": "ServiceHealth",
+          "eventId": "ABC-123",
+          "eventTime": "2023-06-15T04:00:00.009223Z",
+          "impact": {
+            "impactId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadimpacts/impactid",
+            "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.compute/virtualmachines/vm1",
+            "startTime": "2018-11-08T00:00:00Z",
+            "endTime": "2018-11-08T00:00:00Z"
+          },
+          "insightUniqueId": "a3d91a07-698b-4044-a230-e918252c4c59",
+          "content": {
+            "title": "Impact Has been correlated to an outage",
+            "description": "On November 8, 2018, at 00:00 UTC, there may have been disruptions to your services linked to the resource <a href='...'>VM1<a>. We have pinpointed a service outage impacting these resources. For details on this outage, please refer to the service health information available at <a href='...'>service health</a>."
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/Insights_ListBySubscription.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/Insights_ListBySubscription.json
@@ -1,0 +1,37 @@
+{
+  "operationId": "Insights_ListBySubscription",
+  "title": "List Insight resources by workloadImpactName",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "workloadImpactName": "impactid22",
+    "api-version": "2026-01-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/workloadImpacts/impactid22/insights/insightId12",
+            "name": "insightId12",
+            "type": "Microsoft.Impact/insights",
+            "properties": {
+              "eventTime": "2023-06-15T04:00:00.009223Z",
+              "content": {
+                "title": "Impact Has been correlated to an outage",
+                "description": "At 2018-11-08T00:00:00Z UTC, your services dependent on these resources <link href=”…”>VM1</link> may have experienced an issue. <br/><div>We have identified an outage that affected these resources(s). You can look at outage information on <link href=\"https:// portal.azure.com/#view/Microsoft_Azure_Health/AzureHealthBrowseBlade/~/serviceIssues/trackingId/NL2W-VCZ\">NL2W-VCZ</link> link.<div>"
+              },
+              "category": "repair",
+              "status": "resolved",
+              "insightUniqueId": "00000000-0000-0000-0000-000000000000",
+              "impact": {
+                "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+                "startTime": "2023-06-15T01:00:00.009223Z",
+                "impactId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/microsoft.Impact/workloadImpacts/impactid22"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/Operations_List.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/Operations_List.json
@@ -1,0 +1,52 @@
+{
+  "operationId": "Operations_List",
+  "title": "OperationsList",
+  "parameters": {
+    "api-version": "2026-01-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.Impact/workloadImpacts/write",
+            "display": {
+              "provider": "Microsoft.Impact",
+              "resource": "workloadImpacts",
+              "operation": "write",
+              "description": "Write workloadImpact resources"
+            }
+          },
+          {
+            "name": "Microsoft.Impact/workloadImpacts/read",
+            "display": {
+              "provider": "Microsoft.Impact",
+              "resource": "workloadimpacts",
+              "operation": "read",
+              "description": "Read workloadImpact resources"
+            }
+          },
+          {
+            "name": "Microsoft.Impact/impactCategories/read",
+            "display": {
+              "provider": "Microsoft.Impact",
+              "resource": "impactCategories",
+              "operation": "read",
+              "description": "Read impactCategory resources"
+            }
+          },
+          {
+            "name": "Microsoft.Impact/getUploadToken/action",
+            "display": {
+              "provider": "Microsoft.Impact",
+              "resource": "getUploadToken",
+              "operation": "Get Upload Token",
+              "description": "Get an upload token for the storage account and container to upload logs associated with impacts."
+            }
+          }
+        ],
+        "nextLink": null
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/UploadService_GetUploadToken.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/UploadService_GetUploadToken.json
@@ -1,0 +1,15 @@
+{
+  "operationId": "UploadService_GetUploadToken",
+  "title": "Get upload token to use for log upload",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-01-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "uploadUrl": "https://storageAccountHere.blob.core.windows.net/container-here/yyyyMMddHHmmss-12345678.zip?[SAS-token]"
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/WorkloadArmOperation_create.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/WorkloadArmOperation_create.json
@@ -1,0 +1,99 @@
+{
+  "operationId": "WorkloadImpacts_Create",
+  "title": "Reporting Arm operation failure",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-01-01-preview",
+    "workloadImpactName": "impact-002",
+    "resource": {
+      "properties": {
+        "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservercontext",
+        "startDateTime": "2022-06-15T05:59:46.6517821Z",
+        "endDateTime": null,
+        "impactDescription": "deletion of resource failed",
+        "impactCategory": "ArmOperation",
+        "armCorrelationIds": [
+          "00000000-0000-0000-0000-000000000000"
+        ],
+        "workload": {
+          "context": "webapp/scenario1",
+          "toolset": "Other"
+        },
+        "clientIncidentDetails": {
+          "clientIncidentId": "AA123",
+          "clientIncidentSource": "Jira"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadImpacts/impact-001",
+        "name": "impact-001",
+        "type": "Microsoft.Impact/workloadImpacts",
+        "properties": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "deletion of resource failed",
+          "impactCategory": "ArmOperation",
+          "armCorrelationIds": [
+            "00000000-0000-0000-0000-000000000000"
+          ],
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "clientIncidentDetails": {
+            "clientIncidentId": "AA123",
+            "clientIncidentSource": "Jira"
+          },
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z",
+          "insightsByCategory": [
+            {
+              "category": "service health",
+              "status": "investigating",
+              "insights": []
+            }
+          ]
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadImpacts/impact-001",
+        "name": "impact-001",
+        "type": "Microsoft.Impact/workloadImpacts",
+        "properties": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "deletion of resource failed",
+          "impactCategory": "ArmOperation",
+          "armCorrelationIds": [
+            "00000000-0000-0000-0000-000000000000"
+          ],
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "clientIncidentDetails": {
+            "clientIncidentId": "AA123",
+            "clientIncidentSource": "Jira"
+          },
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z",
+          "insightsByCategory": [
+            {
+              "category": "service health",
+              "status": "investigating",
+              "insights": []
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/WorkloadAvailability_Create.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/WorkloadAvailability_Create.json
@@ -1,0 +1,90 @@
+{
+  "operationId": "WorkloadImpacts_Create",
+  "title": "Reporting availability related impact",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-01-01-preview",
+    "workloadImpactName": "impact-002",
+    "resource": {
+      "properties": {
+        "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservercontext",
+        "startDateTime": "2022-06-15T05:59:46.6517821Z",
+        "endDateTime": null,
+        "impactDescription": "read calls failed",
+        "impactCategory": "Availability",
+        "workload": {
+          "context": "webapp/scenario1",
+          "toolset": "Other"
+        },
+        "clientIncidentDetails": {
+          "clientIncidentId": "AA123",
+          "clientIncidentSource": "Jira"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadImpacts/impact-002",
+        "name": "impact-002",
+        "type": "Microsoft.Impact/workloadImpacts",
+        "properties": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "read calls failed",
+          "impactCategory": "Availability",
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "clientIncidentDetails": {
+            "clientIncidentId": "AA123",
+            "clientIncidentSource": "Jira"
+          },
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z",
+          "insightsByCategory": [
+            {
+              "category": "service health",
+              "status": "investigating",
+              "insights": []
+            }
+          ]
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadImpacts/impact-002",
+        "name": "impact-001",
+        "type": "Microsoft.Impact/workloadImpacts",
+        "properties": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "read calls failed",
+          "impactCategory": "Availability",
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "clientIncidentDetails": {
+            "clientIncidentId": "AA123",
+            "clientIncidentSource": "Jira"
+          },
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z",
+          "insightsByCategory": [
+            {
+              "category": "service health",
+              "status": "investigating",
+              "insights": []
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/WorkloadConnectivityImpact_Create.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/WorkloadConnectivityImpact_Create.json
@@ -1,0 +1,120 @@
+{
+  "operationId": "WorkloadImpacts_Create",
+  "title": "Reporting a connectivity impact",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-01-01-preview",
+    "workloadImpactName": "impact-001",
+    "resource": {
+      "properties": {
+        "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservercontext",
+        "startDateTime": "2022-06-15T05:59:46.6517821Z",
+        "endDateTime": null,
+        "impactDescription": "conection failure",
+        "impactCategory": "Resource.Connectivity",
+        "connectivity": {
+          "protocol": "TCP",
+          "port": 1443,
+          "source": {
+            "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceSub/providers/Microsoft.compute/virtualmachines/vm1"
+          },
+          "target": {
+            "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceSub/providers/Microsoft.compute/virtualmachines/vm2"
+          }
+        },
+        "workload": {
+          "context": "webapp/scenario1",
+          "toolset": "Other"
+        },
+        "clientIncidentDetails": {
+          "clientIncidentId": "AA123",
+          "clientIncidentSource": "Jira"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Impacts-rg/providers/Microsoft.Impact/workloadImpacts/impact-001",
+        "name": "impact-001",
+        "type": "Microsoft.Impact/workloadImpacts",
+        "properties": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservercontext",
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "conection failure",
+          "impactCategory": "Resource.Connectivity",
+          "connectivity": {
+            "protocol": "TCP",
+            "port": 1443,
+            "source": {
+              "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceSub/providers/Microsoft.compute/virtualmachines/vm1"
+            },
+            "target": {
+              "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceSub/providers/Microsoft.compute/virtualmachines/vm2"
+            }
+          },
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "clientIncidentDetails": {
+            "clientIncidentId": "AA123",
+            "clientIncidentSource": "Jira"
+          },
+          "insightsByCategory": [
+            {
+              "category": "service health",
+              "status": "investigating",
+              "insights": []
+            }
+          ]
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Impacts-rg/providers/Microsoft.Impact/workloadImpacts/impact-001",
+        "name": "impact-001",
+        "type": "Microsoft.Impact/workloadImpacts",
+        "properties": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservercontext",
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "conection failure",
+          "impactCategory": "Resource.Connectivity",
+          "connectivity": {
+            "protocol": "TCP",
+            "port": 1443,
+            "source": {
+              "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceSub/providers/Microsoft.compute/virtualmachines/vm1"
+            },
+            "target": {
+              "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceSub/providers/Microsoft.compute/virtualmachines/vm2"
+            }
+          },
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "clientIncidentDetails": {
+            "clientIncidentId": "AA123",
+            "clientIncidentSource": "Jira"
+          },
+          "insightsByCategory": [
+            {
+              "category": "service health",
+              "status": "investigating",
+              "insights": []
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/WorkloadImpact_Delete.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/WorkloadImpact_Delete.json
@@ -1,0 +1,13 @@
+{
+  "operationId": "WorkloadImpacts_Delete",
+  "title": "Delete WorkloadImpact Resource by name example",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-01-01-preview",
+    "workloadImpactName": "impact-001"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/WorkloadImpact_Get.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/WorkloadImpact_Get.json
@@ -1,0 +1,46 @@
+{
+  "operationId": "WorkloadImpacts_Get",
+  "title": "Get WorkloadImpact Resource by name example",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-01-01-preview",
+    "workloadImpactName": "impact-001"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadImpacts/impact-001",
+        "name": "impact-001",
+        "type": "Microsoft.Impact/workloadImpacts",
+        "properties": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "high cup utilization",
+          "impactCategory": "Performance",
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "clientIncidentDetails": {
+            "clientIncidentId": "AA123",
+            "clientIncidentSource": "Jira"
+          },
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z",
+          "insightsByCategory": [
+            {
+              "category": "service health",
+              "status": "Completed",
+              "insights": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/workloadImpacts/impact-001/insight/insightId"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/WorkloadImpacts_Create_MaximumSet_Gen.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/WorkloadImpacts_Create_MaximumSet_Gen.json
@@ -1,0 +1,211 @@
+{
+  "title": "WorkloadImpacts_Create_MaximumSet",
+  "operationId": "WorkloadImpacts_Create",
+  "parameters": {
+    "api-version": "2026-01-01-preview",
+    "subscriptionId": "0D045314-435A-41DA-B0A4-2CA7E9F87D12",
+    "workloadImpactName": "testWorkloadImpact",
+    "resource": {
+      "properties": {
+        "startDateTime": "2024-12-04T19:51:13.274Z",
+        "endDateTime": "2024-12-04T19:51:13.274Z",
+        "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+        "impactCategory": "Resource.Other",
+        "impactDescription": "test description",
+        "armCorrelationIds": [
+          "4D045314-435A-41DA-B0A4-2CA7E9F87D12"
+        ],
+        "performance": [
+          {
+            "metricName": "testMetric",
+            "expected": 23,
+            "actual": 20,
+            "expectedValueRange": {
+              "min": 1,
+              "max": 27
+            },
+            "unit": "ByteSeconds"
+          }
+        ],
+        "connectivity": {
+          "protocol": "TCP",
+          "port": 6,
+          "source": {
+            "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm1"
+          },
+          "target": {
+            "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm2"
+          }
+        },
+        "additionalProperties": {},
+        "errorDetails": {
+          "errorCode": "504",
+          "errorMessage": "Gateway timeout error"
+        },
+        "workload": {
+          "context": "webapp/scenario1",
+          "toolset": "Other"
+        },
+        "impactGroupId": "testGroup1",
+        "confidenceLevel": "Low",
+        "clientIncidentDetails": {
+          "clientIncidentId": "123456",
+          "clientIncidentSource": "AzureDevops"
+        },
+        "ongoingImpact": true,
+        "severity": "Critical",
+        "durationInSec": 26,
+        "detectionType": "BusinessAlert",
+        "durationMarginInSec": 28,
+        "hitCount": 21
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "startDateTime": "2024-12-04T19:51:13.274Z",
+          "endDateTime": "2024-12-04T19:51:13.274Z",
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm1",
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2024-12-04T19:51:13.274Z",
+          "impactCategory": "Resource.Other",
+          "impactDescription": "Test description",
+          "armCorrelationIds": [
+            "4D045314-435A-41DA-B0A4-2CA7E9F87D12"
+          ],
+          "performance": [
+            {
+              "metricName": "testMetric",
+              "expected": 23,
+              "actual": 20,
+              "expectedValueRange": {
+                "min": 1,
+                "max": 27
+              },
+              "unit": "ByteSeconds"
+            }
+          ],
+          "connectivity": {
+            "protocol": "TCP",
+            "port": 6,
+            "source": {
+              "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm1"
+            },
+            "target": {
+              "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm2"
+            }
+          },
+          "additionalProperties": {},
+          "errorDetails": {
+            "errorCode": "504",
+            "errorMessage": "Gateway timeout error"
+          },
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "impactGroupId": "testGroup1",
+          "confidenceLevel": "Low",
+          "clientIncidentDetails": {
+            "clientIncidentId": "123456",
+            "clientIncidentSource": "AzureDevops"
+          },
+          "ongoingImpact": true,
+          "severity": "Critical",
+          "durationInSec": 26,
+          "detectionType": "BusinessAlert",
+          "durationMarginInSec": 28,
+          "hitCount": 21
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Impacts-rg/providers/Microsoft.Impact/workloadImpacts/impact2",
+        "name": "testWorkloadImpact",
+        "type": "Microsoft.Impact/workloadImpacts",
+        "systemData": {
+          "createdBy": "testuser@hotmail.com",
+          "createdByType": "User",
+          "createdAt": "2024-03-07T06:19:01.6431721Z",
+          "lastModifiedBy": "testuser@hotmail.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-03-15T08:29:20.8549373Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+      },
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "startDateTime": "2024-12-04T19:51:13.274Z",
+          "endDateTime": "2024-12-04T19:51:13.274Z",
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm1",
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2024-12-04T19:51:13.274Z",
+          "impactCategory": "Resource.Other",
+          "impactDescription": "Test description",
+          "armCorrelationIds": [
+            "4D045314-435A-41DA-B0A4-2CA7E9F87D12"
+          ],
+          "performance": [
+            {
+              "metricName": "testMetric",
+              "expected": 23,
+              "actual": 20,
+              "expectedValueRange": {
+                "min": 1,
+                "max": 27
+              },
+              "unit": "ByteSeconds"
+            }
+          ],
+          "connectivity": {
+            "protocol": "TCP",
+            "port": 6,
+            "source": {
+              "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm1"
+            },
+            "target": {
+              "azureResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm2"
+            }
+          },
+          "additionalProperties": {},
+          "errorDetails": {
+            "errorCode": "504",
+            "errorMessage": "Gateway timeout error"
+          },
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "impactGroupId": "testGroup1",
+          "confidenceLevel": "Low",
+          "clientIncidentDetails": {
+            "clientIncidentId": "123456",
+            "clientIncidentSource": "AzureDevops"
+          },
+          "ongoingImpact": true,
+          "severity": "Critical",
+          "durationInSec": 26,
+          "detectionType": "BusinessAlert",
+          "durationMarginInSec": 28,
+          "hitCount": 21
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Impacts-rg/providers/Microsoft.Impact/workloadImpacts/impact2",
+        "name": "testWorkloadImpact",
+        "type": "Microsoft.Impact/workloadImpacts",
+        "systemData": {
+          "createdBy": "testuser@hotmail.com",
+          "createdByType": "User",
+          "createdAt": "2024-03-07T06:19:01.6431721Z",
+          "lastModifiedBy": "testuser@hotmail.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-03-15T08:29:20.8549373Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/WorkloadImpacts_ListBySubscription.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/WorkloadImpacts_ListBySubscription.json
@@ -1,0 +1,38 @@
+{
+  "operationId": "WorkloadImpacts_ListBySubscription",
+  "title": "List WorkloadImpact resources by subscription",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-01-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Impacts-rg/providers/Microsoft.Impact/workloadImpacts/impact2",
+            "name": "impact2",
+            "type": "Microsoft.Impact/workloadImpacts",
+            "properties": {
+              "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.compute/virtualmachines/vm1",
+              "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+              "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z",
+              "startDateTime": "2022-06-15T05:59:46.6517821Z",
+              "endDateTime": null,
+              "impactDescription": "",
+              "impactCategory": "Resource.Other",
+              "additionalProperties": {
+                "errorCode": "504",
+                "errorMessage": "Gateway timeout error"
+              },
+              "workload": {
+                "context": "webapp/scenario1",
+                "toolset": "Other"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/WorkloadPerformance_Create.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/examples/WorkloadPerformance_Create.json
@@ -1,0 +1,114 @@
+{
+  "operationId": "WorkloadImpacts_Create",
+  "title": "Reporting performance related impact",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-01-01-preview",
+    "workloadImpactName": "impact-002",
+    "resource": {
+      "properties": {
+        "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservercontext",
+        "startDateTime": "2022-06-15T05:59:46.6517821Z",
+        "endDateTime": null,
+        "impactDescription": "high cpu utilization",
+        "impactCategory": "Resource.Performance",
+        "workload": {
+          "context": "webapp/scenario1",
+          "toolset": "Other"
+        },
+        "performance": [
+          {
+            "metricName": "CPU",
+            "actual": 90,
+            "expected": 60,
+            "unit": "garbage"
+          }
+        ],
+        "clientIncidentDetails": {
+          "clientIncidentId": "AA123",
+          "clientIncidentSource": "Jira"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/PerformanceImpacts/impact-001",
+        "name": "impact-001",
+        "type": "Microsoft.Impact/PerformanceImpacts",
+        "properties": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "high cup utilization",
+          "impactCategory": "Resource.Performance",
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "performance": [
+            {
+              "metricName": "CPU",
+              "actual": 90,
+              "expected": 60,
+              "unit": "garbage"
+            }
+          ],
+          "clientIncidentDetails": {
+            "clientIncidentId": "AA123",
+            "clientIncidentSource": "Jira"
+          },
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z",
+          "insightsByCategory": [
+            {
+              "category": "service health",
+              "status": "investigating",
+              "insights": []
+            }
+          ]
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Impact/PerformanceImpacts/impact-001",
+        "name": "impact-001",
+        "type": "Microsoft.Impact/PerformanceImpacts",
+        "properties": {
+          "impactedResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-rg/providers/Microsoft.Sql/sqlserver/dbservername",
+          "startDateTime": "2022-06-15T05:59:46.6517821Z",
+          "endDateTime": null,
+          "impactDescription": "high cup utilization",
+          "impactCategory": "Resource.Performance",
+          "workload": {
+            "context": "webapp/scenario1",
+            "toolset": "Other"
+          },
+          "performance": [
+            {
+              "metricName": "CPU",
+              "actual": 90,
+              "expected": 60,
+              "unit": "garbage"
+            }
+          ],
+          "clientIncidentDetails": {
+            "clientIncidentId": "AA123",
+            "clientIncidentSource": "Jira"
+          },
+          "impactUniqueId": "d7f24d04-e7f0-48bf-b09c-9d36ca9e1777",
+          "reportedTimeUtc": "2022-06-15T06:01:46.6517821Z",
+          "insightsByCategory": [
+            {
+              "category": "service health",
+              "status": "investigating",
+              "insights": []
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/impact.json
+++ b/specification/impact/resource-manager/Microsoft.Impact/preview/2026-01-01-preview/impact.json
@@ -1,0 +1,2217 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Microsoft.Impact",
+    "version": "2026-01-01-preview",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "UploadService"
+    },
+    {
+      "name": "Operations"
+    },
+    {
+      "name": "WorkloadImpacts"
+    },
+    {
+      "name": "ImpactCategories"
+    },
+    {
+      "name": "Insights"
+    },
+    {
+      "name": "Connectors"
+    }
+  ],
+  "paths": {
+    "/providers/Microsoft.Impact/operations": {
+      "get": {
+        "operationId": "Operations_List",
+        "tags": [
+          "Operations"
+        ],
+        "description": "List the operations for the provider",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/OperationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "OperationsList": {
+            "$ref": "./examples/Operations_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Impact/connectors": {
+      "get": {
+        "operationId": "Connectors_ListBySubscription",
+        "tags": [
+          "Connectors"
+        ],
+        "description": "List Connector resources by subscription ID",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectorListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Connectors_ListBySubscription": {
+            "$ref": "./examples/Connectors_ListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Impact/connectors/{connectorName}": {
+      "get": {
+        "operationId": "Connectors_Get",
+        "tags": [
+          "Connectors"
+        ],
+        "description": "Get a Connector",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "connectorName",
+            "in": "path",
+            "description": "The name of the connector",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Connector"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetConnector": {
+            "$ref": "./examples/Connectors_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Connectors_CreateOrUpdate",
+        "tags": [
+          "Connectors"
+        ],
+        "description": "Create a Connector",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "connectorName",
+            "in": "path",
+            "description": "The name of the connector",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Connector"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Connector' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Connector"
+            }
+          },
+          "201": {
+            "description": "Resource 'Connector' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Connector"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "CreateConnector": {
+            "$ref": "./examples/Connectors_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "Connectors_Update",
+        "tags": [
+          "Connectors"
+        ],
+        "description": "Update a Connector",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "connectorName",
+            "in": "path",
+            "description": "The name of the connector",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ConnectorUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Connector"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Connectors_Update": {
+            "$ref": "./examples/Connectors_Update.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Connectors_Delete",
+        "tags": [
+          "Connectors"
+        ],
+        "description": "Delete a Connector",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "connectorName",
+            "in": "path",
+            "description": "The name of the connector",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Connectors_Delete": {
+            "$ref": "./examples/Connectors_Delete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Impact/getUploadToken": {
+      "post": {
+        "operationId": "UploadService_GetUploadToken",
+        "tags": [
+          "UploadService"
+        ],
+        "description": "Only for select HPC customers at this time, who can use this POST endpoint to trigger an action, where the UserRP/AzImpactRP service creates and returns a user-delegate SAS token for the storage account/container unique to the customer (identified by subscription ID).",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/UploadTokenResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get upload token to use for log upload": {
+            "$ref": "./examples/UploadService_GetUploadToken.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Impact/impactCategories": {
+      "get": {
+        "operationId": "ImpactCategories_ListBySubscription",
+        "tags": [
+          "ImpactCategories"
+        ],
+        "description": "List ImpactCategory resources by subscription",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/CustomParameters.categoryName"
+          },
+          {
+            "$ref": "#/parameters/CustomParameters.resourceType"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ImpactCategoryListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get ImpactCategories list by subscription": {
+            "$ref": "./examples/ImpactCategories_ListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Impact/impactCategories/{impactCategoryName}": {
+      "get": {
+        "operationId": "ImpactCategories_Get",
+        "tags": [
+          "ImpactCategories"
+        ],
+        "description": "Get a ImpactCategory",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "impactCategoryName",
+            "in": "path",
+            "description": "Name of the impact category",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9.]*[a-zA-Z0-9]{3,180}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ImpactCategory"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get WorkloadImpact Resource by name": {
+            "$ref": "./examples/ImpactCategories_Get.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Impact/workloadImpacts": {
+      "get": {
+        "operationId": "WorkloadImpacts_ListBySubscription",
+        "tags": [
+          "WorkloadImpacts"
+        ],
+        "description": "List WorkloadImpact resources by subscription ID",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/WorkloadImpactListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List WorkloadImpact resources by subscription": {
+            "$ref": "./examples/WorkloadImpacts_ListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Impact/workloadImpacts/{workloadImpactName}": {
+      "get": {
+        "operationId": "WorkloadImpacts_Get",
+        "tags": [
+          "WorkloadImpacts"
+        ],
+        "description": "Get a WorkloadImpact",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "workloadImpactName",
+            "in": "path",
+            "description": "workloadImpact resource ",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-:]*[a-zA-Z0-9]{3,120}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/WorkloadImpact"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get WorkloadImpact Resource by name example": {
+            "$ref": "./examples/WorkloadImpact_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "WorkloadImpacts_Create",
+        "tags": [
+          "WorkloadImpacts"
+        ],
+        "description": "Create a WorkloadImpact",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "workloadImpactName",
+            "in": "path",
+            "description": "workloadImpact resource ",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-:]*[a-zA-Z0-9]{3,120}$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkloadImpact"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'WorkloadImpact' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/WorkloadImpact"
+            }
+          },
+          "201": {
+            "description": "Resource 'WorkloadImpact' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/WorkloadImpact"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Reporting Arm operation failure": {
+            "$ref": "./examples/WorkloadArmOperation_create.json"
+          },
+          "Reporting a connectivity impact": {
+            "$ref": "./examples/WorkloadConnectivityImpact_Create.json"
+          },
+          "Reporting availability related impact": {
+            "$ref": "./examples/WorkloadAvailability_Create.json"
+          },
+          "Reporting performance related impact": {
+            "$ref": "./examples/WorkloadPerformance_Create.json"
+          },
+          "WorkloadImpacts_Create_MaximumSet": {
+            "$ref": "./examples/WorkloadImpacts_Create_MaximumSet_Gen.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "WorkloadImpacts_Delete",
+        "tags": [
+          "WorkloadImpacts"
+        ],
+        "description": "Delete a WorkloadImpact",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "workloadImpactName",
+            "in": "path",
+            "description": "workloadImpact resource ",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-:]*[a-zA-Z0-9]{3,120}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete WorkloadImpact Resource by name example": {
+            "$ref": "./examples/WorkloadImpact_Delete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Impact/workloadImpacts/{workloadImpactName}/insights": {
+      "get": {
+        "operationId": "Insights_ListBySubscription",
+        "tags": [
+          "Insights"
+        ],
+        "description": "List Insight resources by workloadImpactName",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "workloadImpactName",
+            "in": "path",
+            "description": "workloadImpact resource ",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-:]*[a-zA-Z0-9]{3,120}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/InsightListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Insight resources by workloadImpactName": {
+            "$ref": "./examples/Insights_ListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Impact/workloadImpacts/{workloadImpactName}/insights/{insightName}": {
+      "get": {
+        "operationId": "Insights_Get",
+        "tags": [
+          "Insights"
+        ],
+        "description": "Get Insight resources by workloadImpactName and insightName",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "workloadImpactName",
+            "in": "path",
+            "description": "workloadImpact resource ",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-:]*[a-zA-Z0-9]{3,120}$"
+          },
+          {
+            "name": "insightName",
+            "in": "path",
+            "description": "Name of the insight",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9.]*[a-zA-Z0-9]{3,180}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Insight"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Insight sample for Diagnostics category": {
+            "$ref": "./examples/Insights_Get_diagnostics.json"
+          },
+          "Get Insight sample for MitigationAction category": {
+            "$ref": "./examples/Insights_Get_mitigationAction.json"
+          },
+          "Get Insight sample for service health category": {
+            "$ref": "./examples/Insights_Get_servicehealth.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Insights_Create",
+        "tags": [
+          "Insights"
+        ],
+        "description": "Create Insight resource, This is Admin only operation",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "workloadImpactName",
+            "in": "path",
+            "description": "workloadImpact resource ",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-:]*[a-zA-Z0-9]{3,120}$"
+          },
+          {
+            "name": "insightName",
+            "in": "path",
+            "description": "Name of the insight",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9.]*[a-zA-Z0-9]{3,180}$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Insight"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Insight' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Insight"
+            }
+          },
+          "201": {
+            "description": "Resource 'Insight' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Insight"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Creating an insight": {
+            "$ref": "./examples/Insights_Create.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Insights_Delete",
+        "tags": [
+          "Insights"
+        ],
+        "description": "Delete Insight resource, This is Admin only operation",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "workloadImpactName",
+            "in": "path",
+            "description": "workloadImpact resource ",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-:]*[a-zA-Z0-9]{3,120}$"
+          },
+          {
+            "name": "insightName",
+            "in": "path",
+            "description": "Name of the insight",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9.]*[a-zA-Z0-9]{3,180}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete an Insight": {
+            "$ref": "./examples/Insights_Delete.json"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "AdditionalField": {
+      "type": "object",
+      "description": "additional user defined field.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "name of the field."
+        },
+        "value": {
+          "type": "string",
+          "description": "value of the field."
+        }
+      },
+      "required": [
+        "name",
+        "value"
+      ]
+    },
+    "Azure.Core.uuid": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Universally Unique Identifier"
+    },
+    "ClientIncidentDetails": {
+      "type": "object",
+      "description": "Client incident details ex: incidentId , incident source",
+      "properties": {
+        "clientIncidentId": {
+          "type": "string",
+          "description": "Client incident id. ex : id of the incident created to investigate and address the impact if any."
+        },
+        "clientIncidentSource": {
+          "$ref": "#/definitions/IncidentSource",
+          "description": "Client incident source. ex : source system name where the incident is created"
+        }
+      }
+    },
+    "ConfidenceLevel": {
+      "type": "string",
+      "description": "Degree of confidence on the impact being a platform issue.",
+      "enum": [
+        "Low",
+        "Medium",
+        "High"
+      ],
+      "x-ms-enum": {
+        "name": "ConfidenceLevel",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Low",
+            "value": "Low",
+            "description": "Low confidence on azure being the source of impact"
+          },
+          {
+            "name": "Medium",
+            "value": "Medium",
+            "description": "Medium confidence on azure being the source of impact"
+          },
+          {
+            "name": "High",
+            "value": "High",
+            "description": "High confidence on azure being the source of impact"
+          }
+        ]
+      }
+    },
+    "Connectivity": {
+      "type": "object",
+      "description": "Details about connectivity issue. Applicable when root resource causing the issue is not identified. For example, when a VM is impacted due to a network issue, the impacted resource could be VM or the network. In such cases, the connectivity field will have the details about both VM and network.",
+      "properties": {
+        "protocol": {
+          "$ref": "#/definitions/Protocol",
+          "description": "Protocol used for the connection"
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Port number for the connection"
+        },
+        "source": {
+          "$ref": "#/definitions/SourceOrTarget",
+          "description": "Source from which the connection was attempted"
+        },
+        "target": {
+          "$ref": "#/definitions/SourceOrTarget",
+          "description": "target which connection was attempted"
+        }
+      }
+    },
+    "Connector": {
+      "type": "object",
+      "description": "A connector is a resource that can be used to proactively report impacts against workloads in Azure to Microsoft.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ConnectorProperties",
+          "description": "The resource-specific properties for this resource."
+        },
+        "identity": {
+          "$ref": "#/definitions/ManagedServiceIdentityOnlyUserAssigned",
+          "description": "The managed service identities assigned to this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ConnectorListResult": {
+      "type": "object",
+      "description": "The response of a Connector list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Connector items on this page",
+          "items": {
+            "$ref": "#/definitions/Connector"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ConnectorManagedUserAssignedIdentityProperty": {
+      "type": "object",
+      "description": "The managed service identities envelope.",
+      "properties": {
+        "identity": {
+          "$ref": "#/definitions/ManagedServiceIdentityOnlyUserAssigned",
+          "description": "The managed service identities assigned to this resource."
+        }
+      }
+    },
+    "ConnectorProperties": {
+      "type": "object",
+      "description": "Details of the Connector.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "Resource provisioning state.",
+          "readOnly": true
+        },
+        "connectorId": {
+          "type": "string",
+          "description": "unique id of the connector.",
+          "readOnly": true
+        },
+        "tenantId": {
+          "type": "string",
+          "description": "tenant id of this connector",
+          "readOnly": true
+        },
+        "connectorType": {
+          "$ref": "#/definitions/Platform",
+          "description": "connector type"
+        },
+        "lastRunTimeStamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "last run time stamp of this connector in UTC time zone",
+          "readOnly": true
+        },
+        "processingState": {
+          "type": "string",
+          "description": "returns the processing state of a connector",
+          "readOnly": true
+        },
+        "processingStateMessage": {
+          "type": "string",
+          "description": "detailed description of the state and if any associated action that can be taken",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "connectorId",
+        "tenantId",
+        "connectorType",
+        "lastRunTimeStamp",
+        "processingState",
+        "processingStateMessage"
+      ]
+    },
+    "ConnectorPropertiesUpdate": {
+      "type": "object",
+      "description": "Details of the Connector.",
+      "properties": {
+        "connectorType": {
+          "$ref": "#/definitions/Platform",
+          "description": "connector type"
+        }
+      }
+    },
+    "ConnectorUpdate": {
+      "type": "object",
+      "description": "A connector is a resource that can be used to proactively report impacts against workloads in Azure to Microsoft.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ConnectorPropertiesUpdate",
+          "description": "The resource-specific properties for this resource."
+        },
+        "identity": {
+          "$ref": "#/definitions/ManagedServiceIdentityOnlyUserAssignedUpdate",
+          "description": "The managed service identities assigned to this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "Content": {
+      "type": "object",
+      "description": "Article details of the insight like title, description etc",
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Title of the insight"
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the insight"
+        }
+      },
+      "required": [
+        "title",
+        "description"
+      ]
+    },
+    "DetectionType": {
+      "type": "string",
+      "description": "List of detection types",
+      "enum": [
+        "BusinessAlert",
+        "MetricsThreshold",
+        "MetricsAnomaly"
+      ],
+      "x-ms-enum": {
+        "name": "DetectionType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "BusinessAlert",
+            "value": "BusinessAlert",
+            "description": "Use this when impact is alert based."
+          },
+          {
+            "name": "MetricsThreshold",
+            "value": "MetricsThreshold",
+            "description": "Use this when impact is metrics or expectations based."
+          },
+          {
+            "name": "MetricsAnomaly",
+            "value": "MetricsAnomaly",
+            "description": "Use this when impact is outlier based."
+          }
+        ]
+      }
+    },
+    "ErrorDetailProperties": {
+      "type": "object",
+      "description": "ARM error code and error message associated with the impact",
+      "properties": {
+        "errorCode": {
+          "type": "string",
+          "description": "ARM Error code associated with the impact."
+        },
+        "errorMessage": {
+          "type": "string",
+          "description": "ARM Error Message associated with the impact"
+        }
+      }
+    },
+    "ExpectedValueRange": {
+      "type": "object",
+      "description": "Max and Min Threshold values for the metric",
+      "properties": {
+        "min": {
+          "type": "number",
+          "format": "double",
+          "description": "Min threshold value for the metric"
+        },
+        "max": {
+          "type": "number",
+          "format": "double",
+          "description": "Max threshold value for the metric"
+        }
+      },
+      "required": [
+        "min",
+        "max"
+      ]
+    },
+    "ImpactCategory": {
+      "type": "object",
+      "description": "ImpactCategory resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ImpactCategoryProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ImpactCategoryEnum": {
+      "type": "string",
+      "description": "List of impact categories.",
+      "enum": [
+        "Availability",
+        "Performance",
+        "Other"
+      ],
+      "x-ms-enum": {
+        "name": "ImpactCategoryEnum",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Availability",
+            "value": "Availability",
+            "description": "Availability category"
+          },
+          {
+            "name": "Performance",
+            "value": "Performance",
+            "description": "Performance category"
+          },
+          {
+            "name": "Other",
+            "value": "Other",
+            "description": "Other category"
+          }
+        ]
+      }
+    },
+    "ImpactCategoryListResult": {
+      "type": "object",
+      "description": "The response of a ImpactCategory list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ImpactCategory items on this page",
+          "items": {
+            "$ref": "#/definitions/ImpactCategory"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ImpactCategoryProperties": {
+      "type": "object",
+      "description": "Impact category properties.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "Resource provisioning state.",
+          "readOnly": true
+        },
+        "categoryId": {
+          "type": "string",
+          "description": "Unique ID of the category",
+          "pattern": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+        },
+        "parentCategoryId": {
+          "type": "string",
+          "description": "Unique ID of the parent category",
+          "pattern": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the category"
+        },
+        "requiredImpactProperties": {
+          "type": "array",
+          "description": "The workloadImpact properties which are required when reporting with the impact category",
+          "items": {
+            "$ref": "#/definitions/RequiredImpactProperties"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "required": [
+        "categoryId"
+      ]
+    },
+    "ImpactDetails": {
+      "type": "object",
+      "description": "details of of the impact for which insight has been generated.",
+      "properties": {
+        "impactedResourceId": {
+          "type": "string",
+          "description": "List of impacted Azure resources."
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Time at which impact was started according to reported impact."
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Time at which impact was ended according to reported impact."
+        },
+        "impactId": {
+          "type": "string",
+          "description": "Azure Id of the impact."
+        }
+      },
+      "required": [
+        "impactedResourceId",
+        "startTime",
+        "impactId"
+      ]
+    },
+    "ImpactedResource": {
+      "type": "object",
+      "description": "impacted azure resource id.",
+      "properties": {
+        "impactedResourceId": {
+          "type": "string",
+          "description": "impacted azure resource id"
+        }
+      },
+      "required": [
+        "impactedResourceId"
+      ]
+    },
+    "IncidentSource": {
+      "type": "string",
+      "description": "List of incident interfaces.",
+      "enum": [
+        "AzureDevops",
+        "ICM",
+        "Jira",
+        "ServiceNow",
+        "Other"
+      ],
+      "x-ms-enum": {
+        "name": "IncidentSource",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "AzureDevops",
+            "value": "AzureDevops",
+            "description": "When source of Incident is AzureDevops"
+          },
+          {
+            "name": "ICM",
+            "value": "ICM",
+            "description": "When source of Incident is Microsoft ICM"
+          },
+          {
+            "name": "Jira",
+            "value": "Jira",
+            "description": "When source of Incident is Jira"
+          },
+          {
+            "name": "ServiceNow",
+            "value": "ServiceNow",
+            "description": "When source of Incident is ServiceNow"
+          },
+          {
+            "name": "Other",
+            "value": "Other",
+            "description": "When source of Incident is Other"
+          }
+        ]
+      }
+    },
+    "Insight": {
+      "type": "object",
+      "description": "Insight resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/InsightProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "InsightCategoryGroup": {
+      "type": "object",
+      "description": "Group of insights for a category",
+      "properties": {
+        "category": {
+          "type": "string",
+          "description": "Category name"
+        },
+        "status": {
+          "type": "string",
+          "description": "Status of the insights in this category"
+        },
+        "insights": {
+          "type": "array",
+          "description": "List of insight references in this category",
+          "items": {
+            "$ref": "#/definitions/InsightReference"
+          },
+          "x-ms-identifiers": [
+            "id"
+          ]
+        }
+      },
+      "required": [
+        "category"
+      ]
+    },
+    "InsightCustomResourceCommonParameters": {
+      "type": "object",
+      "description": "context of post call for insight",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "The API version to use for this operation.",
+          "minLength": 1
+        },
+        "subscriptionId": {
+          "$ref": "#/definitions/Azure.Core.uuid",
+          "description": "The ID of the target subscription. The value must be an UUID.",
+          "minLength": 1
+        },
+        "provider": {
+          "type": "string",
+          "description": "The provider namespace for the resource.",
+          "enum": [
+            "Microsoft.Impact"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        },
+        "azureResourceId": {
+          "type": "string",
+          "description": "Filter by resource type",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "apiVersion",
+        "subscriptionId",
+        "provider"
+      ]
+    },
+    "InsightDetails": {
+      "type": "object",
+      "description": "Body of the get all insights",
+      "properties": {
+        "azureResourceId": {
+          "type": "string",
+          "description": "The ID of the azure resource."
+        }
+      }
+    },
+    "InsightListResult": {
+      "type": "object",
+      "description": "The response of a Insight list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Insight items on this page",
+          "items": {
+            "$ref": "#/definitions/Insight"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "InsightProperties": {
+      "type": "object",
+      "description": "Impact category properties.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "Resource provisioning state.",
+          "readOnly": true
+        },
+        "category": {
+          "type": "string",
+          "description": "category of the insight."
+        },
+        "status": {
+          "type": "string",
+          "description": "status of the insight. example resolved, repaired, other."
+        },
+        "eventId": {
+          "type": "string",
+          "description": "Identifier of the event that has been correlated with this insight. This can be used to aggregate insights for the same event."
+        },
+        "groupId": {
+          "type": "string",
+          "description": "Identifier that can be used to group similar insights."
+        },
+        "content": {
+          "$ref": "#/definitions/Content",
+          "description": "Contains title & description for the insight"
+        },
+        "eventTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Time of the event, which has been correlated the impact."
+        },
+        "insightUniqueId": {
+          "type": "string",
+          "description": "unique id of the insight."
+        },
+        "impact": {
+          "$ref": "#/definitions/ImpactDetails",
+          "description": "details of of the impact for which insight has been generated."
+        },
+        "additionalDetails": {
+          "type": "object",
+          "description": "additional details of the insight."
+        }
+      },
+      "required": [
+        "category",
+        "content",
+        "insightUniqueId",
+        "impact"
+      ]
+    },
+    "InsightReference": {
+      "type": "object",
+      "description": "Reference to an Insight resource",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Azure resource ID of the insight"
+        }
+      },
+      "required": [
+        "id"
+      ]
+    },
+    "InsightUnderSubscription": {
+      "type": "object",
+      "description": "Insight resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/InsightProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ManagedServiceIdentityOnlyUserAssigned": {
+      "type": "object",
+      "description": "Managed service identity (system assigned and/or user assigned identities)",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/ManagedServiceIdentityTypeOnlyUserAssigned",
+          "description": "The type of managed identity assigned to this resource."
+        },
+        "userAssignedIdentities": {
+          "type": "object",
+          "description": "The identities assigned to this resource by the user.",
+          "additionalProperties": {
+            "$ref": "../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/UserAssignedIdentity",
+            "x-nullable": true
+          }
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "ManagedServiceIdentityOnlyUserAssignedUpdate": {
+      "type": "object",
+      "description": "Managed service identity (system assigned and/or user assigned identities)",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/ManagedServiceIdentityTypeOnlyUserAssigned",
+          "description": "The type of managed identity assigned to this resource."
+        },
+        "userAssignedIdentities": {
+          "type": "object",
+          "description": "The identities assigned to this resource by the user.",
+          "additionalProperties": {
+            "$ref": "../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/UserAssignedIdentity",
+            "x-nullable": true
+          }
+        }
+      }
+    },
+    "ManagedServiceIdentityTypeOnlyUserAssigned": {
+      "type": "string",
+      "description": "Type of managed service identity, where only UserAssigned type is allowed.",
+      "enum": [
+        "UserAssigned",
+        "None"
+      ],
+      "x-ms-enum": {
+        "name": "ManagedServiceIdentityTypeOnlyUserAssigned",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "UserAssigned",
+            "value": "UserAssigned",
+            "description": "User assigned managed identity."
+          },
+          {
+            "name": "None",
+            "value": "None",
+            "description": "No identity."
+          }
+        ]
+      }
+    },
+    "MetricUnit": {
+      "type": "string",
+      "description": "List of unit of the metric.",
+      "enum": [
+        "ByteSeconds",
+        "Bytes",
+        "BytesPerSecond",
+        "Cores",
+        "Count",
+        "CountPerSecond",
+        "MilliCores",
+        "MilliSeconds",
+        "NanoCores",
+        "Percent",
+        "Seconds",
+        "Other"
+      ],
+      "x-ms-enum": {
+        "name": "MetricUnit",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ByteSeconds",
+            "value": "ByteSeconds",
+            "description": "When measurement is in ByteSeconds"
+          },
+          {
+            "name": "Bytes",
+            "value": "Bytes",
+            "description": "When measurement is in Bytes"
+          },
+          {
+            "name": "BytesPerSecond",
+            "value": "BytesPerSecond",
+            "description": "When measurement is in BytesPerSecond"
+          },
+          {
+            "name": "Cores",
+            "value": "Cores",
+            "description": "When measurement is in Cores"
+          },
+          {
+            "name": "Count",
+            "value": "Count",
+            "description": "When measurement is in Count"
+          },
+          {
+            "name": "CountPerSecond",
+            "value": "CountPerSecond",
+            "description": "When measurement is in CountPerSecond"
+          },
+          {
+            "name": "MilliCores",
+            "value": "MilliCores",
+            "description": "When measurement is in MilliCores"
+          },
+          {
+            "name": "MilliSeconds",
+            "value": "MilliSeconds",
+            "description": "When measurement is in MilliSeconds"
+          },
+          {
+            "name": "NanoCores",
+            "value": "NanoCores",
+            "description": "When measurement is in NanoCores"
+          },
+          {
+            "name": "Percent",
+            "value": "Percent",
+            "description": "When measurement is in Percent"
+          },
+          {
+            "name": "Seconds",
+            "value": "Seconds",
+            "description": "When measurement is in Seconds"
+          },
+          {
+            "name": "Other",
+            "value": "Other",
+            "description": "When measurement is in Other than listed"
+          }
+        ]
+      }
+    },
+    "Performance": {
+      "type": "object",
+      "description": "Details about impacted performance metrics. Applicable for performance related impact",
+      "properties": {
+        "metricName": {
+          "type": "string",
+          "description": "Name of the Metric examples:  Disk, IOPs, CPU, GPU, Memory, details can be found from /impactCategories API"
+        },
+        "expected": {
+          "type": "number",
+          "format": "double",
+          "description": "Threshold value for the metric"
+        },
+        "actual": {
+          "type": "number",
+          "format": "double",
+          "description": "Observed value for the metric"
+        },
+        "expectedValueRange": {
+          "$ref": "#/definitions/ExpectedValueRange",
+          "description": "Max and Min Threshold values for the metric"
+        },
+        "unit": {
+          "$ref": "#/definitions/MetricUnit",
+          "description": "Unit of the metric ex: Bytes, Percentage, Count, Seconds, Milliseconds, Bytes/Second, Count/Second, etc.., Other"
+        }
+      }
+    },
+    "Platform": {
+      "type": "string",
+      "description": "Enum for connector types",
+      "enum": [
+        "AzureMonitor"
+      ],
+      "x-ms-enum": {
+        "name": "Platform",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "AzureMonitor",
+            "value": "AzureMonitor",
+            "description": "Type of Azure Monitor"
+          }
+        ]
+      }
+    },
+    "Protocol": {
+      "type": "string",
+      "description": "List of protocols",
+      "enum": [
+        "TCP",
+        "UDP",
+        "HTTP",
+        "HTTPS",
+        "RDP",
+        "FTP",
+        "SSH",
+        "Other"
+      ],
+      "x-ms-enum": {
+        "name": "Protocol",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "TCP",
+            "value": "TCP",
+            "description": "When communication protocol is TCP"
+          },
+          {
+            "name": "UDP",
+            "value": "UDP",
+            "description": "When communication protocol is UDP"
+          },
+          {
+            "name": "HTTP",
+            "value": "HTTP",
+            "description": "When communication protocol is HTTP"
+          },
+          {
+            "name": "HTTPS",
+            "value": "HTTPS",
+            "description": "When communication protocol is HTTPS"
+          },
+          {
+            "name": "RDP",
+            "value": "RDP",
+            "description": "When communication protocol is RDP"
+          },
+          {
+            "name": "FTP",
+            "value": "FTP",
+            "description": "When communication protocol is FTP"
+          },
+          {
+            "name": "SSH",
+            "value": "SSH",
+            "description": "When communication protocol is SSH"
+          },
+          {
+            "name": "Other",
+            "value": "Other",
+            "description": "When communication protocol is Other"
+          }
+        ]
+      }
+    },
+    "ProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of the resource.",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled"
+      ],
+      "x-ms-enum": {
+        "name": "ProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Provisioning Succeeded"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Provisioning Failed"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Provisioning Canceled"
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "RequiredImpactProperties": {
+      "type": "object",
+      "description": "Required impact properties",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the property"
+        },
+        "allowedValues": {
+          "type": "array",
+          "description": "Allowed values values for the property",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "Severity": {
+      "type": "string",
+      "description": "List of severity of an impact.",
+      "enum": [
+        "Critical",
+        "High",
+        "Medium",
+        "Low"
+      ],
+      "x-ms-enum": {
+        "name": "Severity",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Critical",
+            "value": "Critical",
+            "description": "Use this when the issue is critical. Consider this to be similar to severity 1 incidents."
+          },
+          {
+            "name": "High",
+            "value": "High",
+            "description": "Use this when the issue is high impact similar to severity 2 incidents."
+          },
+          {
+            "name": "Medium",
+            "value": "Medium",
+            "description": "Use this when the issue is medium impact similar to severity 3 incidents."
+          },
+          {
+            "name": "Low",
+            "value": "Low",
+            "description": "Use this for issues that are low impact similar to severity 4 and 5 incidents."
+          }
+        ]
+      }
+    },
+    "SourceOrTarget": {
+      "type": "object",
+      "description": "Resource details",
+      "properties": {
+        "azureResourceId": {
+          "type": "string",
+          "description": "Azure resource id, example /subscription/{subscription}/resourceGroup/{rg}/Microsoft.compute/virtualMachine/{vmName}",
+          "pattern": "(\\/[0-9a-zA-Z]+)*"
+        }
+      }
+    },
+    "Toolset": {
+      "type": "string",
+      "description": "List of azure interfaces.",
+      "enum": [
+        "Terraform",
+        "Puppet",
+        "Chef",
+        "SDK",
+        "Ansible",
+        "ARM",
+        "Portal",
+        "Shell",
+        "Other"
+      ],
+      "x-ms-enum": {
+        "name": "Toolset",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Terraform",
+            "value": "Terraform",
+            "description": "If communication toolset is Terraform"
+          },
+          {
+            "name": "Puppet",
+            "value": "Puppet",
+            "description": "If communication toolset is Puppet"
+          },
+          {
+            "name": "Chef",
+            "value": "Chef",
+            "description": "If communication toolset is Chef"
+          },
+          {
+            "name": "SDK",
+            "value": "SDK",
+            "description": "If communication toolset is SDK"
+          },
+          {
+            "name": "Ansible",
+            "value": "Ansible",
+            "description": "If communication toolset is Ansible"
+          },
+          {
+            "name": "ARM",
+            "value": "ARM",
+            "description": "If communication toolset is ARM"
+          },
+          {
+            "name": "Portal",
+            "value": "Portal",
+            "description": "If communication toolset is Portal"
+          },
+          {
+            "name": "Shell",
+            "value": "Shell",
+            "description": "If communication toolset is Shell"
+          },
+          {
+            "name": "Other",
+            "value": "Other",
+            "description": "If communication toolset is Other"
+          }
+        ]
+      }
+    },
+    "UploadTokenResult": {
+      "type": "object",
+      "description": "A successful response from getUploadToken will contain an 'uploadUrl' field. This uploadUrl field's value should follow the format: https://[storage-account-name].blob.core.windows.net/[container-name]/[your-blob.extension]?[SAS-token]",
+      "properties": {
+        "uploadUrl": {
+          "type": "string",
+          "format": "password",
+          "description": "The SAS token URL for uploading",
+          "x-ms-secret": true
+        }
+      },
+      "required": [
+        "uploadUrl"
+      ]
+    },
+    "Workload": {
+      "type": "object",
+      "description": "Information about the impacted workload",
+      "properties": {
+        "context": {
+          "type": "string",
+          "description": "the scenario for the workload"
+        },
+        "toolset": {
+          "$ref": "#/definitions/Toolset",
+          "description": "Tool used to interact with Azure. SDK, AzPortal, etc.., Other"
+        }
+      }
+    },
+    "WorkloadImpact": {
+      "type": "object",
+      "description": "Workload Impact properties",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/WorkloadImpactProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "WorkloadImpactListResult": {
+      "type": "object",
+      "description": "The response of a WorkloadImpact list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The WorkloadImpact items on this page",
+          "items": {
+            "$ref": "#/definitions/WorkloadImpact"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "WorkloadImpactProperties": {
+      "type": "object",
+      "description": "Workload impact properties",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "Resource provisioning state.",
+          "readOnly": true
+        },
+        "startDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Time at which impact was observed "
+        },
+        "endDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Time at which impact has ended "
+        },
+        "impactedResourceId": {
+          "type": "string",
+          "description": "Azure resource id of the impacted resource"
+        },
+        "impactUniqueId": {
+          "type": "string",
+          "description": "Unique ID of the impact (UUID)",
+          "pattern": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
+          "readOnly": true
+        },
+        "reportedTimeUtc": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Time at which impact is reported",
+          "readOnly": true
+        },
+        "impactCategory": {
+          "type": "string",
+          "description": "Category of the impact,  details can found from /impactCategories API"
+        },
+        "impactDescription": {
+          "type": "string",
+          "description": "A detailed description of the impact"
+        },
+        "armCorrelationIds": {
+          "type": "array",
+          "description": "The ARM correlation ids, this is important field for control plane related impacts",
+          "items": {
+            "type": "string"
+          }
+        },
+        "performance": {
+          "type": "array",
+          "description": "Details about performance issue. Applicable for performance impacts.",
+          "items": {
+            "$ref": "#/definitions/Performance"
+          },
+          "x-ms-identifiers": []
+        },
+        "connectivity": {
+          "$ref": "#/definitions/Connectivity",
+          "description": "Details about connectivity issue. Applicable when root resource causing the issue is not identified. For example, when a VM is impacted due to a network issue, the impacted resource is identified as the VM, but the root cause is the network. In such cases, the connectivity field will have the details about the network issue"
+        },
+        "additionalProperties": {
+          "type": "object",
+          "description": "Additional fields related to impact, applicable fields per resource type are list under /impactCategories API",
+          "additionalProperties": {}
+        },
+        "errorDetails": {
+          "$ref": "#/definitions/ErrorDetailProperties",
+          "description": "ARM error code and error message associated with the impact"
+        },
+        "workload": {
+          "$ref": "#/definitions/Workload",
+          "description": "Information about the impacted workload"
+        },
+        "impactGroupId": {
+          "type": "string",
+          "description": "Use this field to group impacts"
+        },
+        "confidenceLevel": {
+          "$ref": "#/definitions/ConfidenceLevel",
+          "description": "Degree of confidence on the impact being a platform issue"
+        },
+        "clientIncidentDetails": {
+          "$ref": "#/definitions/ClientIncidentDetails",
+          "description": "Client incident details ex: incidentId , incident source"
+        },
+        "ongoingImpact": {
+          "type": "boolean",
+          "description": "This field represents if an impact is ongoing or not. This is a boolean field."
+        },
+        "severity": {
+          "$ref": "#/definitions/Severity",
+          "description": "This field represents the severity of an impact. Severity can be from critical to low severity impact. Severity ranges from 1 to 5 with 1 being critical, 2 is high, 3 is medium and 4,5 represents low severity impact."
+        },
+        "durationInSec": {
+          "type": "number",
+          "format": "double",
+          "description": "Captures the longest interruption duration within the specified start and end times. For example, it can be used to indicate network connectivity loss lasting longer than a specified number of seconds within the given time range.",
+          "minimum": 0
+        },
+        "detectionType": {
+          "$ref": "#/definitions/DetectionType",
+          "description": "This field represents the type of impact. Possible values are MetricsThreshold, MetricsAnomaly, BusinessAlert."
+        },
+        "durationMarginInSec": {
+          "type": "number",
+          "format": "double",
+          "description": "This field represents the duration margin in seconds that can be provided while providing endDateTime.",
+          "minimum": 0
+        },
+        "hitCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "This field represents the number of times a particular issue was observed over a given time range.",
+          "minimum": 0
+        },
+        "insightsByCategory": {
+          "type": "array",
+          "description": "Insights grouped by category. Each category contains status and a list of insight references.",
+          "items": {
+            "$ref": "#/definitions/InsightCategoryGroup"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "category"
+          ]
+        }
+      },
+      "required": [
+        "startDateTime",
+        "impactedResourceId",
+        "impactCategory"
+      ]
+    }
+  },
+  "parameters": {
+    "CustomParameters.categoryName": {
+      "name": "categoryName",
+      "in": "query",
+      "description": "Filter by category name ",
+      "required": false,
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[a-zA-Z0-9][a-zA-Z0-9.]*[a-zA-Z0-9]{3,180}$",
+      "x-ms-parameter-location": "method"
+    },
+    "CustomParameters.resourceType": {
+      "name": "resourceType",
+      "in": "query",
+      "description": "Filter by resource type",
+      "required": false,
+      "type": "string",
+      "minLength": 1,
+      "x-ms-parameter-location": "method"
+    }
+  }
+}

--- a/specification/impact/resource-manager/readme.go.md
+++ b/specification/impact/resource-manager/readme.go.md
@@ -1,0 +1,11 @@
+## Go
+
+These settings apply only when `--go` is specified on the command line.
+
+```yaml $(go) && $(track2)
+azure-arm: true
+license-header: MICROSOFT_MIT_NO_VERSION
+module-name: sdk/resourcemanager/impact/armimpact
+module: github.com/Azure/azure-sdk-for-go/$(module-name)
+output-folder: $(go-sdk-folder)/$(module-name)
+```

--- a/specification/impact/resource-manager/readme.md
+++ b/specification/impact/resource-manager/readme.md
@@ -20,22 +20,24 @@ For other options on installation see [Installing AutoRest](https://aka.ms/autor
 
 ### AutoRest v3 Suppressions
 
-```yaml
+``` yaml
 suppressions:
-  - code: AvoidAdditionalProperties
+    
+  - code: GuidUsage
+    reason: this is for getting a subscriptionId from customers
     from: impact.json
-    where: $.definitions.WorkloadImpactProperties.properties
-    reason:
-      Property additionalProperties in WorkloadImpactProperties is necessary to be dynamic since it contains metadata
-      and will be different for different categories
-  - code: AvoidAdditionalProperties
-    from: impact.json
-    where: $.definitions.WorkloadImpactProperties.properties.additionalProperties
-    reason: Typespec generated definition
+
   - code: AvoidAnonymousTypes
-    where: $.definitions.WorkloadImpactProperties.properties.additionalProperties 
+    reason: this is for associating user assigned managed identity with connectors resource
     from: impact.json
-    reason: Typespec generated definitions contain anonymous types.
+
+  - code: EnumInsteadOfBoolean
+    reason: this is the right data type for the given context.
+    from: impact.json
+
+  - code: AvoidAdditionalProperties
+    reason: this is needed as its the extensible property bag for storing custom metadata associated with an impact.
+    from: impact.json
 ```
 
 ## Configuration
@@ -47,7 +49,27 @@ These are the global settings for the impact.
 ```yaml
 openapi-type: arm
 openapi-subtype: rpaas
-tag: package-2024-05-01-preview
+tag: package-2026-01-01-preview
+```
+
+### Tag: package-2026-01-01-preview
+
+These settings apply only when `--tag=package-2026-01-01-preview` is specified on the command line.
+
+```yaml $(tag) == 'package-2026-01-01-preview'
+input-file:
+  - Microsoft.Impact/preview/2026-01-01-preview/impact.json
+tag: package-2026-01-01-preview
+```
+
+### Tag: package-2025-01-01-preview
+
+These settings apply only when `--tag=package-2025-01-01-preview` is specified on the command line.
+
+```yaml $(tag) == 'package-2025-01-01-preview'
+input-file:
+  - Microsoft.Impact/preview/2025-01-01-preview/impact.json
+tag: package-2025-01-01-preview
 ```
 
 ### Tag: package-2024-05-01-preview
@@ -72,6 +94,9 @@ This is not used by Autorest itself.
 swagger-to-sdk:
   - repo: azure-sdk-for-python-track2
   - repo: azure-sdk-for-java
+  - repo: azure-sdk-for-go
+  - repo: azure-sdk-for-js
+  - repo: azure-sdk-for-net
   - repo: azure-sdk-for-net
   - repo: azure-resource-manager-schemas
   - repo: azure-cli-extensions
@@ -82,9 +107,17 @@ swagger-to-sdk:
 
 See configuration in [readme.az.md](./readme.az.md)
 
+## Go
+
+See configuration in [readme.go.md](./readme.go.md)
+
 ## Python
 
 See configuration in [readme.python.md](./readme.python.md)
+
+## TypeScript
+
+See configuration in [readme.typescript.md](./readme.typescript.md)
 
 ## CSharp
 

--- a/specification/impact/resource-manager/readme.typescript.md
+++ b/specification/impact/resource-manager/readme.typescript.md
@@ -1,0 +1,14 @@
+## TypeScript
+
+These settings apply only when `--typescript` is specified on the command line.
+Please also specify `--typescript-sdks-folder=<path to root folder of your azure-sdk-for-js clone>`.
+
+``` yaml $(typescript)
+typescript:
+  azure-arm: true
+  package-name: "@azure/arm-impact"
+  output-folder: "$(typescript-sdks-folder)/sdk/impact/arm-impact"
+  payload-flattening-threshold: 1
+  clear-output-folder: true
+  generate-metadata: true
+```

--- a/specification/impact/suppressions.yaml
+++ b/specification/impact/suppressions.yaml
@@ -1,0 +1,9 @@
+# Managed centrally by the Azure SDK Team
+# Remove suppressions as specs are fixed
+
+- tool: TypeSpecValidation
+  rules: [Compile]
+  sub-rules: [ExtraSwagger]
+  reason: dont want to modify old swagger specs generated with cadl, Extra swaggers left behind when versions were removed from *.tsp files
+  paths:
+    - resource-manager/Microsoft.Impact/preview/2024-05-01-preview/impact.json


### PR DESCRIPTION
## Summary

Sync Microsoft.Impact RP specs from private repo (`RPSaaSMaster` branch) to public repo.

### Changes

- **New API version**: `2026-01-01-preview` (TypeSpec examples + generated swagger)
- **New API version**: `2025-01-01-preview` (required by TypeSpec Versions enum, TypeSpec examples + generated swagger)
- Updated TypeSpec definitions (`impact.tsp`, `commonModels.tsp`, `connectors.tsp`, `insights.tsp`, `workloadImpacts.tsp`, `ImpactCategories.tsp`, `main.tsp`)
- Updated `tspconfig.yaml` configuration
- Added `readme.go.md` and `readme.typescript.md` for SDK generation
- Updated existing readme files (`readme.md`, `readme.az.md`, `readme.csharp.md`, `readme.python.md`)
- Added `suppressions.yaml`
- Minor fix to `2024-05-01-preview` Connectors example

### Source
- Private repo: `Azure/azure-rest-api-specs-pr`
- Branch: `RPSaaSMaster`
- Path: `specification/impact/`