### PR TITLE
[Microsoft.QueueStorage] updateMessage VisibilityTimeoutParameter

### DIFF
--- a/specification/storage/Microsoft.QueueStorage/routes.tsp
+++ b/specification/storage/Microsoft.QueueStorage/routes.tsp
@@ -414,12 +414,7 @@ interface Queue {
 
       ...MessageIdPathParameter;
       ...PopReceiptQueryParameter;
-
-      @doc("Specifies the new visibility timeout value, in seconds, relative to server time. The default value is 30 seconds. A specified value must be larger than or equal to 1 second, and cannot be larger than 7 days, or larger than 2 hours on REST protocol versions prior to version 2011-08-18. The visibility timeout of a message can be set to a value later than the expiry time.")
-      @maxValue(604800)
-      @query("visibilitytimeout")
-      visibilityTimeout: int32;
-
+      ...VisibilityTimeoutParameter;
       ...TimeoutParameter;
       ...QueueMessageBodyParameter;
     },

--- a/specification/storage/data-plane/Microsoft.QueueStorage/stable/2026-04-06/generated_queue.json
+++ b/specification/storage/data-plane/Microsoft.QueueStorage/stable/2026-04-06/generated_queue.json
@@ -579,7 +579,7 @@
             "name": "visibilitytimeout",
             "in": "query",
             "description": "Specifies the new visibility timeout value, in seconds, relative to server time. The default value is 30 seconds. A specified value must be larger than or equal to 1 second, and cannot be larger than 7 days, or larger than 2 hours on REST protocol versions prior to version 2011-08-18. The visibility timeout of a message can be set to a value later than the expiry time.",
-            "required": true,
+            "required": false,
             "type": "integer",
             "format": "int32",
             "maximum": 604800,


### PR DESCRIPTION
Fixing the `updateMessage` operation to use the existing `VisibilityTimeoutParameter`. This also correctly changes the field to be optional. 