### PR TITLE
Mitigate Java breaking changes for servicefabric TypeSpec migration

### DIFF
--- a/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/ServiceFabric/client.tsp
+++ b/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/ServiceFabric/client.tsp
@@ -101,3 +101,16 @@ using Microsoft.ServiceFabric;
   "ServiceFabricManagementClient",
   "javascript"
 );
+
+@@clientName(Azure.ResourceManager.CommonTypes.ManagedServiceIdentity,
+  "ManagedIdentity",
+  "java"
+);
+
+@@clientName(Azure.ResourceManager.CommonTypes.ManagedServiceIdentityType,
+  "ManagedIdentityType",
+  "java"
+);
+
+@@clientName(ServiceResource.eTag, "etag", "java");
+@@clientName(ServiceResourceUpdate.eTag, "etag", "java");


### PR DESCRIPTION
Rename ManagedServiceIdentity back to ManagedIdentity and ManagedServiceIdentityType back to ManagedIdentityType for Java SDK backward compatibility.