### PR TITLE
feat: Add session file operations TypeSpec for hosted agents

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/main.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/main.tsp
@@ -1,5 +1,6 @@
 import "./src/agents/routes.tsp";
 import "./src/agents-containers/routes.tsp";
+import "./src/agents-session-files/routes.tsp";
 import "./src/common/custom-types.tsp";
 import "./src/common/service.tsp";
 import "./src/connections/routes.tsp";

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-session-files/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-session-files/models.tsp
@@ -1,0 +1,52 @@
+using TypeSpec.Http;
+using TypeSpec.Versioning;
+
+namespace Azure.AI.Projects;
+
+// ---------------------------------------------------------------------------
+// Response models
+// ---------------------------------------------------------------------------
+
+@removed(Versions.v1)
+@doc("Response from uploading a file to a session sandbox.")
+model SessionFileWriteResponse {
+  @doc("The path where the file was written.")
+  path: string;
+
+  @doc("Number of bytes written.")
+  bytes_written: int64;
+}
+
+@removed(Versions.v1)
+@doc("A single entry in a directory listing.")
+model SessionDirectoryEntry {
+  @doc("The name of the file or directory.")
+  name: string;
+
+  @doc("The size in bytes (0 for directories).")
+  size: int64;
+
+  @doc("Whether this entry is a directory.")
+  is_dir: boolean;
+
+  @doc("The last modification time in UTC (ISO 8601).")
+  @encode(DateTimeKnownEncoding.rfc3339)
+  modified_time: utcDateTime;
+}
+
+@removed(Versions.v1)
+@doc("Response from listing a directory in a session sandbox.")
+model SessionDirectoryListResponse {
+  @doc("The path that was listed.")
+  path: string;
+
+  @doc("The directory entries.")
+  entries: SessionDirectoryEntry[];
+}
+
+@removed(Versions.v1)
+@doc("Generic response for session file operations (delete).")
+model SessionFileOperationResponse {
+  @doc("A human-readable message describing the result.")
+  message: string;
+}

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-session-files/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-session-files/routes.tsp
@@ -1,0 +1,145 @@
+import "../common/models.tsp";
+import "./models.tsp";
+
+using TypeSpec.Http;
+using TypeSpec.OpenAPI;
+using TypeSpec.Versioning;
+
+namespace Azure.AI.Projects;
+
+/**
+ * Session-scoped file operations for hosted agent sandboxes.
+ *
+ * These endpoints enable uploading, downloading, listing, and deleting
+ * files within a live ADC sandbox session. All file content is streamed
+ * end-to-end (no buffering in Agents service memory).
+ *
+ * Sessions are scoped to agents (not versions), giving optionality to
+ * mutate the associated agent version independently of the session lifecycle.
+ */
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" ""
+@tag("Agent Session Files")
+@removed(Versions.v1)
+interface AgentSessionFiles {
+
+  /**
+   * Upload a file to the session sandbox via binary stream.
+   */
+  @put
+  @route("/agents/{agent_name}/sessions/{session_id}/files")
+  @extension(
+    "x-ms-foundry-meta",
+    #{
+      required_previews: #[
+        AgentDefinitionOptInKeys.hosted_agents_v1_preview
+      ],
+    }
+  )
+  uploadSessionFile is FoundryDataPlanePreviewOperation<
+    AgentDefinitionOptInKeys.hosted_agents_v1_preview,
+    {
+      /** The name of the agent. */
+      @path agent_name: string;
+
+      /** The session ID. */
+      @path session_id: string;
+
+      /** The destination file path within the sandbox. */
+      @query path: string;
+
+      /** The binary file content to upload. */
+      @header contentType: "application/octet-stream";
+      @body content: bytes;
+    },
+    SessionFileWriteResponse
+  >;
+
+  /**
+   * Download a file from the session sandbox as a binary stream.
+   */
+  @get
+  @route("/agents/{agent_name}/sessions/{session_id}/files")
+  @extension(
+    "x-ms-foundry-meta",
+    #{
+      required_previews: #[
+        AgentDefinitionOptInKeys.hosted_agents_v1_preview
+      ],
+    }
+  )
+  downloadSessionFile is FoundryDataPlanePreviewOperation<
+    AgentDefinitionOptInKeys.hosted_agents_v1_preview,
+    {
+      /** The name of the agent. */
+      @path agent_name: string;
+
+      /** The session ID. */
+      @path session_id: string;
+
+      /** The file path to download from the sandbox. */
+      @query path: string;
+    },
+    bytes
+  >;
+
+  /**
+   * List files and directories at a given path in the session sandbox.
+   * Returns only the immediate children of the specified directory (non-recursive).
+   */
+  @get
+  @route("/agents/{agent_name}/sessions/{session_id}/files/list")
+  @extension(
+    "x-ms-foundry-meta",
+    #{
+      required_previews: #[
+        AgentDefinitionOptInKeys.hosted_agents_v1_preview
+      ],
+    }
+  )
+  listSessionFiles is FoundryDataPlanePreviewOperation<
+    AgentDefinitionOptInKeys.hosted_agents_v1_preview,
+    {
+      /** The name of the agent. */
+      @path agent_name: string;
+
+      /** The session ID. */
+      @path session_id: string;
+
+      /** The directory path to list. */
+      @query path: string;
+    },
+    SessionDirectoryListResponse
+  >;
+
+  /**
+   * Delete a file or directory from the session sandbox.
+   * If `recursive` is false (default) and the target is a non-empty directory, the API returns 409 Conflict.
+   */
+  @delete
+  @route("/agents/{agent_name}/sessions/{session_id}/files")
+  @extension(
+    "x-ms-foundry-meta",
+    #{
+      required_previews: #[
+        AgentDefinitionOptInKeys.hosted_agents_v1_preview
+      ],
+    }
+  )
+  deleteSessionFile is FoundryDataPlanePreviewOperation<
+    AgentDefinitionOptInKeys.hosted_agents_v1_preview,
+    {
+      /** The name of the agent. */
+      @path agent_name: string;
+
+      /** The session ID. */
+      @path session_id: string;
+
+      /** The file or directory path to delete. */
+      @query path: string;
+
+      /** Whether to recursively delete directory contents. Defaults to false. */
+      @query recursive?: boolean;
+    },
+    SessionFileOperationResponse
+  >;
+}

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -159,6 +159,9 @@ union AgentVersionStatus {
 
   @doc("The agent version is being deleted.")
   deleting: "deleting",
+
+  @doc("The agent version has been deleted.")
+  deleted: "deleted",
 }
 
 @doc("Error details for agent version provisioning failure.")

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -126,6 +126,55 @@ model AgentVersionObject {
   created_at: utcDateTime;
 
   definition: AgentDefinition;
+
+  @doc("The provisioning status of the agent version. For hosted agents, reflects ADC snapshot readiness.")
+  @extension(
+    "x-ms-foundry-meta",
+    #{ required_previews: #[AgentDefinitionFeatureKeys.hosted_agents_v1_preview] }
+  )
+  status?: AgentVersionStatus;
+
+  @doc("Error details if the agent version provisioning failed.")
+  @extension(
+    "x-ms-foundry-meta",
+    #{ required_previews: #[AgentDefinitionFeatureKeys.hosted_agents_v1_preview] }
+  )
+  error?: AgentVersionError;
+}
+
+@doc("The provisioning status of an agent version.")
+@extension(
+  "x-ms-foundry-meta",
+  #{ required_previews: #[AgentDefinitionFeatureKeys.hosted_agents_v1_preview] }
+)
+union AgentVersionStatus {
+  @doc("The agent version is being provisioned (e.g., ADC snapshot creation in progress).")
+  creating: "creating",
+
+  @doc("The agent version is active and ready to serve requests.")
+  active: "active",
+
+  @doc("The agent version provisioning failed.")
+  failed: "failed",
+
+  @doc("The agent version is being deleted.")
+  deleting: "deleting",
+}
+
+@doc("Error details for agent version provisioning failure.")
+@extension(
+  "x-ms-foundry-meta",
+  #{ required_previews: #[AgentDefinitionFeatureKeys.hosted_agents_v1_preview] }
+)
+model AgentVersionError {
+  @doc("The error code.")
+  code: string;
+
+  @doc("A human-readable error message.")
+  message: string;
+
+  @doc("Additional error details.")
+  details?: string;
 }
 
 union AgentProtocol {

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -152,7 +152,6 @@ union AgentVersionStatus {
   deleted: "deleted",
 }
 
-
 union AgentProtocol {
   string,
   activity_protocol: "activity_protocol",

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -127,28 +127,16 @@ model AgentVersionObject {
 
   definition: AgentDefinition;
 
-  @doc("The provisioning status of the agent version. For hosted agents, reflects ADC snapshot readiness.")
-  @extension(
-    "x-ms-foundry-meta",
-    #{ required_previews: #[AgentDefinitionFeatureKeys.hosted_agents_v1_preview] }
-  )
-  status?: AgentVersionStatus;
+  @doc("The provisioning status of the agent version. Defaults to 'active' for non-hosted agents. For hosted agents, reflects infrastructure readiness.")
+  status: AgentVersionStatus = AgentVersionStatus.active;
 
   @doc("Error details if the agent version provisioning failed.")
-  @extension(
-    "x-ms-foundry-meta",
-    #{ required_previews: #[AgentDefinitionFeatureKeys.hosted_agents_v1_preview] }
-  )
-  error?: AgentVersionError;
+  error?: ApiError;
 }
 
 @doc("The provisioning status of an agent version.")
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionFeatureKeys.hosted_agents_v1_preview] }
-)
 union AgentVersionStatus {
-  @doc("The agent version is being provisioned (e.g., ADC snapshot creation in progress).")
+  @doc("The agent version is being provisioned.")
   creating: "creating",
 
   @doc("The agent version is active and ready to serve requests.")
@@ -164,21 +152,6 @@ union AgentVersionStatus {
   deleted: "deleted",
 }
 
-@doc("Error details for agent version provisioning failure.")
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionFeatureKeys.hosted_agents_v1_preview] }
-)
-model AgentVersionError {
-  @doc("The error code.")
-  code: string;
-
-  @doc("A human-readable error message.")
-  message: string;
-
-  @doc("Additional error details.")
-  details?: string;
-}
 
 union AgentProtocol {
   string,

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -127,13 +127,16 @@ model AgentVersionObject {
 
   definition: AgentDefinition;
 
+  @removed(Versions.v1)
   @doc("The provisioning status of the agent version. Defaults to 'active' for non-hosted agents. For hosted agents, reflects infrastructure readiness.")
   status: AgentVersionStatus = AgentVersionStatus.active;
 
+  @removed(Versions.v1)
   @doc("Error details if the agent version provisioning failed.")
   error?: ApiError;
 }
 
+@removed(Versions.v1)
 @doc("The provisioning status of an agent version.")
 union AgentVersionStatus {
   @doc("The agent version is being provisioned.")

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
@@ -184,9 +184,6 @@ interface Agents {
 
       /** The version of the agent to delete */
       @path agent_version: string;
-
-      /** When true, force-deletes the version even if active sessions exist. Defaults to false. */
-      @query force?: boolean = false;
     },
     DeleteAgentVersionResponse
   >;

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
@@ -184,6 +184,9 @@ interface Agents {
 
       /** The version of the agent to delete */
       @path agent_version: string;
+
+      /** When true, force-deletes the version even if active sessions exist. Defaults to false. */
+      @query force?: boolean = false;
     },
     DeleteAgentVersionResponse
   >;

--- a/specification/ai-foundry/data-plane/Foundry/src/openai-responses/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai-responses/models.tsp
@@ -34,6 +34,13 @@ namespace Azure.AI.Projects {
 
       /** The structured inputs to the response that can participate in prompt template substitution or tool argument bindings. */
       structured_inputs?: Record<unknown>,
+
+      /** Optional session identifier for sandbox affinity. When provided, the request is routed to the same ADC sandbox. When omitted, auto-derived from conversation_id/prev_response_id or a new UUID is generated. */
+      @extension(
+        "x-ms-foundry-meta",
+        #{ required_previews: #[AgentDefinitionFeatureKeys.hosted_agents_v1_preview] }
+      )
+      foundry_session_id?: string,
     }
   );
 
@@ -48,6 +55,13 @@ namespace Azure.AI.Projects {
 
       /** The agent used for this response */
       agent_reference: AgentReference | null,
+
+      /** The session identifier for this response. Always returned for hosted agents — either the caller-provided value, the auto-derived value, or an auto-generated UUID. Use for session-scoped operations (log streaming) and to maintain sandbox affinity in follow-up calls. */
+      @extension(
+        "x-ms-foundry-meta",
+        #{ required_previews: #[AgentDefinitionFeatureKeys.hosted_agents_v1_preview] }
+      )
+      foundry_session_id?: string,
     }
   );
 

