### PR TITLE
Update CODEOWNERS for Search RP and DP PRLabels

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,7 @@
 /specification/schemaregistry/ @hmlam @nickghardwick @lmazuel @deyaaeldeen @JoshLove-msft @swathipil @conniey @minhanh-phan
 
 # PRLabel: %Cognitive Services
-/dev/cognitiveservices/data-plane/Language/ @assafi @rokulka @ChongTang @annatisch @heaths @deyaaeldeen @joseharriaga @minhanh-phan 
+/dev/cognitiveservices/data-plane/Language/ @assafi @rokulka @ChongTang @annatisch @heaths @deyaaeldeen @joseharriaga @minhanh-phan
 
 # PRLabel: %Analysis Services
 /specification/analysisservices/ @taiwu
@@ -224,10 +224,10 @@
 /specification/scheduler/ @pinwang81
 
 # PRLabel: %Search
-/specification/search/data-plane/ @kuanlu95 @BevLoh @giulianob @xiangyan99
+/specification/search/data-plane/ @BevLoh @giulianob @xiangyan99 @yangylu91 @efrainretana @admayber @Draconicida @JoeyCarson @xiong-qiao
 
 # PRLabel: %Search
-/specification/search/resource-manager/ @efrainretana @BevLoh @xiong-qiao @jonathanserbent @Draconicida @kuanlu95 @admayber
+/specification/search/resource-manager/ @BevLoh @efrainretana @yangylu91 @admayber @Draconicida @JoeyCarson @xiong-qiao
 
 /specification/serialconsole/ @amitchat @craigw @asinn826
 
@@ -246,7 +246,7 @@
 
 # PRLabel: %Storage
 /specification/storage/resource-manager/ @blueww @yifanz7
-/specification/storage/data-plane/ @seanmcc-msft 
+/specification/storage/data-plane/ @seanmcc-msft
 
 # PRLabel: %Import Export
 /specification/storageimportexport/ @leoz-ms

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -224,10 +224,10 @@
 /specification/scheduler/ @pinwang81
 
 # PRLabel: %Search
-/specification/search/data-plane/ @BevLoh @giulianob @xiangyan99 @yangylu91 @efrainretana @admayber @Draconicida @JoeyCarson @xiong-qiao
+/specification/search/data-plane/ @BevLoh @giulianob @xiangyan99 @yangylu91 @efrainretana @admayber @Draconicida @xiong-qiao
 
 # PRLabel: %Search
-/specification/search/resource-manager/ @BevLoh @efrainretana @yangylu91 @admayber @Draconicida @JoeyCarson @xiong-qiao
+/specification/search/resource-manager/ @BevLoh @efrainretana @yangylu91 @admayber @Draconicida @xiong-qiao
 
 /specification/serialconsole/ @amitchat @craigw @asinn826
 


### PR DESCRIPTION
Updated code owners for `# PRLabel: %Search` of both DP and RP paths.
Removed users who left the team and added current team members.