### PR TITLE
Mitigate Java SDK breaking changes for communication

### DIFF
--- a/specification/communication/Communication.Management/client.tsp
+++ b/specification/communication/Communication.Management/client.tsp
@@ -31,6 +31,8 @@ using Microsoft.Communication;
 @@clientName(DomainPropertiesVerificationRecords.DMARC, "dmarc", "java");
 
 @@clientName(CommunicationServiceProperties.hostName, "hostname", "java");
+@@clientName(SuppressionListProperties.createdTimeStamp, "createdTimestamp", "java");
+@@clientName(SuppressionListProperties.lastUpdatedTimeStamp, "lastUpdatedTimestamp", "java");
 @@clientName(NameAvailabilityParameters,
   "CommunicationServiceNameAvailabilityContent",
   "csharp"

--- a/specification/communication/Communication.Management/client.tsp
+++ b/specification/communication/Communication.Management/client.tsp
@@ -31,8 +31,14 @@ using Microsoft.Communication;
 @@clientName(DomainPropertiesVerificationRecords.DMARC, "dmarc", "java");
 
 @@clientName(CommunicationServiceProperties.hostName, "hostname", "java");
-@@clientName(SuppressionListProperties.createdTimeStamp, "createdTimestamp", "java");
-@@clientName(SuppressionListProperties.lastUpdatedTimeStamp, "lastUpdatedTimestamp", "java");
+@@clientName(SuppressionListProperties.createdTimeStamp,
+  "createdTimestamp",
+  "java"
+);
+@@clientName(SuppressionListProperties.lastUpdatedTimeStamp,
+  "lastUpdatedTimestamp",
+  "java"
+);
 @@clientName(NameAvailabilityParameters,
   "CommunicationServiceNameAvailabilityContent",
   "csharp"


### PR DESCRIPTION
Rename SuppressionListProperties property names to preserve Java SDK compatibility:
- createdTimeStamp → createdTimestamp
- lastUpdatedTimeStamp → lastUpdatedTimestamp