### PR TITLE
Fix keyvault lintdiff error

### DIFF
--- a/specification/keyvault/data-plane/Legacy/readme.md
+++ b/specification/keyvault/data-plane/Legacy/readme.md
@@ -180,11 +180,11 @@ These settings apply only when `--tag=package-7.1-preview` is specified on the c
 
 ``` yaml $(tag) == 'package-7.1-preview'
 input-file:
-- preview/7.1/certificates.json
-- preview/7.1/common.json
-- preview/7.1/keys.json
-- preview/7.1/secrets.json
-- preview/7.1/storage.json
+- preview/7.1-preview/certificates.json
+- preview/7.1-preview/common.json
+- preview/7.1-preview/keys.json
+- preview/7.1-preview/secrets.json
+- preview/7.1-preview/storage.json
 ```
 
 ### Tag: package-7.0
@@ -202,7 +202,7 @@ These settings apply only when `--tag=package-7.0-preview` is specified on the c
 
 ``` yaml $(tag) == 'package-7.0-preview'
 input-file:
-- preview/7.0/keyvault.json
+- preview/7.0-preview/keyvault.json
 ```
 
 ### Tag: package-2016-10
@@ -311,13 +311,13 @@ input-file:
   - $(this-folder)/stable/7.1/keys.json
   - $(this-folder)/stable/7.1/secrets.json
   - $(this-folder)/stable/7.1/storage.json
-  - $(this-folder)/preview/7.1/certificates.json
-  - $(this-folder)/preview/7.1/common.json
-  - $(this-folder)/preview/7.1/keys.json
-  - $(this-folder)/preview/7.1/secrets.json
-  - $(this-folder)/preview/7.1/storage.json
+  - $(this-folder)/preview/7.1-preview/certificates.json
+  - $(this-folder)/preview/7.1-preview/common.json
+  - $(this-folder)/preview/7.1-preview/keys.json
+  - $(this-folder)/preview/7.1-preview/secrets.json
+  - $(this-folder)/preview/7.1-preview/storage.json
   - $(this-folder)/stable/7.0/keyvault.json
-  - $(this-folder)/preview/7.0/keyvault.json
+  - $(this-folder)/preview/7.0-preview/keyvault.json
   - $(this-folder)/stable/2016-10-01/keyvault.json
   - $(this-folder)/stable/2015-06-01/keyvault.json
 


### PR DESCRIPTION
Fix keyvault lintdiff error from https://github.com/Azure/azure-rest-api-specs/pull/38668
```
SpecModelError: Failed to parse JSON for swagger: /home/runner/work/azure-rest-api-specs/azure-rest-api-specs/after/specification/keyvault/data-plane/Legacy/preview/7.1/certificates.json
  Problem File: /home/runner/work/azure-rest-api-specs/azure-rest-api-specs/after/specification/keyvault/data-plane/Legacy/preview/7.1/certificates.json
  Readme: /home/runner/work/azure-rest-api-specs/azure-rest-api-specs/after/specification/keyvault/data-plane/Legacy/readme.md
  Tag: package-7.1-preview
  Cause: SpecModelError: Failed to read file for swagger: /home/runner/work/azure-rest-api-specs/azure-rest-api-specs/after/specification/keyvault/data-plane/Legacy/preview/7.1/certificates.json
  Problem File: /home/runner/work/azure-rest-api-specs/azure-rest-api-specs/after/specification/keyvault/data-plane/Legacy/preview/7.1/certificates.json
  Readme: /home/runner/work/azure-rest-api-specs/azure-rest-api-specs/after/specification/keyvault/data-plane/Legacy/readme.md
  Tag: package-7.1-preview
  Cause: Error: ENOENT: no such file or directory, open '/home/runner/work/azure-rest-api-specs/azure-rest-api-specs/after/specification/keyvault/data-plane/Legacy/preview/7.1/certificates.json'
```