--- a/specification/ai-foundry/data-plane/Foundry/src/openai-responses/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai-responses/models.tsp
@@ -35,7 +35,11 @@ namespace Azure.AI.Projects {
       /** The structured inputs to the response that can participate in prompt template substitution or tool argument bindings. */
       structured_inputs?: Record<unknown>,
 
-      /** Optional session identifier for sandbox affinity. When provided, the request is routed to the same sandbox. When omitted, auto-derived from conversation_id/prev_response_id or a new UUID is generated. */
+      /**
+       * Optional session identifier for sandbox affinity. Currently only relevant for hosted agents.
+       * When provided, the request is routed to the same sandbox. When omitted, auto-derived from
+       * conversation_id/prev_response_id or a new UUID is generated.
+       */
       agent_session_id?: string,
     }
   );
@@ -52,7 +56,12 @@ namespace Azure.AI.Projects {
       /** The agent used for this response */
       agent_reference: AgentReference | null,
 
-      /** The session identifier for this response. Always returned for hosted agents — either the caller-provided value, the auto-derived value, or an auto-generated UUID. Use for session-scoped operations (log streaming) and to maintain sandbox affinity in follow-up calls. */
+      /**
+       * The session identifier for this response. Currently only relevant for hosted agents.
+       * Always returned for hosted agents — either the caller-provided value, the auto-derived value,
+       * or an auto-generated UUID. Use for session-scoped operations and to maintain sandbox
+       * affinity in follow-up calls.
+       */
       agent_session_id?: string,
     }
   );

