### PR TITLE
Split ExpiryTimeHeader

### DIFF
--- a/specification/storage/Microsoft.BlobStorage/models.tsp
+++ b/specification/storage/Microsoft.BlobStorage/models.tsp
@@ -1557,8 +1557,18 @@ alias RehydratePriorityHeader = {
   rehydratePriority?: RehydratePriority;
 };
 
+/** The expires parameter. */
+alias ExpiryTimeParameter = {
+  /** The time this blob will expire. */
+  #suppress "@azure-tools/typespec-azure-core/known-encoding" "Existing API"
+  @clientName("ExpiresOn")
+  @encode("rfc7231")
+  @header("x-ms-expiry-time")
+  expiryTime?: utcDateTime;
+};
+
 /** The expires on response header. */
-alias ExpiryTimeHeader = {
+alias ExpiryTimeResponseHeader = {
   /** The time this blob will expire. */
   #suppress "@azure-tools/typespec-azure-core/known-encoding" "Existing API"
   @encode("rfc7231")

--- a/specification/storage/Microsoft.BlobStorage/models.tsp
+++ b/specification/storage/Microsoft.BlobStorage/models.tsp
@@ -1561,10 +1561,9 @@ alias RehydratePriorityHeader = {
 alias ExpiryTimeParameter = {
   /** The time this blob will expire. */
   #suppress "@azure-tools/typespec-azure-core/known-encoding" "Existing API"
-  @clientName("ExpiresOn")
   @encode("rfc7231")
   @header("x-ms-expiry-time")
-  expiryTime?: utcDateTime;
+  expiresOn?: utcDateTime;
 };
 
 /** The expires on response header. */

--- a/specification/storage/Microsoft.BlobStorage/routes.tsp
+++ b/specification/storage/Microsoft.BlobStorage/routes.tsp
@@ -883,7 +883,7 @@ interface Blob {
       ...VersionIdResponseHeader;
       ...IsCurrentVersionResponseHeader;
       ...TagCountResponseHeader;
-      ...ExpiryTimeHeader;
+      ...ExpiryTimeResponseHeader;
       ...IsSealedResponseHeader;
       ...RehydratePriorityHeader;
       ...LastAccessedResponseHeader;
@@ -950,7 +950,7 @@ interface Blob {
     {
       ...TimeoutParameter;
       ...BlobExpiryOptionsParameter;
-      ...ExpiryTimeHeader;
+      ...ExpiryTimeParameter;
     },
     {
       ...EtagResponseHeader;


### PR DESCRIPTION
Splitting `ExpiryTimeHeader` into `ExpiryTimeParameter` and `ExpiryTimeResponseHeader`. No functional change here but need to have the request and response as different definitions, so I can apply client.tsp customizations to just the request or response header.
