### PR TITLE
Split BlobPublicAccess

### DIFF
--- a/specification/storage/Microsoft.BlobStorage/client.tsp
+++ b/specification/storage/Microsoft.BlobStorage/client.tsp
@@ -238,7 +238,7 @@ op setAccessPolicyRequiredContainerAcl is StorageOperationNoBody<
 
     ...TimeoutParameter;
     ...LeaseIdOptionalParameter;
-    ...BlobPublicAccess;
+    ...BlobPublicAccessParameter;
     ...IfModifiedSinceParameter;
     ...IfUnmodifiedSinceParameter;
   },

--- a/specification/storage/Microsoft.BlobStorage/models.tsp
+++ b/specification/storage/Microsoft.BlobStorage/models.tsp
@@ -1544,11 +1544,19 @@ alias DenyEncryptionScopeOverride = {
 };
 
 /** Specifies whether data in the container may be accessed publicly and the level of access */
-alias BlobPublicAccess = {
+alias BlobPublicAccessParameter = {
   /** The public access setting for the container. */
   @header("x-ms-blob-public-access")
   access?: PublicAccessType;
 };
+
+/** Specifies whether data in the container may be accessed publicly and the level of access */
+alias BlobPublicAccessResponseHeader = {
+  /** The public access setting for the container. */
+  @header("x-ms-blob-public-access")
+  blobPublicAccess?: PublicAccessType;
+};
+
 
 /** Optional: Indicates the priority with which to rehydrate an archived blob. */
 alias RehydratePriorityHeader = {

--- a/specification/storage/Microsoft.BlobStorage/models.tsp
+++ b/specification/storage/Microsoft.BlobStorage/models.tsp
@@ -1554,7 +1554,7 @@ alias BlobPublicAccessParameter = {
 alias BlobPublicAccessResponseHeader = {
   /** The public access setting for the container. */
   @header("x-ms-blob-public-access")
-  blobPublicAccess?: PublicAccessType;
+  access?: PublicAccessType;
 };
 
 

--- a/specification/storage/Microsoft.BlobStorage/routes.tsp
+++ b/specification/storage/Microsoft.BlobStorage/routes.tsp
@@ -252,7 +252,7 @@ interface Container {
     {
       ...TimeoutParameter;
       ...MetadataHeaders;
-      ...BlobPublicAccess;
+      ...BlobPublicAccessParameter;
 
       /** Optional.  Version 2019-07-07 and later.  Specifies the default encryption scope to set on the container and use for all future writes. */
       @header("x-ms-default-encryption-scope")
@@ -284,7 +284,7 @@ interface Container {
       ...LeaseDurationResponseHeader;
       ...LeaseStateResponseHeader;
       ...LeaseStatusResponseHeader;
-      ...BlobPublicAccess;
+      ...BlobPublicAccessResponseHeader;
 
       /** Indicates whether the container has an immutability policy set on it. */
       @header("x-ms-has-immutability-policy")
@@ -355,7 +355,7 @@ interface Container {
       /** Signed identifiers */
       @body body: SignedIdentifiers;
 
-      ...BlobPublicAccess;
+      ...BlobPublicAccessResponseHeader;
       ...EtagResponseHeader;
       ...LastModifiedResponseHeader;
     }
@@ -380,7 +380,7 @@ interface Container {
 
       ...TimeoutParameter;
       ...LeaseIdOptionalParameter;
-      ...BlobPublicAccess;
+      ...BlobPublicAccessParameter;
       ...IfModifiedSinceParameter;
       ...IfUnmodifiedSinceParameter;
     },


### PR DESCRIPTION
Splitting `BlobPublicAccess` into `BlobPublicAccessParameter` and `BlobPublicAccessResponseHeader`. No functional change here but need to have the request and response as different definitions, so I can apply client.tsp customizations to just the request or response header.