--- a/specification/ai-foundry/data-plane/Foundry/src/openai-responses/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai-responses/models.tsp
@@ -35,11 +35,7 @@ namespace Azure.AI.Projects {
       /** The structured inputs to the response that can participate in prompt template substitution or tool argument bindings. */
       structured_inputs?: Record<unknown>,
 
-      /** Optional session identifier for sandbox affinity. When provided, the request is routed to the same ADC sandbox. When omitted, auto-derived from conversation_id/prev_response_id or a new UUID is generated. */
-      @extension(
-        "x-ms-foundry-meta",
-        #{ required_previews: #[AgentDefinitionFeatureKeys.hosted_agents_v1_preview] }
-      )
+      /** Optional session identifier for sandbox affinity. When provided, the request is routed to the same sandbox. When omitted, auto-derived from conversation_id/prev_response_id or a new UUID is generated. */
       agent_session_id?: string,
     }
   );
@@ -57,10 +53,6 @@ namespace Azure.AI.Projects {
       agent_reference: AgentReference | null,
 
       /** The session identifier for this response. Always returned for hosted agents — either the caller-provided value, the auto-derived value, or an auto-generated UUID. Use for session-scoped operations (log streaming) and to maintain sandbox affinity in follow-up calls. */
-      @extension(
-        "x-ms-foundry-meta",
-        #{ required_previews: #[AgentDefinitionFeatureKeys.hosted_agents_v1_preview] }
-      )
       agent_session_id?: string,
     }
   );

