### PR TITLE
Remove unused json.schemas entries and update master to main

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,21 +3,9 @@
   "json.schemas": [
     {
       "fileMatch": [
-        "/**/specification/*.json"
-      ],
-      "url": "https://raw.githubusercontent.com/Azure/autorest/master/packages/libs/autorest-schemas/swagger-extensions.json"
-    },
-    {
-      "fileMatch": [
         "/**/examples/*.json"
       ],
-      "url": "https://raw.githubusercontent.com/Azure/autorest/master/packages/libs/autorest-schemas/example-schema.json"
-    },
-    {
-      "fileMatch": [
-        "/**/composite*.json"
-      ],
-      "url": "https://raw.githubusercontent.com/Azure/autorest/master/packages/libs/autorest-schemas/composite-swagger.json"
+      "url": "https://raw.githubusercontent.com/Azure/autorest/main/packages/libs/autorest-schemas/example-schema.json"
     }
   ],
   "typescript.tsdk": "node_modules\\typescript\\lib",

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -4,6 +4,7 @@ flagWords:
   - teh
 ignorePaths:
   - .gitignore
+  - .vscode/**
   - '**/examples/**'
   - '**/package-lock.json'
   - cspell.json


### PR DESCRIPTION
## Summary

Cleans up `.vscode/settings.json` by removing 2 unused `json.schemas` file globbing patterns and updating the remaining entry's URL from the `master` branch to `main`. The schema file is identical between the 2 branches.

## Changes

- **Removed** `/**/specification/*.json` pattern — matches 0 files (JSON files don't exist directly in `specification/` directories)
- **Removed** `/**/composite*.json` pattern — matches 0 files (no composite JSON files exist in the repo)
- **Updated** the remaining `/**/examples/*.json` entry's URL from `master` to `main` branch reference