### PR TITLE
Allow skills file updates (except for synced common skills)

### DIFF
--- a/.github/workflows/protected-files.yaml
+++ b/.github/workflows/protected-files.yaml
@@ -40,15 +40,17 @@ jobs:
         run: |
           . eng/scripts/ChangedFiles-Functions.ps1
 
-          $protectedFiles = @(".gitignore", "cspell.json", "cspell.yaml", "package.json", "package-lock.json", ".github/*", ".vscode/*", "eng/*")
-          $excludedFiles = @(".github/CODEOWNERS")
+          # powershell glob syntax
+          $protectedFiles = @(".gitignore", "cspell.json", "cspell.yaml", "package.json", "package-lock.json", ".github/*", ".github/azsdk-common-*", ".vscode/*", "eng/*")
+          # regex syntax, to support protected paths within larger excluded paths
+          $excludedFiles = @('.github/CODEOWNERS', '.github/skills/(?!azsdk-common-).+')
           $changedFiles = @(Get-ChangedFiles -baseCommitish HEAD^ -headCommitish HEAD -diffFilter "")
 
           $matchedFiles = @(
             $changedFiles | Where-Object {
-              $changedFile = $_; 
+              $changedFile = $_;
               ($protectedFiles | Where-Object { $changedFile -like $_ }) -and
-              -not ($excludedFiles | Where-Object { $changedFile -like $_ })
+              -not ($excludedFiles | Where-Object { $changedFile -match $_ })
             }
           )
 


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-tools/issues/14611

Allow direct updates to the repo `.github/skills` directory, as there are some repo-specific skills planned to be added (e.g. typespec authoring). Preserve merge protection for shared skills in `.github/skills/azsdk-common-*` directories.

CC @ronniegeraghty 