### PR TITLE
Change MCP endpoints from Record to array per ARM review

### DIFF
--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/ApiManagement/examples/2025-09-01-preview/ApiManagementCreateMcpApi.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/ApiManagement/examples/2025-09-01-preview/ApiManagementCreateMcpApi.json
@@ -14,11 +14,12 @@
         "serviceUrl": "https://mcp-backend.contoso.com",
         "mcpProperties": {
           "transportType": "streamable",
-          "endpoints": {
-            "message": {
+          "endpoints": [
+            {
+              "name": "message",
               "uriTemplate": "/mcp/messages"
             }
-          }
+          ]
         }
       }
     },
@@ -49,11 +50,12 @@
           "subscriptionKeyParameterNames": null,
           "mcpProperties": {
             "transportType": "streamable",
-            "endpoints": {
-              "message": {
+            "endpoints": [
+              {
+                "name": "message",
                 "uriTemplate": "/mcp/messages"
               }
-            }
+            ]
           }
         }
       },
@@ -84,11 +86,12 @@
           "subscriptionKeyParameterNames": null,
           "mcpProperties": {
             "transportType": "streamable",
-            "endpoints": {
-              "message": {
+            "endpoints": [
+              {
+                "name": "message",
                 "uriTemplate": "/mcp/messages"
               }
-            }
+            ]
           }
         }
       },

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/ApiManagement/models.tsp
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/ApiManagement/models.tsp
@@ -341,6 +341,13 @@ union McpTransportType {
  */
 model McpEndpoint {
   /**
+   * MCP endpoint name, e.g. 'sse' or 'messages'.
+   */
+  @maxLength(300)
+  @minLength(1)
+  name: string;
+
+  /**
    * Relative URL path that must start with '/'.
    */
   @pattern("^/.*$")
@@ -359,8 +366,8 @@ model McpProperties {
   /**
    * Collection of MCP endpoint definitions with relative URLs.
    */
-  #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "MCP endpoints are a dynamic map of endpoint names to endpoint definitions"
-  endpoints?: Record<McpEndpoint>;
+  @identifiers(#["name"])
+  endpoints?: McpEndpoint[];
 }
 
 /**

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/ApiManagement/preview/2025-09-01-preview/examples/ApiManagementCreateMcpApi.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/ApiManagement/preview/2025-09-01-preview/examples/ApiManagementCreateMcpApi.json
@@ -14,11 +14,12 @@
         "serviceUrl": "https://mcp-backend.contoso.com",
         "mcpProperties": {
           "transportType": "streamable",
-          "endpoints": {
-            "message": {
+          "endpoints": [
+            {
+              "name": "message",
               "uriTemplate": "/mcp/messages"
             }
-          }
+          ]
         }
       }
     },
@@ -49,11 +50,12 @@
           "subscriptionKeyParameterNames": null,
           "mcpProperties": {
             "transportType": "streamable",
-            "endpoints": {
-              "message": {
+            "endpoints": [
+              {
+                "name": "message",
                 "uriTemplate": "/mcp/messages"
               }
-            }
+            ]
           }
         }
       },
@@ -84,11 +86,12 @@
           "subscriptionKeyParameterNames": null,
           "mcpProperties": {
             "transportType": "streamable",
-            "endpoints": {
-              "message": {
+            "endpoints": [
+              {
+                "name": "message",
                 "uriTemplate": "/mcp/messages"
               }
-            }
+            ]
           }
         }
       },

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/ApiManagement/preview/2025-09-01-preview/openapi.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/ApiManagement/preview/2025-09-01-preview/openapi.json
@@ -59762,12 +59762,21 @@
       "type": "object",
       "description": "Endpoint definition for MCP API type.",
       "properties": {
+        "name": {
+          "type": "string",
+          "description": "MCP endpoint name, e.g. 'sse' or 'messages'.",
+          "minLength": 1,
+          "maxLength": 300
+        },
         "uriTemplate": {
           "type": "string",
           "description": "Relative URL path that must start with '/'.",
           "pattern": "^/.*$"
         }
-      }
+      },
+      "required": [
+        "name"
+      ]
     },
     "McpProperties": {
       "type": "object",
@@ -59778,11 +59787,14 @@
           "description": "Transport type for Model Context Protocol API."
         },
         "endpoints": {
-          "type": "object",
+          "type": "array",
           "description": "Collection of MCP endpoint definitions with relative URLs.",
-          "additionalProperties": {
+          "items": {
             "$ref": "#/definitions/McpEndpoint"
-          }
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
         }
       }
     },


### PR DESCRIPTION
- Add 'name' field to McpEndpoint model (required, 1-300 chars)
- Change endpoints from Record<McpEndpoint> (additionalProperties) to McpEndpoint[] (array)
- Update example to use array format
- Regenerate openapi.json

Addresses review feedback: additionalProperties not allowed for service-owned properties.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
