### PR TITLE
MPG migration - NotificationHubs

### DIFF
--- a/specification/notificationhubs/resource-manager/Microsoft.NotificationHubs/NotificationHubs/SharedAccessAuthorizationRuleResource.tsp
+++ b/specification/notificationhubs/resource-manager/Microsoft.NotificationHubs/NotificationHubs/SharedAccessAuthorizationRuleResource.tsp
@@ -71,7 +71,8 @@ interface SharedAccessAuthorizationRuleResourceOps
         @minLength(1)
         @maxLength(256)
         authorizationRuleName: string,
-      }
+      },
+      ResourceName = "NotificationHubAuthorizationRule"
     > {}
 
 @armResourceOperations
@@ -146,7 +147,8 @@ interface NamespaceOps
         @minLength(1)
         @maxLength(256)
         authorizationRuleName: string,
-      }
+      },
+      ResourceName = "NotificationHubNamespaceAuthorizationRule"
     > {}
 
 @armResourceOperations

--- a/specification/notificationhubs/resource-manager/Microsoft.NotificationHubs/NotificationHubs/back-compatible.tsp
+++ b/specification/notificationhubs/resource-manager/Microsoft.NotificationHubs/NotificationHubs/back-compatible.tsp
@@ -100,7 +100,8 @@ using Microsoft.NotificationHubs;
 @@clientName(NamespacesOperationGroup.checkAvailability::parameters.body,
   "parameters"
 );
-@@clientName(CheckAvailabilityParameters, "CheckAvailabilityContent", "csharp");
+// Removed: @@clientName(CheckAvailabilityParameters, "CheckAvailabilityContent", "csharp");
+// Replaced by csharp-scoped rename in client.tsp to "NotificationHubAvailabilityContent"
 @@clientName(DebugSendResponse, "DebugSendResponseResult", "csharp");
 @@clientName(Operation, "Info", "csharp");
 
@@ -118,27 +119,29 @@ using Microsoft.NotificationHubs;
 @@clientLocation(NamespaceResources.listAll, Namespaces);
 @@clientName(NamespaceResources.listAll, "ListAll");
 @@clientLocation(NamespaceResources.checkNotificationHubAvailability,
-  "NotificationHubs"
+  "NotificationHubs",
+  "!csharp"
 );
 @@clientName(NamespaceResources.checkNotificationHubAvailability,
   "CheckNotificationHubAvailability"
 );
 @@clientLocation(NamespaceResources.getPnsCredentials, Namespaces);
 @@clientName(NamespaceResources.getPnsCredentials, "GetPnsCredentials");
-@@clientLocation(NotificationHubResources.get, "NotificationHubs");
+@@clientLocation(NotificationHubResources.get, "NotificationHubs", "!csharp");
 @@clientName(NotificationHubResources.get, "Get");
-@@clientLocation(NotificationHubResources.createOrUpdate, "NotificationHubs");
+@@clientLocation(NotificationHubResources.createOrUpdate, "NotificationHubs", "!csharp");
 @@clientName(NotificationHubResources.createOrUpdate, "CreateOrUpdate");
-@@clientLocation(NotificationHubResources.update, "NotificationHubs");
+@@clientLocation(NotificationHubResources.update, "NotificationHubs", "!csharp");
 @@clientName(NotificationHubResources.update, "Update");
-@@clientLocation(NotificationHubResources.delete, "NotificationHubs");
+@@clientLocation(NotificationHubResources.delete, "NotificationHubs", "!csharp");
 @@clientName(NotificationHubResources.delete, "Delete");
-@@clientLocation(NotificationHubResources.list, "NotificationHubs");
+@@clientLocation(NotificationHubResources.list, "NotificationHubs", "!csharp");
 @@clientName(NotificationHubResources.list, "List");
