### PR TITLE
Mitigate Java breaking change: deduplicate ResourceProvisioningState for eventgrid

### DIFF
--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/Client.tsp
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/Client.tsp
@@ -102,3 +102,7 @@ interface Clients {
   "ArmResourceProvisioningState",
   "python"
 );
+@@clientName(Azure.ResourceManager.ResourceProvisioningState,
+  "ArmResourceProvisioningState",
+  "java"
+);


### PR DESCRIPTION
Mitigate duplicate-client-name error for Java SDK generation of eventgrid service. Renames Azure.ResourceManager.ResourceProvisioningState to ArmResourceProvisioningState in Java scope.