--- a/specification/ai-foundry/data-plane/Foundry/src/openai-responses/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai-responses/models.tsp
@@ -40,6 +40,7 @@ namespace Azure.AI.Projects {
        * When provided, the request is routed to the same sandbox. When omitted, auto-derived from
        * conversation_id/prev_response_id or a new UUID is generated.
        */
+      @removed(Versions.v1)
       agent_session_id?: string,
     }
   );
@@ -62,6 +63,7 @@ namespace Azure.AI.Projects {
        * or an auto-generated UUID. Use for session-scoped operations and to maintain sandbox
        * affinity in follow-up calls.
        */
+      @removed(Versions.v1)
       agent_session_id?: string,
     }
   );

--- a/specification/ai-foundry/data-plane/Foundry/src/openai-responses/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai-responses/models.tsp
@@ -40,7 +40,7 @@ namespace Azure.AI.Projects {
         "x-ms-foundry-meta",
         #{ required_previews: #[AgentDefinitionFeatureKeys.hosted_agents_v1_preview] }
       )
-      foundry_session_id?: string,
+      agent_session_id?: string,
     }
   );
 
@@ -61,7 +61,7 @@ namespace Azure.AI.Projects {
         "x-ms-foundry-meta",
         #{ required_previews: #[AgentDefinitionFeatureKeys.hosted_agents_v1_preview] }
       )
