### PR TITLE
Add provisioning emitter config for Communication

### DIFF
--- a/specification/communication/Communication.Management/tspconfig.yaml
+++ b/specification/communication/Communication.Management/tspconfig.yaml
@@ -16,6 +16,9 @@ options:
     namespace: "Azure.ResourceManager.Communication"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     enable-wire-path-attribute: true
+  "@azure-typespec/http-client-csharp-provisioning":
+    namespace: "Azure.Provisioning.Communication"
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
   "@azure-tools/typespec-python":
     emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-communication"
     namespace: "azure.mgmt.communication"

--- a/specification/communication/Communication.Management/tspconfig.yaml
+++ b/specification/communication/Communication.Management/tspconfig.yaml
@@ -19,6 +19,7 @@ options:
   "@azure-typespec/http-client-csharp-provisioning":
     namespace: "Azure.Provisioning.Communication"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
+    api-version: "2026-03-18"
   "@azure-tools/typespec-python":
     emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-communication"
     namespace: "azure.mgmt.communication"


### PR DESCRIPTION
Add `@azure-typespec/http-client-csharp-provisioning` emitter config to the Communication TypeSpec tspconfig.yaml for generating `Azure.Provisioning.Communication`.