### PR TITLE
Remove readOnly visibility from nodeImageVersion in TypeSpec to fix agentpool rollback

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
@@ -171,7 +171,6 @@ model ManagedClusterAgentPoolProfileProperties {
   /**
    * The version of node image
    */
-  @visibility(Lifecycle.Read)
   nodeImageVersion?: string;
 
   /**

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-01-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-01-02-preview/managedClusters.json
@@ -10247,8 +10247,7 @@
         },
         "nodeImageVersion": {
           "type": "string",
-          "description": "The version of node image",
-          "readOnly": true
+          "description": "The version of node image"
         },
         "upgradeStrategy": {
           "$ref": "#/definitions/UpgradeStrategy",

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2025-10-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2025-10-01/managedClusters.json
@@ -6681,8 +6681,7 @@
         },
         "nodeImageVersion": {
           "type": "string",
-          "description": "The version of node image",
-          "readOnly": true
+          "description": "The version of node image"
         },
         "upgradeSettings": {
           "$ref": "#/definitions/AgentPoolUpgradeSettings",

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-01-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-01-01/managedClusters.json
@@ -6737,8 +6737,7 @@
         },
         "nodeImageVersion": {
           "type": "string",
-          "description": "The version of node image",
-          "readOnly": true
+          "description": "The version of node image"
         },
         "upgradeSettings": {
           "$ref": "#/definitions/AgentPoolUpgradeSettings",


### PR DESCRIPTION
## Problem

The TypeSpec conversion in PR #38641 incorrectly added `@visibility(Lifecycle.Read)` to the `nodeImageVersion` field in `ManagedClusterAgentPoolProfileProperties` (in `AgentPoolModels.tsp`). This is the TypeSpec equivalent of `readOnly: true`, which re-introduced the read-only constraint that was intentionally removed in PR #37229 to enable agentpool rollback functionality.

This regression affects API versions `2025-10-02-preview` and later.

## Fix

Remove `@visibility(Lifecycle.Read)` from `nodeImageVersion` in `AgentPoolModels.tsp`, making the field read-write so users can specify a target node image version when performing an agentpool rollback.

**Note:** The `nodeImageVersion` fields in `Machine.tsp` and `Snapshot.tsp` correctly remain `@visibility(Lifecycle.Read)` since those are genuinely read-only contexts.

## Context

- **Original fix (Swagger):** PR #37229 — removed `readOnly: true` for `nodeImageVersion` in `2025-08-02-preview`
- **Regression (TypeSpec conversion):** PR #38641 — added `@visibility(Lifecycle.Read)` back during TypeSpec conversion