-@@clientLocation(NotificationHubResources.debugSend, "NotificationHubs");
+@@clientLocation(NotificationHubResources.debugSend, "NotificationHubs", "!csharp");
 @@clientName(NotificationHubResources.debugSend, "DebugSend");
 @@clientLocation(NotificationHubResources.getPnsCredentials,
-  "NotificationHubs"
+  "NotificationHubs",
+  "!csharp"
 );
 @@clientName(NotificationHubResources.getPnsCredentials, "GetPnsCredentials");
 @@clientLocation(PrivateEndpointConnectionResources.get,
@@ -166,35 +169,41 @@ using Microsoft.NotificationHubs;
 @@clientLocation(NamespacesOperationGroup.checkAvailability, Namespaces);
 @@clientName(NamespacesOperationGroup.checkAvailability, "CheckAvailability");
 @@clientLocation(SharedAccessAuthorizationRuleResources.getAuthorizationRule,
-  "NotificationHubs"
+  "NotificationHubs",
+  "!csharp"
 );
 @@clientName(SharedAccessAuthorizationRuleResources.getAuthorizationRule,
   "GetAuthorizationRule"
 );
 @@clientLocation(SharedAccessAuthorizationRuleResources.createOrUpdateAuthorizationRule,
-  "NotificationHubs"
+  "NotificationHubs",
+  "!csharp"
 );
 @@clientName(SharedAccessAuthorizationRuleResources.createOrUpdateAuthorizationRule,
   "CreateOrUpdateAuthorizationRule"
 );
 @@clientLocation(SharedAccessAuthorizationRuleResources.deleteAuthorizationRule,
-  "NotificationHubs"
+  "NotificationHubs",
+  "!csharp"
 );
 @@clientName(SharedAccessAuthorizationRuleResources.deleteAuthorizationRule,
   "DeleteAuthorizationRule"
 );
 @@clientLocation(SharedAccessAuthorizationRuleResources.listAuthorizationRules,
-  "NotificationHubs"
+  "NotificationHubs",
+  "!csharp"
 );
 @@clientName(SharedAccessAuthorizationRuleResources.listAuthorizationRules,
   "ListAuthorizationRules"
 );
 @@clientLocation(SharedAccessAuthorizationRuleResources.listKeys,
-  "NotificationHubs"
+  "NotificationHubs",
+  "!csharp"
 );
 @@clientName(SharedAccessAuthorizationRuleResources.listKeys, "ListKeys");
 @@clientLocation(SharedAccessAuthorizationRuleResources.regenerateKeys,
-  "NotificationHubs"
+  "NotificationHubs",
+  "!csharp"
 );
 @@clientName(SharedAccessAuthorizationRuleResources.regenerateKeys,
   "RegenerateKeys"

--- a/specification/notificationhubs/resource-manager/Microsoft.NotificationHubs/NotificationHubs/back-compatible.tsp
+++ b/specification/notificationhubs/resource-manager/Microsoft.NotificationHubs/NotificationHubs/back-compatible.tsp
@@ -100,9 +100,6 @@ using Microsoft.NotificationHubs;
 @@clientName(NamespacesOperationGroup.checkAvailability::parameters.body,
   "parameters"
 );
-// Removed: @@clientName(CheckAvailabilityParameters, "CheckAvailabilityContent", "csharp");
-// Replaced by csharp-scoped rename in client.tsp to "NotificationHubAvailabilityContent"
-@@clientName(Operation, "Info", "csharp");
 
 // @@clientLocation decorators for operations with @operationId
 @@clientLocation(NamespaceResources.get, Namespaces);

--- a/specification/notificationhubs/resource-manager/Microsoft.NotificationHubs/NotificationHubs/back-compatible.tsp
+++ b/specification/notificationhubs/resource-manager/Microsoft.NotificationHubs/NotificationHubs/back-compatible.tsp
@@ -102,7 +102,6 @@ using Microsoft.NotificationHubs;
 );
 // Removed: @@clientName(CheckAvailabilityParameters, "CheckAvailabilityContent", "csharp");
 // Replaced by csharp-scoped rename in client.tsp to "NotificationHubAvailabilityContent"
-@@clientName(DebugSendResponse, "DebugSendResponseResult", "csharp");
 @@clientName(Operation, "Info", "csharp");
 
 // @@clientLocation decorators for operations with @operationId

--- a/specification/notificationhubs/resource-manager/Microsoft.NotificationHubs/NotificationHubs/back-compatible.tsp
+++ b/specification/notificationhubs/resource-manager/Microsoft.NotificationHubs/NotificationHubs/back-compatible.tsp
@@ -129,15 +129,27 @@ using Microsoft.NotificationHubs;
 @@clientName(NamespaceResources.getPnsCredentials, "GetPnsCredentials");
 @@clientLocation(NotificationHubResources.get, "NotificationHubs", "!csharp");
 @@clientName(NotificationHubResources.get, "Get");
-@@clientLocation(NotificationHubResources.createOrUpdate, "NotificationHubs", "!csharp");
+@@clientLocation(NotificationHubResources.createOrUpdate,
+  "NotificationHubs",
+  "!csharp"
+);
 @@clientName(NotificationHubResources.createOrUpdate, "CreateOrUpdate");
-@@clientLocation(NotificationHubResources.update, "NotificationHubs", "!csharp");
+@@clientLocation(NotificationHubResources.update,
+  "NotificationHubs",
+  "!csharp"
+);
 @@clientName(NotificationHubResources.update, "Update");
-@@clientLocation(NotificationHubResources.delete, "NotificationHubs", "!csharp");
+@@clientLocation(NotificationHubResources.delete,
+  "NotificationHubs",
+  "!csharp"
+);
 @@clientName(NotificationHubResources.delete, "Delete");
 @@clientLocation(NotificationHubResources.list, "NotificationHubs", "!csharp");
 @@clientName(NotificationHubResources.list, "List");
-@@clientLocation(NotificationHubResources.debugSend, "NotificationHubs", "!csharp");
+@@clientLocation(NotificationHubResources.debugSend,
+  "NotificationHubs",
+  "!csharp"
+);
 @@clientName(NotificationHubResources.debugSend, "DebugSend");
 @@clientLocation(NotificationHubResources.getPnsCredentials,
   "NotificationHubs",

--- a/specification/notificationhubs/resource-manager/Microsoft.NotificationHubs/NotificationHubs/client.tsp
+++ b/specification/notificationhubs/resource-manager/Microsoft.NotificationHubs/NotificationHubs/client.tsp
@@ -106,7 +106,8 @@ using Microsoft.NotificationHubs;
   "csharp"
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy decorator required for SDK compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(PnsCredentialsResourceReplacement.properties
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(PnsCredentialsResourceReplacement.properties,
+  "csharp"
 );
 @@clientName(PolicyKeyResource, "NotificationHubPolicyKey", "csharp");
 @@clientName(ResourceListKeys, "NotificationHubResourceKeys", "csharp");
@@ -205,7 +206,8 @@ using Microsoft.NotificationHubs;
   "csharp"
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(NotificationHubPatchParametersReplacement.properties
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(NotificationHubPatchParametersReplacement.properties,
+  "csharp"
 );
 
 // Change SharedAccessAuthorizationRuleResource base type from ProxyResource (ResourceData)

--- a/specification/notificationhubs/resource-manager/Microsoft.NotificationHubs/NotificationHubs/client.tsp
+++ b/specification/notificationhubs/resource-manager/Microsoft.NotificationHubs/NotificationHubs/client.tsp
@@ -68,6 +68,8 @@ using Microsoft.NotificationHubs;
 @@clientName(AdmCredential, "NotificationHubAdmCredential", "csharp");
 @@alternateType(AdmCredentialProperties.authTokenUrl, url, "csharp");
 @@clientName(AccessRights, "AuthorizationRuleAccessRightExt", "csharp");
+// TODO: Replace @@alternateType workaround with @@hierarchyBuilding once https://github.com/microsoft/typespec/issues/9234 is fixed.
+// CheckAvailabilityResult is a ProxyResource; hierarchyBuilding should be able to change its base to TrackedResource.
 @@clientName(CheckAvailabilityResult,
   "NotificationHubAvailabilityResultTemp",
   "csharp"
@@ -89,6 +91,8 @@ using Microsoft.NotificationHubs;
   "csharp"
 );
 @@clientName(NamespaceType, "NotificationHubNamespaceTypeExt", "csharp");
+// TODO: Replace @@alternateType workaround with @@hierarchyBuilding once https://github.com/microsoft/typespec/issues/9234 is fixed.
+// PnsCredentialsResource is a ProxyResource; hierarchyBuilding should be able to change its base to TrackedResource.
 @@clientName(PnsCredentialsResource,
   "NotificationHubPnsCredentialsTemp",
   "csharp"
@@ -162,6 +166,8 @@ using Microsoft.NotificationHubs;
 );
 @@clientName(NamespaceProperties.status, "NamespaceStatus", "csharp");
 @@clientName(NamespaceProperties.namespaceType, "HubNamespaceType", "csharp");
+// TODO: Replace @@alternateType workaround with @@hierarchyBuilding once https://github.com/microsoft/typespec/issues/9234 is fixed.
+// CheckAvailabilityParameters is a plain model (not a resource); hierarchyBuilding may not support this case.
 @@clientName(CheckAvailabilityParameters,
   "NotificationHubAvailabilityContentTemp",
   "csharp"
@@ -174,6 +180,8 @@ using Microsoft.NotificationHubs;
   "NotificationHubAvailabilityContent",
   "csharp"
 );
+// TODO: Replace @@alternateType workaround with @@hierarchyBuilding once https://github.com/microsoft/typespec/issues/9234 is fixed.
+// DebugSendResponse is a ProxyResource; hierarchyBuilding should be able to change its base to TrackedResource.
 @@clientName(DebugSendResponse, "NotificationHubTestSendResultTemp", "csharp");
 @@alternateType(DebugSendResponse, DebugSendResponseReplacement, "csharp");
 @@clientName(DebugSendResponseReplacement,
@@ -196,6 +204,8 @@ using Microsoft.NotificationHubs;
   "csharp"
 );
 
+// TODO: Replace @@alternateType workaround with @@hierarchyBuilding once https://github.com/microsoft/typespec/issues/9234 is fixed.
+// NotificationHubPatchParameters is a plain model (not a resource); hierarchyBuilding may not support this case.
 // Replacement model swaps: ProxyResource → TrackedResource for C# backward compat (TrackedResourceData base class)
 @@alternateType(NotificationHubPatchParameters,
   NotificationHubPatchParametersReplacement,
@@ -220,17 +230,6 @@ using Microsoft.NotificationHubs;
 );
 
 // C#-only replacement models — swap ProxyResource → TrackedResource to preserve TrackedResourceData base class.
-
-/**
- * Properties for CheckAvailabilityResult replacement model.
- */
-model CheckAvailabilityResultProperties {
-  /**
-   * Gets or sets true if the name is available and can be used to
-   * create new Namespace/NotificationHub. Otherwise false.
-   */
-  isAvailiable?: boolean;
-}
 
 /**
  * Replacement for CheckAvailabilityResult — uses TrackedResource base for C# backward compat.
@@ -260,18 +259,6 @@ model PnsCredentialsResourceReplacement
    * Collection of Notification Hub or Notification Hub Namespace PNS credentials.
    */
   properties?: PnsCredentials;
-}
-
-/**
- * Replacement for SharedAccessAuthorizationRuleResource — uses TrackedResource base for C# backward compat.
- */
-#suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "C#-only replacement model"
-model SharedAccessAuthorizationRuleResourceReplacement
-  extends Azure.ResourceManager.Foundations.TrackedResource {
-  /**
-   * SharedAccessAuthorizationRule properties.
-   */
-  properties?: SharedAccessAuthorizationRuleProperties;
 }
 
 /**

--- a/specification/notificationhubs/resource-manager/Microsoft.NotificationHubs/NotificationHubs/client.tsp
+++ b/specification/notificationhubs/resource-manager/Microsoft.NotificationHubs/NotificationHubs/client.tsp
@@ -23,3 +23,195 @@ using Microsoft.NotificationHubs;
   100,
   "javascript"
 );
+@@clientName(NamespaceResources.listAll, "GetNotificationHubNamespaces", "csharp");
+@@clientName(NamespaceResource, "NotificationHubNamespace", "csharp");
+@@clientName(ApnsCredential, "NotificationHubApnsCredential", "csharp");
+@@alternateType(ApnsCredentialProperties.endpoint, url, "csharp");
+@@clientName(ApnsCredentialProperties.thumbprint, "ThumbprintString", "csharp");
+@@clientName(BaiduCredential, "NotificationHubBaiduCredential", "csharp");
+@@clientName(BaiduCredentialProperties.baiduEndPoint, "BaiduEndpoint", "csharp");
+@@alternateType(BaiduCredentialProperties.baiduEndPoint, url, "csharp");
+@@clientName(GcmCredential, "NotificationHubGcmCredential", "csharp");
+@@alternateType(GcmCredentialProperties.gcmEndpoint, url, "csharp");
+@@clientName(GcmCredentialProperties.googleApiKey, "gcmApiKey", "csharp");
+@@clientName(WnsCredential, "NotificationHubWnsCredential", "csharp");
+@@alternateType(WnsCredentialProperties.windowsLiveEndpoint, url, "csharp");
+@@clientName(NotificationHubResource, "NotificationHub", "csharp");
+@@clientName(SharedAccessAuthorizationRuleResource, "NotificationHubAuthorizationRule", "csharp");
+@@clientName(SharedAccessAuthorizationRuleProperties.createdTime, "CreatedOn", "csharp");
+@@alternateType(SharedAccessAuthorizationRuleProperties.createdTime, utcDateTime, "csharp");
+@@clientName(SharedAccessAuthorizationRuleProperties.modifiedTime, "ModifiedOn", "csharp");
+@@alternateType(SharedAccessAuthorizationRuleProperties.modifiedTime, utcDateTime, "csharp");
+@@clientName(MpnsCredential, "NotificationHubMpnsCredential", "csharp");
+@@clientName(MpnsCredentialProperties.thumbprint, "ThumbprintString", "csharp");
+@@clientName(AdmCredential, "NotificationHubAdmCredential", "csharp");
+@@alternateType(AdmCredentialProperties.authTokenUrl, url, "csharp");
+@@clientName(AccessRights, "AuthorizationRuleAccessRightExt", "csharp");
+@@clientName(CheckAvailabilityResult, "NotificationHubAvailabilityResultTemp", "csharp");
+@@alternateType(CheckAvailabilityResult, CheckAvailabilityResultReplacement, "csharp");
+@@clientName(CheckAvailabilityResultReplacement, "NotificationHubAvailabilityResult", "csharp");
+@@usage(CheckAvailabilityResultReplacement, Usage.input | Usage.output, "csharp");
+@@clientName(NamespaceListResult, "NotificationHubNamespaceListResult", "csharp");
+@@clientName(NamespaceType, "NotificationHubNamespaceTypeExt", "csharp");
+@@clientName(PnsCredentialsResource, "NotificationHubPnsCredentialsTemp", "csharp");
+@@alternateType(PnsCredentialsResource, PnsCredentialsResourceReplacement, "csharp");
+@@clientName(PnsCredentialsResourceReplacement, "NotificationHubPnsCredentials", "csharp");
+@@usage(PnsCredentialsResourceReplacement, Usage.input | Usage.output, "csharp");
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(PnsCredentialsResourceReplacement.properties);
+@@clientName(PolicyKeyResource, "NotificationHubPolicyKey", "csharp");
+@@clientName(ResourceListKeys, "NotificationHubResourceKeys", "csharp");
+@@clientName(Sku, "NotificationHubSku", "csharp");
+@@clientName(SkuName, "NotificationHubSkuName", "csharp");
+@@clientName(IpRule, "NotificationHubIPRule", "csharp");
+@@clientName(IpRule.rights, "AccessRights", "csharp");
+@@clientName(NetworkAcls, "NotificationHubNetworkAcls", "csharp");
+@@clientName(PublicInternetAuthorizationRule.rights, "AccessRights", "csharp");
+@@clientName(SharedAccessAuthorizationRuleProperties.rights, "AccessRights", "csharp");
+@@clientName(PrivateLinkResource, "NotificationHubsPrivateLinkResource", "csharp");
+@@usage(PrivateLinkResource, Usage.input | Usage.output, "csharp");
+@@clientName(PrivateEndpointConnectionResource, "NotificationHubPrivateEndpointConnection", "csharp");
+@@clientName(PrivateEndpointConnectionProperties, "NotificationHubPrivateEndpointConnectionProperties", "csharp");
+@@clientName(NamespaceProperties, "NotificationHubNamespaceProperties", "csharp");
+@@clientName(NamespaceProperties.enabled, "IsEnabled", "csharp");
+@@clientName(NamespaceProperties.critical, "IsCritical", "csharp");
+@@clientName(NamespaceStatus, "NotificationHubNamespaceStatus", "csharp");
+@@clientName(PrivateLinkConnectionStatus, "NotificationHubPrivateLinkConnectionStatus", "csharp");
+@@clientName(PublicNetworkAccess, "NotificationHubPublicNetworkAccess", "csharp");
+@@clientName(RegistrationResult, "NotificationHubPubRegistrationResult", "csharp");
+@@clientName(ReplicationRegion, "AllowedReplicationRegion", "csharp");
+@@clientName(ReplicationRegion.WestUs2, "WestUS2", "csharp");
+@@alternateType(NamespaceProperties.serviceBusEndpoint, url, "csharp");
+@@clientName(NamespaceProperties.provisioningState, "OperationProvisioningState", "csharp");
+@@clientName(NamespaceProperties.status, "NamespaceStatus", "csharp");
+@@clientName(NamespaceProperties.namespaceType, "HubNamespaceType", "csharp");
+@@clientName(CheckAvailabilityParameters, "NotificationHubAvailabilityContentTemp", "csharp");
+@@alternateType(CheckAvailabilityParameters, CheckAvailabilityParametersReplacement, "csharp");
+@@clientName(CheckAvailabilityParametersReplacement, "NotificationHubAvailabilityContent", "csharp");
+@@clientName(DebugSendResponse, "NotificationHubTestSendResultTemp", "csharp");
+@@alternateType(DebugSendResponse, DebugSendResponseReplacement, "csharp");
+@@clientName(DebugSendResponseReplacement, "NotificationHubTestSendResult", "csharp");
+@@usage(DebugSendResponseReplacement, Usage.input | Usage.output, "csharp");
+@@clientName(NotificationHubProperties.name, "NotificationHubName", "csharp");
+@@alternateType(NotificationHubProperties.registrationTtl, duration, "csharp");
+@@clientName(NamespaceProperties.name, "NamespaceName", "csharp");
+@@clientName(DebugSendResult.results, "FailureDescription", "csharp");
+@@clientName(NamespacesOperationGroup.checkAvailability, "CheckNotificationHubNamespaceAvailability", "csharp");
+@@clientName(IpRule.ipMask, "IPMask", "csharp");
+@@clientName(NetworkAcls.ipRules, "IPRules", "csharp");
+@@alternateType(RemotePrivateEndpointConnection.id, Azure.Core.armResourceIdentifier, "csharp");
+
+// Replacement model swaps: ProxyResource → TrackedResource for C# backward compat (TrackedResourceData base class)
+@@alternateType(NotificationHubPatchParameters, NotificationHubPatchParametersReplacement, "csharp");
+@@clientName(NotificationHubPatchParametersReplacement, "NotificationHubPatch", "csharp");
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(NotificationHubPatchParametersReplacement.properties);
+
+// Change SharedAccessAuthorizationRuleResource base type from ProxyResource (ResourceData)
+// to TrackedResource (TrackedResourceData) for C# backward compatibility.
+// The pre-migration SDK had TrackedResourceData as the base with location/tags.
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
+@@Azure.ClientGenerator.Core.Legacy.hierarchyBuilding(SharedAccessAuthorizationRuleResource,
+  Azure.ResourceManager.Foundations.TrackedResource,
+  "csharp"
+);
+
+// C#-only replacement models — swap ProxyResource → TrackedResource to preserve TrackedResourceData base class.
+
+/**
+ * Properties for CheckAvailabilityResult replacement model.
+ */
+model CheckAvailabilityResultProperties {
+  /**
+   * Gets or sets true if the name is available and can be used to
+   * create new Namespace/NotificationHub. Otherwise false.
+   */
+  isAvailiable?: boolean;
+}
+
+/**
+ * Replacement for CheckAvailabilityResult — uses TrackedResource base for C# backward compat.
+ */
+#suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "C#-only replacement model"
+model CheckAvailabilityResultReplacement
+  extends Azure.ResourceManager.Foundations.TrackedResource {
+  /**
+   * Gets or sets true if the name is available and can be used to
+   * create new Namespace/NotificationHub. Otherwise false.
+   */
+  isAvailiable?: boolean;
+
+  /**
+   * The Sku description for a namespace
+   */
+  sku?: Sku;
+}
+
+/**
+ * Replacement for PnsCredentialsResource — uses TrackedResource base for C# backward compat.
+ */
+#suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "C#-only replacement model"
+model PnsCredentialsResourceReplacement
+  extends Azure.ResourceManager.Foundations.TrackedResource {
+  /**
+   * Collection of Notification Hub or Notification Hub Namespace PNS credentials.
+   */
+  properties?: PnsCredentials;
+}
+
+/**
+ * Replacement for SharedAccessAuthorizationRuleResource — uses TrackedResource base for C# backward compat.
+ */
+#suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "C#-only replacement model"
+model SharedAccessAuthorizationRuleResourceReplacement
+  extends Azure.ResourceManager.Foundations.TrackedResource {
+  /**
+   * SharedAccessAuthorizationRule properties.
+   */
+  properties?: SharedAccessAuthorizationRuleProperties;
+}
+
+/**
+ * Replacement for DebugSendResponse — uses TrackedResource base for C# backward compat.
+ */
+#suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "C#-only replacement model"
+model DebugSendResponseReplacement
+  extends Azure.ResourceManager.Foundations.TrackedResource {
+  /**
+   * Result of DebugSend operations.
+   */
+  properties?: DebugSendResult;
+}
+
+/**
+ * Replacement for NotificationHubPatchParameters — uses TrackedResource base for C# backward compat.
+ */
+#suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "C#-only replacement model"
+model NotificationHubPatchParametersReplacement
+  extends Azure.ResourceManager.Foundations.TrackedResource {
+  /**
+   * NotificationHub properties.
+   */
+  properties?: NotificationHubProperties;
+
+  /**
+   * The Sku description for a namespace
+   */
+  sku?: Sku;
+}
+
+/**
+ * Replacement for CheckAvailabilityParameters — uses TrackedResource base for C# backward compat.
+ */
+#suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "C#-only replacement model"
+model CheckAvailabilityParametersReplacement
+  extends Azure.ResourceManager.Foundations.TrackedResource {
+  /**
+   * Not used and deprecated since API version 2023-01-01-preview
+   */
+  isAvailiable?: boolean;
+
+  /**
+   * The Sku description for a namespace
+   */
+  sku?: Sku;
+}

--- a/specification/notificationhubs/resource-manager/Microsoft.NotificationHubs/NotificationHubs/client.tsp
+++ b/specification/notificationhubs/resource-manager/Microsoft.NotificationHubs/NotificationHubs/client.tsp
@@ -57,6 +57,7 @@ using Microsoft.NotificationHubs;
 @@alternateType(PnsCredentialsResource, PnsCredentialsResourceReplacement, "csharp");
 @@clientName(PnsCredentialsResourceReplacement, "NotificationHubPnsCredentials", "csharp");
 @@usage(PnsCredentialsResourceReplacement, Usage.input | Usage.output, "csharp");
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy decorator required for SDK compatibility"
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(PnsCredentialsResourceReplacement.properties);
 @@clientName(PolicyKeyResource, "NotificationHubPolicyKey", "csharp");
 @@clientName(ResourceListKeys, "NotificationHubResourceKeys", "csharp");

--- a/specification/notificationhubs/resource-manager/Microsoft.NotificationHubs/NotificationHubs/client.tsp
+++ b/specification/notificationhubs/resource-manager/Microsoft.NotificationHubs/NotificationHubs/client.tsp
@@ -68,49 +68,20 @@ using Microsoft.NotificationHubs;
 @@clientName(AdmCredential, "NotificationHubAdmCredential", "csharp");
 @@alternateType(AdmCredentialProperties.authTokenUrl, url, "csharp");
 @@clientName(AccessRights, "AuthorizationRuleAccessRightExt", "csharp");
-// TODO: Replace @@alternateType workaround with @@hierarchyBuilding once https://github.com/microsoft/typespec/issues/9234 is fixed.
-// CheckAvailabilityResult is a ProxyResource; hierarchyBuilding should be able to change its base to TrackedResource.
 @@clientName(CheckAvailabilityResult,
-  "NotificationHubAvailabilityResultTemp",
-  "csharp"
-);
-@@alternateType(CheckAvailabilityResult,
-  CheckAvailabilityResultReplacement,
-  "csharp"
-);
-@@clientName(CheckAvailabilityResultReplacement,
   "NotificationHubAvailabilityResult",
   "csharp"
 );
-@@usage(CheckAvailabilityResultReplacement,
-  Usage.input | Usage.output,
-  "csharp"
-);
+@@usage(CheckAvailabilityResult, Usage.input | Usage.output, "csharp");
 @@clientName(NamespaceListResult,
   "NotificationHubNamespaceListResult",
   "csharp"
 );
 @@clientName(NamespaceType, "NotificationHubNamespaceTypeExt", "csharp");
-// TODO: Replace @@alternateType workaround with @@hierarchyBuilding once https://github.com/microsoft/typespec/issues/9234 is fixed.
-// PnsCredentialsResource is a ProxyResource; hierarchyBuilding should be able to change its base to TrackedResource.
-@@clientName(PnsCredentialsResource,
-  "NotificationHubPnsCredentialsTemp",
-  "csharp"
-);
-@@alternateType(PnsCredentialsResource,
-  PnsCredentialsResourceReplacement,
-  "csharp"
-);
-@@clientName(PnsCredentialsResourceReplacement,
-  "NotificationHubPnsCredentials",
-  "csharp"
-);
-@@usage(PnsCredentialsResourceReplacement,
-  Usage.input | Usage.output,
-  "csharp"
-);
+@@clientName(PnsCredentialsResource, "NotificationHubPnsCredentials", "csharp");
+@@usage(PnsCredentialsResource, Usage.input | Usage.output, "csharp");
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy decorator required for SDK compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(PnsCredentialsResourceReplacement.properties,
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(PnsCredentialsResource.properties,
   "csharp"
 );
 @@clientName(PolicyKeyResource, "NotificationHubPolicyKey", "csharp");
@@ -166,29 +137,6 @@ using Microsoft.NotificationHubs;
 );
 @@clientName(NamespaceProperties.status, "NamespaceStatus", "csharp");
 @@clientName(NamespaceProperties.namespaceType, "HubNamespaceType", "csharp");
-// TODO: Replace @@alternateType workaround with @@hierarchyBuilding once https://github.com/microsoft/typespec/issues/9234 is fixed.
-// CheckAvailabilityParameters is a plain model (not a resource); hierarchyBuilding may not support this case.
-@@clientName(CheckAvailabilityParameters,
-  "NotificationHubAvailabilityContentTemp",
-  "csharp"
-);
-@@alternateType(CheckAvailabilityParameters,
-  CheckAvailabilityParametersReplacement,
-  "csharp"
-);
-@@clientName(CheckAvailabilityParametersReplacement,
-  "NotificationHubAvailabilityContent",
-  "csharp"
-);
-// TODO: Replace @@alternateType workaround with @@hierarchyBuilding once https://github.com/microsoft/typespec/issues/9234 is fixed.
-// DebugSendResponse is a ProxyResource; hierarchyBuilding should be able to change its base to TrackedResource.
-@@clientName(DebugSendResponse, "NotificationHubTestSendResultTemp", "csharp");
-@@alternateType(DebugSendResponse, DebugSendResponseReplacement, "csharp");
-@@clientName(DebugSendResponseReplacement,
-  "NotificationHubTestSendResult",
-  "csharp"
-);
-@@usage(DebugSendResponseReplacement, Usage.input | Usage.output, "csharp");
 @@clientName(NotificationHubProperties.name, "NotificationHubName", "csharp");
 @@alternateType(NotificationHubProperties.registrationTtl, duration, "csharp");
 @@clientName(NamespaceProperties.name, "NamespaceName", "csharp");
@@ -204,77 +152,35 @@ using Microsoft.NotificationHubs;
   "csharp"
 );
 
-// TODO: Replace @@alternateType workaround with @@hierarchyBuilding once https://github.com/microsoft/typespec/issues/9234 is fixed.
-// NotificationHubPatchParameters is a plain model (not a resource); hierarchyBuilding may not support this case.
-// Replacement model swaps: ProxyResource → TrackedResource for C# backward compat (TrackedResourceData base class)
-@@alternateType(NotificationHubPatchParameters,
-  NotificationHubPatchParametersReplacement,
-  "csharp"
-);
-@@clientName(NotificationHubPatchParametersReplacement,
-  "NotificationHubPatch",
+// Change base type from ProxyResource (ResourceData) to TrackedResource (TrackedResourceData)
+// for C# backward compatibility. The pre-migration SDK had TrackedResourceData as the base with location/tags.
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
+@@Azure.ClientGenerator.Core.Legacy.hierarchyBuilding(CheckAvailabilityResult,
+  Azure.ResourceManager.Foundations.TrackedResource,
   "csharp"
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(NotificationHubPatchParametersReplacement.properties,
+@@Azure.ClientGenerator.Core.Legacy.hierarchyBuilding(PnsCredentialsResource,
+  Azure.ResourceManager.Foundations.TrackedResource,
   "csharp"
 );
-
-// Change SharedAccessAuthorizationRuleResource base type from ProxyResource (ResourceData)
-// to TrackedResource (TrackedResourceData) for C# backward compatibility.
-// The pre-migration SDK had TrackedResourceData as the base with location/tags.
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
 @@Azure.ClientGenerator.Core.Legacy.hierarchyBuilding(SharedAccessAuthorizationRuleResource,
   Azure.ResourceManager.Foundations.TrackedResource,
   "csharp"
 );
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
+@@Azure.ClientGenerator.Core.Legacy.hierarchyBuilding(DebugSendResponse,
+  Azure.ResourceManager.Foundations.TrackedResource,
+  "csharp"
+);
+@@clientName(DebugSendResponse, "NotificationHubTestSendResult", "csharp");
+@@usage(DebugSendResponse, Usage.input | Usage.output, "csharp");
 
-// C#-only replacement models — swap ProxyResource → TrackedResource to preserve TrackedResourceData base class.
-
+// Cannot use @@hierarchyBuilding because NotificationHubPatchParameters' properties are not a strict superset
+// of TrackedResource (missing id, name, type, systemData, location).
 /**
- * Replacement for CheckAvailabilityResult — uses TrackedResource base for C# backward compat.
- */
-#suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "C#-only replacement model"
-model CheckAvailabilityResultReplacement
-  extends Azure.ResourceManager.Foundations.TrackedResource {
-  /**
-   * Gets or sets true if the name is available and can be used to
-   * create new Namespace/NotificationHub. Otherwise false.
-   */
-  isAvailiable?: boolean;
-
-  /**
-   * The Sku description for a namespace
-   */
-  sku?: Sku;
-}
-
-/**
- * Replacement for PnsCredentialsResource — uses TrackedResource base for C# backward compat.
- */
-#suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "C#-only replacement model"
-model PnsCredentialsResourceReplacement
-  extends Azure.ResourceManager.Foundations.TrackedResource {
-  /**
-   * Collection of Notification Hub or Notification Hub Namespace PNS credentials.
-   */
-  properties?: PnsCredentials;
-}
-
-/**
- * Replacement for DebugSendResponse — uses TrackedResource base for C# backward compat.
- */
-#suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "C#-only replacement model"
-model DebugSendResponseReplacement
-  extends Azure.ResourceManager.Foundations.TrackedResource {
-  /**
-   * Result of DebugSend operations.
-   */
-  properties?: DebugSendResult;
-}
-
-/**
- * Replacement for NotificationHubPatchParameters — uses TrackedResource base for C# backward compat.
+ * Patch parameter for NamespaceResource.
  */
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "C#-only replacement model"
 model NotificationHubPatchParametersReplacement
@@ -290,8 +196,24 @@ model NotificationHubPatchParametersReplacement
   sku?: Sku;
 }
 
+@@alternateType(NotificationHubPatchParameters,
+  NotificationHubPatchParametersReplacement,
+  "csharp"
+);
+@@clientName(NotificationHubPatchParametersReplacement,
+  "NotificationHubPatch",
+  "csharp"
+);
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(NotificationHubPatchParametersReplacement.properties,
+  "csharp"
+);
+
+// Cannot use @@hierarchyBuilding because CheckAvailabilityParameters' properties are not a strict superset
+// of TrackedResource (e.g. location is string vs azureLocation, id is string vs armResourceIdentifier).
 /**
- * Replacement for CheckAvailabilityParameters — uses TrackedResource base for C# backward compat.
+ * Parameters supplied to the Check Name Availability for Namespace and
+ * NotificationHubs.
  */
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "C#-only replacement model"
 model CheckAvailabilityParametersReplacement
@@ -306,3 +228,16 @@ model CheckAvailabilityParametersReplacement
    */
   sku?: Sku;
 }
+
+@@clientName(CheckAvailabilityParameters,
+  "NotificationHubAvailabilityContentTemp",
+  "csharp"
+);
+@@alternateType(CheckAvailabilityParameters,
+  CheckAvailabilityParametersReplacement,
+  "csharp"
+);
+@@clientName(CheckAvailabilityParametersReplacement,
+  "NotificationHubAvailabilityContent",
+  "csharp"
+);

--- a/specification/notificationhubs/resource-manager/Microsoft.NotificationHubs/NotificationHubs/client.tsp
+++ b/specification/notificationhubs/resource-manager/Microsoft.NotificationHubs/NotificationHubs/client.tsp
@@ -23,13 +23,19 @@ using Microsoft.NotificationHubs;
   100,
   "javascript"
 );
-@@clientName(NamespaceResources.listAll, "GetNotificationHubNamespaces", "csharp");
+@@clientName(NamespaceResources.listAll,
+  "GetNotificationHubNamespaces",
+  "csharp"
+);
 @@clientName(NamespaceResource, "NotificationHubNamespace", "csharp");
 @@clientName(ApnsCredential, "NotificationHubApnsCredential", "csharp");
 @@alternateType(ApnsCredentialProperties.endpoint, url, "csharp");
 @@clientName(ApnsCredentialProperties.thumbprint, "ThumbprintString", "csharp");
 @@clientName(BaiduCredential, "NotificationHubBaiduCredential", "csharp");
-@@clientName(BaiduCredentialProperties.baiduEndPoint, "BaiduEndpoint", "csharp");
+@@clientName(BaiduCredentialProperties.baiduEndPoint,
+  "BaiduEndpoint",
+  "csharp"
+);
 @@alternateType(BaiduCredentialProperties.baiduEndPoint, url, "csharp");
 @@clientName(GcmCredential, "NotificationHubGcmCredential", "csharp");
 @@alternateType(GcmCredentialProperties.gcmEndpoint, url, "csharp");
@@ -37,28 +43,71 @@ using Microsoft.NotificationHubs;
 @@clientName(WnsCredential, "NotificationHubWnsCredential", "csharp");
 @@alternateType(WnsCredentialProperties.windowsLiveEndpoint, url, "csharp");
 @@clientName(NotificationHubResource, "NotificationHub", "csharp");
-@@clientName(SharedAccessAuthorizationRuleResource, "NotificationHubAuthorizationRule", "csharp");
-@@clientName(SharedAccessAuthorizationRuleProperties.createdTime, "CreatedOn", "csharp");
-@@alternateType(SharedAccessAuthorizationRuleProperties.createdTime, utcDateTime, "csharp");
-@@clientName(SharedAccessAuthorizationRuleProperties.modifiedTime, "ModifiedOn", "csharp");
-@@alternateType(SharedAccessAuthorizationRuleProperties.modifiedTime, utcDateTime, "csharp");
+@@clientName(SharedAccessAuthorizationRuleResource,
+  "NotificationHubAuthorizationRule",
+  "csharp"
+);
+@@clientName(SharedAccessAuthorizationRuleProperties.createdTime,
+  "CreatedOn",
+  "csharp"
+);
+@@alternateType(SharedAccessAuthorizationRuleProperties.createdTime,
+  utcDateTime,
+  "csharp"
+);
+@@clientName(SharedAccessAuthorizationRuleProperties.modifiedTime,
+  "ModifiedOn",
+  "csharp"
+);
+@@alternateType(SharedAccessAuthorizationRuleProperties.modifiedTime,
+  utcDateTime,
+  "csharp"
+);
 @@clientName(MpnsCredential, "NotificationHubMpnsCredential", "csharp");
 @@clientName(MpnsCredentialProperties.thumbprint, "ThumbprintString", "csharp");
 @@clientName(AdmCredential, "NotificationHubAdmCredential", "csharp");
 @@alternateType(AdmCredentialProperties.authTokenUrl, url, "csharp");
 @@clientName(AccessRights, "AuthorizationRuleAccessRightExt", "csharp");
-@@clientName(CheckAvailabilityResult, "NotificationHubAvailabilityResultTemp", "csharp");
-@@alternateType(CheckAvailabilityResult, CheckAvailabilityResultReplacement, "csharp");
-@@clientName(CheckAvailabilityResultReplacement, "NotificationHubAvailabilityResult", "csharp");
-@@usage(CheckAvailabilityResultReplacement, Usage.input | Usage.output, "csharp");
-@@clientName(NamespaceListResult, "NotificationHubNamespaceListResult", "csharp");
+@@clientName(CheckAvailabilityResult,
+  "NotificationHubAvailabilityResultTemp",
+  "csharp"
+);
+@@alternateType(CheckAvailabilityResult,
+  CheckAvailabilityResultReplacement,
+  "csharp"
+);
+@@clientName(CheckAvailabilityResultReplacement,
+  "NotificationHubAvailabilityResult",
+  "csharp"
+);
+@@usage(CheckAvailabilityResultReplacement,
+  Usage.input | Usage.output,
+  "csharp"
+);
+@@clientName(NamespaceListResult,
+  "NotificationHubNamespaceListResult",
+  "csharp"
+);
 @@clientName(NamespaceType, "NotificationHubNamespaceTypeExt", "csharp");
-@@clientName(PnsCredentialsResource, "NotificationHubPnsCredentialsTemp", "csharp");
-@@alternateType(PnsCredentialsResource, PnsCredentialsResourceReplacement, "csharp");
-@@clientName(PnsCredentialsResourceReplacement, "NotificationHubPnsCredentials", "csharp");
-@@usage(PnsCredentialsResourceReplacement, Usage.input | Usage.output, "csharp");
+@@clientName(PnsCredentialsResource,
+  "NotificationHubPnsCredentialsTemp",
+  "csharp"
+);
+@@alternateType(PnsCredentialsResource,
+  PnsCredentialsResourceReplacement,
+  "csharp"
+);
+@@clientName(PnsCredentialsResourceReplacement,
+  "NotificationHubPnsCredentials",
+  "csharp"
+);
+@@usage(PnsCredentialsResourceReplacement,
+  Usage.input | Usage.output,
+  "csharp"
+);
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy decorator required for SDK compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(PnsCredentialsResourceReplacement.properties);
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(PnsCredentialsResourceReplacement.properties
+);
 @@clientName(PolicyKeyResource, "NotificationHubPolicyKey", "csharp");
 @@clientName(ResourceListKeys, "NotificationHubResourceKeys", "csharp");
 @@clientName(Sku, "NotificationHubSku", "csharp");
@@ -67,45 +116,97 @@ using Microsoft.NotificationHubs;
 @@clientName(IpRule.rights, "AccessRights", "csharp");
 @@clientName(NetworkAcls, "NotificationHubNetworkAcls", "csharp");
 @@clientName(PublicInternetAuthorizationRule.rights, "AccessRights", "csharp");
-@@clientName(SharedAccessAuthorizationRuleProperties.rights, "AccessRights", "csharp");
-@@clientName(PrivateLinkResource, "NotificationHubsPrivateLinkResource", "csharp");
+@@clientName(SharedAccessAuthorizationRuleProperties.rights,
+  "AccessRights",
+  "csharp"
+);
+@@clientName(PrivateLinkResource,
+  "NotificationHubsPrivateLinkResource",
+  "csharp"
+);
 @@usage(PrivateLinkResource, Usage.input | Usage.output, "csharp");
-@@clientName(PrivateEndpointConnectionResource, "NotificationHubPrivateEndpointConnection", "csharp");
-@@clientName(PrivateEndpointConnectionProperties, "NotificationHubPrivateEndpointConnectionProperties", "csharp");
-@@clientName(NamespaceProperties, "NotificationHubNamespaceProperties", "csharp");
+@@clientName(PrivateEndpointConnectionResource,
+  "NotificationHubPrivateEndpointConnection",
+  "csharp"
+);
+@@clientName(PrivateEndpointConnectionProperties,
+  "NotificationHubPrivateEndpointConnectionProperties",
+  "csharp"
+);
+@@clientName(NamespaceProperties,
+  "NotificationHubNamespaceProperties",
+  "csharp"
+);
 @@clientName(NamespaceProperties.enabled, "IsEnabled", "csharp");
 @@clientName(NamespaceProperties.critical, "IsCritical", "csharp");
 @@clientName(NamespaceStatus, "NotificationHubNamespaceStatus", "csharp");
-@@clientName(PrivateLinkConnectionStatus, "NotificationHubPrivateLinkConnectionStatus", "csharp");
-@@clientName(PublicNetworkAccess, "NotificationHubPublicNetworkAccess", "csharp");
-@@clientName(RegistrationResult, "NotificationHubPubRegistrationResult", "csharp");
+@@clientName(PrivateLinkConnectionStatus,
+  "NotificationHubPrivateLinkConnectionStatus",
+  "csharp"
+);
+@@clientName(PublicNetworkAccess,
+  "NotificationHubPublicNetworkAccess",
+  "csharp"
+);
+@@clientName(RegistrationResult,
+  "NotificationHubPubRegistrationResult",
+  "csharp"
+);
 @@clientName(ReplicationRegion, "AllowedReplicationRegion", "csharp");
 @@clientName(ReplicationRegion.WestUs2, "WestUS2", "csharp");
 @@alternateType(NamespaceProperties.serviceBusEndpoint, url, "csharp");
-@@clientName(NamespaceProperties.provisioningState, "OperationProvisioningState", "csharp");
+@@clientName(NamespaceProperties.provisioningState,
+  "OperationProvisioningState",
+  "csharp"
+);
 @@clientName(NamespaceProperties.status, "NamespaceStatus", "csharp");
 @@clientName(NamespaceProperties.namespaceType, "HubNamespaceType", "csharp");
-@@clientName(CheckAvailabilityParameters, "NotificationHubAvailabilityContentTemp", "csharp");
-@@alternateType(CheckAvailabilityParameters, CheckAvailabilityParametersReplacement, "csharp");
-@@clientName(CheckAvailabilityParametersReplacement, "NotificationHubAvailabilityContent", "csharp");
+@@clientName(CheckAvailabilityParameters,
+  "NotificationHubAvailabilityContentTemp",
+  "csharp"
+);
+@@alternateType(CheckAvailabilityParameters,
+  CheckAvailabilityParametersReplacement,
+  "csharp"
+);
+@@clientName(CheckAvailabilityParametersReplacement,
+  "NotificationHubAvailabilityContent",
+  "csharp"
+);
 @@clientName(DebugSendResponse, "NotificationHubTestSendResultTemp", "csharp");
 @@alternateType(DebugSendResponse, DebugSendResponseReplacement, "csharp");
-@@clientName(DebugSendResponseReplacement, "NotificationHubTestSendResult", "csharp");
+@@clientName(DebugSendResponseReplacement,
+  "NotificationHubTestSendResult",
+  "csharp"
+);
 @@usage(DebugSendResponseReplacement, Usage.input | Usage.output, "csharp");
 @@clientName(NotificationHubProperties.name, "NotificationHubName", "csharp");
 @@alternateType(NotificationHubProperties.registrationTtl, duration, "csharp");
 @@clientName(NamespaceProperties.name, "NamespaceName", "csharp");
 @@clientName(DebugSendResult.results, "FailureDescription", "csharp");
-@@clientName(NamespacesOperationGroup.checkAvailability, "CheckNotificationHubNamespaceAvailability", "csharp");
+@@clientName(NamespacesOperationGroup.checkAvailability,
+  "CheckNotificationHubNamespaceAvailability",
+  "csharp"
+);
 @@clientName(IpRule.ipMask, "IPMask", "csharp");
 @@clientName(NetworkAcls.ipRules, "IPRules", "csharp");
-@@alternateType(RemotePrivateEndpointConnection.id, Azure.Core.armResourceIdentifier, "csharp");
+@@alternateType(RemotePrivateEndpointConnection.id,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
 
 // Replacement model swaps: ProxyResource → TrackedResource for C# backward compat (TrackedResourceData base class)
-@@alternateType(NotificationHubPatchParameters, NotificationHubPatchParametersReplacement, "csharp");
-@@clientName(NotificationHubPatchParametersReplacement, "NotificationHubPatch", "csharp");
+@@alternateType(NotificationHubPatchParameters,
+  NotificationHubPatchParametersReplacement,
+  "csharp"
+);
+@@clientName(NotificationHubPatchParametersReplacement,
+  "NotificationHubPatch",
+  "csharp"
+);
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(NotificationHubPatchParametersReplacement.properties);
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(NotificationHubPatchParametersReplacement.properties
+);
 
 // Change SharedAccessAuthorizationRuleResource base type from ProxyResource (ResourceData)
 // to TrackedResource (TrackedResourceData) for C# backward compatibility.

--- a/specification/notificationhubs/resource-manager/Microsoft.NotificationHubs/NotificationHubs/tspconfig.yaml
+++ b/specification/notificationhubs/resource-manager/Microsoft.NotificationHubs/NotificationHubs/tspconfig.yaml
@@ -37,6 +37,9 @@ options:
     generate-fakes: true
     head-as-boolean: true
     inject-spans: true
+  "@azure-typespec/http-client-csharp-mgmt":
+    namespace: "Azure.ResourceManager.NotificationHubs"
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/resource-manager"


### PR DESCRIPTION
Migrate NotificationHubs service to use new management plane SDK generator.

- Add C#-scoped clientName decorators in client.tsp
- Add flatten and clientLocation decorators in back-compatible.tsp  
- Update tspconfig.yaml with C# mgmt emitter config
- Update SharedAccessAuthorizationRuleResource.tsp for custom listKey return type