### PR TITLE
Read SDK-reported isSpecGenSdkCheckRequired in spec-gen-sdk-runner

### DIFF
--- a/eng/tools/spec-gen-sdk-runner/src/command-helpers.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/command-helpers.ts
@@ -285,6 +285,40 @@ export function getBreakingChangeInfo(executionReport: ExecutionReport): boolean
 }
 
 /**
+ * Read isSpecGenSdkCheckRequired from the SDK generation output (generateOutput.json).
+ * For .NET SDK, the generation script explicitly declares whether the SDK validation
+ * check should be required, based on whether the package uses the new mgmt emitter.
+ * @param commandInput - The command input.
+ * @returns true/false if SDK explicitly declares the value, undefined if the property
+ *          is not present (e.g., older SDK script) or the file doesn't exist.
+ */
+export function readSdkOutputCheckRequired(commandInput: SpecGenSdkCmdInput): boolean | undefined {
+  const generateOutputPath = path.join(
+    commandInput.workingFolder,
+    `${commandInput.sdkRepoName}_tmp/generateOutput.json`,
+  );
+  if (!fs.existsSync(generateOutputPath)) {
+    return undefined;
+  }
+  try {
+    const generateOutput = JSON.parse(fs.readFileSync(generateOutputPath, "utf8")) as {
+      isSpecGenSdkCheckRequired?: boolean;
+    };
+    if (typeof generateOutput.isSpecGenSdkCheckRequired === "boolean") {
+      return generateOutput.isSpecGenSdkCheckRequired;
+    }
+    return undefined;
+  } catch (error) {
+    logMessage(
+      `Runner: failed to parse generateOutput.json at '${generateOutputPath}': ${inspect(error)}. ` +
+        `Falling back to legacy inference logic.`,
+      LogLevel.Warn,
+    );
+    return undefined;
+  }
+}
+
+/**
  * Generate the spec-gen-sdk artifacts.
  * @param commandInput - The command input.
  * @param result - The spec-gen-sdk execution result.
@@ -294,6 +328,7 @@ export function getBreakingChangeInfo(executionReport: ExecutionReport): boolean
  * @param stagedArtifactsFolder - The staged artifacts folder.
  * @param apiViewRequestData - The API view request data.
  * @param sdkGenerationExecuted - A flag indicating whether the SDK generation was executed.
+ * @param sdkReportedCheckRequired - Optional value from SDK output indicating whether the check is required.
  * @returns the run status code.
  */
 export function generateArtifact(
@@ -305,6 +340,7 @@ export function generateArtifact(
   stagedArtifactsFolder: string,
   apiViewRequestData: APIViewRequestData[],
   sdkGenerationExecuted: boolean = true,
+  sdkReportedCheckRequired?: boolean,
 ): number {
   const specGenSdkArtifactName = "spec-gen-sdk-artifact";
   const specGenSdkArtifactFileName = specGenSdkArtifactName + ".json";
@@ -323,6 +359,7 @@ export function generateArtifact(
         hasManagementPlaneSpecs,
         hasTypeSpecProjects,
         commandInput.sdkLanguage,
+        sdkReportedCheckRequired,
       );
     }
 
@@ -374,13 +411,21 @@ export function getServiceFolderPath(specConfigPath: string): string {
  * @param hasManagementPlaneSpecs - A flag indicating whether there are management plane specs.
  * @param hasTypeSpecProjects - A flag indicating whether there are TypeSpec projects.
  * @param sdkName - The SDK name.
+ * @param sdkReportedCheckRequired - Optional value from SDK output indicating whether the check is required.
  * @returns boolean indicating whether the SDK check is required.
  */
 export function getRequiredSettingValue(
   hasManagementPlaneSpecs: boolean,
   hasTypeSpecProjects: boolean,
   sdkName: SdkName,
+  sdkReportedCheckRequired?: boolean,
 ): boolean {
+  // If the SDK explicitly reported whether the check is required (e.g., .NET SDK
+  // reports this based on whether the package uses the new mgmt emitter), use that
+  // value directly instead of inferring from the broad hasTypeSpecProjects flag.
+  if (sdkName === "azure-sdk-for-net" && sdkReportedCheckRequired !== undefined) {
+    return sdkReportedCheckRequired;
+  }
   // If the SDK is azure-sdk-for-net, return false if there are no TypeSpec projects.
   if (sdkName === "azure-sdk-for-net" && !hasTypeSpecProjects) {
     return false;

--- a/eng/tools/spec-gen-sdk-runner/src/commands.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/commands.ts
@@ -11,6 +11,7 @@ import {
   logIssuesToPipeline,
   parseArguments,
   prepareSpecGenSdkCommand,
+  readSdkOutputCheckRequired,
   setPipelineVariables,
 } from "./command-helpers.js";
 import { LogLevel, logMessage, vsoAddAttachment, vsoLogIssue } from "./log.js";
@@ -105,6 +106,7 @@ export async function generateSdkForSpecPr(): Promise<number> {
   let overallExecutionResult = "";
   let currentExecutionResult: string;
   let stagedArtifactsFolder = "";
+  let sdkReportedCheckRequired: boolean | undefined;
   const apiViewRequestData: APIViewRequestData[] = [];
 
   if (changedSpecs.length === 0) {
@@ -181,6 +183,19 @@ export async function generateSdkForSpecPr(): Promise<number> {
       currentRunHasBreakingChange = getBreakingChangeInfo(executionReport);
       overallRunHasBreakingChange = overallRunHasBreakingChange || currentRunHasBreakingChange;
       logMessage(`Runner command execution result:${currentExecutionResult}`);
+
+      // For .NET, read the SDK's explicit isSpecGenSdkCheckRequired from the generation output.
+      // Only override when the SDK explicitly provides the value (not undefined).
+      if (commandInput.sdkLanguage === "azure-sdk-for-net") {
+        const currentRunCheckRequired = readSdkOutputCheckRequired(commandInput);
+        if (currentRunCheckRequired === true) {
+          sdkReportedCheckRequired = true;
+        } else if (currentRunCheckRequired === false && sdkReportedCheckRequired === undefined) {
+          sdkReportedCheckRequired = false;
+        }
+        // If currentRunCheckRequired is undefined (old SDK script), sdkReportedCheckRequired
+        // stays undefined and getRequiredSettingValue falls back to existing logic.
+      }
     } catch (error) {
       logMessage(`Runner: error reading execution-report.json:${inspect(error)}`, LogLevel.Error);
       statusCode = 1;
@@ -202,6 +217,7 @@ export async function generateSdkForSpecPr(): Promise<number> {
       stagedArtifactsFolder,
       apiViewRequestData,
       sdkGenerationExecuted,
+      sdkReportedCheckRequired,
     ) || statusCode;
   return statusCode;
 }

--- a/eng/tools/spec-gen-sdk-runner/test/command-helpers.test.ts
+++ b/eng/tools/spec-gen-sdk-runner/test/command-helpers.test.ts
@@ -11,6 +11,7 @@ import {
   logIssuesToPipeline,
   parseArguments,
   prepareSpecGenSdkCommand,
+  readSdkOutputCheckRequired,
   setPipelineVariables,
 } from "../src/command-helpers.js";
 import * as log from "../src/log.js";
@@ -603,6 +604,65 @@ describe("commands.ts", () => {
         ),
       );
     });
+
+    test("should use sdkReportedCheckRequired for .NET SDK when provided", () => {
+      vi.spyOn(fs, "existsSync").mockReturnValue(false);
+      vi.spyOn(fs, "mkdirSync").mockImplementation(() => undefined);
+      vi.spyOn(fs, "writeFileSync").mockImplementation(() => {
+        // mock implementation intentionally left blank
+      });
+      vi.spyOn(log, "setVsoVariable").mockImplementation(() => {
+        // mock implementation intentionally left blank
+      });
+
+      const mockCommandInput = {
+        workingFolder: "/working/folder",
+        sdkLanguage: "azure-sdk-for-net" as SdkName,
+        runMode: "",
+        localSpecRepoPath: "",
+        localSdkRepoPath: "",
+        prNumber: "456",
+        sdkRepoName: "",
+        specCommitSha: "def456",
+        specRepoHttpsUrl: "",
+      };
+
+      // Even though hasManagementPlaneSpecs=true and hasTypeSpecProjects=true
+      // (which would normally make .NET required), sdkReportedCheckRequired=false overrides
+      const result = generateArtifact(
+        mockCommandInput,
+        "succeeded",
+        false,
+        true, // hasManagementPlaneSpecs
+        true, // hasTypeSpecProjects
+        "mockStagedArtifactsFolder",
+        [],
+        true, // sdkGenerationExecuted
+        false, // sdkReportedCheckRequired - SDK says not required
+      );
+
+      const breakingChangeLabelArtifactPath = path.normalize(
+        "/working/folder/out/spec-gen-sdk-artifact",
+      );
+
+      expect(result).toBe(0);
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        path.join(breakingChangeLabelArtifactPath, "spec-gen-sdk-artifact.json"),
+        JSON.stringify(
+          {
+            language: "azure-sdk-for-net",
+            result: "succeeded",
+            headSha: "def456",
+            prNumber: "456",
+            labelAction: false,
+            isSpecGenSdkCheckRequired: false,
+            apiViewRequestData: [],
+          },
+          undefined,
+          2,
+        ),
+      );
+    });
   });
 
   describe("getRequiredSettingValue", () => {
@@ -646,6 +706,112 @@ describe("commands.ts", () => {
 
       const result2 = getRequiredSettingValue(false, false, "azure-sdk-for-python");
       expect(result2).toBe(true);
+    });
+    test("should use sdkReportedCheckRequired for .NET when provided as true", () => {
+      // When sdkReportedCheckRequired is true, .NET should be required regardless of other flags
+      const result = getRequiredSettingValue(true, false, "azure-sdk-for-net", true);
+      expect(result).toBe(true);
+
+      const result2 = getRequiredSettingValue(false, false, "azure-sdk-for-net", true);
+      expect(result2).toBe(true);
+
+      const result3 = getRequiredSettingValue(true, true, "azure-sdk-for-net", true);
+      expect(result3).toBe(true);
+    });
+
+    test("should use sdkReportedCheckRequired for .NET when provided as false", () => {
+      // When sdkReportedCheckRequired is false, .NET should not be required even if
+      // hasTypeSpecProjects is true and hasManagementPlaneSpecs is true
+      const result = getRequiredSettingValue(true, true, "azure-sdk-for-net", false);
+      expect(result).toBe(false);
+
+      const result2 = getRequiredSettingValue(false, true, "azure-sdk-for-net", false);
+      expect(result2).toBe(false);
+    });
+
+    test("should ignore sdkReportedCheckRequired for non-.NET SDKs", () => {
+      // sdkReportedCheckRequired should be ignored for other SDKs
+      const result = getRequiredSettingValue(true, true, "azure-sdk-for-go", false);
+      expect(result).toBe(true);
+
+      const result2 = getRequiredSettingValue(false, true, "azure-sdk-for-python", false);
+      expect(result2).toBe(true);
+    });
+
+    test("should fall back to existing logic for .NET when sdkReportedCheckRequired is undefined", () => {
+      // When sdkReportedCheckRequired is undefined, .NET should use existing logic
+      const result = getRequiredSettingValue(true, true, "azure-sdk-for-net", undefined);
+      expect(result).toBe(true);
+
+      const result2 = getRequiredSettingValue(true, false, "azure-sdk-for-net", undefined);
+      expect(result2).toBe(false);
+    });
+  });
+
+  describe("readSdkOutputCheckRequired", () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    const mockInput = {
+      workingFolder: "/working",
+      sdkRepoName: "azure-sdk-for-net",
+      sdkLanguage: SdkName.Net,
+      runMode: "",
+      localSpecRepoPath: "",
+      localSdkRepoPath: "",
+      specCommitSha: "",
+      specRepoHttpsUrl: "",
+    };
+
+    test("should return true when generateOutput.json has isSpecGenSdkCheckRequired=true", () => {
+      vi.spyOn(fs, "existsSync").mockReturnValue(true);
+      vi.spyOn(fs, "readFileSync").mockReturnValue(
+        JSON.stringify({ packages: [], isSpecGenSdkCheckRequired: true }),
+      );
+
+      const result = readSdkOutputCheckRequired(mockInput);
+      expect(result).toBe(true);
+    });
+
+    test("should return false when generateOutput.json has isSpecGenSdkCheckRequired=false", () => {
+      vi.spyOn(fs, "existsSync").mockReturnValue(true);
+      vi.spyOn(fs, "readFileSync").mockReturnValue(
+        JSON.stringify({ packages: [], isSpecGenSdkCheckRequired: false }),
+      );
+
+      const result = readSdkOutputCheckRequired(mockInput);
+      expect(result).toBe(false);
+    });
+
+    test("should return undefined when generateOutput.json does not exist", () => {
+      vi.spyOn(fs, "existsSync").mockReturnValue(false);
+
+      const result = readSdkOutputCheckRequired(mockInput);
+      expect(result).toBeUndefined();
+    });
+
+    test("should return undefined and log warning when generateOutput.json is invalid JSON", () => {
+      vi.spyOn(fs, "existsSync").mockReturnValue(true);
+      vi.spyOn(fs, "readFileSync").mockReturnValue("invalid json");
+      vi.spyOn(log, "logMessage").mockImplementation(() => {
+        // mock implementation intentionally left blank
+      });
+
+      const result = readSdkOutputCheckRequired(mockInput);
+      expect(result).toBeUndefined();
+      expect(log.logMessage).toHaveBeenCalledWith(
+        expect.stringContaining("failed to parse generateOutput.json"),
+        LogLevel.Warn,
+      );
+    });
+
+    test("should return undefined when generateOutput.json has no isSpecGenSdkCheckRequired field", () => {
+      vi.spyOn(fs, "existsSync").mockReturnValue(true);
+      vi.spyOn(fs, "readFileSync").mockReturnValue(JSON.stringify({ packages: [] }));
+
+      const result = readSdkOutputCheckRequired(mockInput);
+      expect(result).toBeUndefined();
     });
   });
 });

