### PR TITLE
Mitigate Java breaking changes for purview TypeSpec migration

### DIFF
--- a/specification/purview/resource-manager/Microsoft.Purview/Purview/back-compatible.tsp
+++ b/specification/purview/resource-manager/Microsoft.Purview/Purview/back-compatible.tsp
@@ -38,7 +38,7 @@ using Microsoft.Purview;
 @@Legacy.flattenProperty(KafkaConfiguration.properties);
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-@@Legacy.flattenProperty(PrivateLinkResource.properties, "!javascript");
+@@Legacy.flattenProperty(PrivateLinkResource.properties, "!javascript&!java");
 
 @@clientLocation(AccountsOperationGroup.checkNameAvailability, Accounts);
 

--- a/specification/purview/resource-manager/Microsoft.Purview/Purview/back-compatible.tsp
+++ b/specification/purview/resource-manager/Microsoft.Purview/Purview/back-compatible.tsp
@@ -38,7 +38,7 @@ using Microsoft.Purview;
 @@Legacy.flattenProperty(KafkaConfiguration.properties);
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-@@Legacy.flattenProperty(PrivateLinkResource.properties, "!javascript&!java");
+@@Legacy.flattenProperty(PrivateLinkResource.properties, "!javascript,!java");
 
 @@clientLocation(AccountsOperationGroup.checkNameAvailability, Accounts);
 


### PR DESCRIPTION
Add !java scope to flattenProperty on PrivateLinkResource.properties to avoid flattening in Java SDK.