-      foundry_session_id?: string,
+      agent_session_id?: string,
     }
   );
 


### PR DESCRIPTION
## Summary

Add TypeSpec definitions for session-scoped file operations on hosted agent sandboxes (stream-only).

### Operations (4 CRUDL)

| Method | Route | Description |
|--------|-------|-------------|
| `PUT` | `/agents/{name}/sessions/{id}/files?path=` | Upload file (binary stream) |
| `GET` | `/agents/{name}/sessions/{id}/files?path=` | Download file (binary stream) |
| `GET` | `/agents/{name}/sessions/{id}/files/list?path=` | List directory (non-recursive, single level) |
| `DELETE` | `/agents/{name}/sessions/{id}/files?path=` | Delete file/directory |

### Models (4)
- `SessionFileWriteResponse` — path, bytes_written
- `SessionDirectoryEntry` — name, size, is_dir, modified_time
- `SessionDirectoryListResponse` — path, entries[]
- `SessionFileOperationResponse` — message

### Preview Gating
- `@removed(Versions.v1)` on interface and all models — hidden from GA SDK
- `x-ms-foundry-meta` with `required_previews: hosted_agents_v1_preview` on each operation
- `FoundryDataPlanePreviewOperation` requires `Foundry-Features: HostedAgents=V1Preview` header

### Key Design Decisions
- **Sessions under agents (not versions)** — `/agents/{name}/sessions/` gives optionality to mutate the associated agent version independently of the session lifecycle
- **Non-recursive list** — returns immediate children only (cost/performance)
- **No symlink fields** — users can't create symlinks via the API
- **No `success` boolean** — HTTP status code suffices
- **No `file_api_root_path`** — consolidating with `$HOME` semantics (follow-up)
- **409 Conflict** on non-recursive delete of non-empty directory

### Note on `main.tsp` diff
The `main.tsp` diff includes an unrelated `managed-blueprints` import line because the fork branch predates that upstream change. Only the `agents-session-files` import is from this PR.

### Related
- Design doc: https://msdata.visualstudio.com/Vienna/_git/vienna/pullrequest/1970903
- API review doc: https://github.com/Azure/agent-first-sdk/pull/189
- ADC integration spec (merged): https://github.com/Azure/azure-rest-api-specs/pull/40739