--- a/eng/tools/spec-gen-sdk-runner/test/commands.test.ts
+++ b/eng/tools/spec-gen-sdk-runner/test/commands.test.ts
@@ -253,6 +253,7 @@ describe("generateSdkForSpecPr", () => {
       "", // stagedArtifactsFolder
       [], // apiViewRequestData
       true, // sdkGenerationExecuted
+      undefined, // sdkReportedCheckRequired
     );
   });
 
@@ -296,6 +297,7 @@ describe("generateSdkForSpecPr", () => {
       "", // stagedArtifactsFolder
       [], // apiViewRequestData
       false, // sdkGenerationExecuted should be set to false
+      undefined, // sdkReportedCheckRequired
     );
   });
 
@@ -335,6 +337,7 @@ describe("generateSdkForSpecPr", () => {
       "", // stagedArtifactsFolder
       [], // apiViewRequestData
       true, // sdkGenerationExecuted is true because there were some changed specs but they had no valid config
+      undefined, // sdkReportedCheckRequired
     );
   });
 


### PR DESCRIPTION
## Problem

In TypeSpec migration PRs, `SDK Validation - .NET` incorrectly becomes required and blocks the PR, even when the .NET SDK has no TypeSpec generation path (no C# emitter configured in `tspconfig.yaml`).

The root cause is that `getRequiredSettingValue()` uses the broad `hasTypeSpecProjects` flag (derived from `generateFromTypeSpec` in execution-report.json) to decide if the .NET check is required. This can be incorrectly `true` when the PR has TypeSpec files but the .NET SDK doesn't use the new mgmt emitter.

## Fix

Read `isSpecGenSdkCheckRequired` from the SDK generation output (`generateOutput.json`) instead of computing it from the broad `hasTypeSpecProjects` flag. For .NET SDK, the generation script explicitly declares whether the SDK validation check should be required.

### Changes
- **`command-helpers.ts`**: Add `readSdkOutputCheckRequired()` to read SDK output directly. Add `sdkReportedCheckRequired` parameter to `getRequiredSettingValue()` and `generateArtifact()` for .NET-specific override.
- **`commands.ts`**: In `generateSdkForSpecPr()`, read and accumulate `sdkReportedCheckRequired` across runs, pass to `generateArtifact()`.
- **Tests**: 9 new test cases for the new parameter and `readSdkOutputCheckRequired()`. All 45 tests pass.

**Companion PR (SDK repo):** https://github.com/Azure/azure-sdk-for-net/pull/57279

Fixes Azure/azure-sdk-for-net#57275
