### PR TITLE
Add enforceHierarchicalPartitionKeyIdLastLevel to DatabaseAccount

### DIFF
--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-03-15/CosmosDBDatabaseAccountCreateMax.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-03-15/CosmosDBDatabaseAccountCreateMax.json
@@ -84,6 +84,7 @@
         "capacity": {
           "totalThroughputLimit": 2000
         },
+        "enforceHierarchicalPartitionKeyIdLastLevel": false,
         "minimalTlsVersion": "Tls12"
       }
     }
@@ -235,6 +236,7 @@
               "generationTime": "2021-03-12T22:05:09Z"
             }
           },
+          "enforceHierarchicalPartitionKeyIdLastLevel": false,
           "minimalTlsVersion": "Tls12"
         },
         "systemData": {

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-03-15/CosmosDBDatabaseAccountGet.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-03-15/CosmosDBDatabaseAccountGet.json
@@ -119,6 +119,7 @@
             }
           },
           "enablePartitionMerge": true,
+          "enforceHierarchicalPartitionKeyIdLastLevel": false,
           "minimalTlsVersion": "Tls"
         },
         "identity": {

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-03-15/CosmosDBDatabaseAccountList.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-03-15/CosmosDBDatabaseAccountList.json
@@ -112,6 +112,7 @@
                 }
               },
               "enablePartitionMerge": true,
+              "enforceHierarchicalPartitionKeyIdLastLevel": false,
               "minimalTlsVersion": "Tls"
             },
             "systemData": {

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-03-15/CosmosDBDatabaseAccountListByResourceGroup.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-03-15/CosmosDBDatabaseAccountListByResourceGroup.json
@@ -79,6 +79,7 @@
                   "generationTime": "2022-02-25T20:30:11Z"
                 }
               },
+              "enforceHierarchicalPartitionKeyIdLastLevel": false,
               "minimalTlsVersion": "Tls"
             },
             "identity": {

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-03-15/CosmosDBDatabaseAccountPatch.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-03-15/CosmosDBDatabaseAccountPatch.json
@@ -62,6 +62,7 @@
           "totalThroughputLimit": 2000
         },
         "enablePartitionMerge": true,
+        "enforceHierarchicalPartitionKeyIdLastLevel": false,
         "minimalTlsVersion": "Tls"
       }
     }
@@ -202,6 +203,7 @@
             }
           },
           "enablePartitionMerge": true,
+          "enforceHierarchicalPartitionKeyIdLastLevel": false,
           "minimalTlsVersion": "Tls"
         }
       }

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-03-15/CosmosDBRestoreDatabaseAccountCreateUpdate.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-03-15/CosmosDBRestoreDatabaseAccountCreateUpdate.json
@@ -58,6 +58,7 @@
           "serverVersion": "3.2"
         },
         "enableAnalyticalStorage": true,
+        "enforceHierarchicalPartitionKeyIdLastLevel": false,
         "minimalTlsVersion": "Tls"
       }
     }
@@ -140,6 +141,7 @@
               "generationTime": "2022-02-25T20:30:11Z"
             }
           },
+          "enforceHierarchicalPartitionKeyIdLastLevel": false,
           "minimalTlsVersion": "Tls"
         },
         "systemData": {

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBDatabaseAccountCreateMax.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBDatabaseAccountCreateMax.json
@@ -83,6 +83,7 @@
         "capacityMode": "Provisioned",
         "enableMaterializedViews": false,
         "enableBurstCapacity": true,
+        "enforceHierarchicalPartitionKeyIdLastLevel": false,
         "minimalTlsVersion": "Tls12",
         "enablePriorityBasedExecution": true,
         "defaultPriorityLevel": "Low",
@@ -224,6 +225,7 @@
           "capacityMode": "Provisioned",
           "enableMaterializedViews": false,
           "enableBurstCapacity": true,
+          "enforceHierarchicalPartitionKeyIdLastLevel": false,
           "minimalTlsVersion": "Tls12",
           "keysMetadata": {
             "primaryMasterKey": {

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBDatabaseAccountGet.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBDatabaseAccountGet.json
@@ -102,6 +102,7 @@
           "networkAclBypassResourceIds": [],
           "enablePartitionMerge": true,
           "enableBurstCapacity": true,
+          "enforceHierarchicalPartitionKeyIdLastLevel": false,
           "minimalTlsVersion": "Tls",
           "diagnosticLogSettings": {
             "enableFullTextQuery": "False"

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBDatabaseAccountList.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBDatabaseAccountList.json
@@ -95,6 +95,7 @@
               "networkAclBypassResourceIds": [],
               "enablePartitionMerge": true,
               "enableBurstCapacity": true,
+              "enforceHierarchicalPartitionKeyIdLastLevel": false,
               "minimalTlsVersion": "Tls",
               "capacityMode": "Provisioned",
               "capacityModeChangeTransitionState": {

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBDatabaseAccountListByResourceGroup.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBDatabaseAccountListByResourceGroup.json
@@ -85,6 +85,7 @@
                 "previousCapacityMode": "Serverless"
               },
               "enableMaterializedViews": false,
+              "enforceHierarchicalPartitionKeyIdLastLevel": false,
               "minimalTlsVersion": "Tls",
               "keysMetadata": {
                 "primaryMasterKey": {

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBDatabaseAccountPatch.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBDatabaseAccountPatch.json
@@ -63,6 +63,7 @@
         },
         "enablePartitionMerge": true,
         "enableBurstCapacity": true,
+        "enforceHierarchicalPartitionKeyIdLastLevel": false,
         "minimalTlsVersion": "Tls",
         "enablePriorityBasedExecution": true,
         "defaultPriorityLevel": "Low",
@@ -204,6 +205,7 @@
           },
           "enableMaterializedViews": false,
           "enableBurstCapacity": true,
+          "enforceHierarchicalPartitionKeyIdLastLevel": false,
           "minimalTlsVersion": "Tls",
           "keysMetadata": {
             "primaryMasterKey": {

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBRestoreDatabaseAccountCreateUpdate.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBRestoreDatabaseAccountCreateUpdate.json
@@ -33,6 +33,7 @@
             "locationName": "southcentralus"
           }
         ],
+        "enforceHierarchicalPartitionKeyIdLastLevel": false,
         "minimalTlsVersion": "Tls",
         "restoreParameters": {
           "databasesToRestore": [
@@ -124,6 +125,7 @@
               "provisioningState": "Initializing"
             }
           ],
+          "enforceHierarchicalPartitionKeyIdLastLevel": false,
           "minimalTlsVersion": "Tls",
           "networkAclBypass": "None",
           "networkAclBypassResourceIds": [],

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/models.tsp
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/models.tsp
@@ -1727,6 +1727,13 @@ model DatabaseAccountGetProperties {
    */
   #suppress "@azure-tools/typespec-azure-core/casing-style" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
   throughputPoolMaxConsumableRUs?: int64;
+
+  /**
+   * Flag to indicate enabling/disabling of hierarchical partition key ID last level enforcement on the account.
+   */
+  @added(Versions.v2026_03_15)
+  @removed(Versions.v2026_04_01_preview)
+  enforceHierarchicalPartitionKeyIdLastLevel?: boolean;
 }
 
 /**
@@ -2491,6 +2498,13 @@ model DatabaseAccountUpdateProperties {
    * Flag to indicate if All Versions and Deletes Change feed feature is enabled on the account
    */
   enableAllVersionsAndDeletesChangeFeed?: boolean;
+
+  /**
+   * Flag to indicate enabling/disabling of hierarchical partition key ID last level enforcement on the account.
+   */
+  @added(Versions.v2026_03_15)
+  @removed(Versions.v2026_04_01_preview)
+  enforceHierarchicalPartitionKeyIdLastLevel?: boolean;
 }
 
 /**
@@ -2713,6 +2727,13 @@ model DatabaseAccountCreateUpdateProperties {
    * Flag to indicate if All Versions and Deletes Change feed feature is enabled on the account
    */
   enableAllVersionsAndDeletesChangeFeed?: boolean;
+
+  /**
+   * Flag to indicate enabling/disabling of hierarchical partition key ID last level enforcement on the account.
+   */
+  @added(Versions.v2026_03_15)
+  @removed(Versions.v2026_04_01_preview)
+  enforceHierarchicalPartitionKeyIdLastLevel?: boolean;
 }
 
 /**

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/models.tsp
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/models.tsp
@@ -1731,8 +1731,6 @@ model DatabaseAccountGetProperties {
   /**
    * Flag to indicate enabling/disabling of hierarchical partition key ID last level enforcement on the account.
    */
-  @added(Versions.v2026_03_15)
-  @removed(Versions.v2026_04_01_preview)
   enforceHierarchicalPartitionKeyIdLastLevel?: boolean;
 }
 
@@ -2502,8 +2500,6 @@ model DatabaseAccountUpdateProperties {
   /**
    * Flag to indicate enabling/disabling of hierarchical partition key ID last level enforcement on the account.
    */
-  @added(Versions.v2026_03_15)
-  @removed(Versions.v2026_04_01_preview)
   enforceHierarchicalPartitionKeyIdLastLevel?: boolean;
 }
 
@@ -2731,8 +2727,6 @@ model DatabaseAccountCreateUpdateProperties {
   /**
    * Flag to indicate enabling/disabling of hierarchical partition key ID last level enforcement on the account.
    */
-  @added(Versions.v2026_03_15)
-  @removed(Versions.v2026_04_01_preview)
   enforceHierarchicalPartitionKeyIdLastLevel?: boolean;
 }
 

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBDatabaseAccountCreateMax.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBDatabaseAccountCreateMax.json
@@ -83,6 +83,7 @@
         "capacityMode": "Provisioned",
         "enableMaterializedViews": false,
         "enableBurstCapacity": true,
+        "enforceHierarchicalPartitionKeyIdLastLevel": false,
         "minimalTlsVersion": "Tls12",
         "enablePriorityBasedExecution": true,
         "defaultPriorityLevel": "Low",
@@ -224,6 +225,7 @@
           "capacityMode": "Provisioned",
           "enableMaterializedViews": false,
           "enableBurstCapacity": true,
+          "enforceHierarchicalPartitionKeyIdLastLevel": false,
           "minimalTlsVersion": "Tls12",
           "keysMetadata": {
             "primaryMasterKey": {

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBDatabaseAccountGet.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBDatabaseAccountGet.json
@@ -102,6 +102,7 @@
           "networkAclBypassResourceIds": [],
           "enablePartitionMerge": true,
           "enableBurstCapacity": true,
+          "enforceHierarchicalPartitionKeyIdLastLevel": false,
           "minimalTlsVersion": "Tls",
           "diagnosticLogSettings": {
             "enableFullTextQuery": "False"

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBDatabaseAccountList.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBDatabaseAccountList.json
@@ -95,6 +95,7 @@
               "networkAclBypassResourceIds": [],
               "enablePartitionMerge": true,
               "enableBurstCapacity": true,
+              "enforceHierarchicalPartitionKeyIdLastLevel": false,
               "minimalTlsVersion": "Tls",
               "capacityMode": "Provisioned",
               "capacityModeChangeTransitionState": {

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBDatabaseAccountListByResourceGroup.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBDatabaseAccountListByResourceGroup.json
@@ -85,6 +85,7 @@
                 "previousCapacityMode": "Serverless"
               },
               "enableMaterializedViews": false,
+              "enforceHierarchicalPartitionKeyIdLastLevel": false,
               "minimalTlsVersion": "Tls",
               "keysMetadata": {
                 "primaryMasterKey": {

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBDatabaseAccountPatch.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBDatabaseAccountPatch.json
@@ -63,6 +63,7 @@
         },
         "enablePartitionMerge": true,
         "enableBurstCapacity": true,
+        "enforceHierarchicalPartitionKeyIdLastLevel": false,
         "minimalTlsVersion": "Tls",
         "enablePriorityBasedExecution": true,
         "defaultPriorityLevel": "Low",
@@ -204,6 +205,7 @@
           },
           "enableMaterializedViews": false,
           "enableBurstCapacity": true,
+          "enforceHierarchicalPartitionKeyIdLastLevel": false,
           "minimalTlsVersion": "Tls",
           "keysMetadata": {
             "primaryMasterKey": {

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBRestoreDatabaseAccountCreateUpdate.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBRestoreDatabaseAccountCreateUpdate.json
@@ -33,6 +33,7 @@
             "locationName": "southcentralus"
           }
         ],
+        "enforceHierarchicalPartitionKeyIdLastLevel": false,
         "minimalTlsVersion": "Tls",
         "restoreParameters": {
           "databasesToRestore": [
@@ -124,6 +125,7 @@
               "provisioningState": "Initializing"
             }
           ],
+          "enforceHierarchicalPartitionKeyIdLastLevel": false,
           "minimalTlsVersion": "Tls",
           "networkAclBypass": "None",
           "networkAclBypassResourceIds": [],

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/openapi.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/openapi.json
@@ -24052,6 +24052,10 @@
         "enableAllVersionsAndDeletesChangeFeed": {
           "type": "boolean",
           "description": "Flag to indicate if All Versions and Deletes Change feed feature is enabled on the account"
+        },
+        "enforceHierarchicalPartitionKeyIdLastLevel": {
+          "type": "boolean",
+          "description": "Flag to indicate enabling/disabling of hierarchical partition key ID last level enforcement on the account."
         }
       },
       "required": [
@@ -24334,6 +24338,10 @@
           "type": "integer",
           "format": "int64",
           "description": "When this account is part of a fleetspace with throughput pooling enabled, this is the maximum additional throughput (RU/s) that can be consumed from the pool, summed across all shared throughput databases and dedicated throughput containers in the account for 1 region.  READ ONLY."
+        },
+        "enforceHierarchicalPartitionKeyIdLastLevel": {
+          "type": "boolean",
+          "description": "Flag to indicate enabling/disabling of hierarchical partition key ID last level enforcement on the account."
         }
       }
     },
@@ -24685,6 +24693,10 @@
         "enableAllVersionsAndDeletesChangeFeed": {
           "type": "boolean",
           "description": "Flag to indicate if All Versions and Deletes Change feed feature is enabled on the account"
+        },
+        "enforceHierarchicalPartitionKeyIdLastLevel": {
+          "type": "boolean",
+          "description": "Flag to indicate enabling/disabling of hierarchical partition key ID last level enforcement on the account."
         }
       }
     },

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/stable/2026-03-15/examples/CosmosDBDatabaseAccountCreateMax.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/stable/2026-03-15/examples/CosmosDBDatabaseAccountCreateMax.json
@@ -84,6 +84,7 @@
         "capacity": {
           "totalThroughputLimit": 2000
         },
+        "enforceHierarchicalPartitionKeyIdLastLevel": false,
         "minimalTlsVersion": "Tls12"
       }
     }
@@ -235,6 +236,7 @@
               "generationTime": "2021-03-12T22:05:09Z"
             }
           },
+          "enforceHierarchicalPartitionKeyIdLastLevel": false,
           "minimalTlsVersion": "Tls12"
         },
         "systemData": {

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/stable/2026-03-15/examples/CosmosDBDatabaseAccountGet.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/stable/2026-03-15/examples/CosmosDBDatabaseAccountGet.json
@@ -119,6 +119,7 @@
             }
           },
           "enablePartitionMerge": true,
+          "enforceHierarchicalPartitionKeyIdLastLevel": false,
           "minimalTlsVersion": "Tls"
         },
         "identity": {

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/stable/2026-03-15/examples/CosmosDBDatabaseAccountList.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/stable/2026-03-15/examples/CosmosDBDatabaseAccountList.json
@@ -112,6 +112,7 @@
                 }
               },
               "enablePartitionMerge": true,
+              "enforceHierarchicalPartitionKeyIdLastLevel": false,
               "minimalTlsVersion": "Tls"
             },
             "systemData": {

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/stable/2026-03-15/examples/CosmosDBDatabaseAccountListByResourceGroup.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/stable/2026-03-15/examples/CosmosDBDatabaseAccountListByResourceGroup.json
@@ -79,6 +79,7 @@
                   "generationTime": "2022-02-25T20:30:11Z"
                 }
               },
+              "enforceHierarchicalPartitionKeyIdLastLevel": false,
               "minimalTlsVersion": "Tls"
             },
             "identity": {

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/stable/2026-03-15/examples/CosmosDBDatabaseAccountPatch.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/stable/2026-03-15/examples/CosmosDBDatabaseAccountPatch.json
@@ -62,6 +62,7 @@
           "totalThroughputLimit": 2000
         },
         "enablePartitionMerge": true,
+        "enforceHierarchicalPartitionKeyIdLastLevel": false,
         "minimalTlsVersion": "Tls"
       }
     }
@@ -202,6 +203,7 @@
             }
           },
           "enablePartitionMerge": true,
+          "enforceHierarchicalPartitionKeyIdLastLevel": false,
           "minimalTlsVersion": "Tls"
         }
       }

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/stable/2026-03-15/examples/CosmosDBRestoreDatabaseAccountCreateUpdate.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/stable/2026-03-15/examples/CosmosDBRestoreDatabaseAccountCreateUpdate.json
@@ -58,6 +58,7 @@
           "serverVersion": "3.2"
         },
         "enableAnalyticalStorage": true,
+        "enforceHierarchicalPartitionKeyIdLastLevel": false,
         "minimalTlsVersion": "Tls"
       }
     }
@@ -140,6 +141,7 @@
               "generationTime": "2022-02-25T20:30:11Z"
             }
           },
+          "enforceHierarchicalPartitionKeyIdLastLevel": false,
           "minimalTlsVersion": "Tls"
         },
         "systemData": {

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/stable/2026-03-15/openapi.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/stable/2026-03-15/openapi.json
@@ -43,6 +43,9 @@
       "name": "Operations"
     },
     {
+      "name": "NetworkSecurityPerimeterConfigurations"
+    },
+    {
       "name": "NotebookWorkspacesResource"
     },
     {
@@ -62,6 +65,9 @@
     },
     {
       "name": "MaterializedViewsBuilder"
+    },
+    {
+      "name": "ThroughputPools"
     },
     {
       "name": "Fleets"
@@ -100,11 +106,6 @@
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
-        },
-        "x-ms-examples": {
-          "CosmosDBDatabaseAccountCheckNameExists": {
-            "$ref": "./examples/CosmosDBDatabaseAccountCheckNameExists.json"
-          }
         }
       }
     },
@@ -132,11 +133,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBOperationsList": {
-            "$ref": "./examples/CosmosDBOperationsList.json"
           }
         },
         "x-ms-pageable": {
@@ -170,11 +166,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBManagedCassandraClusterListBySubscription": {
-            "$ref": "./examples/CosmosDBManagedCassandraClusterListBySubscription.json"
-          }
-        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -204,11 +195,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBDatabaseAccountList": {
-            "$ref": "./examples/CosmosDBDatabaseAccountList.json"
           }
         },
         "x-ms-pageable": {
@@ -242,9 +228,35 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDB Fleet List by subscription": {
-            "$ref": "./examples/fleet/CosmosDBFleetList.json"
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.DocumentDB/garnetClusters": {
+      "get": {
+        "operationId": "GarnetClusters_ListBySubscription",
+        "description": "List all Garnet clusters in this subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListGarnetClusters"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
           }
         },
         "x-ms-pageable": {
@@ -276,11 +288,6 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBLocationList": {
-            "$ref": "./examples/CosmosDBLocationList.json"
           }
         },
         "x-ms-pageable": {
@@ -320,11 +327,6 @@
               "$ref": "#/definitions/CloudError"
             }
           }
-        },
-        "x-ms-examples": {
-          "CosmosDBLocationGet": {
-            "$ref": "./examples/CosmosDBLocationGet.json"
-          }
         }
       }
     },
@@ -359,11 +361,6 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBRestorableDatabaseAccountList": {
-            "$ref": "./examples/CosmosDBRestorableDatabaseAccountList.json"
           }
         },
         "x-ms-pageable": {
@@ -409,11 +406,6 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBRestorableDatabaseAccountGet": {
-            "$ref": "./examples/CosmosDBRestorableDatabaseAccountGet.json"
           }
         }
       }
@@ -479,11 +471,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBRestorableGremlinGraphList": {
-            "$ref": "./examples/CosmosDBRestorableGremlinGraphList.json"
-          }
-        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -527,11 +514,6 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBRestorableGremlinDatabaseList": {
-            "$ref": "./examples/CosmosDBRestorableGremlinDatabaseList.json"
           }
         },
         "x-ms-pageable": {
@@ -591,11 +573,6 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBRestorableGremlinResourceList": {
-            "$ref": "./examples/CosmosDBRestorableGremlinResourceList.json"
           }
         },
         "x-ms-pageable": {
@@ -664,11 +641,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBRestorableMongodbCollectionList": {
-            "$ref": "./examples/CosmosDBRestorableMongodbCollectionList.json"
-          }
-        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -712,11 +684,6 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBRestorableMongodbDatabaseList": {
-            "$ref": "./examples/CosmosDBRestorableMongodbDatabaseList.json"
           }
         },
         "x-ms-pageable": {
@@ -776,11 +743,6 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBRestorableMongodbResourceList": {
-            "$ref": "./examples/CosmosDBRestorableMongodbResourceList.json"
           }
         },
         "x-ms-pageable": {
@@ -849,11 +811,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBRestorableSqlContainerList": {
-            "$ref": "./examples/CosmosDBRestorableSqlContainerList.json"
-          }
-        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -897,11 +854,6 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBRestorableSqlDatabaseList": {
-            "$ref": "./examples/CosmosDBRestorableSqlDatabaseList.json"
           }
         },
         "x-ms-pageable": {
@@ -963,11 +915,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBRestorableSqlResourceList": {
-            "$ref": "./examples/CosmosDBRestorableSqlResourceList.json"
-          }
-        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -1025,11 +972,6 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBRestorableTableResourceList": {
-            "$ref": "./examples/CosmosDBRestorableTableResourceList.json"
           }
         },
         "x-ms-pageable": {
@@ -1091,11 +1033,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBRestorableTableList": {
-            "$ref": "./examples/CosmosDBRestorableTableList.json"
-          }
-        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -1127,9 +1064,35 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBRestorableDatabaseAccountNoLocationList": {
-            "$ref": "./examples/CosmosDBRestorableDatabaseAccountNoLocationList.json"
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.DocumentDB/throughputPools": {
+      "get": {
+        "operationId": "ThroughputPools_List",
+        "description": "Lists all the Azure Cosmos DB Throughput Pools available under the subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ThroughputPoolsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
           }
         },
         "x-ms-pageable": {
@@ -1164,11 +1127,6 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBManagedCassandraClusterListByResourceGroup": {
-            "$ref": "./examples/CosmosDBManagedCassandraClusterListByResourceGroup.json"
           }
         },
         "x-ms-pageable": {
@@ -1213,11 +1171,6 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBManagedCassandraClusterGet": {
-            "$ref": "./examples/CosmosDBManagedCassandraClusterGet.json"
           }
         }
       },
@@ -1283,11 +1236,6 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBManagedCassandraClusterCreate": {
-            "$ref": "./examples/CosmosDBManagedCassandraClusterCreate.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -1360,11 +1308,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBManagedCassandraClusterPatch": {
-            "$ref": "./examples/CosmosDBManagedCassandraClusterPatch.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ClusterResource"
@@ -1420,15 +1363,200 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBManagedCassandraClusterDelete": {
-            "$ref": "./examples/CosmosDBManagedCassandraClusterDelete.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
         "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/cassandraClusters/{clusterName}/backups": {
+      "get": {
+        "operationId": "CassandraClusters_ListBackups",
+        "description": "List the backups of this cluster that are available to restore.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "Managed Cassandra cluster name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100,
+            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListBackups"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/cassandraClusters/{clusterName}/backups/{backupId}": {
+      "get": {
+        "operationId": "CassandraClusters_GetBackup",
+        "description": "Get the properties of an individual backup of this cluster that is available to restore.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "Managed Cassandra cluster name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100,
+            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
+          },
+          {
+            "name": "backupId",
+            "in": "path",
+            "description": "Id of a restorable backup of a Cassandra cluster.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 15,
+            "pattern": "^[0-9]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BackupResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/cassandraClusters/{clusterName}/commands": {
+      "get": {
+        "operationId": "CassandraClusters_ListCommand",
+        "description": "List all commands currently running on ring info",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "Managed Cassandra cluster name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100,
+            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListCommands"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/cassandraClusters/{clusterName}/commands/{commandId}": {
+      "get": {
+        "operationId": "CassandraClusters_GetCommandAsync",
+        "description": "Get details about a specified command that was run asynchronously.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "Managed Cassandra cluster name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100,
+            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
+          },
+          {
+            "name": "commandId",
+            "in": "path",
+            "description": "Managed Cassandra cluster command id.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100,
+            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CommandPublicResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        }
       }
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/cassandraClusters/{clusterName}/dataCenters": {
@@ -1468,11 +1596,6 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBManagedCassandraDataCenterList": {
-            "$ref": "./examples/CosmosDBManagedCassandraDataCenterList.json"
           }
         },
         "x-ms-pageable": {
@@ -1527,11 +1650,6 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBManagedCassandraDataCenterGet": {
-            "$ref": "./examples/CosmosDBManagedCassandraDataCenterGet.json"
           }
         }
       },
@@ -1607,11 +1725,6 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBManagedCassandraDataCenterCreate": {
-            "$ref": "./examples/CosmosDBManagedCassandraDataCenterCreate.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -1694,11 +1807,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBManagedCassandraDataCenterUpdate": {
-            "$ref": "./examples/CosmosDBManagedCassandraDataCenterPatch.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/DataCenterResource"
@@ -1764,11 +1872,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBManagedCassandraDataCenterDelete": {
-            "$ref": "./examples/CosmosDBManagedCassandraDataCenterDelete.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -1827,11 +1930,6 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBManagedCassandraClusterDeallocate": {
-            "$ref": "./examples/CosmosDBManagedCassandraClusterDeallocate.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -1899,14 +1997,83 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBManagedCassandraCommand": {
-            "$ref": "./examples/CosmosDBManagedCassandraCommand.json"
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/CommandOutput"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/cassandraClusters/{clusterName}/invokeCommandAsync": {
+      "post": {
+        "operationId": "CassandraClusters_InvokeCommandAsync",
+        "description": "Invoke a command like nodetool for cassandra maintenance asynchronously",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "Managed Cassandra cluster name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100,
+            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Specification which command to run where",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CommandAsyncPostBody"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CommandPublicResource"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
           }
         },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
-          "final-state-schema": "#/definitions/CommandOutput"
+          "final-state-schema": "#/definitions/CommandPublicResource"
         },
         "x-ms-long-running-operation": true
       }
@@ -1958,11 +2125,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBManagedCassandraClusterStart": {
-            "$ref": "./examples/CosmosDBManagedCassandraClusterStart.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -2007,11 +2169,6 @@
               "$ref": "#/definitions/CloudError"
             }
           }
-        },
-        "x-ms-examples": {
-          "CosmosDBManagedCassandraStatus": {
-            "$ref": "./examples/CosmosDBManagedCassandraStatus.json"
-          }
         }
       }
     },
@@ -2042,11 +2199,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBDatabaseAccountListByResourceGroup": {
-            "$ref": "./examples/CosmosDBDatabaseAccountListByResourceGroup.json"
           }
         },
         "x-ms-pageable": {
@@ -2091,11 +2243,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBDatabaseAccountGet": {
-            "$ref": "./examples/CosmosDBDatabaseAccountGet.json"
           }
         }
       },
@@ -2150,17 +2297,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBDatabaseAccountCreateMax": {
-            "$ref": "./examples/CosmosDBDatabaseAccountCreateMax.json"
-          },
-          "CosmosDBDatabaseAccountCreateMin": {
-            "$ref": "./examples/CosmosDBDatabaseAccountCreateMin.json"
-          },
-          "CosmosDBRestoreDatabaseAccountCreateUpdate.json": {
-            "$ref": "./examples/CosmosDBRestoreDatabaseAccountCreateUpdate.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -2222,11 +2358,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBDatabaseAccountPatch": {
-            "$ref": "./examples/CosmosDBDatabaseAccountPatch.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/DatabaseAccountGetResults"
@@ -2282,11 +2413,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBDatabaseAccountDelete": {
-            "$ref": "./examples/CosmosDBDatabaseAccountDelete.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -2330,11 +2456,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBCassandraKeyspaceList": {
-            "$ref": "./examples/CosmosDBCassandraKeyspaceList.json"
           }
         },
         "x-ms-pageable": {
@@ -2386,11 +2507,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBCassandraKeyspaceGet": {
-            "$ref": "./examples/CosmosDBCassandraKeyspaceGet.json"
           }
         }
       },
@@ -2467,11 +2583,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBCassandraKeyspaceCreateUpdate": {
-            "$ref": "./examples/CosmosDBCassandraKeyspaceCreateUpdate.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/CassandraKeyspaceGetResults"
@@ -2534,11 +2645,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBCassandraKeyspaceDelete": {
-            "$ref": "./examples/CosmosDBCassandraKeyspaceDelete.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -2589,11 +2695,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBCassandraTableList": {
-            "$ref": "./examples/CosmosDBCassandraTableList.json"
           }
         },
         "x-ms-pageable": {
@@ -2652,11 +2753,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBCassandraTableGet": {
-            "$ref": "./examples/CosmosDBCassandraTableGet.json"
           }
         }
       },
@@ -2740,11 +2836,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBCassandraTableCreateUpdate": {
-            "$ref": "./examples/CosmosDBCassandraTableCreateUpdate.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/CassandraTableGetResults"
@@ -2814,11 +2905,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBCassandraTableDelete": {
-            "$ref": "./examples/CosmosDBCassandraTableDelete.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -2876,11 +2962,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBCassandraTableThroughputGet": {
-            "$ref": "./examples/CosmosDBCassandraTableThroughputGet.json"
           }
         }
       },
@@ -2964,11 +3045,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBCassandraTableThroughputUpdate": {
-            "$ref": "./examples/CosmosDBCassandraTableThroughputUpdate.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
@@ -3046,11 +3122,6 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBCassandraTableMigrateToAutoscale": {
-            "$ref": "./examples/CosmosDBCassandraTableMigrateToAutoscale.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -3132,11 +3203,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBCassandraTableMigrateToManualThroughput": {
-            "$ref": "./examples/CosmosDBCassandraTableMigrateToManualThroughput.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
@@ -3188,11 +3254,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBCassandraKeyspaceThroughputGet": {
-            "$ref": "./examples/CosmosDBCassandraKeyspaceThroughputGet.json"
           }
         }
       },
@@ -3269,11 +3330,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBCassandraKeyspaceThroughputUpdate": {
-            "$ref": "./examples/CosmosDBCassandraKeyspaceThroughputUpdate.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
@@ -3344,11 +3400,6 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBCassandraKeyspaceMigrateToAutoscale": {
-            "$ref": "./examples/CosmosDBCassandraKeyspaceMigrateToAutoscale.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -3423,9 +3474,413 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBCassandraKeyspaceMigrateToManualThroughput": {
-            "$ref": "./examples/CosmosDBCassandraKeyspaceMigrateToManualThroughput.json"
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/cassandraKeyspaces/{keyspaceName}/views": {
+      "get": {
+        "operationId": "CassandraResources_ListCassandraViews",
+        "description": "Lists the Cassandra materialized views under an existing Azure Cosmos DB database account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "keyspaceName",
+            "in": "path",
+            "description": "Cosmos DB keyspace name.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CassandraViewListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/cassandraKeyspaces/{keyspaceName}/views/{viewName}": {
+      "get": {
+        "operationId": "CassandraResources_GetCassandraView",
+        "description": "Gets the Cassandra view under an existing Azure Cosmos DB database account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "keyspaceName",
+            "in": "path",
+            "description": "Cosmos DB keyspace name.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "viewName",
+            "in": "path",
+            "description": "Cosmos DB view name.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CassandraViewGetResults"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "CassandraResources_CreateUpdateCassandraView",
+        "description": "Create or update an Azure Cosmos DB Cassandra View",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "keyspaceName",
+            "in": "path",
+            "description": "Cosmos DB keyspace name.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "viewName",
+            "in": "path",
+            "description": "Cosmos DB view name.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "createUpdateCassandraViewParameters",
+            "in": "body",
+            "description": "The parameters to provide for the current Cassandra View.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CassandraViewCreateUpdateParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'CassandraViewGetResults' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/CassandraViewGetResults"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/CassandraViewGetResults"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "CassandraResources_DeleteCassandraView",
+        "description": "Deletes an existing Azure Cosmos DB Cassandra view.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "keyspaceName",
+            "in": "path",
+            "description": "Cosmos DB keyspace name.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "viewName",
+            "in": "path",
+            "description": "Cosmos DB view name.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/cassandraKeyspaces/{keyspaceName}/views/{viewName}/throughputSettings/default": {
+      "get": {
+        "operationId": "CassandraResources_GetCassandraViewThroughput",
+        "description": "Gets the RUs per second of the Cassandra view under an existing Azure Cosmos DB database account with the provided name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "keyspaceName",
+            "in": "path",
+            "description": "Cosmos DB keyspace name.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "viewName",
+            "in": "path",
+            "description": "Cosmos DB view name.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ThroughputSettingsGetResults"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "CassandraResources_UpdateCassandraViewThroughput",
+        "description": "Update RUs per second of an Azure Cosmos DB Cassandra view",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "keyspaceName",
+            "in": "path",
+            "description": "Cosmos DB keyspace name.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "viewName",
+            "in": "path",
+            "description": "Cosmos DB view name.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "updateThroughputParameters",
+            "in": "body",
+            "description": "The RUs per second of the parameters to provide for the current Cassandra view.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ThroughputSettingsUpdateParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ThroughputSettingsGetResults' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ThroughputSettingsGetResults"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
           }
         },
         "x-ms-long-running-operation-options": {
@@ -3433,6 +3888,1499 @@
           "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
         },
         "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/cassandraKeyspaces/{keyspaceName}/views/{viewName}/throughputSettings/default/migrateToAutoscale": {
+      "post": {
+        "operationId": "CassandraResources_MigrateCassandraViewToAutoscale",
+        "description": "Migrate an Azure Cosmos DB Cassandra view from manual throughput to autoscale",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "keyspaceName",
+            "in": "path",
+            "description": "Cosmos DB keyspace name.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "viewName",
+            "in": "path",
+            "description": "Cosmos DB view name.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ThroughputSettingsGetResults"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/cassandraKeyspaces/{keyspaceName}/views/{viewName}/throughputSettings/default/migrateToManualThroughput": {
+      "post": {
+        "operationId": "CassandraResources_MigrateCassandraViewToManualThroughput",
+        "description": "Migrate an Azure Cosmos DB Cassandra view from autoscale to manual throughput",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "keyspaceName",
+            "in": "path",
+            "description": "Cosmos DB keyspace name.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "viewName",
+            "in": "path",
+            "description": "Cosmos DB view name.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ThroughputSettingsGetResults"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/cassandraRoleAssignments": {
+      "get": {
+        "operationId": "CassandraResources_ListCassandraRoleAssignments",
+        "description": "Retrieves the list of all Azure Cosmos DB Cassandra Role Assignments.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CassandraRoleAssignmentListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/cassandraRoleAssignments/{roleAssignmentId}": {
+      "get": {
+        "operationId": "CassandraResources_GetCassandraRoleAssignment",
+        "description": "Retrieves the properties of an existing Azure Cosmos DB Cassandra Role Assignment with the given Id.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "roleAssignmentId",
+            "in": "path",
+            "description": "The GUID for the Role Assignment.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CassandraRoleAssignmentResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "CassandraResources_CreateUpdateCassandraRoleAssignment",
+        "description": "Creates or updates an Azure Cosmos DB Cassandra Role Assignment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "roleAssignmentId",
+            "in": "path",
+            "description": "The GUID for the Role Assignment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "createUpdateCassandraRoleAssignmentParameters",
+            "in": "body",
+            "description": "The properties required to create or update a Role Assignment.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CassandraRoleAssignmentResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'CassandraRoleAssignmentResource' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/CassandraRoleAssignmentResource"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/CassandraRoleAssignmentResource"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "CassandraResources_DeleteCassandraRoleAssignment",
+        "description": "Deletes an existing Azure Cosmos DB Cassandra Role Assignment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "roleAssignmentId",
+            "in": "path",
+            "description": "The GUID for the Role Assignment.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/cassandraRoleDefinitions": {
+      "get": {
+        "operationId": "CassandraResources_ListCassandraRoleDefinitions",
+        "description": "Retrieves the list of all Azure Cosmos DB Cassandra Role Definitions.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CassandraRoleDefinitionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/cassandraRoleDefinitions/{roleDefinitionId}": {
+      "get": {
+        "operationId": "CassandraResources_GetCassandraRoleDefinition",
+        "description": "Retrieves the properties of an existing Azure Cosmos DB Cassandra Role Definition with the given Id.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "roleDefinitionId",
+            "in": "path",
+            "description": "The GUID for the Role Definition.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CassandraRoleDefinitionResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "CassandraResources_CreateUpdateCassandraRoleDefinition",
+        "description": "Creates or updates an Azure Cosmos DB Cassandra Role Definition.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "roleDefinitionId",
+            "in": "path",
+            "description": "The GUID for the Role Definition.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "createUpdateCassandraRoleDefinitionParameters",
+            "in": "body",
+            "description": "The properties required to create or update a Role Definition.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CassandraRoleDefinitionResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'CassandraRoleDefinitionResource' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/CassandraRoleDefinitionResource"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/CassandraRoleDefinitionResource"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "CassandraResources_DeleteCassandraRoleDefinition",
+        "description": "Deletes an existing Azure Cosmos DB Cassandra Role Definition.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "roleDefinitionId",
+            "in": "path",
+            "description": "The GUID for the Role Definition.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/chaosFaults": {
+      "get": {
+        "operationId": "ChaosFault_List",
+        "description": "List Chaos Faults for CosmosDB account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/chaosFaultListResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/chaosFaults/{chaosFault}": {
+      "get": {
+        "operationId": "ChaosFault_Get",
+        "description": "Get Chaos Fault for a CosmosdB account for a particular Chaos Fault.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "chaosFault",
+            "in": "path",
+            "description": "The name of the ChaosFault.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/chaosFaultResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "ChaosFault_EnableDisable",
+        "description": "Enable, disable Chaos Fault in a CosmosDB account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "chaosFault",
+            "in": "path",
+            "description": "The name of the ChaosFault.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "chaosFaultRequest",
+            "in": "body",
+            "description": "A request object to enable/disable the chaos fault.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chaosFaultResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'chaosFaultResource' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/chaosFaultResource"
+            }
+          },
+          "201": {
+            "description": "Resource 'chaosFaultResource' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/chaosFaultResource"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/chaosFaultResource"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/copyJobs": {
+      "get": {
+        "operationId": "CopyJobs_ListByDatabaseAccount",
+        "description": "Get a list of Copy jobs.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CopyJobFeedResults"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/copyJobs/{jobName}": {
+      "get": {
+        "operationId": "CopyJobs_Get",
+        "description": "Get a Copy Job.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "jobName",
+            "in": "path",
+            "description": "Name of the Copy Job",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CopyJobGetResults"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "CopyJobs_Create",
+        "description": "Creates a Copy Job.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "jobName",
+            "in": "path",
+            "description": "Name of the Copy Job",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
+          },
+          {
+            "name": "jobCreateParameters",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CopyJobGetResults"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'CopyJobGetResults' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/CopyJobGetResults"
+            }
+          },
+          "201": {
+            "description": "Resource 'CopyJobGetResults' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/CopyJobGetResults"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/copyJobs/{jobName}/cancel": {
+      "post": {
+        "operationId": "CopyJobs_Cancel",
+        "description": "Cancels a Copy Job.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "jobName",
+            "in": "path",
+            "description": "Name of the Copy Job",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CopyJobGetResults"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/copyJobs/{jobName}/complete": {
+      "post": {
+        "operationId": "CopyJobs_Complete",
+        "description": "Completes an Online Copy Job.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "jobName",
+            "in": "path",
+            "description": "Name of the Copy Job",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CopyJobGetResults"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/copyJobs/{jobName}/pause": {
+      "post": {
+        "operationId": "CopyJobs_Pause",
+        "description": "Pause a Copy Job.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "jobName",
+            "in": "path",
+            "description": "Name of the Copy Job",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CopyJobGetResults"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/copyJobs/{jobName}/resume": {
+      "post": {
+        "operationId": "CopyJobs_Resume",
+        "description": "Resumes a Copy Job.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "jobName",
+            "in": "path",
+            "description": "Name of the Copy Job",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CopyJobGetResults"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/dataTransferJobs": {
+      "get": {
+        "operationId": "DataTransferJobs_ListByDatabaseAccount",
+        "description": "Get a list of Data Transfer jobs.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DataTransferJobFeedResults"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/dataTransferJobs/{jobName}": {
+      "get": {
+        "operationId": "DataTransferJobs_Get",
+        "description": "Get a Data Transfer Job.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "jobName",
+            "in": "path",
+            "description": "Name of the Data Transfer Job",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DataTransferJobGetResults"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "DataTransferJobs_Create",
+        "description": "Creates a Data Transfer Job.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "jobName",
+            "in": "path",
+            "description": "Name of the Data Transfer Job",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
+          },
+          {
+            "name": "jobCreateParameters",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CreateJobRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'DataTransferJobGetResults' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/DataTransferJobGetResults"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/dataTransferJobs/{jobName}/cancel": {
+      "post": {
+        "operationId": "DataTransferJobs_Cancel",
+        "description": "Cancels a Data Transfer Job.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "jobName",
+            "in": "path",
+            "description": "Name of the Data Transfer Job",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DataTransferJobGetResults"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/dataTransferJobs/{jobName}/complete": {
+      "post": {
+        "operationId": "DataTransferJobs_Complete",
+        "description": "Completes a Data Transfer Online Job.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "jobName",
+            "in": "path",
+            "description": "Name of the Data Transfer Job",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DataTransferJobGetResults"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/dataTransferJobs/{jobName}/pause": {
+      "post": {
+        "operationId": "DataTransferJobs_Pause",
+        "description": "Pause a Data Transfer Job.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "jobName",
+            "in": "path",
+            "description": "Name of the Data Transfer Job",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DataTransferJobGetResults"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/dataTransferJobs/{jobName}/resume": {
+      "post": {
+        "operationId": "DataTransferJobs_Resume",
+        "description": "Resumes a Data Transfer Job.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "jobName",
+            "in": "path",
+            "description": "Name of the Data Transfer Job",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DataTransferJobGetResults"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        }
       }
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/databases/{databaseRid}/collections/{collectionRid}/metricDefinitions": {
@@ -3486,11 +5434,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBCollectionGetMetricDefinitions": {
-            "$ref": "./examples/CosmosDBCollectionGetMetricDefinitions.json"
           }
         },
         "x-ms-pageable": {
@@ -3556,11 +5499,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBCollectionGetMetrics": {
-            "$ref": "./examples/CosmosDBCollectionGetMetrics.json"
           }
         },
         "x-ms-pageable": {
@@ -3635,11 +5573,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBDatabaseAccountRegionGetMetrics": {
-            "$ref": "./examples/CosmosDBPKeyRangeIdGetMetrics.json"
-          }
-        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -3703,11 +5636,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBDatabaseAccountRegionGetMetrics": {
-            "$ref": "./examples/CosmosDBCollectionPartitionGetMetrics.json"
           }
         },
         "x-ms-pageable": {
@@ -3775,11 +5703,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBCollectionGetUsages": {
-            "$ref": "./examples/CosmosDBCollectionPartitionGetUsages.json"
-          }
-        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -3845,11 +5768,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBCollectionGetUsages": {
-            "$ref": "./examples/CosmosDBCollectionGetUsages.json"
-          }
-        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -3899,11 +5817,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBDatabaseGetMetricDefinitions": {
-            "$ref": "./examples/CosmosDBDatabaseGetMetricDefinitions.json"
           }
         },
         "x-ms-pageable": {
@@ -3964,11 +5877,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBDatabaseGetMetrics": {
-            "$ref": "./examples/CosmosDBDatabaseGetMetrics.json"
-          }
-        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -4025,11 +5933,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBDatabaseGetUsages": {
-            "$ref": "./examples/CosmosDBDatabaseGetUsages.json"
           }
         },
         "x-ms-pageable": {
@@ -4101,9 +6004,239 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBDatabaseAccountFailoverPriorityChange": {
-            "$ref": "./examples/CosmosDBDatabaseAccountFailoverPriorityChange.json"
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/graphs": {
+      "get": {
+        "operationId": "GraphResources_ListGraphs",
+        "description": "Lists the graphs under an existing Azure Cosmos DB database account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/GraphResourcesListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/graphs/{graphName}": {
+      "get": {
+        "operationId": "GraphResources_GetGraph",
+        "description": "Gets the Graph resource under an existing Azure Cosmos DB database account with the provided name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "graphName",
+            "in": "path",
+            "description": "Cosmos DB graph resource name.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/GraphResourceGetResults"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "GraphResources_CreateUpdateGraph",
+        "description": "Create or update an Azure Cosmos DB Graph.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "graphName",
+            "in": "path",
+            "description": "Cosmos DB graph resource name.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "createUpdateGraphParameters",
+            "in": "body",
+            "description": "The parameters to provide for the current graph.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/GraphResourceCreateUpdateParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'GraphResourceGetResults' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/GraphResourceGetResults"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/GraphResourceGetResults"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "GraphResources_DeleteGraphResource",
+        "description": "Deletes an existing Azure Cosmos DB Graph Resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "graphName",
+            "in": "path",
+            "description": "Cosmos DB graph resource name.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
           }
         },
         "x-ms-long-running-operation-options": {
@@ -4149,11 +6282,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBGremlinDatabaseList": {
-            "$ref": "./examples/CosmosDBGremlinDatabaseList.json"
           }
         },
         "x-ms-pageable": {
@@ -4205,11 +6333,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBGremlinDatabaseGet": {
-            "$ref": "./examples/CosmosDBGremlinDatabaseGet.json"
           }
         }
       },
@@ -4286,11 +6409,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBGremlinDatabaseCreateUpdate": {
-            "$ref": "./examples/CosmosDBGremlinDatabaseCreateUpdate.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/GremlinDatabaseGetResults"
@@ -4353,11 +6471,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBGremlinDatabaseDelete": {
-            "$ref": "./examples/CosmosDBGremlinDatabaseDelete.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -4408,11 +6521,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBGremlinGraphList": {
-            "$ref": "./examples/CosmosDBGremlinGraphList.json"
           }
         },
         "x-ms-pageable": {
@@ -4471,11 +6579,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBGremlinGraphGet": {
-            "$ref": "./examples/CosmosDBGremlinGraphGet.json"
           }
         }
       },
@@ -4559,11 +6662,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBGremlinGraphCreateUpdate": {
-            "$ref": "./examples/CosmosDBGremlinGraphCreateUpdate.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/GremlinGraphGetResults"
@@ -4631,11 +6729,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBGremlinGraphDelete": {
-            "$ref": "./examples/CosmosDBGremlinGraphDelete.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -4720,11 +6813,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBGremlinGraphBackupInformation": {
-            "$ref": "./examples/CosmosDBGremlinGraphBackupInformation.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/BackupInformation"
@@ -4783,11 +6871,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBGremlinGraphThroughputGet": {
-            "$ref": "./examples/CosmosDBGremlinGraphThroughputGet.json"
           }
         }
       },
@@ -4871,11 +6954,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBGremlinGraphThroughputUpdate": {
-            "$ref": "./examples/CosmosDBGremlinGraphThroughputUpdate.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
@@ -4953,11 +7031,6 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBGremlinGraphMigrateToAutoscale": {
-            "$ref": "./examples/CosmosDBGremlinGraphMigrateToAutoscale.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -5039,11 +7112,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBGremlinGraphMigrateToManualThroughput": {
-            "$ref": "./examples/CosmosDBGremlinGraphMigrateToManualThroughput.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
@@ -5095,11 +7163,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBGremlinDatabaseThroughputGet": {
-            "$ref": "./examples/CosmosDBGremlinDatabaseThroughputGet.json"
           }
         }
       },
@@ -5176,11 +7239,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBGremlinDatabaseThroughputUpdate": {
-            "$ref": "./examples/CosmosDBGremlinDatabaseThroughputUpdate.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
@@ -5251,11 +7309,6 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBGremlinDatabaseMigrateToAutoscale": {
-            "$ref": "./examples/CosmosDBGremlinDatabaseMigrateToAutoscale.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -5330,14 +7383,479 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBGremlinDatabaseMigrateToManualThroughput": {
-            "$ref": "./examples/CosmosDBGremlinDatabaseMigrateToManualThroughput.json"
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/gremlinRoleAssignments": {
+      "get": {
+        "operationId": "GremlinResources_ListGremlinRoleAssignments",
+        "description": "Retrieves the list of all Azure Cosmos DB Gremlin Role Assignments.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/GremlinRoleAssignmentListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/gremlinRoleAssignments/{roleAssignmentId}": {
+      "get": {
+        "operationId": "GremlinResources_GetGremlinRoleAssignment",
+        "description": "Retrieves the properties of an existing Azure Cosmos DB Gremlin Role Assignment with the given Id.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "roleAssignmentId",
+            "in": "path",
+            "description": "The GUID for the Role Assignment.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/GremlinRoleAssignmentResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "GremlinResources_CreateUpdateGremlinRoleAssignment",
+        "description": "Creates or updates an Azure Cosmos DB Gremlin Role Assignment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "roleAssignmentId",
+            "in": "path",
+            "description": "The GUID for the Role Assignment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "createUpdateGremlinRoleAssignmentParameters",
+            "in": "body",
+            "description": "The properties required to create or update a Role Assignment.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/GremlinRoleAssignmentResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'GremlinRoleAssignmentResource' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/GremlinRoleAssignmentResource"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
           }
         },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
-          "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
+          "final-state-schema": "#/definitions/GremlinRoleAssignmentResource"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "GremlinResources_DeleteGremlinRoleAssignment",
+        "description": "Deletes an existing Azure Cosmos DB Gremlin Role Assignment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "roleAssignmentId",
+            "in": "path",
+            "description": "The GUID for the Role Assignment.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/gremlinRoleDefinitions": {
+      "get": {
+        "operationId": "GremlinResources_ListGremlinRoleDefinitions",
+        "description": "Retrieves the list of all Azure Cosmos DB Gremlin Role Definitions.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/GremlinRoleDefinitionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/gremlinRoleDefinitions/{roleDefinitionId}": {
+      "get": {
+        "operationId": "GremlinResources_GetGremlinRoleDefinition",
+        "description": "Retrieves the properties of an existing Azure Cosmos DB Gremlin Role Definition with the given Id.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "roleDefinitionId",
+            "in": "path",
+            "description": "The GUID for the Role Definition.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/GremlinRoleDefinitionResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "GremlinResources_CreateUpdateGremlinRoleDefinition",
+        "description": "Creates or updates an Azure Cosmos DB Gremlin Role Definition.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "roleDefinitionId",
+            "in": "path",
+            "description": "The GUID for the Role Definition.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "createUpdateGremlinRoleDefinitionParameters",
+            "in": "body",
+            "description": "The properties required to create or update a Role Definition.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/GremlinRoleDefinitionResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'GremlinRoleDefinitionResource' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/GremlinRoleDefinitionResource"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/GremlinRoleDefinitionResource"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "GremlinResources_DeleteGremlinRoleDefinition",
+        "description": "Deletes an existing Azure Cosmos DB Gremlin Role Definition.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "roleDefinitionId",
+            "in": "path",
+            "description": "The GUID for the Role Definition.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
         },
         "x-ms-long-running-operation": true
       }
@@ -5380,14 +7898,6 @@
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
-        },
-        "x-ms-examples": {
-          "CosmosDBDatabaseAccountListConnectionStrings": {
-            "$ref": "./examples/CosmosDBDatabaseAccountListConnectionStrings.json"
-          },
-          "CosmosDBDatabaseAccountListConnectionStringsMongo": {
-            "$ref": "./examples/CosmosDBDatabaseAccountListConnectionStringsMongo.json"
-          }
         }
       }
     },
@@ -5429,11 +7939,6 @@
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
-        },
-        "x-ms-examples": {
-          "CosmosDBDatabaseAccountListKeys": {
-            "$ref": "./examples/CosmosDBDatabaseAccountListKeys.json"
-          }
         }
       }
     },
@@ -5474,11 +7979,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBDatabaseAccountGetMetricDefinitions": {
-            "$ref": "./examples/CosmosDBDatabaseAccountGetMetricDefinitions.json"
           }
         },
         "x-ms-pageable": {
@@ -5532,14 +8032,479 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBDatabaseAccountGetMetrics": {
-            "$ref": "./examples/CosmosDBDatabaseAccountGetMetrics.json"
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/mongoMIRoleAssignments": {
+      "get": {
+        "operationId": "MongoMIResources_ListMongoMIRoleAssignments",
+        "description": "Retrieves the list of all Azure Cosmos DB MongoMI Role Assignments.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MongoMIRoleAssignmentListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
           }
         },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/mongoMIRoleAssignments/{roleAssignmentId}": {
+      "get": {
+        "operationId": "MongoMIResources_GetMongoMIRoleAssignment",
+        "description": "Retrieves the properties of an existing Azure Cosmos DB MongoMI Role Assignment with the given Id.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "roleAssignmentId",
+            "in": "path",
+            "description": "The GUID for the Role Assignment.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MongoMIRoleAssignmentResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "MongoMIResources_CreateUpdateMongoMIRoleAssignment",
+        "description": "Creates or updates an Azure Cosmos DB MongoMI Role Assignment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "roleAssignmentId",
+            "in": "path",
+            "description": "The GUID for the Role Assignment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "createUpdateMongoMIRoleAssignmentParameters",
+            "in": "body",
+            "description": "The properties required to create or update a Role Assignment.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/MongoMIRoleAssignmentResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'MongoMIRoleAssignmentResource' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/MongoMIRoleAssignmentResource"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/MongoMIRoleAssignmentResource"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "MongoMIResources_DeleteMongoMIRoleAssignment",
+        "description": "Deletes an existing Azure Cosmos DB MongoMI Role Assignment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "roleAssignmentId",
+            "in": "path",
+            "description": "The GUID for the Role Assignment.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/mongoMIRoleDefinitions": {
+      "get": {
+        "operationId": "MongoMIResources_ListMongoMIRoleDefinitions",
+        "description": "Retrieves the list of all Azure Cosmos DB MongoMI Role Definitions.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MongoMIRoleDefinitionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/mongoMIRoleDefinitions/{roleDefinitionId}": {
+      "get": {
+        "operationId": "MongoMIResources_GetMongoMIRoleDefinition",
+        "description": "Retrieves the properties of an existing Azure Cosmos DB MongoMI Role Definition with the given Id.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "roleDefinitionId",
+            "in": "path",
+            "description": "The GUID for the Role Definition.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MongoMIRoleDefinitionResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "MongoMIResources_CreateUpdateMongoMIRoleDefinition",
+        "description": "Creates or updates an Azure Cosmos DB MongoMI Role Definition.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "roleDefinitionId",
+            "in": "path",
+            "description": "The GUID for the Role Definition.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "createUpdateMongoMIRoleDefinitionParameters",
+            "in": "body",
+            "description": "The properties required to create or update a Role Definition.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/MongoMIRoleDefinitionResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'MongoMIRoleDefinitionResource' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/MongoMIRoleDefinitionResource"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/MongoMIRoleDefinitionResource"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "MongoMIResources_DeleteMongoMIRoleDefinition",
+        "description": "Deletes an existing Azure Cosmos DB MongoMI Role Definition.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "roleDefinitionId",
+            "in": "path",
+            "description": "The GUID for the Role Definition.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
       }
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases": {
@@ -5579,11 +8544,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBMongoDBDatabaseList": {
-            "$ref": "./examples/CosmosDBMongoDBDatabaseList.json"
           }
         },
         "x-ms-pageable": {
@@ -5635,11 +8595,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBMongoDBDatabaseGet": {
-            "$ref": "./examples/CosmosDBMongoDBDatabaseGet.json"
           }
         }
       },
@@ -5716,11 +8671,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBMongoDBDatabaseCreateUpdate": {
-            "$ref": "./examples/CosmosDBMongoDBDatabaseCreateUpdate.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/MongoDBDatabaseGetResults"
@@ -5783,11 +8733,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBMongoDBDatabaseDelete": {
-            "$ref": "./examples/CosmosDBMongoDBDatabaseDelete.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -5838,11 +8783,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBMongoDBCollectionList": {
-            "$ref": "./examples/CosmosDBMongoDBCollectionList.json"
           }
         },
         "x-ms-pageable": {
@@ -5901,11 +8841,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBMongoDBCollectionGet": {
-            "$ref": "./examples/CosmosDBMongoDBCollectionGet.json"
           }
         }
       },
@@ -5989,11 +8924,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBMongoDBCollectionCreateUpdate": {
-            "$ref": "./examples/CosmosDBMongoDBCollectionCreateUpdate.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/MongoDBCollectionGetResults"
@@ -6063,13 +8993,96 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBMongoDBCollectionDelete": {
-            "$ref": "./examples/CosmosDBMongoDBCollectionDelete.json"
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/collections/{collectionName}/partitionMerge": {
+      "post": {
+        "operationId": "MongoDBResources_ListMongoDBCollectionPartitionMerge",
+        "description": "Merges the partitions of a MongoDB Collection",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "Cosmos DB database name.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "collectionName",
+            "in": "path",
+            "description": "Cosmos DB collection name.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "mergeParameters",
+            "in": "body",
+            "description": "The parameters for the merge operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/MergeParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PhysicalPartitionStorageInfoCollection"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
           }
         },
         "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/PhysicalPartitionStorageInfoCollection"
         },
         "x-ms-long-running-operation": true
       }
@@ -6150,11 +9163,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBMongoDBCollectionBackupInformation": {
-            "$ref": "./examples/CosmosDBMongoDBCollectionBackupInformation.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/BackupInformation"
@@ -6213,11 +9221,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBMongoDBCollectionThroughputGet": {
-            "$ref": "./examples/CosmosDBMongoDBCollectionThroughputGet.json"
           }
         }
       },
@@ -6301,11 +9304,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBMongoDBCollectionThroughputUpdate": {
-            "$ref": "./examples/CosmosDBMongoDBCollectionThroughputUpdate.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
@@ -6383,11 +9381,6 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBMongoDBCollectionMigrateToAutoscale": {
-            "$ref": "./examples/CosmosDBMongoDBCollectionMigrateToAutoscale.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -6469,14 +9462,266 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBMongoDBCollectionMigrateToManualThroughput": {
-            "$ref": "./examples/CosmosDBMongoDBCollectionMigrateToManualThroughput.json"
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/collections/{collectionName}/throughputSettings/default/redistributeThroughput": {
+      "post": {
+        "operationId": "MongoDBResources_MongoDBContainerRedistributeThroughput",
+        "description": "Redistribute throughput for an Azure Cosmos DB MongoDB container",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "Cosmos DB database name.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "collectionName",
+            "in": "path",
+            "description": "Cosmos DB collection name.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "redistributeThroughputParameters",
+            "in": "body",
+            "description": "The parameters to provide for redistributing throughput for the current MongoDB container.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RedistributeThroughputParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PhysicalPartitionThroughputInfoResult"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
           }
         },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
-          "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
+          "final-state-schema": "#/definitions/PhysicalPartitionThroughputInfoResult"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/collections/{collectionName}/throughputSettings/default/retrieveThroughputDistribution": {
+      "post": {
+        "operationId": "MongoDBResources_MongoDBContainerRetrieveThroughputDistribution",
+        "description": "Retrieve throughput distribution for an Azure Cosmos DB MongoDB container",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "Cosmos DB database name.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "collectionName",
+            "in": "path",
+            "description": "Cosmos DB collection name.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "retrieveThroughputParameters",
+            "in": "body",
+            "description": "The parameters to provide for retrieving throughput distribution for the current MongoDB container.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RetrieveThroughputParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PhysicalPartitionThroughputInfoResult"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/PhysicalPartitionThroughputInfoResult"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/partitionMerge": {
+      "post": {
+        "operationId": "MongoDBResources_MongoDBDatabasePartitionMerge",
+        "description": "Merges the partitions of a MongoDB database",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "Cosmos DB database name.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "mergeParameters",
+            "in": "body",
+            "description": "The parameters for the merge operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/MergeParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PhysicalPartitionStorageInfoCollection"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/PhysicalPartitionStorageInfoCollection"
         },
         "x-ms-long-running-operation": true
       }
@@ -6525,11 +9770,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBMongoDBDatabaseThroughputGet": {
-            "$ref": "./examples/CosmosDBMongoDBDatabaseThroughputGet.json"
           }
         }
       },
@@ -6606,11 +9846,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBMongoDBDatabaseThroughputUpdate": {
-            "$ref": "./examples/CosmosDBMongoDBDatabaseThroughputUpdate.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
@@ -6681,11 +9916,6 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBMongoDBDatabaseMigrateToAutoscale": {
-            "$ref": "./examples/CosmosDBMongoDBDatabaseMigrateToAutoscale.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -6760,14 +9990,171 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBMongoDBDatabaseMigrateToManualThroughput": {
-            "$ref": "./examples/CosmosDBMongoDBDatabaseMigrateToManualThroughput.json"
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/throughputSettings/default/redistributeThroughput": {
+      "post": {
+        "operationId": "MongoDBResources_MongoDBDatabaseRedistributeThroughput",
+        "description": "Redistribute throughput for an Azure Cosmos DB MongoDB database",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "Cosmos DB database name.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "redistributeThroughputParameters",
+            "in": "body",
+            "description": "The parameters to provide for redistributing throughput for the current MongoDB database.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RedistributeThroughputParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PhysicalPartitionThroughputInfoResult"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
           }
         },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
-          "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
+          "final-state-schema": "#/definitions/PhysicalPartitionThroughputInfoResult"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/throughputSettings/default/retrieveThroughputDistribution": {
+      "post": {
+        "operationId": "MongoDBResources_MongoDBDatabaseRetrieveThroughputDistribution",
+        "description": "Retrieve throughput distribution for an Azure Cosmos DB MongoDB database",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "Cosmos DB database name.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "retrieveThroughputParameters",
+            "in": "body",
+            "description": "The parameters to provide for retrieving throughput distribution for the current MongoDB database.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RetrieveThroughputParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PhysicalPartitionThroughputInfoResult"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/PhysicalPartitionThroughputInfoResult"
         },
         "x-ms-long-running-operation": true
       }
@@ -6809,11 +10196,6 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBMongoDBRoleDefinitionList": {
-            "$ref": "./examples/CosmosDBMongoDBRoleDefinitionList.json"
           }
         },
         "x-ms-pageable": {
@@ -6865,11 +10247,6 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBMongoRoleDefinitionGet": {
-            "$ref": "./examples/CosmosDBMongoDBRoleDefinitionGet.json"
           }
         }
       },
@@ -6941,11 +10318,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBMongoDBRoleDefinitionCreateUpdate": {
-            "$ref": "./examples/CosmosDBMongoDBRoleDefinitionCreateUpdate.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/MongoRoleDefinitionGetResults"
@@ -7011,11 +10383,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBMongoDBRoleDefinitionDelete": {
-            "$ref": "./examples/CosmosDBMongoDBRoleDefinitionDelete.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -7059,11 +10426,6 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBMongoDBUserDefinitionList": {
-            "$ref": "./examples/CosmosDBMongoDBUserDefinitionList.json"
           }
         },
         "x-ms-pageable": {
@@ -7115,11 +10477,6 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBMongoDBUserDefinitionGet": {
-            "$ref": "./examples/CosmosDBMongoDBUserDefinitionGet.json"
           }
         }
       },
@@ -7191,11 +10548,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBMongoDBUserDefinitionCreateUpdate": {
-            "$ref": "./examples/CosmosDBMongoDBUserDefinitionCreateUpdate.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/MongoUserDefinitionGetResults"
@@ -7261,9 +10613,167 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBMongoDBUserDefinitionDelete": {
-            "$ref": "./examples/CosmosDBMongoDBUserDefinitionDelete.json"
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/networkSecurityPerimeterConfigurations": {
+      "get": {
+        "operationId": "NetworkSecurityPerimeterConfigurations_List",
+        "tags": [
+          "NetworkSecurityPerimeterConfigurations"
+        ],
+        "description": "Gets list of effective Network Security Perimeter Configuration for cosmos db account",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/networkSecurityPerimeterConfigurations/{networkSecurityPerimeterConfigurationName}": {
+      "get": {
+        "operationId": "NetworkSecurityPerimeterConfigurations_Get",
+        "tags": [
+          "NetworkSecurityPerimeterConfigurations"
+        ],
+        "description": "Gets effective Network Security Perimeter Configuration for association",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "networkSecurityPerimeterConfigurationName",
+            "in": "path",
+            "description": "The name for Network Security Perimeter configuration",
+            "required": true,
+            "type": "string",
+            "pattern": "^.*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityPerimeterConfiguration"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/networkSecurityPerimeterConfigurations/{networkSecurityPerimeterConfigurationName}/reconcile": {
+      "post": {
+        "operationId": "NetworkSecurityPerimeterConfigurations_Reconcile",
+        "tags": [
+          "NetworkSecurityPerimeterConfigurations"
+        ],
+        "description": "Refreshes any information about the association.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "networkSecurityPerimeterConfigurationName",
+            "in": "path",
+            "description": "The name for Network Security Perimeter configuration",
+            "required": true,
+            "type": "string",
+            "pattern": "^.*$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
           }
         },
         "x-ms-long-running-operation-options": {
@@ -7312,11 +10822,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBNotebookWorkspaceList": {
-            "$ref": "./examples/CosmosDBNotebookWorkspaceList.json"
           }
         },
         "x-ms-pageable": {
@@ -7384,11 +10889,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBNotebookWorkspaceGet": {
-            "$ref": "./examples/CosmosDBNotebookWorkspaceGet.json"
           }
         }
       },
@@ -7466,11 +10966,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBNotebookWorkspaceCreate": {
-            "$ref": "./examples/CosmosDBNotebookWorkspaceCreate.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -7551,11 +11046,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBNotebookWorkspaceDelete": {
-            "$ref": "./examples/CosmosDBNotebookWorkspaceDelete.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -7622,11 +11112,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBNotebookWorkspaceListConnectionInfo": {
-            "$ref": "./examples/CosmosDBNotebookWorkspaceListConnectionInfo.json"
           }
         }
       }
@@ -7702,11 +11187,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBNotebookWorkspaceRegenerateAuthToken": {
-            "$ref": "./examples/CosmosDBNotebookWorkspaceRegenerateAuthToken.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -7788,11 +11268,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBNotebookWorkspaceStart": {
-            "$ref": "./examples/CosmosDBNotebookWorkspaceStart.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -7861,11 +11336,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBDatabaseAccountOfflineRegion": {
-            "$ref": "./examples/CosmosDBDatabaseAccountOfflineRegion.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -7938,11 +11408,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBDatabaseAccountOnlineRegion": {
-            "$ref": "./examples/CosmosDBDatabaseAccountOnlineRegion.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -7995,11 +11460,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBDatabaseAccountRegionGetMetrics": {
-            "$ref": "./examples/CosmosDBPercentileGetMetrics.json"
-          }
-        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -8045,11 +11505,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "Gets private endpoint connection.": {
-            "$ref": "./examples/CosmosDBPrivateEndpointConnectionListGet.json"
           }
         },
         "x-ms-pageable": {
@@ -8104,11 +11559,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "Gets private endpoint connection.": {
-            "$ref": "./examples/CosmosDBPrivateEndpointConnectionGet.json"
           }
         }
       },
@@ -8183,11 +11633,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "Approve or reject a private endpoint connection with a given name.": {
-            "$ref": "./examples/CosmosDBPrivateEndpointConnectionUpdate.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/PrivateEndpointConnection"
@@ -8253,11 +11698,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "Deletes a private endpoint connection with a given name.": {
-            "$ref": "./examples/CosmosDBPrivateEndpointConnectionDelete.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -8304,11 +11744,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "Gets private endpoint connection.": {
-            "$ref": "./examples/CosmosDBPrivateLinkResourceListGet.json"
           }
         },
         "x-ms-pageable": {
@@ -8364,11 +11799,6 @@
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
-        },
-        "x-ms-examples": {
-          "Gets private endpoint connection.": {
-            "$ref": "./examples/CosmosDBPrivateLinkResourceGet.json"
-          }
         }
       }
     },
@@ -8410,11 +11840,6 @@
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
-        },
-        "x-ms-examples": {
-          "CosmosDBDatabaseAccountListReadOnlyKeys": {
-            "$ref": "./examples/CosmosDBDatabaseAccountListReadOnlyKeys_GetReadOnlyKeys.json"
-          }
         }
       },
       "post": {
@@ -8453,11 +11878,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBDatabaseAccountListReadOnlyKeys": {
-            "$ref": "./examples/CosmosDBDatabaseAccountListReadOnlyKeys.json"
           }
         }
       }
@@ -8524,11 +11944,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBDatabaseAccountRegenerateKey": {
-            "$ref": "./examples/CosmosDBDatabaseAccountRegenerateKey.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -8602,11 +12017,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBRegionCollectionGetMetrics": {
-            "$ref": "./examples/CosmosDBRegionCollectionGetMetrics.json"
           }
         },
         "x-ms-pageable": {
@@ -8688,11 +12098,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBDatabaseAccountRegionGetMetrics": {
-            "$ref": "./examples/CosmosDBPKeyRangeIdRegionGetMetrics.json"
-          }
-        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -8765,11 +12170,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBDatabaseAccountRegionGetMetrics": {
-            "$ref": "./examples/CosmosDBCollectionPartitionRegionGetMetrics.json"
-          }
-        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -8828,11 +12228,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBDatabaseAccountRegionGetMetrics": {
-            "$ref": "./examples/CosmosDBDatabaseAccountRegionGetMetrics.json"
-          }
-        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -8875,11 +12270,6 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBServicesList": {
-            "$ref": "./examples/CosmosDBServicesList.json"
           }
         },
         "x-ms-pageable": {
@@ -8939,20 +12329,6 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
-          }
-        },
-        "x-ms-examples": {
-          "DataTransferServiceGet": {
-            "$ref": "./examples/CosmosDBDataTransferServiceGet.json"
-          },
-          "GraphAPIComputeServiceGet": {
-            "$ref": "./examples/CosmosDBGraphAPIComputeServiceGet.json"
-          },
-          "MaterializedViewsBuilderServiceGet": {
-            "$ref": "./examples/CosmosDBMaterializedViewsBuilderServiceGet.json"
-          },
-          "SqlDedicatedGatewayServiceGet": {
-            "$ref": "./examples/services/sqldedicatedgateway/CosmosDBSqlDedicatedGatewayServiceGet.json"
           }
         }
       },
@@ -9032,20 +12408,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "DataTransferServiceCreate": {
-            "$ref": "./examples/CosmosDBDataTransferServiceCreate.json"
-          },
-          "GraphAPIComputeServiceCreate": {
-            "$ref": "./examples/CosmosDBGraphAPIComputeServiceCreate.json"
-          },
-          "MaterializedViewsBuilderServiceCreate": {
-            "$ref": "./examples/CosmosDBMaterializedViewsBuilderServiceCreate.json"
-          },
-          "SqlDedicatedGatewayServiceCreate": {
-            "$ref": "./examples/services/sqldedicatedgateway/CosmosDBSqlDedicatedGatewayServiceCreate.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ServiceResource"
@@ -9119,20 +12481,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "DataTransferServiceDelete": {
-            "$ref": "./examples/CosmosDBDataTransferServiceDelete.json"
-          },
-          "GraphAPIComputeServiceDelete": {
-            "$ref": "./examples/CosmosDBGraphAPIComputeServiceDelete.json"
-          },
-          "MaterializedViewsBuilderServiceDelete": {
-            "$ref": "./examples/CosmosDBMaterializedViewsBuilderServiceDelete.json"
-          },
-          "SqlDedicatedGatewayServiceDelete": {
-            "$ref": "./examples/services/sqldedicatedgateway/CosmosDBSqlDedicatedGatewayServiceDelete.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -9199,11 +12547,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBDatabaseAccountRegionGetMetrics": {
-            "$ref": "./examples/CosmosDBPercentileSourceTargetGetMetrics.json"
-          }
-        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -9246,11 +12589,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBSqlDatabaseList": {
-            "$ref": "./examples/CosmosDBSqlDatabaseList.json"
           }
         },
         "x-ms-pageable": {
@@ -9302,11 +12640,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBSqlDatabaseGet": {
-            "$ref": "./examples/CosmosDBSqlDatabaseGet.json"
           }
         }
       },
@@ -9383,11 +12716,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBSqlDatabaseCreateUpdate": {
-            "$ref": "./examples/CosmosDBSqlDatabaseCreateUpdate.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/SqlDatabaseGetResults"
@@ -9450,11 +12778,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBSqlDatabaseDelete": {
-            "$ref": "./examples/CosmosDBSqlDatabaseDelete.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -9505,11 +12828,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBClientEncryptionKeysList": {
-            "$ref": "./examples/CosmosDBSqlClientEncryptionKeysList.json"
           }
         },
         "x-ms-pageable": {
@@ -9568,11 +12886,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBClientEncryptionKeyGet": {
-            "$ref": "./examples/CosmosDBSqlClientEncryptionKeyGet.json"
           }
         }
       },
@@ -9656,11 +12969,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBClientEncryptionKeyCreateUpdate": {
-            "$ref": "./examples/CosmosDBSqlClientEncryptionKeyCreateUpdate.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ClientEncryptionKeyGetResults"
@@ -9712,11 +13020,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBSqlContainerList": {
-            "$ref": "./examples/CosmosDBSqlContainerList.json"
           }
         },
         "x-ms-pageable": {
@@ -9775,11 +13078,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBSqlContainerGet": {
-            "$ref": "./examples/CosmosDBSqlContainerGet.json"
           }
         }
       },
@@ -9863,11 +13161,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBSqlContainerCreateUpdate": {
-            "$ref": "./examples/CosmosDBSqlContainerCreateUpdate.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/SqlContainerGetResults"
@@ -9937,13 +13230,91 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBSqlContainerDelete": {
-            "$ref": "./examples/CosmosDBSqlContainerDelete.json"
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/partitionMerge": {
+      "post": {
+        "operationId": "SqlResources_ListSqlContainerPartitionMerge",
+        "description": "Merges the partitions of a SQL Container",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "Cosmos DB database name.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "Cosmos DB container name.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "mergeParameters",
+            "in": "body",
+            "description": "The parameters for the merge operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/MergeParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PhysicalPartitionStorageInfoCollection"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
           }
         },
         "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/PhysicalPartitionStorageInfoCollection"
         },
         "x-ms-long-running-operation": true
       }
@@ -10024,11 +13395,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBSqlContainerBackupInformation": {
-            "$ref": "./examples/CosmosDBSqlContainerBackupInformation.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/BackupInformation"
@@ -10087,11 +13453,6 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBSqlStoredProcedureList": {
-            "$ref": "./examples/CosmosDBSqlStoredProcedureList.json"
           }
         },
         "x-ms-pageable": {
@@ -10157,11 +13518,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBSqlStoredProcedureGet": {
-            "$ref": "./examples/CosmosDBSqlStoredProcedureGet.json"
           }
         }
       },
@@ -10252,11 +13608,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBSqlStoredProcedureCreateUpdate": {
-            "$ref": "./examples/CosmosDBSqlStoredProcedureCreateUpdate.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/SqlStoredProcedureGetResults"
@@ -10333,11 +13684,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBSqlStoredProcedureDelete": {
-            "$ref": "./examples/CosmosDBSqlStoredProcedureDelete.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -10395,11 +13741,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBSqlContainerThroughputGet": {
-            "$ref": "./examples/CosmosDBSqlContainerThroughputGet.json"
           }
         }
       },
@@ -10483,11 +13824,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBSqlContainerThroughputUpdate": {
-            "$ref": "./examples/CosmosDBSqlContainerThroughputUpdate.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
@@ -10560,11 +13896,6 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBSqlContainerMigrateToAutoscale": {
-            "$ref": "./examples/CosmosDBSqlContainerMigrateToAutoscale.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -10641,14 +13972,175 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBSqlContainerMigrateToManualThroughput": {
-            "$ref": "./examples/CosmosDBSqlContainerMigrateToManualThroughput.json"
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/throughputSettings/default/redistributeThroughput": {
+      "post": {
+        "operationId": "SqlResources_SqlContainerRedistributeThroughput",
+        "description": "Redistribute throughput for an Azure Cosmos DB SQL container",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "Cosmos DB database name.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "Cosmos DB container name.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "redistributeThroughputParameters",
+            "in": "body",
+            "description": "The parameters to provide for redistributing throughput for the current SQL container.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RedistributeThroughputParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PhysicalPartitionThroughputInfoResult"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
           }
         },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
-          "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
+          "final-state-schema": "#/definitions/PhysicalPartitionThroughputInfoResult"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/throughputSettings/default/retrieveThroughputDistribution": {
+      "post": {
+        "operationId": "SqlResources_SqlContainerRetrieveThroughputDistribution",
+        "description": "Retrieve throughput distribution for an Azure Cosmos DB SQL container",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "Cosmos DB database name.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "Cosmos DB container name.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "retrieveThroughputParameters",
+            "in": "body",
+            "description": "The parameters to provide for retrieving throughput distribution for the current SQL container.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RetrieveThroughputParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PhysicalPartitionThroughputInfoResult"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/PhysicalPartitionThroughputInfoResult"
         },
         "x-ms-long-running-operation": true
       }
@@ -10704,11 +14196,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBSqlTriggerList": {
-            "$ref": "./examples/CosmosDBSqlTriggerList.json"
           }
         },
         "x-ms-pageable": {
@@ -10774,11 +14261,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBSqlTriggerGet": {
-            "$ref": "./examples/CosmosDBSqlTriggerGet.json"
           }
         }
       },
@@ -10869,11 +14351,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBSqlTriggerCreateUpdate": {
-            "$ref": "./examples/CosmosDBSqlTriggerCreateUpdate.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/SqlTriggerGetResults"
@@ -10950,11 +14427,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBSqlTriggerDelete": {
-            "$ref": "./examples/CosmosDBSqlTriggerDelete.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -11012,11 +14484,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBSqlUserDefinedFunctionList": {
-            "$ref": "./examples/CosmosDBSqlUserDefinedFunctionList.json"
           }
         },
         "x-ms-pageable": {
@@ -11082,11 +14549,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBSqlUserDefinedFunctionGet": {
-            "$ref": "./examples/CosmosDBSqlUserDefinedFunctionGet.json"
           }
         }
       },
@@ -11177,11 +14639,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBSqlUserDefinedFunctionCreateUpdate": {
-            "$ref": "./examples/CosmosDBSqlUserDefinedFunctionCreateUpdate.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/SqlUserDefinedFunctionGetResults"
@@ -11258,13 +14715,89 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBSqlUserDefinedFunctionDelete": {
-            "$ref": "./examples/CosmosDBSqlUserDefinedFunctionDelete.json"
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/partitionMerge": {
+      "post": {
+        "operationId": "SqlResources_SqlDatabasePartitionMerge",
+        "description": "Merges the partitions of a SQL database",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "Cosmos DB database name.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "mergeParameters",
+            "in": "body",
+            "description": "The parameters for the merge operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/MergeParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PhysicalPartitionStorageInfoCollection"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
           }
         },
         "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/PhysicalPartitionStorageInfoCollection"
         },
         "x-ms-long-running-operation": true
       }
@@ -11313,11 +14846,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBSqlDatabaseThroughputGet": {
-            "$ref": "./examples/CosmosDBSqlDatabaseThroughputGet.json"
           }
         }
       },
@@ -11394,11 +14922,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBSqlDatabaseThroughputUpdate": {
-            "$ref": "./examples/CosmosDBSqlDatabaseThroughputUpdate.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
@@ -11469,11 +14992,6 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBSqlDatabaseMigrateToAutoscale": {
-            "$ref": "./examples/CosmosDBSqlDatabaseMigrateToAutoscale.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -11548,14 +15066,171 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBSqlDatabaseMigrateToManualThroughput": {
-            "$ref": "./examples/CosmosDBSqlDatabaseMigrateToManualThroughput.json"
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/throughputSettings/default/redistributeThroughput": {
+      "post": {
+        "operationId": "SqlResources_SqlDatabaseRedistributeThroughput",
+        "description": "Redistribute throughput for an Azure Cosmos DB SQL database",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "Cosmos DB database name.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "redistributeThroughputParameters",
+            "in": "body",
+            "description": "The parameters to provide for redistributing throughput for the current SQL database.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RedistributeThroughputParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PhysicalPartitionThroughputInfoResult"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
           }
         },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
-          "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
+          "final-state-schema": "#/definitions/PhysicalPartitionThroughputInfoResult"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/throughputSettings/default/retrieveThroughputDistribution": {
+      "post": {
+        "operationId": "SqlResources_SqlDatabaseRetrieveThroughputDistribution",
+        "description": "Retrieve throughput distribution for an Azure Cosmos DB SQL database",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "Cosmos DB database name.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "retrieveThroughputParameters",
+            "in": "body",
+            "description": "The parameters to provide for retrieving throughput distribution for the current SQL database.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RetrieveThroughputParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PhysicalPartitionThroughputInfoResult"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/PhysicalPartitionThroughputInfoResult"
         },
         "x-ms-long-running-operation": true
       }
@@ -11597,11 +15272,6 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBSqlRoleAssignmentList": {
-            "$ref": "./examples/CosmosDBSqlRoleAssignmentList.json"
           }
         },
         "x-ms-pageable": {
@@ -11653,11 +15323,6 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBSqlRoleAssignmentGet": {
-            "$ref": "./examples/CosmosDBSqlRoleAssignmentGet.json"
           }
         }
       },
@@ -11729,11 +15394,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBSqlRoleAssignmentCreateUpdate": {
-            "$ref": "./examples/CosmosDBSqlRoleAssignmentCreateUpdate.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/SqlRoleAssignmentGetResults"
@@ -11799,11 +15459,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBSqlRoleAssignmentDelete": {
-            "$ref": "./examples/CosmosDBSqlRoleAssignmentDelete.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -11847,11 +15502,6 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBSqlRoleDefinitionList": {
-            "$ref": "./examples/CosmosDBSqlRoleDefinitionList.json"
           }
         },
         "x-ms-pageable": {
@@ -11903,11 +15553,6 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBSqlRoleDefinitionGet": {
-            "$ref": "./examples/CosmosDBSqlRoleDefinitionGet.json"
           }
         }
       },
@@ -11979,11 +15624,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBSqlRoleDefinitionCreateUpdate": {
-            "$ref": "./examples/CosmosDBSqlRoleDefinitionCreateUpdate.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/SqlRoleDefinitionGetResults"
@@ -12049,9 +15689,469 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBSqlRoleDefinitionDelete": {
-            "$ref": "./examples/CosmosDBSqlRoleDefinitionDelete.json"
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/tableRoleAssignments": {
+      "get": {
+        "operationId": "TableResources_ListTableRoleAssignments",
+        "description": "Retrieves the list of all Azure Cosmos DB Table Role Assignments.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/TableRoleAssignmentListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/tableRoleAssignments/{roleAssignmentId}": {
+      "get": {
+        "operationId": "TableResources_GetTableRoleAssignment",
+        "description": "Retrieves the properties of an existing Azure Cosmos DB Table Role Assignment with the given Id.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "roleAssignmentId",
+            "in": "path",
+            "description": "The GUID for the Role Assignment.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/TableRoleAssignmentResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "TableResources_CreateUpdateTableRoleAssignment",
+        "description": "Creates or updates an Azure Cosmos DB Table Role Assignment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "roleAssignmentId",
+            "in": "path",
+            "description": "The GUID for the Role Assignment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "createUpdateTableRoleAssignmentParameters",
+            "in": "body",
+            "description": "The properties required to create or update a Role Assignment.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/TableRoleAssignmentResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'TableRoleAssignmentResource' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/TableRoleAssignmentResource"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/TableRoleAssignmentResource"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "TableResources_DeleteTableRoleAssignment",
+        "description": "Deletes an existing Azure Cosmos DB Table Role Assignment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "roleAssignmentId",
+            "in": "path",
+            "description": "The GUID for the Role Assignment.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/tableRoleDefinitions": {
+      "get": {
+        "operationId": "TableResources_ListTableRoleDefinitions",
+        "description": "Retrieves the list of all Azure Cosmos DB Table Role Definitions.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/TableRoleDefinitionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/tableRoleDefinitions/{roleDefinitionId}": {
+      "get": {
+        "operationId": "TableResources_GetTableRoleDefinition",
+        "description": "Retrieves the properties of an existing Azure Cosmos DB Table Role Definition with the given Id.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "roleDefinitionId",
+            "in": "path",
+            "description": "The GUID for the Role Definition.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/TableRoleDefinitionResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "TableResources_CreateUpdateTableRoleDefinition",
+        "description": "Creates or updates an Azure Cosmos DB Table Role Definition.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "roleDefinitionId",
+            "in": "path",
+            "description": "The GUID for the Role Definition.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "createUpdateTableRoleDefinitionParameters",
+            "in": "body",
+            "description": "The properties required to create or update a Role Definition.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/TableRoleDefinitionResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'TableRoleDefinitionResource' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/TableRoleDefinitionResource"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/TableRoleDefinitionResource"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "TableResources_DeleteTableRoleDefinition",
+        "description": "Deletes an existing Azure Cosmos DB Table Role Definition.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "roleDefinitionId",
+            "in": "path",
+            "description": "The GUID for the Role Definition.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
           }
         },
         "x-ms-long-running-operation-options": {
@@ -12097,11 +16197,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBTableList": {
-            "$ref": "./examples/CosmosDBTableList.json"
           }
         },
         "x-ms-pageable": {
@@ -12153,11 +16248,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBTableGet": {
-            "$ref": "./examples/CosmosDBTableGet.json"
           }
         }
       },
@@ -12234,11 +16324,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBTableReplace": {
-            "$ref": "./examples/CosmosDBTableCreateUpdate.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/TableGetResults"
@@ -12299,11 +16384,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBTableDelete": {
-            "$ref": "./examples/CosmosDBTableDelete.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -12381,11 +16461,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBTableCollectionBackupInformation": {
-            "$ref": "./examples/CosmosDBTableBackupInformation.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/BackupInformation"
@@ -12437,11 +16512,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBTableThroughputGet": {
-            "$ref": "./examples/CosmosDBTableThroughputGet.json"
           }
         }
       },
@@ -12518,11 +16588,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBTableThroughputUpdate": {
-            "$ref": "./examples/CosmosDBTableThroughputUpdate.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
@@ -12593,11 +16658,6 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBTableMigrateToAutoscale": {
-            "$ref": "./examples/CosmosDBTableMigrateToAutoscale.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -12672,11 +16732,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBTableMigrateToManualThroughput": {
-            "$ref": "./examples/CosmosDBTableMigrateToManualThroughput.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
@@ -12737,11 +16792,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBDatabaseAccountRegionGetMetrics": {
-            "$ref": "./examples/CosmosDBPercentileTargetGetMetrics.json"
-          }
-        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -12793,11 +16843,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDBDatabaseAccountGetUsages": {
-            "$ref": "./examples/CosmosDBDatabaseAccountGetUsages.json"
-          }
-        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -12833,11 +16878,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDB Fleet List by Resource Group": {
-            "$ref": "./examples/fleet/CosmosDBFleetList_ListByResourceGroup.json"
           }
         },
         "x-ms-pageable": {
@@ -12882,11 +16922,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDB Fleet Get": {
-            "$ref": "./examples/fleet/CosmosDBFleetGet.json"
           }
         }
       },
@@ -12942,11 +16977,6 @@
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
-        },
-        "x-ms-examples": {
-          "CosmosDB Fleet Create": {
-            "$ref": "./examples/fleet/CosmosDBFleetCreate.json"
-          }
         }
       },
       "patch": {
@@ -12994,11 +17024,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDB Fleet Update": {
-            "$ref": "./examples/fleet/CosmosDBFleetUpdate.json"
           }
         }
       },
@@ -13056,9 +17081,232 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDB Fleet Delete": {
-            "$ref": "./examples/fleet/CosmosDBFleetDelete.json"
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/fleets/{fleetName}/fleetAnalytics": {
+      "get": {
+        "operationId": "FleetAnalytics_List",
+        "description": "Lists all the FleetAnalytics under a fleet.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "fleetName",
+            "in": "path",
+            "description": "Cosmos DB fleet name. Needs to be unique under a subscription.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/FleetAnalyticsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/fleets/{fleetName}/fleetAnalytics/{fleetAnalyticsName}": {
+      "get": {
+        "operationId": "FleetAnalytics_Get",
+        "description": "Retrieves the properties of an existing Azure Cosmos DB FleetAnalytics under a fleet",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "fleetName",
+            "in": "path",
+            "description": "Cosmos DB fleet name. Needs to be unique under a subscription.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "fleetAnalyticsName",
+            "in": "path",
+            "description": "Cosmos DB fleetAnalytics name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/FleetAnalyticsResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "FleetAnalytics_Create",
+        "description": "Creates an Azure Cosmos DB FleetAnalytics under a fleet.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "fleetName",
+            "in": "path",
+            "description": "Cosmos DB fleet name. Needs to be unique under a subscription.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "fleetAnalyticsName",
+            "in": "path",
+            "description": "Cosmos DB fleetAnalytics name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "The parameters to provide for the current FleetAnalytics.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FleetAnalyticsResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'FleetAnalyticsResource' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/FleetAnalyticsResource"
+            }
+          },
+          "201": {
+            "description": "Resource 'FleetAnalyticsResource' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/FleetAnalyticsResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "FleetAnalytics_Delete",
+        "description": "Deletes an existing Azure Cosmos DB FleetAnalytics.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "fleetName",
+            "in": "path",
+            "description": "Cosmos DB fleet name. Needs to be unique under a subscription.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "fleetAnalyticsName",
+            "in": "path",
+            "description": "Cosmos DB fleetAnalytics name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
           }
         },
         "x-ms-long-running-operation-options": {
@@ -13104,11 +17352,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDB Fleetspace List": {
-            "$ref": "./examples/fleet/CosmosDBFleetspaceList.json"
           }
         },
         "x-ms-pageable": {
@@ -13163,11 +17406,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDB Fleetspace Get": {
-            "$ref": "./examples/fleet/CosmosDBFleetspaceGet.json"
           }
         }
       },
@@ -13243,11 +17481,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDB Fleetspace Create": {
-            "$ref": "./examples/fleet/CosmosDBFleetspaceCreate.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -13332,11 +17565,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDB Fleetspace Update": {
-            "$ref": "./examples/fleet/CosmosDBFleetspaceUpdate.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "azure-async-operation",
           "final-state-schema": "#/definitions/FleetspaceResource"
@@ -13407,11 +17635,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDB Fleetspace Delete": {
-            "$ref": "./examples/fleet/CosmosDBFleetspaceDelete.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "azure-async-operation"
         },
@@ -13465,11 +17688,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDB FleetspaceAccount List": {
-            "$ref": "./examples/fleet/CosmosDBFleetspaceAccountList.json"
           }
         },
         "x-ms-pageable": {
@@ -13534,11 +17752,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDB FleetspaceAccount Get": {
-            "$ref": "./examples/fleet/CosmosDBFleetspaceAccountGet.json"
           }
         }
       },
@@ -13626,11 +17839,6 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDB FleetspaceAccount Create": {
-            "$ref": "./examples/fleet/CosmosDBFleetspaceAccountCreate.json"
-          }
-        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "azure-async-operation",
           "final-state-schema": "#/definitions/FleetspaceAccountResource"
@@ -13711,13 +17919,797 @@
             }
           }
         },
-        "x-ms-examples": {
-          "CosmosDB FleetspaceAccount Delete": {
-            "$ref": "./examples/fleet/CosmosDBFleetspaceAccountDelete.json"
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/garnetClusters": {
+      "get": {
+        "operationId": "GarnetClusters_ListByResourceGroup",
+        "description": "List all Garnet clusters in this resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListGarnetClusters"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/garnetClusters/{clusterName}": {
+      "get": {
+        "operationId": "GarnetClusters_Get",
+        "description": "Get the properties of a Garnet cache cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the GarnetClusterResource",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100,
+            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/GarnetClusterResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "GarnetClusters_CreateUpdate",
+        "description": "Create or update a Garnet cache cluster. When updating, you must specify all writable properties.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the GarnetClusterResource",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100,
+            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/GarnetClusterResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'GarnetClusterResource' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/GarnetClusterResource"
+            }
+          },
+          "201": {
+            "description": "Resource 'GarnetClusterResource' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/GarnetClusterResource"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
           }
         },
         "x-ms-long-running-operation-options": {
-          "final-state-via": "azure-async-operation"
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/GarnetClusterResource"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "GarnetClusters_Update",
+        "description": "Updates some of the properties of a garnet cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the GarnetClusterResource",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100,
+            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/GarnetClusterResourcePatch"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/GarnetClusterResource"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/GarnetClusterResource"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "GarnetClusters_Delete",
+        "description": "Deletes a Garnet cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the GarnetClusterResource",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100,
+            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/throughputPools": {
+      "get": {
+        "operationId": "ThroughputPools_ListByResourceGroup",
+        "tags": [
+          "ThroughputPools"
+        ],
+        "description": "List all the ThroughputPools in a given resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ThroughputPoolsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/throughputPools/{throughputPoolName}": {
+      "get": {
+        "operationId": "ThroughputPool_Get",
+        "description": "Retrieves the properties of an existing Azure Cosmos DB Throughput Pool",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "throughputPoolName",
+            "in": "path",
+            "description": "Cosmos DB Throughput Pool name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ThroughputPoolResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "ThroughputPool_CreateOrUpdate",
+        "description": "Creates or updates an Azure Cosmos DB ThroughputPool account. The \"Update\" method is preferred when performing updates on an account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "throughputPoolName",
+            "in": "path",
+            "description": "Cosmos DB Throughput Pool name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "The parameters to provide for the current ThroughputPool.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ThroughputPoolResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ThroughputPoolResource' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ThroughputPoolResource"
+            }
+          },
+          "201": {
+            "description": "Resource 'ThroughputPoolResource' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ThroughputPoolResource"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ThroughputPoolResource"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "ThroughputPool_Update",
+        "description": "Updates the properties of an existing Azure Cosmos DB Throughput Pool.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "throughputPoolName",
+            "in": "path",
+            "description": "Cosmos DB Throughput Pool name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "The parameters to provide for the current Throughput Pool.",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/ThroughputPoolUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ThroughputPoolResource"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ThroughputPoolResource"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "ThroughputPool_Delete",
+        "description": "Deletes an existing Azure Cosmos DB Throughput Pool.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "throughputPoolName",
+            "in": "path",
+            "description": "Cosmos DB Throughput Pool name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/throughputPools/{throughputPoolName}/throughputPoolAccounts": {
+      "get": {
+        "operationId": "ThroughputPoolAccounts_List",
+        "description": "Lists all the Azure Cosmos DB accounts available under the subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "throughputPoolName",
+            "in": "path",
+            "description": "Cosmos DB Throughput Pool name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ThroughputPoolAccountsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/throughputPools/{throughputPoolName}/throughputPoolAccounts/{throughputPoolAccountName}": {
+      "get": {
+        "operationId": "ThroughputPoolAccount_Get",
+        "description": "Retrieves the properties of an existing Azure Cosmos DB Throughput Pool",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "throughputPoolName",
+            "in": "path",
+            "description": "Cosmos DB Throughput Pool name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "throughputPoolAccountName",
+            "in": "path",
+            "description": "Cosmos DB global database account in a Throughput Pool",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ThroughputPoolAccountResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "ThroughputPoolAccount_Create",
+        "description": "Creates or updates an Azure Cosmos DB ThroughputPool account. The \"Update\" method is preferred when performing updates on an account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "throughputPoolName",
+            "in": "path",
+            "description": "Cosmos DB Throughput Pool name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "throughputPoolAccountName",
+            "in": "path",
+            "description": "Cosmos DB global database account in a Throughput Pool",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "The parameters to provide for the current ThroughputPoolAccount.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ThroughputPoolAccountResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ThroughputPoolAccountResource' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ThroughputPoolAccountResource"
+            }
+          },
+          "201": {
+            "description": "Resource 'ThroughputPoolAccountResource' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ThroughputPoolAccountResource"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ThroughputPoolAccountResource"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "ThroughputPoolAccount_Delete",
+        "description": "Removes an existing Azure Cosmos DB database account from a throughput pool.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "throughputPoolName",
+            "in": "path",
+            "description": "Cosmos DB Throughput Pool name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "throughputPoolAccountName",
+            "in": "path",
+            "description": "Cosmos DB global database account in a Throughput Pool",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
         },
         "x-ms-long-running-operation": true
       }
@@ -13791,6 +18783,30 @@
           "description": "Generation time in UTC of the key in ISO-8601 format. If the value is missing from the object, it means that the last key regeneration was triggered before 2022-06-18.",
           "readOnly": true
         }
+      }
+    },
+    "AllocationState": {
+      "type": "string",
+      "description": "Allocation state of the cluster and data center resources.",
+      "enum": [
+        "Active",
+        "Deallocated"
+      ],
+      "x-ms-enum": {
+        "name": "AllocationState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Active",
+            "value": "Active",
+            "description": "Active implies the virtual machines of the cluster are allocated."
+          },
+          {
+            "name": "Deallocated",
+            "value": "Deallocated",
+            "description": "Deallocated implies virtual machines and resources are deallocated."
+          }
+        ]
       }
     },
     "AnalyticalStorageConfiguration": {
@@ -14017,6 +19033,54 @@
         "maxThroughput"
       ]
     },
+    "AzureBlobContainer": {
+      "type": "object",
+      "description": "An Azure Blob container",
+      "properties": {
+        "containerName": {
+          "type": "string",
+          "description": "Azure Blob container."
+        }
+      },
+      "required": [
+        "containerName"
+      ]
+    },
+    "AzureBlobDataTransferDataSourceSink": {
+      "type": "object",
+      "description": "An Azure Blob Storage data source/sink",
+      "properties": {
+        "containerName": {
+          "type": "string"
+        },
+        "endpointUrl": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "containerName"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/DataTransferDataSourceSink"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureBlobStorage"
+    },
+    "AzureBlobSourceSinkDetails": {
+      "type": "object",
+      "description": "An Azure Blob Storage data source/sink",
+      "properties": {
+        "endpointUrl": {
+          "type": "string",
+          "description": "Azure Blob container endpoint.",
+          "pattern": "^https?://[^/$.?# ]+.[^ ]*$"
+        }
+      },
+      "required": [
+        "endpointUrl"
+      ]
+    },
     "AzureConnectionType": {
       "type": "string",
       "description": "How to connect to the azure services needed for running the cluster",
@@ -14140,6 +19204,35 @@
         ]
       }
     },
+    "BackupResource": {
+      "type": "object",
+      "description": "A restorable backup of a Cassandra cluster.",
+      "properties": {
+        "backupId": {
+          "type": "string",
+          "description": "The unique identifier of backup."
+        },
+        "backupState": {
+          "$ref": "#/definitions/BackupState",
+          "description": "The current state of the backup."
+        },
+        "backupStartTimestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time at which the backup process begins."
+        },
+        "backupStopTimestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time at which the backup process ends."
+        },
+        "backupExpiryTimestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time at which the backup will expire."
+        }
+      }
+    },
     "BackupSchedule": {
       "type": "object",
       "properties": {
@@ -14156,6 +19249,38 @@
           "format": "int32",
           "description": "The retention period (hours) of the backups. If you want to retain data forever, set retention to 0."
         }
+      }
+    },
+    "BackupState": {
+      "type": "string",
+      "description": "The current state of the backup.",
+      "enum": [
+        "Initiated",
+        "InProgress",
+        "Succeeded",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "BackupState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Initiated",
+            "value": "Initiated"
+          },
+          {
+            "name": "InProgress",
+            "value": "InProgress"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed"
+          }
+        ]
       }
     },
     "BackupStorageRedundancy": {
@@ -14184,6 +19309,146 @@
           }
         ]
       }
+    },
+    "BaseCopyJobProperties": {
+      "type": "object",
+      "description": "Base copy job properties",
+      "properties": {
+        "jobType": {
+          "type": "string",
+          "description": "Copy Job Type",
+          "default": "NoSqlRUToNoSqlRU",
+          "enum": [
+            "CassandraRUToCassandraRU",
+            "CassandraRUToAzureBlobStorage",
+            "AzureBlobStorageToCassandraRU",
+            "MongoRUToMongoRU",
+            "MongoRUToMongoVCore",
+            "NoSqlRUToNoSqlRU"
+          ],
+          "x-ms-enum": {
+            "name": "CopyJobType",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "CassandraRUToCassandraRU",
+                "value": "CassandraRUToCassandraRU"
+              },
+              {
+                "name": "CassandraRUToAzureBlobStorage",
+                "value": "CassandraRUToAzureBlobStorage"
+              },
+              {
+                "name": "AzureBlobStorageToCassandraRU",
+                "value": "AzureBlobStorageToCassandraRU"
+              },
+              {
+                "name": "MongoRUToMongoRU",
+                "value": "MongoRUToMongoRU"
+              },
+              {
+                "name": "MongoRUToMongoVCore",
+                "value": "MongoRUToMongoVCore"
+              },
+              {
+                "name": "NoSqlRUToNoSqlRU",
+                "value": "NoSqlRUToNoSqlRU"
+              }
+            ]
+          }
+        }
+      },
+      "discriminator": "jobType",
+      "required": [
+        "jobType"
+      ]
+    },
+    "BaseCopyJobTask": {
+      "type": "object",
+      "description": "The properties of a Copy Job Task",
+      "properties": {
+        "totalCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Task level Total Count.",
+          "readOnly": true
+        },
+        "processedCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Task level Processed Count.",
+          "readOnly": true
+        }
+      }
+    },
+    "BaseCosmosDataTransferDataSourceSink": {
+      "type": "object",
+      "description": "A base CosmosDB data source/sink",
+      "properties": {
+        "remoteAccountName": {
+          "type": "string"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/DataTransferDataSourceSink"
+        }
+      ],
+      "x-ms-discriminator-value": "BaseCosmosDataTransferDataSourceSink"
+    },
+    "BlobToCassandraRUCopyJobProperties": {
+      "type": "object",
+      "description": "Source Azure Blob Storage to Destination Cassandra copy job properties",
+      "properties": {
+        "sourceDetails": {
+          "$ref": "#/definitions/AzureBlobSourceSinkDetails",
+          "description": "Azure Storage container DataStore details"
+        },
+        "destinationDetails": {
+          "$ref": "#/definitions/CosmosDBSourceSinkDetails",
+          "description": "Destination Cassandra DataStore details"
+        },
+        "tasks": {
+          "type": "array",
+          "description": "Copy Job tasks.",
+          "items": {
+            "$ref": "#/definitions/BlobToCassandraRUCopyJobTask"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "required": [
+        "sourceDetails",
+        "tasks"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/BaseCopyJobProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureBlobStorageToCassandraRU"
+    },
+    "BlobToCassandraRUCopyJobTask": {
+      "type": "object",
+      "properties": {
+        "source": {
+          "$ref": "#/definitions/AzureBlobContainer",
+          "description": "Source Azure Blob container"
+        },
+        "destination": {
+          "$ref": "#/definitions/CosmosDBCassandraTable",
+          "description": "Destination Cassandra table"
+        }
+      },
+      "required": [
+        "source",
+        "destination"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/BaseCopyJobTask"
+        }
+      ]
     },
     "Capability": {
       "type": "object",
@@ -14544,6 +19809,242 @@
         }
       }
     },
+    "CassandraRUToBlobCopyJobProperties": {
+      "type": "object",
+      "description": "Source Cassandra to Destination Azure Blob Storage copy job properties",
+      "properties": {
+        "sourceDetails": {
+          "$ref": "#/definitions/CosmosDBSourceSinkDetails",
+          "description": "Source Cassandra DataStore details"
+        },
+        "destinationDetails": {
+          "$ref": "#/definitions/AzureBlobSourceSinkDetails",
+          "description": "Destination Cassandra DataStore details"
+        },
+        "tasks": {
+          "type": "array",
+          "description": "Copy Job tasks.",
+          "items": {
+            "$ref": "#/definitions/CassandraRUToBlobCopyJobTask"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "required": [
+        "destinationDetails",
+        "tasks"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/BaseCopyJobProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "CassandraRUToAzureBlobStorage"
+    },
+    "CassandraRUToBlobCopyJobTask": {
+      "type": "object",
+      "properties": {
+        "source": {
+          "$ref": "#/definitions/CosmosDBCassandraTable",
+          "description": "Source Cassandra table"
+        },
+        "destination": {
+          "$ref": "#/definitions/AzureBlobContainer",
+          "description": "Destination Azure Blob container"
+        }
+      },
+      "required": [
+        "source",
+        "destination"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/BaseCopyJobTask"
+        }
+      ]
+    },
+    "CassandraRUToCassandraRUCopyJobProperties": {
+      "type": "object",
+      "description": "Source Cassandra to Destination Cassandra copy job properties",
+      "properties": {
+        "sourceDetails": {
+          "$ref": "#/definitions/CosmosDBSourceSinkDetails",
+          "description": "Source Cassandra DataStore details"
+        },
+        "destinationDetails": {
+          "$ref": "#/definitions/CosmosDBSourceSinkDetails",
+          "description": "Destination Cassandra DataStore details"
+        },
+        "tasks": {
+          "type": "array",
+          "description": "Copy Job tasks.",
+          "items": {
+            "$ref": "#/definitions/CassandraRUToCassandraRUCopyJobTask"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "required": [
+        "tasks"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/BaseCopyJobProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "CassandraRUToCassandraRU"
+    },
+    "CassandraRUToCassandraRUCopyJobTask": {
+      "type": "object",
+      "properties": {
+        "source": {
+          "$ref": "#/definitions/CosmosDBCassandraTable",
+          "description": "Source Cassandra table"
+        },
+        "destination": {
+          "$ref": "#/definitions/CosmosDBCassandraTable",
+          "description": "Destination Cassandra table"
+        }
+      },
+      "required": [
+        "source",
+        "destination"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/BaseCopyJobTask"
+        }
+      ]
+    },
+    "CassandraRoleAssignmentListResult": {
+      "type": "object",
+      "description": "The response of a CassandraRoleAssignmentResource list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The CassandraRoleAssignmentResource items on this page",
+          "items": {
+            "$ref": "#/definitions/CassandraRoleAssignmentResource"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "CassandraRoleAssignmentResource": {
+      "type": "object",
+      "description": "Parameters to create and update an Azure Cosmos DB Cassandra Role Assignment.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/CassandraRoleAssignmentResourceProperties",
+          "description": "Properties to create and update an Azure Cosmos DB Cassandra Role Assignment.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "CassandraRoleAssignmentResourceProperties": {
+      "type": "object",
+      "description": "Azure Cosmos DB Cassandra Role Assignment resource object.",
+      "properties": {
+        "roleDefinitionId": {
+          "type": "string",
+          "description": "The unique identifier for the associated Role Definition."
+        },
+        "scope": {
+          "type": "string",
+          "description": "The data plane resource path for which access is being granted through this Cassandra Role Assignment."
+        },
+        "principalId": {
+          "type": "string",
+          "description": "The unique identifier for the associated AAD principal in the AAD graph to which access is being granted through this Cassandra Role Assignment. Tenant ID for the principal is inferred using the tenant associated with the subscription."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "Provisioning state of the resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "CassandraRoleDefinitionListResult": {
+      "type": "object",
+      "description": "The response of a CassandraRoleDefinitionResource list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The CassandraRoleDefinitionResource items on this page",
+          "items": {
+            "$ref": "#/definitions/CassandraRoleDefinitionResource"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "CassandraRoleDefinitionResource": {
+      "type": "object",
+      "description": "Parameters to create and update an Azure Cosmos DB Cassandra Role Definition.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/CassandraRoleDefinitionResourceProperties",
+          "description": "Properties to create and update an Azure Cosmos DB Cassandra Role Definition.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "CassandraRoleDefinitionResourceProperties": {
+      "type": "object",
+      "description": "Azure Cosmos DB Cassandra Role Definition resource object.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The path id for the Role Definition."
+        },
+        "roleName": {
+          "type": "string",
+          "description": "A user-friendly name for the Role Definition. Must be unique for the database account."
+        },
+        "type": {
+          "$ref": "#/definitions/RoleDefinitionType",
+          "description": "Indicates whether the Role Definition was built-in or user created."
+        },
+        "assignableScopes": {
+          "type": "array",
+          "description": "A set of fully qualified Scopes at or below which Cassandra Role Assignments may be created using this Role Definition. This will allow application of this Role Definition on the entire database account or any underlying Database / Collection. Must have at least one element. Scopes higher than Database account are not enforceable as assignable Scopes. Note that resources referenced in assignable Scopes need not exist.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "permissions": {
+          "type": "array",
+          "description": "The set of operations allowed through this Role Definition.",
+          "items": {
+            "$ref": "#/definitions/Permission"
+          }
+        }
+      }
+    },
     "CassandraSchema": {
       "type": "object",
       "description": "Cosmos DB Cassandra table schema",
@@ -14731,6 +20232,159 @@
       },
       "required": [
         "id"
+      ]
+    },
+    "CassandraViewCreateUpdateParameters": {
+      "type": "object",
+      "description": "Parameters to create and update Cosmos DB Cassandra view.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/CassandraViewCreateUpdateProperties",
+          "description": "Properties to create and update Azure Cosmos DB Cassandra view.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ARMResourceProperties"
+        }
+      ]
+    },
+    "CassandraViewCreateUpdateProperties": {
+      "type": "object",
+      "description": "Properties to create and update Azure Cosmos DB Cassandra view.",
+      "properties": {
+        "resource": {
+          "$ref": "#/definitions/CassandraViewResource",
+          "description": "The standard JSON format of a Cassandra view"
+        },
+        "options": {
+          "$ref": "#/definitions/CreateUpdateOptions",
+          "description": "A key-value pair of options to be applied for the request. This corresponds to the headers sent with the request."
+        }
+      },
+      "required": [
+        "resource"
+      ]
+    },
+    "CassandraViewGetProperties": {
+      "type": "object",
+      "description": "The properties of an Azure Cosmos DB Cassandra view",
+      "properties": {
+        "resource": {
+          "$ref": "#/definitions/CassandraViewGetPropertiesResource"
+        },
+        "options": {
+          "$ref": "#/definitions/CassandraViewGetPropertiesOptions"
+        }
+      }
+    },
+    "CassandraViewGetPropertiesOptions": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/OptionsResource"
+        }
+      ]
+    },
+    "CassandraViewGetPropertiesResource": {
+      "type": "object",
+      "properties": {
+        "_rid": {
+          "type": "string",
+          "description": "A system generated property. A unique identifier.",
+          "readOnly": true
+        },
+        "_ts": {
+          "type": "number",
+          "format": "float",
+          "description": "A system generated property that denotes the last updated timestamp of the resource.",
+          "readOnly": true
+        },
+        "_etag": {
+          "type": "string",
+          "description": "A system generated property representing the resource etag required for optimistic concurrency control.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/CassandraViewResource"
+        }
+      ]
+    },
+    "CassandraViewGetResults": {
+      "type": "object",
+      "description": "An Azure Cosmos DB Cassandra view.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/CassandraViewGetProperties",
+          "description": "The properties of an Azure Cosmos DB Cassandra view",
+          "x-ms-client-flatten": true
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives",
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        },
+        "identity": {
+          "$ref": "#/definitions/ManagedServiceIdentity",
+          "description": "Identity for the resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/Resource"
+        }
+      ]
+    },
+    "CassandraViewListResult": {
+      "type": "object",
+      "description": "The List operation response, that contains the Cassandra views and their properties.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "List of Cassandra views and their properties.",
+          "items": {
+            "$ref": "#/definitions/CassandraViewGetResults"
+          },
+          "readOnly": true
+        },
+        "nextLink": {
+          "type": "string"
+        }
+      }
+    },
+    "CassandraViewResource": {
+      "type": "object",
+      "description": "Cosmos DB Cassandra view resource object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Name of the Cosmos DB Cassandra view"
+        },
+        "viewDefinition": {
+          "type": "string",
+          "description": "View Definition of the Cosmos DB Cassandra view"
+        }
+      },
+      "required": [
+        "id",
+        "viewDefinition"
       ]
     },
     "Certificate": {
@@ -15095,6 +20749,10 @@
           "type": "boolean",
           "description": "Whether Cassandra audit logging is enabled"
         },
+        "clusterType": {
+          "$ref": "#/definitions/ClusterType",
+          "description": "Type of the cluster. If set to Production, some operations might not be permitted on cluster."
+        },
         "provisionError": {
           "$ref": "#/definitions/CassandraError",
           "description": "Error related to resource provisioning."
@@ -15137,6 +20795,28 @@
         }
       }
     },
+    "ClusterType": {
+      "type": "string",
+      "description": "Type of the cluster. If set to Production, some operations might not be permitted on cluster.",
+      "enum": [
+        "Production",
+        "NonProduction"
+      ],
+      "x-ms-enum": {
+        "name": "ClusterType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Production",
+            "value": "Production"
+          },
+          {
+            "name": "NonProduction",
+            "value": "NonProduction"
+          }
+        ]
+      }
+    },
     "Column": {
       "type": "object",
       "description": "Cosmos DB Cassandra table column",
@@ -15150,6 +20830,35 @@
           "description": "Type of the Cosmos DB Cassandra table column"
         }
       }
+    },
+    "CommandAsyncPostBody": {
+      "type": "object",
+      "description": "Specification of which command to run where",
+      "properties": {
+        "command": {
+          "type": "string",
+          "description": "The command which should be run"
+        },
+        "arguments": {
+          "description": "The arguments for the command to be run"
+        },
+        "host": {
+          "type": "string",
+          "description": "IP address of the cassandra host to run the command on"
+        },
+        "cassandra-stop-start": {
+          "type": "boolean",
+          "description": "If true, stops cassandra before executing the command and then start it again"
+        },
+        "readWrite": {
+          "type": "boolean",
+          "description": "If true, allows the command to *write* to the cassandra directory, otherwise read-only."
+        }
+      },
+      "required": [
+        "command",
+        "host"
+      ]
     },
     "CommandOutput": {
       "type": "object",
@@ -15193,6 +20902,93 @@
         "command",
         "host"
       ]
+    },
+    "CommandPublicResource": {
+      "type": "object",
+      "description": "resource representing a command",
+      "properties": {
+        "command": {
+          "type": "string",
+          "description": "The command which should be run"
+        },
+        "commandId": {
+          "type": "string",
+          "description": "The unique id of command"
+        },
+        "arguments": {
+          "description": "The arguments for the command to be run"
+        },
+        "host": {
+          "type": "string",
+          "description": "IP address of the cassandra host to run the command on"
+        },
+        "isAdmin": {
+          "type": "boolean",
+          "description": "Whether command has admin privileges"
+        },
+        "cassandraStopStart": {
+          "type": "boolean",
+          "description": "If true, stops cassandra before executing the command and then start it again"
+        },
+        "readWrite": {
+          "type": "boolean",
+          "description": "If true, allows the command to *write* to the cassandra directory, otherwise read-only."
+        },
+        "result": {
+          "type": "string",
+          "description": "Result output of the command."
+        },
+        "status": {
+          "$ref": "#/definitions/CommandStatus",
+          "description": "Status of the command."
+        },
+        "outputFile": {
+          "type": "string",
+          "description": "The name of the file where the result is written."
+        }
+      }
+    },
+    "CommandStatus": {
+      "type": "string",
+      "description": "Status of the command.",
+      "enum": [
+        "Done",
+        "Running",
+        "Enqueue",
+        "Processing",
+        "Finished",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "CommandStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Done",
+            "value": "Done"
+          },
+          {
+            "name": "Running",
+            "value": "Running"
+          },
+          {
+            "name": "Enqueue",
+            "value": "Enqueue"
+          },
+          {
+            "name": "Processing",
+            "value": "Processing"
+          },
+          {
+            "name": "Finished",
+            "value": "Finished"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed"
+          }
+        ]
+      }
     },
     "ComponentsM9L909SchemasCassandraclusterpublicstatusPropertiesDatacentersItemsPropertiesNodesItems": {
       "type": "object",
@@ -15599,6 +21395,171 @@
         ]
       }
     },
+    "CopyJobFeedResults": {
+      "type": "object",
+      "description": "The List operation response, that contains the Copy Jobs and their properties.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The CopyJobGetResults items on this page",
+          "items": {
+            "$ref": "#/definitions/CopyJobGetResults"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "CopyJobGetResults": {
+      "type": "object",
+      "description": "A Cosmos DB Copy Job",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/CopyJobProperties",
+          "description": "The properties of a Copy Job"
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "CopyJobMode": {
+      "type": "string",
+      "description": "Mode of job execution",
+      "enum": [
+        "Offline",
+        "Online"
+      ],
+      "x-ms-enum": {
+        "name": "CopyJobMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Offline",
+            "value": "Offline"
+          },
+          {
+            "name": "Online",
+            "value": "Online"
+          }
+        ]
+      }
+    },
+    "CopyJobProperties": {
+      "type": "object",
+      "description": "The properties of a Copy Job",
+      "properties": {
+        "jobProperties": {
+          "$ref": "#/definitions/BaseCopyJobProperties",
+          "description": "Job Properties"
+        },
+        "status": {
+          "$ref": "#/definitions/CopyJobStatus",
+          "description": "Job Status",
+          "readOnly": true
+        },
+        "processedCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Processed Count",
+          "readOnly": true
+        },
+        "totalCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Total Count",
+          "readOnly": true
+        },
+        "lastUpdatedUtcTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last Updated Time (ISO-8601 format)",
+          "readOnly": true
+        },
+        "workerCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Worker count",
+          "minimum": 0
+        },
+        "error": {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse",
+          "description": "Error response for Faulted job",
+          "readOnly": true
+        },
+        "duration": {
+          "type": "string",
+          "format": "duration-constant",
+          "description": "Total Duration of Job",
+          "readOnly": true
+        },
+        "mode": {
+          "$ref": "#/definitions/CopyJobMode",
+          "description": "Mode of job execution"
+        }
+      },
+      "required": [
+        "jobProperties"
+      ]
+    },
+    "CopyJobStatus": {
+      "type": "string",
+      "description": "Job Status",
+      "enum": [
+        "Pending",
+        "Partitioning",
+        "Running",
+        "Paused",
+        "Completed",
+        "Faulted",
+        "Cancelled"
+      ],
+      "x-ms-enum": {
+        "name": "CopyJobStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Pending",
+            "value": "Pending"
+          },
+          {
+            "name": "Partitioning",
+            "value": "Partitioning"
+          },
+          {
+            "name": "Running",
+            "value": "Running"
+          },
+          {
+            "name": "Paused",
+            "value": "Paused"
+          },
+          {
+            "name": "Completed",
+            "value": "Completed"
+          },
+          {
+            "name": "Faulted",
+            "value": "Faulted"
+          },
+          {
+            "name": "Cancelled",
+            "value": "Cancelled"
+          }
+        ]
+      }
+    },
     "CorsPolicy": {
       "type": "object",
       "description": "The CORS policy for the Cosmos DB database account.",
@@ -15629,6 +21590,200 @@
       },
       "required": [
         "allowedOrigins"
+      ]
+    },
+    "CosmosCassandraDataTransferDataSourceSink": {
+      "type": "object",
+      "description": "A CosmosDB Cassandra API data source/sink",
+      "properties": {
+        "keyspaceName": {
+          "type": "string"
+        },
+        "tableName": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "keyspaceName",
+        "tableName"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/BaseCosmosDataTransferDataSourceSink"
+        }
+      ],
+      "x-ms-discriminator-value": "CosmosDBCassandra"
+    },
+    "CosmosDBCassandraTable": {
+      "type": "object",
+      "description": "A CosmosDB Cassandra table",
+      "properties": {
+        "keyspaceName": {
+          "type": "string",
+          "description": "Azure Cosmos DB for Apache Cassandra keyspace."
+        },
+        "tableName": {
+          "type": "string",
+          "description": "Azure Cosmos DB for Apache Cassandra table."
+        }
+      },
+      "required": [
+        "keyspaceName",
+        "tableName"
+      ]
+    },
+    "CosmosDBMongoCollection": {
+      "type": "object",
+      "description": "A CosmosDB Mongo collection",
+      "properties": {
+        "databaseName": {
+          "type": "string",
+          "description": "Azure Cosmos DB for MongoDB (RU) database."
+        },
+        "collectionName": {
+          "type": "string",
+          "description": "Azure Cosmos DB for MongoDB (RU) collection."
+        }
+      },
+      "required": [
+        "databaseName",
+        "collectionName"
+      ]
+    },
+    "CosmosDBMongoVCoreCollection": {
+      "type": "object",
+      "description": "A CosmosDB Mongo vCore collection",
+      "properties": {
+        "databaseName": {
+          "type": "string",
+          "description": "Azure Cosmos DB for MongoDB (vCore) database."
+        },
+        "collectionName": {
+          "type": "string",
+          "description": "Azure Cosmos DB for MongoDB (vCore) collection."
+        }
+      },
+      "required": [
+        "databaseName",
+        "collectionName"
+      ]
+    },
+    "CosmosDBNoSqlContainer": {
+      "type": "object",
+      "description": "A CosmosDB NoSQL container",
+      "properties": {
+        "databaseName": {
+          "type": "string",
+          "description": "Azure Cosmos DB for NoSQL database."
+        },
+        "containerName": {
+          "type": "string",
+          "description": "Azure Cosmos DB for NoSQL container."
+        }
+      },
+      "required": [
+        "databaseName",
+        "containerName"
+      ]
+    },
+    "CosmosDBSourceSinkDetails": {
+      "type": "object",
+      "description": "A CosmosDB data source/sink details",
+      "properties": {
+        "remoteAccountName": {
+          "type": "string",
+          "description": "Name of remote account in case of cross-account data transfer."
+        }
+      }
+    },
+    "CosmosMongoDataTransferDataSourceSink": {
+      "type": "object",
+      "description": "A CosmosDB Mongo API data source/sink",
+      "properties": {
+        "databaseName": {
+          "type": "string"
+        },
+        "collectionName": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "databaseName",
+        "collectionName"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/BaseCosmosDataTransferDataSourceSink"
+        }
+      ],
+      "x-ms-discriminator-value": "CosmosDBMongo"
+    },
+    "CosmosMongoVCoreDataTransferDataSourceSink": {
+      "type": "object",
+      "description": "A CosmosDB Mongo vCore API data source/sink",
+      "properties": {
+        "databaseName": {
+          "type": "string"
+        },
+        "collectionName": {
+          "type": "string"
+        },
+        "hostName": {
+          "type": "string"
+        },
+        "connectionStringKeyVaultUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "databaseName",
+        "collectionName"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/DataTransferDataSourceSink"
+        }
+      ],
+      "x-ms-discriminator-value": "CosmosDBMongoVCore"
+    },
+    "CosmosSqlDataTransferDataSourceSink": {
+      "type": "object",
+      "description": "A CosmosDB No Sql API data source/sink",
+      "properties": {
+        "databaseName": {
+          "type": "string"
+        },
+        "containerName": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "databaseName",
+        "containerName"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/BaseCosmosDataTransferDataSourceSink"
+        }
+      ],
+      "x-ms-discriminator-value": "CosmosDBSql"
+    },
+    "CreateJobRequest": {
+      "type": "object",
+      "description": "Parameters to create Data Transfer Job",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/DataTransferJobProperties",
+          "description": "Data Transfer Create Job Properties"
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ARMProxyResource"
+        }
       ]
     },
     "CreateUpdateOptions": {
@@ -15810,6 +21965,184 @@
       },
       "required": [
         "path"
+      ]
+    },
+    "DataTransferDataSourceSink": {
+      "type": "object",
+      "description": "Base class for all DataTransfer source/sink",
+      "properties": {
+        "component": {
+          "type": "string",
+          "default": "CosmosDBCassandra",
+          "enum": [
+            "CosmosDBCassandra",
+            "CosmosDBMongo",
+            "CosmosDBMongoVCore",
+            "CosmosDBSql",
+            "AzureBlobStorage",
+            "BaseCosmosDataTransferDataSourceSink"
+          ],
+          "x-ms-enum": {
+            "name": "DataTransferComponent",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "CosmosDBCassandra",
+                "value": "CosmosDBCassandra"
+              },
+              {
+                "name": "CosmosDBMongo",
+                "value": "CosmosDBMongo"
+              },
+              {
+                "name": "CosmosDBMongoVCore",
+                "value": "CosmosDBMongoVCore"
+              },
+              {
+                "name": "CosmosDBSql",
+                "value": "CosmosDBSql"
+              },
+              {
+                "name": "AzureBlobStorage",
+                "value": "AzureBlobStorage"
+              },
+              {
+                "name": "BaseCosmosDataTransferDataSourceSink",
+                "value": "BaseCosmosDataTransferDataSourceSink"
+              }
+            ]
+          }
+        }
+      },
+      "discriminator": "component",
+      "required": [
+        "component"
+      ]
+    },
+    "DataTransferJobFeedResults": {
+      "type": "object",
+      "description": "The List operation response, that contains the Data Transfer jobs and their properties.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The DataTransferJobGetResults items on this page",
+          "items": {
+            "$ref": "#/definitions/DataTransferJobGetResults"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "DataTransferJobGetResults": {
+      "type": "object",
+      "description": "A Cosmos DB Data Transfer Job",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/DataTransferJobProperties",
+          "description": "The properties of a DataTransfer Job",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "DataTransferJobMode": {
+      "type": "string",
+      "description": "Mode of job execution",
+      "enum": [
+        "Offline",
+        "Online"
+      ],
+      "x-ms-enum": {
+        "name": "DataTransferJobMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Offline",
+            "value": "Offline"
+          },
+          {
+            "name": "Online",
+            "value": "Online"
+          }
+        ]
+      }
+    },
+    "DataTransferJobProperties": {
+      "type": "object",
+      "description": "The properties of a DataTransfer Job",
+      "properties": {
+        "jobName": {
+          "type": "string",
+          "description": "Job Name",
+          "readOnly": true
+        },
+        "source": {
+          "$ref": "#/definitions/DataTransferDataSourceSink",
+          "description": "Source DataStore details"
+        },
+        "destination": {
+          "$ref": "#/definitions/DataTransferDataSourceSink",
+          "description": "Destination DataStore details"
+        },
+        "status": {
+          "type": "string",
+          "description": "Job Status",
+          "readOnly": true
+        },
+        "processedCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Processed Count.",
+          "readOnly": true
+        },
+        "totalCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Total Count.",
+          "readOnly": true
+        },
+        "lastUpdatedUtcTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last Updated Time (ISO-8601 format).",
+          "readOnly": true
+        },
+        "workerCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Worker count",
+          "minimum": 0
+        },
+        "error": {
+          "$ref": "#/definitions/ErrorResponse",
+          "description": "Error response for Faulted job",
+          "readOnly": true
+        },
+        "duration": {
+          "type": "string",
+          "format": "duration-constant",
+          "description": "Total Duration of Job",
+          "readOnly": true
+        },
+        "mode": {
+          "$ref": "#/definitions/DataTransferJobMode",
+          "description": "Mode of job execution"
+        }
+      },
+      "required": [
+        "source",
+        "destination"
       ]
     },
     "DataTransferRegionalServiceResource": {
@@ -16132,6 +22465,10 @@
         "enableAllVersionsAndDeletesChangeFeed": {
           "type": "boolean",
           "description": "Flag to indicate if All Versions and Deletes Change feed feature is enabled on the account"
+        },
+        "enforceHierarchicalPartitionKeyIdLastLevel": {
+          "type": "boolean",
+          "description": "Flag to indicate enabling/disabling of hierarchical partition key ID last level enforcement on the account."
         }
       },
       "required": [
@@ -16414,6 +22751,10 @@
           "type": "integer",
           "format": "int64",
           "description": "When this account is part of a fleetspace with throughput pooling enabled, this is the maximum additional throughput (RU/s) that can be consumed from the pool, summed across all shared throughput databases and dedicated throughput containers in the account for 1 region.  READ ONLY."
+        },
+        "enforceHierarchicalPartitionKeyIdLastLevel": {
+          "type": "boolean",
+          "description": "Flag to indicate enabling/disabling of hierarchical partition key ID last level enforcement on the account."
         }
       }
     },
@@ -16765,6 +23106,10 @@
         "enableAllVersionsAndDeletesChangeFeed": {
           "type": "boolean",
           "description": "Flag to indicate if All Versions and Deletes Change feed feature is enabled on the account"
+        },
+        "enforceHierarchicalPartitionKeyIdLastLevel": {
+          "type": "boolean",
+          "description": "Flag to indicate enabling/disabling of hierarchical partition key ID last level enforcement on the account."
         }
       }
     },
@@ -16971,6 +23316,82 @@
           "minimum": 0
         }
       }
+    },
+    "FleetAnalyticsListResult": {
+      "type": "object",
+      "description": "The response of a FleetAnalyticsResource list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The FleetAnalyticsResource items on this page",
+          "items": {
+            "$ref": "#/definitions/FleetAnalyticsResource"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "FleetAnalyticsProperties": {
+      "type": "object",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/Status",
+          "description": "A provisioning state of the FleetAnalytics.",
+          "readOnly": true
+        },
+        "storageLocationType": {
+          "$ref": "#/definitions/FleetAnalyticsPropertiesStorageLocationType",
+          "description": "The type of the fleet analytics resource."
+        },
+        "storageLocationUri": {
+          "type": "string",
+          "description": "The unique identifier of the fleet analytics resource."
+        }
+      }
+    },
+    "FleetAnalyticsPropertiesStorageLocationType": {
+      "type": "string",
+      "description": "The type of the fleet analytics resource.",
+      "enum": [
+        "StorageAccount",
+        "FabricLakehouse"
+      ],
+      "x-ms-enum": {
+        "name": "FleetAnalyticsPropertiesStorageLocationType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "StorageAccount",
+            "value": "StorageAccount"
+          },
+          {
+            "name": "FabricLakehouse",
+            "value": "FabricLakehouse"
+          }
+        ]
+      }
+    },
+    "FleetAnalyticsResource": {
+      "type": "object",
+      "description": "An Azure Cosmos DB FleetAnalytics.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/FleetAnalyticsProperties",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
     },
     "FleetListResult": {
       "type": "object",
@@ -17289,6 +23710,187 @@
         }
       }
     },
+    "GarnetCacheProvisioningState": {
+      "type": "string",
+      "description": "The status of the resource at the time the operation was called.",
+      "enum": [
+        "Creating",
+        "Updating",
+        "Deleting",
+        "Succeeded",
+        "Failed",
+        "Canceled"
+      ],
+      "x-ms-enum": {
+        "name": "GarnetCacheProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "Creating"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          }
+        ]
+      }
+    },
+    "GarnetClusterResource": {
+      "type": "object",
+      "description": "Representation of a Garnet cache cluster.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/GarnetClusterResourceProperties",
+          "description": "The resource-specific properties for this resource."
+        },
+        "identity": {
+          "$ref": "#/definitions/ManagedCassandraManagedServiceIdentity",
+          "description": "Identity for the resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "GarnetClusterResourcePatch": {
+      "type": "object",
+      "description": "Representation of a Garnet cache cluster for updates.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/GarnetClusterResourcePatchProperties",
+          "description": "Properties of a Garnet cache cluster for updates."
+        }
+      }
+    },
+    "GarnetClusterResourcePatchProperties": {
+      "type": "object",
+      "description": "Properties of a Garnet cache cluster for updates.",
+      "properties": {
+        "clusterType": {
+          "$ref": "#/definitions/ClusterType",
+          "description": "Type of the cluster. If set to Production, some operations might not be permitted on cluster."
+        },
+        "extensions": {
+          "type": "array",
+          "description": "Extensions to be added or updated on cluster.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "GarnetClusterResourceProperties": {
+      "type": "object",
+      "description": "Properties of a Garnet cache cluster.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/GarnetCacheProvisioningState",
+          "description": "The provisioning state of the resource.",
+          "readOnly": true
+        },
+        "subnetId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Resource id of a subnet that this cluster's management service should have its network interface attached to. The subnet must be routable to all subnets that will be delegated to data centers. The resource id must be of the form '/subscriptions/<subscription id>/resourceGroups/<resource group>/providers/Microsoft.Network/virtualNetworks/<virtual network>/subnets/<subnet>'",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ],
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/virtualNetworks/subnets"
+              }
+            ]
+          }
+        },
+        "endPoints": {
+          "type": "array",
+          "description": "Endpoints for clients to connect to the cluster.",
+          "items": {
+            "$ref": "#/definitions/GarnetClusterResourcePropertiesEndPointsItem"
+          },
+          "readOnly": true
+        },
+        "replicationFactor": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of copies of data maintained by the cluster."
+        },
+        "nodeCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of nodes."
+        },
+        "nodeSku": {
+          "type": "string",
+          "description": "Virtual Machine SKU used for clusters. Default value is Standard_DS14_v2."
+        },
+        "availabilityZone": {
+          "type": "boolean",
+          "description": "If the data center has Availability Zone support, apply it to the Virtual Machine ScaleSet that host the garnet cluster virtual machines."
+        },
+        "allocationState": {
+          "$ref": "#/definitions/AllocationState",
+          "description": "Allocation state of the cluster and data center resources. Active implies the virtual machines of the cluster are allocated, deallocated implies virtual machines and resources are deallocated."
+        },
+        "clusterType": {
+          "$ref": "#/definitions/ClusterType",
+          "description": "Type of the cluster. If set to Production, some operations might not be permitted on cluster."
+        },
+        "provisionError": {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorDetail",
+          "description": "Error related to resource provisioning."
+        },
+        "extensions": {
+          "type": "array",
+          "description": "Extensions to be added or updated on cluster.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "GarnetClusterResourcePropertiesEndPointsItem": {
+      "type": "object",
+      "description": "Endpoint for clients to connect to the cluster.",
+      "properties": {
+        "ipAddress": {
+          "type": "string",
+          "description": "Ipv4 address of the endpoint."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Port number."
+        }
+      }
+    },
     "GraphAPIComputeRegionalServiceResource": {
       "type": "object",
       "description": "Resource for a regional service location.",
@@ -17338,6 +23940,136 @@
         }
       ],
       "x-ms-discriminator-value": "GraphAPICompute"
+    },
+    "GraphResource": {
+      "type": "object",
+      "description": "Cosmos DB Graph resource object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Name of the Cosmos DB Graph"
+        }
+      },
+      "required": [
+        "id"
+      ]
+    },
+    "GraphResourceCreateUpdateParameters": {
+      "type": "object",
+      "description": "Parameters to create and update Cosmos DB Graph resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/GraphResourceCreateUpdateProperties",
+          "description": "Properties to create and update Azure Cosmos DB Graph resource.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ARMResourceProperties"
+        }
+      ]
+    },
+    "GraphResourceCreateUpdateProperties": {
+      "type": "object",
+      "description": "Properties to create and update Azure Cosmos DB Graph resource.",
+      "properties": {
+        "resource": {
+          "$ref": "#/definitions/GraphResource",
+          "description": "The standard JSON format of a Graph resource"
+        },
+        "options": {
+          "$ref": "#/definitions/CreateUpdateOptions",
+          "description": "A key-value pair of options to be applied for the request. This corresponds to the headers sent with the request."
+        }
+      },
+      "required": [
+        "resource"
+      ]
+    },
+    "GraphResourceGetProperties": {
+      "type": "object",
+      "description": "The properties of an Azure Cosmos DB SQL database",
+      "properties": {
+        "resource": {
+          "$ref": "#/definitions/GraphResourceGetPropertiesResource"
+        },
+        "options": {
+          "$ref": "#/definitions/GraphResourceGetPropertiesOptions"
+        }
+      }
+    },
+    "GraphResourceGetPropertiesOptions": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/OptionsResource"
+        }
+      ]
+    },
+    "GraphResourceGetPropertiesResource": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/GraphResource"
+        }
+      ]
+    },
+    "GraphResourceGetResults": {
+      "type": "object",
+      "description": "An Azure Cosmos DB Graph resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/GraphResourceGetProperties",
+          "description": "The properties of an Azure Cosmos DB Graph resource.",
+          "x-ms-client-flatten": true
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives",
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        },
+        "identity": {
+          "$ref": "#/definitions/ManagedServiceIdentity",
+          "description": "Identity for the resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/Resource"
+        }
+      ]
+    },
+    "GraphResourcesListResult": {
+      "type": "object",
+      "description": "The List operation response, that contains the Graph resource and their properties.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "List of Graph resource and their properties.",
+          "items": {
+            "$ref": "#/definitions/GraphResourceGetResults"
+          },
+          "readOnly": true
+        },
+        "nextLink": {
+          "type": "string"
+        }
+      }
     },
     "GremlinDatabaseCreateUpdateParameters": {
       "type": "object",
@@ -17732,6 +24464,135 @@
         "id"
       ]
     },
+    "GremlinRoleAssignmentListResult": {
+      "type": "object",
+      "description": "The response of a GremlinRoleAssignmentResource list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The GremlinRoleAssignmentResource items on this page",
+          "items": {
+            "$ref": "#/definitions/GremlinRoleAssignmentResource"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "GremlinRoleAssignmentResource": {
+      "type": "object",
+      "description": "Parameters to create and update an Azure Cosmos DB Gremlin Role Assignment.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/GremlinRoleAssignmentResourceProperties",
+          "description": "Properties to create and update an Azure Cosmos DB Gremlin Role Assignment.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "GremlinRoleAssignmentResourceProperties": {
+      "type": "object",
+      "description": "Azure Cosmos DB Gremlin Role Assignment resource object.",
+      "properties": {
+        "roleDefinitionId": {
+          "type": "string",
+          "description": "The unique identifier for the associated Role Definition."
+        },
+        "scope": {
+          "type": "string",
+          "description": "The data plane resource path for which access is being granted through this Gremlin Role Assignment."
+        },
+        "principalId": {
+          "type": "string",
+          "description": "The unique identifier for the associated AAD principal in the AAD graph to which access is being granted through this Gremlin Role Assignment. Tenant ID for the principal is inferred using the tenant associated with the subscription."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "Provisioning state of the resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "GremlinRoleDefinitionListResult": {
+      "type": "object",
+      "description": "The response of a GremlinRoleDefinitionResource list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The GremlinRoleDefinitionResource items on this page",
+          "items": {
+            "$ref": "#/definitions/GremlinRoleDefinitionResource"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "GremlinRoleDefinitionResource": {
+      "type": "object",
+      "description": "Parameters to create and update an Azure Cosmos DB Gremlin Role Definition.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/GremlinRoleDefinitionResourceProperties",
+          "description": "Properties to create and update an Azure Cosmos DB Gremlin Role Definition.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "GremlinRoleDefinitionResourceProperties": {
+      "type": "object",
+      "description": "Azure Cosmos DB Gremlin Role Definition resource object.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The path id for the Role Definition."
+        },
+        "roleName": {
+          "type": "string",
+          "description": "A user-friendly name for the Role Definition. Must be unique for the database account."
+        },
+        "type": {
+          "$ref": "#/definitions/RoleDefinitionType",
+          "description": "Indicates whether the Role Definition was built-in or user created."
+        },
+        "assignableScopes": {
+          "type": "array",
+          "description": "A set of fully qualified Scopes at or below which Gremlin Role Assignments may be created using this Role Definition. This will allow application of this Role Definition on the entire database account or any underlying Database / Collection. Must have at least one element. Scopes higher than Database account are not enforceable as assignable Scopes. Note that resources referenced in assignable Scopes need not exist.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "permissions": {
+          "type": "array",
+          "description": "The set of operations allowed through this Role Definition.",
+          "items": {
+            "$ref": "#/definitions/Permission"
+          }
+        }
+      }
+    },
     "IncludedPath": {
       "type": "object",
       "description": "The paths that are included in indexing",
@@ -18017,6 +24878,24 @@
         ]
       }
     },
+    "ListBackups": {
+      "type": "object",
+      "description": "List of restorable backups for a Cassandra cluster.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "Container for array of backups.",
+          "items": {
+            "$ref": "#/definitions/BackupResource"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": []
+        },
+        "nextLink": {
+          "type": "string"
+        }
+      }
+    },
     "ListClusters": {
       "type": "object",
       "description": "List of managed Cassandra clusters.",
@@ -18027,6 +24906,24 @@
           "items": {
             "$ref": "#/definitions/ClusterResource"
           }
+        },
+        "nextLink": {
+          "type": "string"
+        }
+      }
+    },
+    "ListCommands": {
+      "type": "object",
+      "description": "List of commands for cluster.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "Container for array of commands.",
+          "items": {
+            "$ref": "#/definitions/CommandPublicResource"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": []
         },
         "nextLink": {
           "type": "string"
@@ -18047,6 +24944,23 @@
         },
         "nextLink": {
           "type": "string"
+        }
+      }
+    },
+    "ListGarnetClusters": {
+      "type": "object",
+      "description": "List of Garnet clusters.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "Container for the array of clusters.",
+          "items": {
+            "$ref": "#/definitions/GarnetClusterResource"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of results."
         }
       }
     },
@@ -18393,6 +25307,16 @@
           "type": "integer",
           "format": "int32",
           "description": "Throughput bucket assigned for the materialized view operations on source container."
+        }
+      }
+    },
+    "MergeParameters": {
+      "type": "object",
+      "description": "The properties of an Azure Cosmos DB merge operations",
+      "properties": {
+        "isDryRun": {
+          "type": "boolean",
+          "description": "Specifies whether the operation is a real merge operation or a simulation."
         }
       }
     },
@@ -19020,6 +25944,242 @@
         }
       }
     },
+    "MongoMIRoleAssignmentListResult": {
+      "type": "object",
+      "description": "The response of a MongoMIRoleAssignmentResource list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The MongoMIRoleAssignmentResource items on this page",
+          "items": {
+            "$ref": "#/definitions/MongoMIRoleAssignmentResource"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "MongoMIRoleAssignmentResource": {
+      "type": "object",
+      "description": "Parameters to create and update an Azure Cosmos DB MongoMI Role Assignment.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/MongoMIRoleAssignmentResourceProperties",
+          "description": "Properties to create and update an Azure Cosmos DB MongoMI Role Assignment.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "MongoMIRoleAssignmentResourceProperties": {
+      "type": "object",
+      "description": "Azure Cosmos DB MongoMI Role Assignment resource object.",
+      "properties": {
+        "roleDefinitionId": {
+          "type": "string",
+          "description": "The unique identifier for the associated Role Definition."
+        },
+        "scope": {
+          "type": "string",
+          "description": "The data plane resource path for which access is being granted through this MongoMI Role Assignment."
+        },
+        "principalId": {
+          "type": "string",
+          "description": "The unique identifier for the associated AAD principal in the AAD graph to which access is being granted through this MongoMI Role Assignment. Tenant ID for the principal is inferred using the tenant associated with the subscription."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "Provisioning state of the resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "MongoMIRoleDefinitionListResult": {
+      "type": "object",
+      "description": "The response of a MongoMIRoleDefinitionResource list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The MongoMIRoleDefinitionResource items on this page",
+          "items": {
+            "$ref": "#/definitions/MongoMIRoleDefinitionResource"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "MongoMIRoleDefinitionResource": {
+      "type": "object",
+      "description": "Parameters to create and update an Azure Cosmos DB MongoMI Role Definition.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/MongoMIRoleDefinitionResourceProperties",
+          "description": "Properties to create and update an Azure Cosmos DB MongoMI Role Definition.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "MongoMIRoleDefinitionResourceProperties": {
+      "type": "object",
+      "description": "Azure Cosmos DB MongoMI Role Definition resource object.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The path id for the Role Definition."
+        },
+        "roleName": {
+          "type": "string",
+          "description": "A user-friendly name for the Role Definition. Must be unique for the database account."
+        },
+        "type": {
+          "$ref": "#/definitions/RoleDefinitionType",
+          "description": "Indicates whether the Role Definition was built-in or user created."
+        },
+        "assignableScopes": {
+          "type": "array",
+          "description": "A set of fully qualified Scopes at or below which MongoMI Role Assignments may be created using this Role Definition. This will allow application of this Role Definition on the entire database account or any underlying Database / Collection. Must have at least one element. Scopes higher than Database account are not enforceable as assignable Scopes. Note that resources referenced in assignable Scopes need not exist.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "permissions": {
+          "type": "array",
+          "description": "The set of operations allowed through this Role Definition.",
+          "items": {
+            "$ref": "#/definitions/Permission"
+          }
+        }
+      }
+    },
+    "MongoRUToMongoRUCopyJobProperties": {
+      "type": "object",
+      "description": "Source Mongo to Destination Mongo copy job properties",
+      "properties": {
+        "sourceDetails": {
+          "$ref": "#/definitions/CosmosDBSourceSinkDetails",
+          "description": "Source Mongo DataStore details"
+        },
+        "destinationDetails": {
+          "$ref": "#/definitions/CosmosDBSourceSinkDetails",
+          "description": "Destination Mongo DataStore details"
+        },
+        "tasks": {
+          "type": "array",
+          "description": "Copy Job tasks.",
+          "items": {
+            "$ref": "#/definitions/MongoRUToMongoRUCopyJobTask"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "required": [
+        "tasks"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/BaseCopyJobProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "MongoRUToMongoRU"
+    },
+    "MongoRUToMongoRUCopyJobTask": {
+      "type": "object",
+      "properties": {
+        "source": {
+          "$ref": "#/definitions/CosmosDBMongoCollection",
+          "description": "Source Mongo (RU) collection"
+        },
+        "destination": {
+          "$ref": "#/definitions/CosmosDBMongoCollection",
+          "description": "Destination Mongo (RU) collection"
+        }
+      },
+      "required": [
+        "source",
+        "destination"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/BaseCopyJobTask"
+        }
+      ]
+    },
+    "MongoRUToMongoVCoreCopyJobProperties": {
+      "type": "object",
+      "description": "Source Mongo to Destination Mongo vCore copy job properties",
+      "properties": {
+        "sourceDetails": {
+          "$ref": "#/definitions/CosmosDBSourceSinkDetails",
+          "description": "Source Mongo (RU) DataStore details"
+        },
+        "destinationDetails": {
+          "$ref": "#/definitions/MongoVCoreSourceSinkDetails",
+          "description": "Destination Mongo (vCore) DataStore details"
+        },
+        "tasks": {
+          "type": "array",
+          "description": "Copy Job tasks.",
+          "items": {
+            "$ref": "#/definitions/MongoRUToMongoVCoreCopyJobTask"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "required": [
+        "destinationDetails",
+        "tasks"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/BaseCopyJobProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "MongoRUToMongoVCore"
+    },
+    "MongoRUToMongoVCoreCopyJobTask": {
+      "type": "object",
+      "properties": {
+        "source": {
+          "$ref": "#/definitions/CosmosDBMongoCollection",
+          "description": "Source Mongo (RU) collection"
+        },
+        "destination": {
+          "$ref": "#/definitions/CosmosDBMongoVCoreCollection",
+          "description": "Destination Mongo (vCore) collection"
+        }
+      },
+      "required": [
+        "source",
+        "destination"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/BaseCopyJobTask"
+        }
+      ]
+    },
     "MongoRoleDefinitionCreateUpdateParameters": {
       "type": "object",
       "description": "Parameters to create and update an Azure Cosmos DB Mongo Role Definition.",
@@ -19188,6 +26348,20 @@
         }
       }
     },
+    "MongoVCoreSourceSinkDetails": {
+      "type": "object",
+      "description": "A CosmosDB Mongo vCore data source/sink details",
+      "properties": {
+        "hostName": {
+          "type": "string"
+        },
+        "connectionStringKeyVaultUri": {
+          "type": "string",
+          "description": "URI of Azure KeyVault secret containing connection string.",
+          "pattern": "^https?://[^/$.?# ]+.[^ ]*$"
+        }
+      }
+    },
     "NetworkAclBypass": {
       "type": "string",
       "description": "Indicates what services are allowed to bypass firewall checks.",
@@ -19199,6 +26373,95 @@
         "name": "NetworkAclBypass",
         "modelAsString": false
       }
+    },
+    "NetworkSecurityPerimeterConfiguration": {
+      "type": "object",
+      "description": "Network security perimeter (NSP) configuration resource",
+      "properties": {
+        "properties": {
+          "$ref": "../../../../../../common-types/resource-management/v6/networksecurityperimeter.json#/definitions/NetworkSecurityPerimeterConfigurationProperties",
+          "description": "Network security configuration properties."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "NetworkSecurityPerimeterConfigurationListResult": {
+      "type": "object",
+      "description": "The response of a NetworkSecurityPerimeterConfiguration list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The NetworkSecurityPerimeterConfiguration items on this page",
+          "items": {
+            "$ref": "#/definitions/NetworkSecurityPerimeterConfiguration"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "NoSqlRUToNoSqlRUCopyJobProperties": {
+      "type": "object",
+      "description": "Source SQL to Destination SQL copy job properties",
+      "properties": {
+        "sourceDetails": {
+          "$ref": "#/definitions/CosmosDBSourceSinkDetails",
+          "description": "Source SQL DataStore details"
+        },
+        "destinationDetails": {
+          "$ref": "#/definitions/CosmosDBSourceSinkDetails",
+          "description": "Destination SQL DataStore details"
+        },
+        "tasks": {
+          "type": "array",
+          "description": "Copy Job tasks.",
+          "items": {
+            "$ref": "#/definitions/NoSqlRUToNoSqlRUCopyJobTask"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "required": [
+        "tasks"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/BaseCopyJobProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "NoSqlRUToNoSqlRU"
+    },
+    "NoSqlRUToNoSqlRUCopyJobTask": {
+      "type": "object",
+      "properties": {
+        "source": {
+          "$ref": "#/definitions/CosmosDBNoSqlContainer",
+          "description": "Source SQL container"
+        },
+        "destination": {
+          "$ref": "#/definitions/CosmosDBNoSqlContainer",
+          "description": "Destination SQL container"
+        }
+      },
+      "required": [
+        "source",
+        "destination"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/BaseCopyJobTask"
+        }
+      ]
     },
     "NodeState": {
       "type": "string",
@@ -19668,6 +26931,104 @@
         }
       }
     },
+    "PhysicalPartitionId": {
+      "type": "object",
+      "description": "PhysicalPartitionId object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Id of a physical partition"
+        }
+      },
+      "required": [
+        "id"
+      ]
+    },
+    "PhysicalPartitionStorageInfoCollection": {
+      "type": "object",
+      "description": "List of physical partitions and their properties returned by a merge operation.",
+      "properties": {
+        "physicalPartitionStorageInfoCollection": {
+          "type": "array",
+          "description": "List of physical partitions and their properties.",
+          "items": {
+            "$ref": "#/definitions/physicalPartitionStorageInfo"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "PhysicalPartitionThroughputInfoProperties": {
+      "type": "object",
+      "description": "The properties of an Azure Cosmos DB PhysicalPartitionThroughputInfoProperties object",
+      "properties": {
+        "physicalPartitionThroughputInfo": {
+          "type": "array",
+          "description": "Array of physical partition throughput info objects",
+          "items": {
+            "$ref": "#/definitions/PhysicalPartitionThroughputInfoResource"
+          }
+        }
+      }
+    },
+    "PhysicalPartitionThroughputInfoResource": {
+      "type": "object",
+      "description": "PhysicalPartitionThroughputInfo object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Id of a physical partition"
+        },
+        "throughput": {
+          "type": "number",
+          "format": "double",
+          "description": "Throughput of a physical partition"
+        },
+        "targetThroughput": {
+          "type": "number",
+          "format": "double",
+          "description": "Target throughput of a physical partition"
+        }
+      },
+      "required": [
+        "id"
+      ]
+    },
+    "PhysicalPartitionThroughputInfoResult": {
+      "type": "object",
+      "description": "An Azure Cosmos DB PhysicalPartitionThroughputInfoResult object.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PhysicalPartitionThroughputInfoResultProperties",
+          "description": "The properties of an Azure Cosmos DB PhysicalPartitionThroughputInfoResult object",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ARMResourceProperties"
+        }
+      ]
+    },
+    "PhysicalPartitionThroughputInfoResultProperties": {
+      "type": "object",
+      "description": "The properties of an Azure Cosmos DB PhysicalPartitionThroughputInfoResult object",
+      "properties": {
+        "resource": {
+          "$ref": "#/definitions/PhysicalPartitionThroughputInfoResultPropertiesResource",
+          "description": "properties of physical partition throughput info"
+        }
+      }
+    },
+    "PhysicalPartitionThroughputInfoResultPropertiesResource": {
+      "type": "object",
+      "description": "properties of physical partition throughput info",
+      "allOf": [
+        {
+          "$ref": "#/definitions/PhysicalPartitionThroughputInfoProperties"
+        }
+      ]
+    },
     "PrimaryAggregationType": {
       "type": "string",
       "description": "The primary aggregation type of the metric.",
@@ -19909,6 +27270,67 @@
           }
         ]
       }
+    },
+    "RedistributeThroughputParameters": {
+      "type": "object",
+      "description": "Cosmos DB redistribute throughput parameters object",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/RedistributeThroughputProperties",
+          "description": "Properties to redistribute throughput parameters object",
+          "x-ms-client-flatten": true
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ARMResourceProperties"
+        }
+      ]
+    },
+    "RedistributeThroughputProperties": {
+      "type": "object",
+      "description": "Properties to redistribute throughput for Azure Cosmos DB resource.",
+      "properties": {
+        "resource": {
+          "$ref": "#/definitions/RedistributeThroughputPropertiesResource",
+          "description": "The standard JSON format of a resource throughput"
+        }
+      },
+      "required": [
+        "resource"
+      ]
+    },
+    "RedistributeThroughputPropertiesResource": {
+      "type": "object",
+      "description": "Resource to redistribute throughput for Azure Cosmos DB resource",
+      "properties": {
+        "throughputPolicy": {
+          "$ref": "#/definitions/ThroughputPolicyType",
+          "description": "ThroughputPolicy to apply for throughput redistribution"
+        },
+        "targetPhysicalPartitionThroughputInfo": {
+          "type": "array",
+          "description": "Array of PhysicalPartitionThroughputInfoResource objects.",
+          "items": {
+            "$ref": "#/definitions/PhysicalPartitionThroughputInfoResource"
+          }
+        },
+        "sourcePhysicalPartitionThroughputInfo": {
+          "type": "array",
+          "description": "Array of PhysicalPartitionThroughputInfoResource objects.",
+          "items": {
+            "$ref": "#/definitions/PhysicalPartitionThroughputInfoResource"
+          }
+        }
+      },
+      "required": [
+        "throughputPolicy",
+        "targetPhysicalPartitionThroughputInfo",
+        "sourcePhysicalPartitionThroughputInfo"
+      ]
     },
     "RegionForOnlineOffline": {
       "type": "object",
@@ -21100,6 +28522,54 @@
           "description": "Specifies whether the restored account will have Time-To-Live disabled upon the successful restore."
         }
       }
+    },
+    "RetrieveThroughputParameters": {
+      "type": "object",
+      "description": "Cosmos DB retrieve throughput parameters object",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/RetrieveThroughputProperties",
+          "description": "Properties to retrieve throughput parameters object",
+          "x-ms-client-flatten": true
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ARMResourceProperties"
+        }
+      ]
+    },
+    "RetrieveThroughputProperties": {
+      "type": "object",
+      "description": "Properties to retrieve throughput for Azure Cosmos DB resource.",
+      "properties": {
+        "resource": {
+          "$ref": "#/definitions/RetrieveThroughputPropertiesResource",
+          "description": "The standard JSON format of a resource throughput"
+        }
+      },
+      "required": [
+        "resource"
+      ]
+    },
+    "RetrieveThroughputPropertiesResource": {
+      "type": "object",
+      "description": "Resource to retrieve throughput information for Cosmos DB resource",
+      "properties": {
+        "physicalPartitionIds": {
+          "type": "array",
+          "description": "Array of PhysicalPartitionId objects.",
+          "items": {
+            "$ref": "#/definitions/PhysicalPartitionId"
+          }
+        }
+      },
+      "required": [
+        "physicalPartitionIds"
+      ]
     },
     "Role": {
       "type": "object",
@@ -22571,6 +30041,18 @@
         ]
       }
     },
+    "SupportedActions": {
+      "type": "string",
+      "description": "Indicates whether what action to take for the Chaos Fault.",
+      "enum": [
+        "Enable",
+        "Disable"
+      ],
+      "x-ms-enum": {
+        "name": "SupportedActions",
+        "modelAsString": false
+      }
+    },
     "TableCreateUpdateParameters": {
       "type": "object",
       "description": "Parameters to create and update Cosmos DB Table.",
@@ -22746,6 +30228,135 @@
         "id"
       ]
     },
+    "TableRoleAssignmentListResult": {
+      "type": "object",
+      "description": "The response of a TableRoleAssignmentResource list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The TableRoleAssignmentResource items on this page",
+          "items": {
+            "$ref": "#/definitions/TableRoleAssignmentResource"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "TableRoleAssignmentResource": {
+      "type": "object",
+      "description": "Parameters to create and update an Azure Cosmos DB Table Role Assignment.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/TableRoleAssignmentResourceProperties",
+          "description": "Properties to create and update an Azure Cosmos DB Table Role Assignment.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "TableRoleAssignmentResourceProperties": {
+      "type": "object",
+      "description": "Azure Cosmos DB Table Role Assignment resource object.",
+      "properties": {
+        "roleDefinitionId": {
+          "type": "string",
+          "description": "The unique identifier for the associated Role Definition."
+        },
+        "scope": {
+          "type": "string",
+          "description": "The data plane resource path for which access is being granted through this Table Role Assignment."
+        },
+        "principalId": {
+          "type": "string",
+          "description": "The unique identifier for the associated AAD principal in the AAD graph to which access is being granted through this Table Role Assignment. Tenant ID for the principal is inferred using the tenant associated with the subscription."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "Provisioning state of the resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "TableRoleDefinitionListResult": {
+      "type": "object",
+      "description": "The response of a TableRoleDefinitionResource list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The TableRoleDefinitionResource items on this page",
+          "items": {
+            "$ref": "#/definitions/TableRoleDefinitionResource"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "TableRoleDefinitionResource": {
+      "type": "object",
+      "description": "Parameters to create and update an Azure Cosmos DB Table Role Definition.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/TableRoleDefinitionResourceProperties",
+          "description": "Properties to create and update an Azure Cosmos DB Table Role Definition.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "TableRoleDefinitionResourceProperties": {
+      "type": "object",
+      "description": "Azure Cosmos DB Table Role Definition resource object.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The path id for the Role Definition."
+        },
+        "roleName": {
+          "type": "string",
+          "description": "A user-friendly name for the Role Definition. Must be unique for the database account."
+        },
+        "type": {
+          "$ref": "#/definitions/RoleDefinitionType",
+          "description": "Indicates whether the Role Definition was built-in or user created."
+        },
+        "assignableScopes": {
+          "type": "array",
+          "description": "A set of fully qualified Scopes at or below which Table Role Assignments may be created using this Role Definition. This will allow application of this Role Definition on the entire database account or any underlying Database / Collection. Must have at least one element. Scopes higher than Database account are not enforceable as assignable Scopes. Note that resources referenced in assignable Scopes need not exist.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "permissions": {
+          "type": "array",
+          "description": "The set of operations allowed through this Role Definition.",
+          "items": {
+            "$ref": "#/definitions/Permission"
+          }
+        }
+      }
+    },
     "ThroughputBucketResource": {
       "type": "object",
       "description": "Cosmos DB throughput bucket object",
@@ -22784,6 +30395,157 @@
           "description": "Represents the percentage by which throughput can increase every time throughput policy kicks in."
         }
       }
+    },
+    "ThroughputPolicyType": {
+      "type": "string",
+      "description": "ThroughputPolicy to apply for throughput redistribution",
+      "enum": [
+        "none",
+        "equal",
+        "custom"
+      ],
+      "x-ms-enum": {
+        "name": "ThroughputPolicyType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "none"
+          },
+          {
+            "name": "Equal",
+            "value": "equal"
+          },
+          {
+            "name": "Custom",
+            "value": "custom"
+          }
+        ]
+      }
+    },
+    "ThroughputPoolAccountProperties": {
+      "type": "object",
+      "description": "An Azure Cosmos DB Global Database Account which is part of a Throughputpool.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/Status",
+          "description": "A provisioning state of the ThroughputPool Account.",
+          "readOnly": true
+        },
+        "accountResourceIdentifier": {
+          "type": "string",
+          "description": "The resource identifier of global database account in the throughputPool."
+        },
+        "accountLocation": {
+          "type": "string",
+          "description": "The location of  global database account in the throughputPool."
+        },
+        "accountInstanceId": {
+          "type": "string",
+          "description": "The instance id of global database account in the throughputPool.",
+          "readOnly": true
+        }
+      }
+    },
+    "ThroughputPoolAccountResource": {
+      "type": "object",
+      "description": "An Azure Cosmos DB Throughputpool Account",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ThroughputPoolAccountProperties",
+          "description": "An Azure Cosmos DB Global Database Account which is part of a Throughputpool.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ThroughputPoolAccountsListResult": {
+      "type": "object",
+      "description": "The response of a ThroughputPoolAccountResource list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ThroughputPoolAccountResource items on this page",
+          "items": {
+            "$ref": "#/definitions/ThroughputPoolAccountResource"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ThroughputPoolProperties": {
+      "type": "object",
+      "description": "Properties to update Azure Cosmos DB throughput pool.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/Status",
+          "description": "A provisioning state of the ThroughputPool."
+        },
+        "maxThroughput": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Value for throughput to be shared among CosmosDB resources in the pool."
+        }
+      }
+    },
+    "ThroughputPoolResource": {
+      "type": "object",
+      "description": "An Azure Cosmos DB Throughputpool.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ThroughputPoolProperties",
+          "description": "Properties to update Azure Cosmos DB throughput pool.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "ThroughputPoolUpdate": {
+      "type": "object",
+      "description": "Represents a throughput pool resource for updates.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ThroughputPoolProperties",
+          "description": "Properties of the throughput pool.",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "ThroughputPoolsListResult": {
+      "type": "object",
+      "description": "The response of a ThroughputPoolResource list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ThroughputPoolResource items on this page",
+          "items": {
+            "$ref": "#/definitions/ThroughputPoolResource"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
     },
     "ThroughputSettingsGetProperties": {
       "type": "object",
@@ -23329,6 +31091,87 @@
         "ignoreMissingVNetServiceEndpoint": {
           "type": "boolean",
           "description": "Create firewall rule before the virtual network has vnet service endpoint enabled."
+        }
+      }
+    },
+    "chaosFaultListResponse": {
+      "type": "object",
+      "description": "Chaos Fault List Response.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The chaosFaultResource items on this page",
+          "items": {
+            "$ref": "#/definitions/chaosFaultResource"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "chaosFaultProperties": {
+      "type": "object",
+      "description": "A request object to enable/disable the chaos fault.",
+      "properties": {
+        "action": {
+          "$ref": "#/definitions/SupportedActions",
+          "description": "Indicates whether what action to take for the Chaos Fault."
+        },
+        "region": {
+          "type": "string",
+          "description": "Region of the account where the Chaos Fault is to be enabled/disabled."
+        },
+        "databaseName": {
+          "type": "string",
+          "description": "Database name."
+        },
+        "containerName": {
+          "type": "string",
+          "description": "Container name."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "A provisioning state of the Chaos Fault.",
+          "readOnly": true
+        }
+      }
+    },
+    "chaosFaultResource": {
+      "type": "object",
+      "description": "A request object to enable/disable the chaos fault",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/chaosFaultProperties",
+          "description": "A request object to enable/disable the chaos fault.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "physicalPartitionStorageInfo": {
+      "type": "object",
+      "description": "The storage of a physical partition",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The unique identifier of the partition.",
+          "readOnly": true
+        },
+        "storageInKB": {
+          "type": "number",
+          "format": "double",
+          "description": "The storage in KB for the physical partition.",
+          "readOnly": true
         }
       }
     }

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/stable/2026-03-15/openapi.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/stable/2026-03-15/openapi.json
@@ -43,9 +43,6 @@
       "name": "Operations"
     },
     {
-      "name": "NetworkSecurityPerimeterConfigurations"
-    },
-    {
       "name": "NotebookWorkspacesResource"
     },
     {
@@ -65,9 +62,6 @@
     },
     {
       "name": "MaterializedViewsBuilder"
-    },
-    {
-      "name": "ThroughputPools"
     },
     {
       "name": "Fleets"
@@ -106,6 +100,11 @@
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "CosmosDBDatabaseAccountCheckNameExists": {
+            "$ref": "./examples/CosmosDBDatabaseAccountCheckNameExists.json"
+          }
         }
       }
     },
@@ -133,6 +132,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBOperationsList": {
+            "$ref": "./examples/CosmosDBOperationsList.json"
           }
         },
         "x-ms-pageable": {
@@ -166,6 +170,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBManagedCassandraClusterListBySubscription": {
+            "$ref": "./examples/CosmosDBManagedCassandraClusterListBySubscription.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -195,6 +204,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBDatabaseAccountList": {
+            "$ref": "./examples/CosmosDBDatabaseAccountList.json"
           }
         },
         "x-ms-pageable": {
@@ -228,35 +242,9 @@
             }
           }
         },
-        "x-ms-pageable": {
-          "nextLinkName": "nextLink"
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/providers/Microsoft.DocumentDB/garnetClusters": {
-      "get": {
-        "operationId": "GarnetClusters_ListBySubscription",
-        "description": "List all Garnet clusters in this subscription.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/ListGarnetClusters"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
+        "x-ms-examples": {
+          "CosmosDB Fleet List by subscription": {
+            "$ref": "./examples/fleet/CosmosDBFleetList.json"
           }
         },
         "x-ms-pageable": {
@@ -288,6 +276,11 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBLocationList": {
+            "$ref": "./examples/CosmosDBLocationList.json"
           }
         },
         "x-ms-pageable": {
@@ -327,6 +320,11 @@
               "$ref": "#/definitions/CloudError"
             }
           }
+        },
+        "x-ms-examples": {
+          "CosmosDBLocationGet": {
+            "$ref": "./examples/CosmosDBLocationGet.json"
+          }
         }
       }
     },
@@ -361,6 +359,11 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBRestorableDatabaseAccountList": {
+            "$ref": "./examples/CosmosDBRestorableDatabaseAccountList.json"
           }
         },
         "x-ms-pageable": {
@@ -406,6 +409,11 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBRestorableDatabaseAccountGet": {
+            "$ref": "./examples/CosmosDBRestorableDatabaseAccountGet.json"
           }
         }
       }
@@ -471,6 +479,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBRestorableGremlinGraphList": {
+            "$ref": "./examples/CosmosDBRestorableGremlinGraphList.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -514,6 +527,11 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBRestorableGremlinDatabaseList": {
+            "$ref": "./examples/CosmosDBRestorableGremlinDatabaseList.json"
           }
         },
         "x-ms-pageable": {
@@ -573,6 +591,11 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBRestorableGremlinResourceList": {
+            "$ref": "./examples/CosmosDBRestorableGremlinResourceList.json"
           }
         },
         "x-ms-pageable": {
@@ -641,6 +664,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBRestorableMongodbCollectionList": {
+            "$ref": "./examples/CosmosDBRestorableMongodbCollectionList.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -684,6 +712,11 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBRestorableMongodbDatabaseList": {
+            "$ref": "./examples/CosmosDBRestorableMongodbDatabaseList.json"
           }
         },
         "x-ms-pageable": {
@@ -743,6 +776,11 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBRestorableMongodbResourceList": {
+            "$ref": "./examples/CosmosDBRestorableMongodbResourceList.json"
           }
         },
         "x-ms-pageable": {
@@ -811,6 +849,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBRestorableSqlContainerList": {
+            "$ref": "./examples/CosmosDBRestorableSqlContainerList.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -854,6 +897,11 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBRestorableSqlDatabaseList": {
+            "$ref": "./examples/CosmosDBRestorableSqlDatabaseList.json"
           }
         },
         "x-ms-pageable": {
@@ -915,6 +963,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBRestorableSqlResourceList": {
+            "$ref": "./examples/CosmosDBRestorableSqlResourceList.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -972,6 +1025,11 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBRestorableTableResourceList": {
+            "$ref": "./examples/CosmosDBRestorableTableResourceList.json"
           }
         },
         "x-ms-pageable": {
@@ -1033,6 +1091,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBRestorableTableList": {
+            "$ref": "./examples/CosmosDBRestorableTableList.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -1064,35 +1127,9 @@
             }
           }
         },
-        "x-ms-pageable": {
-          "nextLinkName": "nextLink"
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/providers/Microsoft.DocumentDB/throughputPools": {
-      "get": {
-        "operationId": "ThroughputPools_List",
-        "description": "Lists all the Azure Cosmos DB Throughput Pools available under the subscription.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/ThroughputPoolsListResult"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
+        "x-ms-examples": {
+          "CosmosDBRestorableDatabaseAccountNoLocationList": {
+            "$ref": "./examples/CosmosDBRestorableDatabaseAccountNoLocationList.json"
           }
         },
         "x-ms-pageable": {
@@ -1127,6 +1164,11 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBManagedCassandraClusterListByResourceGroup": {
+            "$ref": "./examples/CosmosDBManagedCassandraClusterListByResourceGroup.json"
           }
         },
         "x-ms-pageable": {
@@ -1171,6 +1213,11 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBManagedCassandraClusterGet": {
+            "$ref": "./examples/CosmosDBManagedCassandraClusterGet.json"
           }
         }
       },
@@ -1236,6 +1283,11 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBManagedCassandraClusterCreate": {
+            "$ref": "./examples/CosmosDBManagedCassandraClusterCreate.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -1308,6 +1360,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBManagedCassandraClusterPatch": {
+            "$ref": "./examples/CosmosDBManagedCassandraClusterPatch.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ClusterResource"
@@ -1363,200 +1420,15 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBManagedCassandraClusterDelete": {
+            "$ref": "./examples/CosmosDBManagedCassandraClusterDelete.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
         "x-ms-long-running-operation": true
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/cassandraClusters/{clusterName}/backups": {
-      "get": {
-        "operationId": "CassandraClusters_ListBackups",
-        "description": "List the backups of this cluster that are available to restore.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "clusterName",
-            "in": "path",
-            "description": "Managed Cassandra cluster name.",
-            "required": true,
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 100,
-            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/ListBackups"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/CloudError"
-            }
-          }
-        },
-        "x-ms-pageable": {
-          "nextLinkName": "nextLink"
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/cassandraClusters/{clusterName}/backups/{backupId}": {
-      "get": {
-        "operationId": "CassandraClusters_GetBackup",
-        "description": "Get the properties of an individual backup of this cluster that is available to restore.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "clusterName",
-            "in": "path",
-            "description": "Managed Cassandra cluster name.",
-            "required": true,
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 100,
-            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
-          },
-          {
-            "name": "backupId",
-            "in": "path",
-            "description": "Id of a restorable backup of a Cassandra cluster.",
-            "required": true,
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 15,
-            "pattern": "^[0-9]+$"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/BackupResource"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/CloudError"
-            }
-          }
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/cassandraClusters/{clusterName}/commands": {
-      "get": {
-        "operationId": "CassandraClusters_ListCommand",
-        "description": "List all commands currently running on ring info",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "clusterName",
-            "in": "path",
-            "description": "Managed Cassandra cluster name.",
-            "required": true,
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 100,
-            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/ListCommands"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/CloudError"
-            }
-          }
-        },
-        "x-ms-pageable": {
-          "nextLinkName": "nextLink"
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/cassandraClusters/{clusterName}/commands/{commandId}": {
-      "get": {
-        "operationId": "CassandraClusters_GetCommandAsync",
-        "description": "Get details about a specified command that was run asynchronously.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "clusterName",
-            "in": "path",
-            "description": "Managed Cassandra cluster name.",
-            "required": true,
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 100,
-            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
-          },
-          {
-            "name": "commandId",
-            "in": "path",
-            "description": "Managed Cassandra cluster command id.",
-            "required": true,
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 100,
-            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/CommandPublicResource"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/CloudError"
-            }
-          }
-        }
       }
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/cassandraClusters/{clusterName}/dataCenters": {
@@ -1596,6 +1468,11 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBManagedCassandraDataCenterList": {
+            "$ref": "./examples/CosmosDBManagedCassandraDataCenterList.json"
           }
         },
         "x-ms-pageable": {
@@ -1650,6 +1527,11 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBManagedCassandraDataCenterGet": {
+            "$ref": "./examples/CosmosDBManagedCassandraDataCenterGet.json"
           }
         }
       },
@@ -1725,6 +1607,11 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBManagedCassandraDataCenterCreate": {
+            "$ref": "./examples/CosmosDBManagedCassandraDataCenterCreate.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -1807,6 +1694,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBManagedCassandraDataCenterUpdate": {
+            "$ref": "./examples/CosmosDBManagedCassandraDataCenterPatch.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/DataCenterResource"
@@ -1872,6 +1764,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBManagedCassandraDataCenterDelete": {
+            "$ref": "./examples/CosmosDBManagedCassandraDataCenterDelete.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -1930,6 +1827,11 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBManagedCassandraClusterDeallocate": {
+            "$ref": "./examples/CosmosDBManagedCassandraClusterDeallocate.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -1997,83 +1899,14 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBManagedCassandraCommand": {
+            "$ref": "./examples/CosmosDBManagedCassandraCommand.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/CommandOutput"
-        },
-        "x-ms-long-running-operation": true
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/cassandraClusters/{clusterName}/invokeCommandAsync": {
-      "post": {
-        "operationId": "CassandraClusters_InvokeCommandAsync",
-        "description": "Invoke a command like nodetool for cassandra maintenance asynchronously",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "clusterName",
-            "in": "path",
-            "description": "Managed Cassandra cluster name.",
-            "required": true,
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 100,
-            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "description": "Specification which command to run where",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/CommandAsyncPostBody"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/CommandPublicResource"
-            }
-          },
-          "202": {
-            "description": "Resource operation accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location",
-          "final-state-schema": "#/definitions/CommandPublicResource"
         },
         "x-ms-long-running-operation": true
       }
@@ -2125,6 +1958,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBManagedCassandraClusterStart": {
+            "$ref": "./examples/CosmosDBManagedCassandraClusterStart.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -2169,6 +2007,11 @@
               "$ref": "#/definitions/CloudError"
             }
           }
+        },
+        "x-ms-examples": {
+          "CosmosDBManagedCassandraStatus": {
+            "$ref": "./examples/CosmosDBManagedCassandraStatus.json"
+          }
         }
       }
     },
@@ -2199,6 +2042,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBDatabaseAccountListByResourceGroup": {
+            "$ref": "./examples/CosmosDBDatabaseAccountListByResourceGroup.json"
           }
         },
         "x-ms-pageable": {
@@ -2243,6 +2091,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBDatabaseAccountGet": {
+            "$ref": "./examples/CosmosDBDatabaseAccountGet.json"
           }
         }
       },
@@ -2297,6 +2150,17 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBDatabaseAccountCreateMax": {
+            "$ref": "./examples/CosmosDBDatabaseAccountCreateMax.json"
+          },
+          "CosmosDBDatabaseAccountCreateMin": {
+            "$ref": "./examples/CosmosDBDatabaseAccountCreateMin.json"
+          },
+          "CosmosDBRestoreDatabaseAccountCreateUpdate.json": {
+            "$ref": "./examples/CosmosDBRestoreDatabaseAccountCreateUpdate.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -2358,6 +2222,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBDatabaseAccountPatch": {
+            "$ref": "./examples/CosmosDBDatabaseAccountPatch.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/DatabaseAccountGetResults"
@@ -2413,6 +2282,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBDatabaseAccountDelete": {
+            "$ref": "./examples/CosmosDBDatabaseAccountDelete.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -2456,6 +2330,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBCassandraKeyspaceList": {
+            "$ref": "./examples/CosmosDBCassandraKeyspaceList.json"
           }
         },
         "x-ms-pageable": {
@@ -2507,6 +2386,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBCassandraKeyspaceGet": {
+            "$ref": "./examples/CosmosDBCassandraKeyspaceGet.json"
           }
         }
       },
@@ -2583,6 +2467,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBCassandraKeyspaceCreateUpdate": {
+            "$ref": "./examples/CosmosDBCassandraKeyspaceCreateUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/CassandraKeyspaceGetResults"
@@ -2645,6 +2534,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBCassandraKeyspaceDelete": {
+            "$ref": "./examples/CosmosDBCassandraKeyspaceDelete.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -2695,6 +2589,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBCassandraTableList": {
+            "$ref": "./examples/CosmosDBCassandraTableList.json"
           }
         },
         "x-ms-pageable": {
@@ -2753,6 +2652,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBCassandraTableGet": {
+            "$ref": "./examples/CosmosDBCassandraTableGet.json"
           }
         }
       },
@@ -2836,6 +2740,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBCassandraTableCreateUpdate": {
+            "$ref": "./examples/CosmosDBCassandraTableCreateUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/CassandraTableGetResults"
@@ -2905,6 +2814,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBCassandraTableDelete": {
+            "$ref": "./examples/CosmosDBCassandraTableDelete.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -2962,6 +2876,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBCassandraTableThroughputGet": {
+            "$ref": "./examples/CosmosDBCassandraTableThroughputGet.json"
           }
         }
       },
@@ -3045,6 +2964,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBCassandraTableThroughputUpdate": {
+            "$ref": "./examples/CosmosDBCassandraTableThroughputUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
@@ -3122,6 +3046,11 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBCassandraTableMigrateToAutoscale": {
+            "$ref": "./examples/CosmosDBCassandraTableMigrateToAutoscale.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -3203,6 +3132,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBCassandraTableMigrateToManualThroughput": {
+            "$ref": "./examples/CosmosDBCassandraTableMigrateToManualThroughput.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
@@ -3254,6 +3188,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBCassandraKeyspaceThroughputGet": {
+            "$ref": "./examples/CosmosDBCassandraKeyspaceThroughputGet.json"
           }
         }
       },
@@ -3330,6 +3269,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBCassandraKeyspaceThroughputUpdate": {
+            "$ref": "./examples/CosmosDBCassandraKeyspaceThroughputUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
@@ -3400,6 +3344,11 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBCassandraKeyspaceMigrateToAutoscale": {
+            "$ref": "./examples/CosmosDBCassandraKeyspaceMigrateToAutoscale.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -3474,413 +3423,9 @@
             }
           }
         },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location",
-          "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
-        },
-        "x-ms-long-running-operation": true
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/cassandraKeyspaces/{keyspaceName}/views": {
-      "get": {
-        "operationId": "CassandraResources_ListCassandraViews",
-        "description": "Lists the Cassandra materialized views under an existing Azure Cosmos DB database account.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "keyspaceName",
-            "in": "path",
-            "description": "Cosmos DB keyspace name.",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/CassandraViewListResult"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-pageable": {
-          "nextLinkName": "nextLink"
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/cassandraKeyspaces/{keyspaceName}/views/{viewName}": {
-      "get": {
-        "operationId": "CassandraResources_GetCassandraView",
-        "description": "Gets the Cassandra view under an existing Azure Cosmos DB database account.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "keyspaceName",
-            "in": "path",
-            "description": "Cosmos DB keyspace name.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "viewName",
-            "in": "path",
-            "description": "Cosmos DB view name.",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/CassandraViewGetResults"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        }
-      },
-      "put": {
-        "operationId": "CassandraResources_CreateUpdateCassandraView",
-        "description": "Create or update an Azure Cosmos DB Cassandra View",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "keyspaceName",
-            "in": "path",
-            "description": "Cosmos DB keyspace name.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "viewName",
-            "in": "path",
-            "description": "Cosmos DB view name.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "createUpdateCassandraViewParameters",
-            "in": "body",
-            "description": "The parameters to provide for the current Cassandra View.",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/CassandraViewCreateUpdateParameters"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Resource 'CassandraViewGetResults' update operation succeeded",
-            "schema": {
-              "$ref": "#/definitions/CassandraViewGetResults"
-            }
-          },
-          "202": {
-            "description": "Resource operation accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location",
-          "final-state-schema": "#/definitions/CassandraViewGetResults"
-        },
-        "x-ms-long-running-operation": true
-      },
-      "delete": {
-        "operationId": "CassandraResources_DeleteCassandraView",
-        "description": "Deletes an existing Azure Cosmos DB Cassandra view.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "keyspaceName",
-            "in": "path",
-            "description": "Cosmos DB keyspace name.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "viewName",
-            "in": "path",
-            "description": "Cosmos DB view name.",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Resource deleted successfully."
-          },
-          "202": {
-            "description": "Resource deletion accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
-          },
-          "204": {
-            "description": "Resource does not exist."
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
-        },
-        "x-ms-long-running-operation": true
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/cassandraKeyspaces/{keyspaceName}/views/{viewName}/throughputSettings/default": {
-      "get": {
-        "operationId": "CassandraResources_GetCassandraViewThroughput",
-        "description": "Gets the RUs per second of the Cassandra view under an existing Azure Cosmos DB database account with the provided name.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "keyspaceName",
-            "in": "path",
-            "description": "Cosmos DB keyspace name.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "viewName",
-            "in": "path",
-            "description": "Cosmos DB view name.",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/ThroughputSettingsGetResults"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        }
-      },
-      "put": {
-        "operationId": "CassandraResources_UpdateCassandraViewThroughput",
-        "description": "Update RUs per second of an Azure Cosmos DB Cassandra view",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "keyspaceName",
-            "in": "path",
-            "description": "Cosmos DB keyspace name.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "viewName",
-            "in": "path",
-            "description": "Cosmos DB view name.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "updateThroughputParameters",
-            "in": "body",
-            "description": "The RUs per second of the parameters to provide for the current Cassandra view.",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/ThroughputSettingsUpdateParameters"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Resource 'ThroughputSettingsGetResults' update operation succeeded",
-            "schema": {
-              "$ref": "#/definitions/ThroughputSettingsGetResults"
-            }
-          },
-          "202": {
-            "description": "Resource operation accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
+        "x-ms-examples": {
+          "CosmosDBCassandraKeyspaceMigrateToManualThroughput": {
+            "$ref": "./examples/CosmosDBCassandraKeyspaceMigrateToManualThroughput.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -3888,1499 +3433,6 @@
           "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
         },
         "x-ms-long-running-operation": true
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/cassandraKeyspaces/{keyspaceName}/views/{viewName}/throughputSettings/default/migrateToAutoscale": {
-      "post": {
-        "operationId": "CassandraResources_MigrateCassandraViewToAutoscale",
-        "description": "Migrate an Azure Cosmos DB Cassandra view from manual throughput to autoscale",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "keyspaceName",
-            "in": "path",
-            "description": "Cosmos DB keyspace name.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "viewName",
-            "in": "path",
-            "description": "Cosmos DB view name.",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/ThroughputSettingsGetResults"
-            }
-          },
-          "202": {
-            "description": "Resource operation accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/CloudError"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location",
-          "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
-        },
-        "x-ms-long-running-operation": true
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/cassandraKeyspaces/{keyspaceName}/views/{viewName}/throughputSettings/default/migrateToManualThroughput": {
-      "post": {
-        "operationId": "CassandraResources_MigrateCassandraViewToManualThroughput",
-        "description": "Migrate an Azure Cosmos DB Cassandra view from autoscale to manual throughput",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "keyspaceName",
-            "in": "path",
-            "description": "Cosmos DB keyspace name.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "viewName",
-            "in": "path",
-            "description": "Cosmos DB view name.",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/ThroughputSettingsGetResults"
-            }
-          },
-          "202": {
-            "description": "Resource operation accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/CloudError"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location",
-          "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
-        },
-        "x-ms-long-running-operation": true
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/cassandraRoleAssignments": {
-      "get": {
-        "operationId": "CassandraResources_ListCassandraRoleAssignments",
-        "description": "Retrieves the list of all Azure Cosmos DB Cassandra Role Assignments.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/CassandraRoleAssignmentListResult"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-pageable": {
-          "nextLinkName": "nextLink"
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/cassandraRoleAssignments/{roleAssignmentId}": {
-      "get": {
-        "operationId": "CassandraResources_GetCassandraRoleAssignment",
-        "description": "Retrieves the properties of an existing Azure Cosmos DB Cassandra Role Assignment with the given Id.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "roleAssignmentId",
-            "in": "path",
-            "description": "The GUID for the Role Assignment.",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/CassandraRoleAssignmentResource"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        }
-      },
-      "put": {
-        "operationId": "CassandraResources_CreateUpdateCassandraRoleAssignment",
-        "description": "Creates or updates an Azure Cosmos DB Cassandra Role Assignment.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "roleAssignmentId",
-            "in": "path",
-            "description": "The GUID for the Role Assignment.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "createUpdateCassandraRoleAssignmentParameters",
-            "in": "body",
-            "description": "The properties required to create or update a Role Assignment.",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/CassandraRoleAssignmentResource"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Resource 'CassandraRoleAssignmentResource' update operation succeeded",
-            "schema": {
-              "$ref": "#/definitions/CassandraRoleAssignmentResource"
-            }
-          },
-          "202": {
-            "description": "Resource operation accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location",
-          "final-state-schema": "#/definitions/CassandraRoleAssignmentResource"
-        },
-        "x-ms-long-running-operation": true
-      },
-      "delete": {
-        "operationId": "CassandraResources_DeleteCassandraRoleAssignment",
-        "description": "Deletes an existing Azure Cosmos DB Cassandra Role Assignment.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "roleAssignmentId",
-            "in": "path",
-            "description": "The GUID for the Role Assignment.",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Resource deleted successfully."
-          },
-          "202": {
-            "description": "Resource deletion accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              }
-            }
-          },
-          "204": {
-            "description": "Resource does not exist."
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
-        },
-        "x-ms-long-running-operation": true
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/cassandraRoleDefinitions": {
-      "get": {
-        "operationId": "CassandraResources_ListCassandraRoleDefinitions",
-        "description": "Retrieves the list of all Azure Cosmos DB Cassandra Role Definitions.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/CassandraRoleDefinitionListResult"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-pageable": {
-          "nextLinkName": "nextLink"
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/cassandraRoleDefinitions/{roleDefinitionId}": {
-      "get": {
-        "operationId": "CassandraResources_GetCassandraRoleDefinition",
-        "description": "Retrieves the properties of an existing Azure Cosmos DB Cassandra Role Definition with the given Id.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "roleDefinitionId",
-            "in": "path",
-            "description": "The GUID for the Role Definition.",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/CassandraRoleDefinitionResource"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        }
-      },
-      "put": {
-        "operationId": "CassandraResources_CreateUpdateCassandraRoleDefinition",
-        "description": "Creates or updates an Azure Cosmos DB Cassandra Role Definition.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "roleDefinitionId",
-            "in": "path",
-            "description": "The GUID for the Role Definition.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "createUpdateCassandraRoleDefinitionParameters",
-            "in": "body",
-            "description": "The properties required to create or update a Role Definition.",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/CassandraRoleDefinitionResource"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Resource 'CassandraRoleDefinitionResource' update operation succeeded",
-            "schema": {
-              "$ref": "#/definitions/CassandraRoleDefinitionResource"
-            }
-          },
-          "202": {
-            "description": "Resource operation accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location",
-          "final-state-schema": "#/definitions/CassandraRoleDefinitionResource"
-        },
-        "x-ms-long-running-operation": true
-      },
-      "delete": {
-        "operationId": "CassandraResources_DeleteCassandraRoleDefinition",
-        "description": "Deletes an existing Azure Cosmos DB Cassandra Role Definition.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "roleDefinitionId",
-            "in": "path",
-            "description": "The GUID for the Role Definition.",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Resource deleted successfully."
-          },
-          "202": {
-            "description": "Resource deletion accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              }
-            }
-          },
-          "204": {
-            "description": "Resource does not exist."
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
-        },
-        "x-ms-long-running-operation": true
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/chaosFaults": {
-      "get": {
-        "operationId": "ChaosFault_List",
-        "description": "List Chaos Faults for CosmosDB account.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/chaosFaultListResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-pageable": {
-          "nextLinkName": "nextLink"
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/chaosFaults/{chaosFault}": {
-      "get": {
-        "operationId": "ChaosFault_Get",
-        "description": "Get Chaos Fault for a CosmosdB account for a particular Chaos Fault.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "chaosFault",
-            "in": "path",
-            "description": "The name of the ChaosFault.",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/chaosFaultResource"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        }
-      },
-      "put": {
-        "operationId": "ChaosFault_EnableDisable",
-        "description": "Enable, disable Chaos Fault in a CosmosDB account.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "chaosFault",
-            "in": "path",
-            "description": "The name of the ChaosFault.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "chaosFaultRequest",
-            "in": "body",
-            "description": "A request object to enable/disable the chaos fault.",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/chaosFaultResource"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Resource 'chaosFaultResource' update operation succeeded",
-            "schema": {
-              "$ref": "#/definitions/chaosFaultResource"
-            }
-          },
-          "201": {
-            "description": "Resource 'chaosFaultResource' create operation succeeded",
-            "schema": {
-              "$ref": "#/definitions/chaosFaultResource"
-            },
-            "headers": {
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location",
-          "final-state-schema": "#/definitions/chaosFaultResource"
-        },
-        "x-ms-long-running-operation": true
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/copyJobs": {
-      "get": {
-        "operationId": "CopyJobs_ListByDatabaseAccount",
-        "description": "Get a list of Copy jobs.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/CopyJobFeedResults"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/CloudError"
-            }
-          }
-        },
-        "x-ms-pageable": {
-          "nextLinkName": "nextLink"
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/copyJobs/{jobName}": {
-      "get": {
-        "operationId": "CopyJobs_Get",
-        "description": "Get a Copy Job.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "jobName",
-            "in": "path",
-            "description": "Name of the Copy Job",
-            "required": true,
-            "type": "string",
-            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/CopyJobGetResults"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/CloudError"
-            }
-          }
-        }
-      },
-      "put": {
-        "operationId": "CopyJobs_Create",
-        "description": "Creates a Copy Job.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "jobName",
-            "in": "path",
-            "description": "Name of the Copy Job",
-            "required": true,
-            "type": "string",
-            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
-          },
-          {
-            "name": "jobCreateParameters",
-            "in": "body",
-            "description": "",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/CopyJobGetResults"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Resource 'CopyJobGetResults' update operation succeeded",
-            "schema": {
-              "$ref": "#/definitions/CopyJobGetResults"
-            }
-          },
-          "201": {
-            "description": "Resource 'CopyJobGetResults' create operation succeeded",
-            "schema": {
-              "$ref": "#/definitions/CopyJobGetResults"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/CloudError"
-            }
-          }
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/copyJobs/{jobName}/cancel": {
-      "post": {
-        "operationId": "CopyJobs_Cancel",
-        "description": "Cancels a Copy Job.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "jobName",
-            "in": "path",
-            "description": "Name of the Copy Job",
-            "required": true,
-            "type": "string",
-            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/CopyJobGetResults"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/CloudError"
-            }
-          }
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/copyJobs/{jobName}/complete": {
-      "post": {
-        "operationId": "CopyJobs_Complete",
-        "description": "Completes an Online Copy Job.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "jobName",
-            "in": "path",
-            "description": "Name of the Copy Job",
-            "required": true,
-            "type": "string",
-            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/CopyJobGetResults"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/CloudError"
-            }
-          }
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/copyJobs/{jobName}/pause": {
-      "post": {
-        "operationId": "CopyJobs_Pause",
-        "description": "Pause a Copy Job.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "jobName",
-            "in": "path",
-            "description": "Name of the Copy Job",
-            "required": true,
-            "type": "string",
-            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/CopyJobGetResults"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/CloudError"
-            }
-          }
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/copyJobs/{jobName}/resume": {
-      "post": {
-        "operationId": "CopyJobs_Resume",
-        "description": "Resumes a Copy Job.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "jobName",
-            "in": "path",
-            "description": "Name of the Copy Job",
-            "required": true,
-            "type": "string",
-            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/CopyJobGetResults"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/CloudError"
-            }
-          }
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/dataTransferJobs": {
-      "get": {
-        "operationId": "DataTransferJobs_ListByDatabaseAccount",
-        "description": "Get a list of Data Transfer jobs.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/DataTransferJobFeedResults"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/CloudError"
-            }
-          }
-        },
-        "x-ms-pageable": {
-          "nextLinkName": "nextLink"
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/dataTransferJobs/{jobName}": {
-      "get": {
-        "operationId": "DataTransferJobs_Get",
-        "description": "Get a Data Transfer Job.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "jobName",
-            "in": "path",
-            "description": "Name of the Data Transfer Job",
-            "required": true,
-            "type": "string",
-            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/DataTransferJobGetResults"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/CloudError"
-            }
-          }
-        }
-      },
-      "put": {
-        "operationId": "DataTransferJobs_Create",
-        "description": "Creates a Data Transfer Job.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "jobName",
-            "in": "path",
-            "description": "Name of the Data Transfer Job",
-            "required": true,
-            "type": "string",
-            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
-          },
-          {
-            "name": "jobCreateParameters",
-            "in": "body",
-            "description": "",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/CreateJobRequest"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Resource 'DataTransferJobGetResults' update operation succeeded",
-            "schema": {
-              "$ref": "#/definitions/DataTransferJobGetResults"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/CloudError"
-            }
-          }
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/dataTransferJobs/{jobName}/cancel": {
-      "post": {
-        "operationId": "DataTransferJobs_Cancel",
-        "description": "Cancels a Data Transfer Job.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "jobName",
-            "in": "path",
-            "description": "Name of the Data Transfer Job",
-            "required": true,
-            "type": "string",
-            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/DataTransferJobGetResults"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/CloudError"
-            }
-          }
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/dataTransferJobs/{jobName}/complete": {
-      "post": {
-        "operationId": "DataTransferJobs_Complete",
-        "description": "Completes a Data Transfer Online Job.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "jobName",
-            "in": "path",
-            "description": "Name of the Data Transfer Job",
-            "required": true,
-            "type": "string",
-            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/DataTransferJobGetResults"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/CloudError"
-            }
-          }
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/dataTransferJobs/{jobName}/pause": {
-      "post": {
-        "operationId": "DataTransferJobs_Pause",
-        "description": "Pause a Data Transfer Job.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "jobName",
-            "in": "path",
-            "description": "Name of the Data Transfer Job",
-            "required": true,
-            "type": "string",
-            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/DataTransferJobGetResults"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/CloudError"
-            }
-          }
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/dataTransferJobs/{jobName}/resume": {
-      "post": {
-        "operationId": "DataTransferJobs_Resume",
-        "description": "Resumes a Data Transfer Job.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "jobName",
-            "in": "path",
-            "description": "Name of the Data Transfer Job",
-            "required": true,
-            "type": "string",
-            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/DataTransferJobGetResults"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/CloudError"
-            }
-          }
-        }
       }
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/databases/{databaseRid}/collections/{collectionRid}/metricDefinitions": {
@@ -5434,6 +3486,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBCollectionGetMetricDefinitions": {
+            "$ref": "./examples/CosmosDBCollectionGetMetricDefinitions.json"
           }
         },
         "x-ms-pageable": {
@@ -5499,6 +3556,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBCollectionGetMetrics": {
+            "$ref": "./examples/CosmosDBCollectionGetMetrics.json"
           }
         },
         "x-ms-pageable": {
@@ -5573,6 +3635,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBDatabaseAccountRegionGetMetrics": {
+            "$ref": "./examples/CosmosDBPKeyRangeIdGetMetrics.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -5636,6 +3703,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBDatabaseAccountRegionGetMetrics": {
+            "$ref": "./examples/CosmosDBCollectionPartitionGetMetrics.json"
           }
         },
         "x-ms-pageable": {
@@ -5703,6 +3775,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBCollectionGetUsages": {
+            "$ref": "./examples/CosmosDBCollectionPartitionGetUsages.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -5768,6 +3845,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBCollectionGetUsages": {
+            "$ref": "./examples/CosmosDBCollectionGetUsages.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -5817,6 +3899,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBDatabaseGetMetricDefinitions": {
+            "$ref": "./examples/CosmosDBDatabaseGetMetricDefinitions.json"
           }
         },
         "x-ms-pageable": {
@@ -5877,6 +3964,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBDatabaseGetMetrics": {
+            "$ref": "./examples/CosmosDBDatabaseGetMetrics.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -5933,6 +4025,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBDatabaseGetUsages": {
+            "$ref": "./examples/CosmosDBDatabaseGetUsages.json"
           }
         },
         "x-ms-pageable": {
@@ -6004,239 +4101,9 @@
             }
           }
         },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
-        },
-        "x-ms-long-running-operation": true
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/graphs": {
-      "get": {
-        "operationId": "GraphResources_ListGraphs",
-        "description": "Lists the graphs under an existing Azure Cosmos DB database account.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/GraphResourcesListResult"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-pageable": {
-          "nextLinkName": "nextLink"
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/graphs/{graphName}": {
-      "get": {
-        "operationId": "GraphResources_GetGraph",
-        "description": "Gets the Graph resource under an existing Azure Cosmos DB database account with the provided name.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "graphName",
-            "in": "path",
-            "description": "Cosmos DB graph resource name.",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/GraphResourceGetResults"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        }
-      },
-      "put": {
-        "operationId": "GraphResources_CreateUpdateGraph",
-        "description": "Create or update an Azure Cosmos DB Graph.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "graphName",
-            "in": "path",
-            "description": "Cosmos DB graph resource name.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "createUpdateGraphParameters",
-            "in": "body",
-            "description": "The parameters to provide for the current graph.",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/GraphResourceCreateUpdateParameters"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Resource 'GraphResourceGetResults' update operation succeeded",
-            "schema": {
-              "$ref": "#/definitions/GraphResourceGetResults"
-            }
-          },
-          "202": {
-            "description": "Resource operation accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location",
-          "final-state-schema": "#/definitions/GraphResourceGetResults"
-        },
-        "x-ms-long-running-operation": true
-      },
-      "delete": {
-        "operationId": "GraphResources_DeleteGraphResource",
-        "description": "Deletes an existing Azure Cosmos DB Graph Resource.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "graphName",
-            "in": "path",
-            "description": "Cosmos DB graph resource name.",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Resource deleted successfully."
-          },
-          "202": {
-            "description": "Resource deletion accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              }
-            }
-          },
-          "204": {
-            "description": "Resource does not exist."
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
+        "x-ms-examples": {
+          "CosmosDBDatabaseAccountFailoverPriorityChange": {
+            "$ref": "./examples/CosmosDBDatabaseAccountFailoverPriorityChange.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -6282,6 +4149,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBGremlinDatabaseList": {
+            "$ref": "./examples/CosmosDBGremlinDatabaseList.json"
           }
         },
         "x-ms-pageable": {
@@ -6333,6 +4205,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBGremlinDatabaseGet": {
+            "$ref": "./examples/CosmosDBGremlinDatabaseGet.json"
           }
         }
       },
@@ -6409,6 +4286,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBGremlinDatabaseCreateUpdate": {
+            "$ref": "./examples/CosmosDBGremlinDatabaseCreateUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/GremlinDatabaseGetResults"
@@ -6471,6 +4353,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBGremlinDatabaseDelete": {
+            "$ref": "./examples/CosmosDBGremlinDatabaseDelete.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -6521,6 +4408,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBGremlinGraphList": {
+            "$ref": "./examples/CosmosDBGremlinGraphList.json"
           }
         },
         "x-ms-pageable": {
@@ -6579,6 +4471,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBGremlinGraphGet": {
+            "$ref": "./examples/CosmosDBGremlinGraphGet.json"
           }
         }
       },
@@ -6662,6 +4559,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBGremlinGraphCreateUpdate": {
+            "$ref": "./examples/CosmosDBGremlinGraphCreateUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/GremlinGraphGetResults"
@@ -6729,6 +4631,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBGremlinGraphDelete": {
+            "$ref": "./examples/CosmosDBGremlinGraphDelete.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -6813,6 +4720,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBGremlinGraphBackupInformation": {
+            "$ref": "./examples/CosmosDBGremlinGraphBackupInformation.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/BackupInformation"
@@ -6871,6 +4783,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBGremlinGraphThroughputGet": {
+            "$ref": "./examples/CosmosDBGremlinGraphThroughputGet.json"
           }
         }
       },
@@ -6954,6 +4871,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBGremlinGraphThroughputUpdate": {
+            "$ref": "./examples/CosmosDBGremlinGraphThroughputUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
@@ -7031,6 +4953,11 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBGremlinGraphMigrateToAutoscale": {
+            "$ref": "./examples/CosmosDBGremlinGraphMigrateToAutoscale.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -7112,6 +5039,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBGremlinGraphMigrateToManualThroughput": {
+            "$ref": "./examples/CosmosDBGremlinGraphMigrateToManualThroughput.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
@@ -7163,6 +5095,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBGremlinDatabaseThroughputGet": {
+            "$ref": "./examples/CosmosDBGremlinDatabaseThroughputGet.json"
           }
         }
       },
@@ -7239,6 +5176,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBGremlinDatabaseThroughputUpdate": {
+            "$ref": "./examples/CosmosDBGremlinDatabaseThroughputUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
@@ -7309,6 +5251,11 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBGremlinDatabaseMigrateToAutoscale": {
+            "$ref": "./examples/CosmosDBGremlinDatabaseMigrateToAutoscale.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -7383,479 +5330,14 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBGremlinDatabaseMigrateToManualThroughput": {
+            "$ref": "./examples/CosmosDBGremlinDatabaseMigrateToManualThroughput.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
-        },
-        "x-ms-long-running-operation": true
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/gremlinRoleAssignments": {
-      "get": {
-        "operationId": "GremlinResources_ListGremlinRoleAssignments",
-        "description": "Retrieves the list of all Azure Cosmos DB Gremlin Role Assignments.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/GremlinRoleAssignmentListResult"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-pageable": {
-          "nextLinkName": "nextLink"
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/gremlinRoleAssignments/{roleAssignmentId}": {
-      "get": {
-        "operationId": "GremlinResources_GetGremlinRoleAssignment",
-        "description": "Retrieves the properties of an existing Azure Cosmos DB Gremlin Role Assignment with the given Id.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "roleAssignmentId",
-            "in": "path",
-            "description": "The GUID for the Role Assignment.",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/GremlinRoleAssignmentResource"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        }
-      },
-      "put": {
-        "operationId": "GremlinResources_CreateUpdateGremlinRoleAssignment",
-        "description": "Creates or updates an Azure Cosmos DB Gremlin Role Assignment.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "roleAssignmentId",
-            "in": "path",
-            "description": "The GUID for the Role Assignment.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "createUpdateGremlinRoleAssignmentParameters",
-            "in": "body",
-            "description": "The properties required to create or update a Role Assignment.",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/GremlinRoleAssignmentResource"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Resource 'GremlinRoleAssignmentResource' update operation succeeded",
-            "schema": {
-              "$ref": "#/definitions/GremlinRoleAssignmentResource"
-            }
-          },
-          "202": {
-            "description": "Resource operation accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location",
-          "final-state-schema": "#/definitions/GremlinRoleAssignmentResource"
-        },
-        "x-ms-long-running-operation": true
-      },
-      "delete": {
-        "operationId": "GremlinResources_DeleteGremlinRoleAssignment",
-        "description": "Deletes an existing Azure Cosmos DB Gremlin Role Assignment.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "roleAssignmentId",
-            "in": "path",
-            "description": "The GUID for the Role Assignment.",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Resource deleted successfully."
-          },
-          "202": {
-            "description": "Resource deletion accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              }
-            }
-          },
-          "204": {
-            "description": "Resource does not exist."
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
-        },
-        "x-ms-long-running-operation": true
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/gremlinRoleDefinitions": {
-      "get": {
-        "operationId": "GremlinResources_ListGremlinRoleDefinitions",
-        "description": "Retrieves the list of all Azure Cosmos DB Gremlin Role Definitions.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/GremlinRoleDefinitionListResult"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-pageable": {
-          "nextLinkName": "nextLink"
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/gremlinRoleDefinitions/{roleDefinitionId}": {
-      "get": {
-        "operationId": "GremlinResources_GetGremlinRoleDefinition",
-        "description": "Retrieves the properties of an existing Azure Cosmos DB Gremlin Role Definition with the given Id.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "roleDefinitionId",
-            "in": "path",
-            "description": "The GUID for the Role Definition.",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/GremlinRoleDefinitionResource"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        }
-      },
-      "put": {
-        "operationId": "GremlinResources_CreateUpdateGremlinRoleDefinition",
-        "description": "Creates or updates an Azure Cosmos DB Gremlin Role Definition.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "roleDefinitionId",
-            "in": "path",
-            "description": "The GUID for the Role Definition.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "createUpdateGremlinRoleDefinitionParameters",
-            "in": "body",
-            "description": "The properties required to create or update a Role Definition.",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/GremlinRoleDefinitionResource"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Resource 'GremlinRoleDefinitionResource' update operation succeeded",
-            "schema": {
-              "$ref": "#/definitions/GremlinRoleDefinitionResource"
-            }
-          },
-          "202": {
-            "description": "Resource operation accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location",
-          "final-state-schema": "#/definitions/GremlinRoleDefinitionResource"
-        },
-        "x-ms-long-running-operation": true
-      },
-      "delete": {
-        "operationId": "GremlinResources_DeleteGremlinRoleDefinition",
-        "description": "Deletes an existing Azure Cosmos DB Gremlin Role Definition.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "roleDefinitionId",
-            "in": "path",
-            "description": "The GUID for the Role Definition.",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Resource deleted successfully."
-          },
-          "202": {
-            "description": "Resource deletion accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              }
-            }
-          },
-          "204": {
-            "description": "Resource does not exist."
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
         },
         "x-ms-long-running-operation": true
       }
@@ -7898,6 +5380,14 @@
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "CosmosDBDatabaseAccountListConnectionStrings": {
+            "$ref": "./examples/CosmosDBDatabaseAccountListConnectionStrings.json"
+          },
+          "CosmosDBDatabaseAccountListConnectionStringsMongo": {
+            "$ref": "./examples/CosmosDBDatabaseAccountListConnectionStringsMongo.json"
+          }
         }
       }
     },
@@ -7939,6 +5429,11 @@
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "CosmosDBDatabaseAccountListKeys": {
+            "$ref": "./examples/CosmosDBDatabaseAccountListKeys.json"
+          }
         }
       }
     },
@@ -7979,6 +5474,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBDatabaseAccountGetMetricDefinitions": {
+            "$ref": "./examples/CosmosDBDatabaseAccountGetMetricDefinitions.json"
           }
         },
         "x-ms-pageable": {
@@ -8032,479 +5532,14 @@
             }
           }
         },
-        "x-ms-pageable": {
-          "nextLinkName": "nextLink"
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/mongoMIRoleAssignments": {
-      "get": {
-        "operationId": "MongoMIResources_ListMongoMIRoleAssignments",
-        "description": "Retrieves the list of all Azure Cosmos DB MongoMI Role Assignments.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/MongoMIRoleAssignmentListResult"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
+        "x-ms-examples": {
+          "CosmosDBDatabaseAccountGetMetrics": {
+            "$ref": "./examples/CosmosDBDatabaseAccountGetMetrics.json"
           }
         },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/mongoMIRoleAssignments/{roleAssignmentId}": {
-      "get": {
-        "operationId": "MongoMIResources_GetMongoMIRoleAssignment",
-        "description": "Retrieves the properties of an existing Azure Cosmos DB MongoMI Role Assignment with the given Id.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "roleAssignmentId",
-            "in": "path",
-            "description": "The GUID for the Role Assignment.",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/MongoMIRoleAssignmentResource"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        }
-      },
-      "put": {
-        "operationId": "MongoMIResources_CreateUpdateMongoMIRoleAssignment",
-        "description": "Creates or updates an Azure Cosmos DB MongoMI Role Assignment.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "roleAssignmentId",
-            "in": "path",
-            "description": "The GUID for the Role Assignment.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "createUpdateMongoMIRoleAssignmentParameters",
-            "in": "body",
-            "description": "The properties required to create or update a Role Assignment.",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/MongoMIRoleAssignmentResource"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Resource 'MongoMIRoleAssignmentResource' update operation succeeded",
-            "schema": {
-              "$ref": "#/definitions/MongoMIRoleAssignmentResource"
-            }
-          },
-          "202": {
-            "description": "Resource operation accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location",
-          "final-state-schema": "#/definitions/MongoMIRoleAssignmentResource"
-        },
-        "x-ms-long-running-operation": true
-      },
-      "delete": {
-        "operationId": "MongoMIResources_DeleteMongoMIRoleAssignment",
-        "description": "Deletes an existing Azure Cosmos DB MongoMI Role Assignment.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "roleAssignmentId",
-            "in": "path",
-            "description": "The GUID for the Role Assignment.",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Resource deleted successfully."
-          },
-          "202": {
-            "description": "Resource deletion accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              }
-            }
-          },
-          "204": {
-            "description": "Resource does not exist."
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
-        },
-        "x-ms-long-running-operation": true
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/mongoMIRoleDefinitions": {
-      "get": {
-        "operationId": "MongoMIResources_ListMongoMIRoleDefinitions",
-        "description": "Retrieves the list of all Azure Cosmos DB MongoMI Role Definitions.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/MongoMIRoleDefinitionListResult"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-pageable": {
-          "nextLinkName": "nextLink"
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/mongoMIRoleDefinitions/{roleDefinitionId}": {
-      "get": {
-        "operationId": "MongoMIResources_GetMongoMIRoleDefinition",
-        "description": "Retrieves the properties of an existing Azure Cosmos DB MongoMI Role Definition with the given Id.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "roleDefinitionId",
-            "in": "path",
-            "description": "The GUID for the Role Definition.",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/MongoMIRoleDefinitionResource"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        }
-      },
-      "put": {
-        "operationId": "MongoMIResources_CreateUpdateMongoMIRoleDefinition",
-        "description": "Creates or updates an Azure Cosmos DB MongoMI Role Definition.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "roleDefinitionId",
-            "in": "path",
-            "description": "The GUID for the Role Definition.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "createUpdateMongoMIRoleDefinitionParameters",
-            "in": "body",
-            "description": "The properties required to create or update a Role Definition.",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/MongoMIRoleDefinitionResource"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Resource 'MongoMIRoleDefinitionResource' update operation succeeded",
-            "schema": {
-              "$ref": "#/definitions/MongoMIRoleDefinitionResource"
-            }
-          },
-          "202": {
-            "description": "Resource operation accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location",
-          "final-state-schema": "#/definitions/MongoMIRoleDefinitionResource"
-        },
-        "x-ms-long-running-operation": true
-      },
-      "delete": {
-        "operationId": "MongoMIResources_DeleteMongoMIRoleDefinition",
-        "description": "Deletes an existing Azure Cosmos DB MongoMI Role Definition.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "roleDefinitionId",
-            "in": "path",
-            "description": "The GUID for the Role Definition.",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Resource deleted successfully."
-          },
-          "202": {
-            "description": "Resource deletion accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              }
-            }
-          },
-          "204": {
-            "description": "Resource does not exist."
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
-        },
-        "x-ms-long-running-operation": true
       }
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases": {
@@ -8544,6 +5579,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBMongoDBDatabaseList": {
+            "$ref": "./examples/CosmosDBMongoDBDatabaseList.json"
           }
         },
         "x-ms-pageable": {
@@ -8595,6 +5635,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBMongoDBDatabaseGet": {
+            "$ref": "./examples/CosmosDBMongoDBDatabaseGet.json"
           }
         }
       },
@@ -8671,6 +5716,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBMongoDBDatabaseCreateUpdate": {
+            "$ref": "./examples/CosmosDBMongoDBDatabaseCreateUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/MongoDBDatabaseGetResults"
@@ -8733,6 +5783,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBMongoDBDatabaseDelete": {
+            "$ref": "./examples/CosmosDBMongoDBDatabaseDelete.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -8783,6 +5838,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBMongoDBCollectionList": {
+            "$ref": "./examples/CosmosDBMongoDBCollectionList.json"
           }
         },
         "x-ms-pageable": {
@@ -8841,6 +5901,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBMongoDBCollectionGet": {
+            "$ref": "./examples/CosmosDBMongoDBCollectionGet.json"
           }
         }
       },
@@ -8924,6 +5989,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBMongoDBCollectionCreateUpdate": {
+            "$ref": "./examples/CosmosDBMongoDBCollectionCreateUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/MongoDBCollectionGetResults"
@@ -8993,96 +6063,13 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBMongoDBCollectionDelete": {
+            "$ref": "./examples/CosmosDBMongoDBCollectionDelete.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
-        },
-        "x-ms-long-running-operation": true
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/collections/{collectionName}/partitionMerge": {
-      "post": {
-        "operationId": "MongoDBResources_ListMongoDBCollectionPartitionMerge",
-        "description": "Merges the partitions of a MongoDB Collection",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "databaseName",
-            "in": "path",
-            "description": "Cosmos DB database name.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "collectionName",
-            "in": "path",
-            "description": "Cosmos DB collection name.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "mergeParameters",
-            "in": "body",
-            "description": "The parameters for the merge operation.",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/MergeParameters"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/PhysicalPartitionStorageInfoCollection"
-            }
-          },
-          "202": {
-            "description": "Resource operation accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/CloudError"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location",
-          "final-state-schema": "#/definitions/PhysicalPartitionStorageInfoCollection"
         },
         "x-ms-long-running-operation": true
       }
@@ -9163,6 +6150,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBMongoDBCollectionBackupInformation": {
+            "$ref": "./examples/CosmosDBMongoDBCollectionBackupInformation.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/BackupInformation"
@@ -9221,6 +6213,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBMongoDBCollectionThroughputGet": {
+            "$ref": "./examples/CosmosDBMongoDBCollectionThroughputGet.json"
           }
         }
       },
@@ -9304,6 +6301,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBMongoDBCollectionThroughputUpdate": {
+            "$ref": "./examples/CosmosDBMongoDBCollectionThroughputUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
@@ -9381,6 +6383,11 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBMongoDBCollectionMigrateToAutoscale": {
+            "$ref": "./examples/CosmosDBMongoDBCollectionMigrateToAutoscale.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -9462,266 +6469,14 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBMongoDBCollectionMigrateToManualThroughput": {
+            "$ref": "./examples/CosmosDBMongoDBCollectionMigrateToManualThroughput.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
-        },
-        "x-ms-long-running-operation": true
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/collections/{collectionName}/throughputSettings/default/redistributeThroughput": {
-      "post": {
-        "operationId": "MongoDBResources_MongoDBContainerRedistributeThroughput",
-        "description": "Redistribute throughput for an Azure Cosmos DB MongoDB container",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "databaseName",
-            "in": "path",
-            "description": "Cosmos DB database name.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "collectionName",
-            "in": "path",
-            "description": "Cosmos DB collection name.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "redistributeThroughputParameters",
-            "in": "body",
-            "description": "The parameters to provide for redistributing throughput for the current MongoDB container.",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/RedistributeThroughputParameters"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/PhysicalPartitionThroughputInfoResult"
-            }
-          },
-          "202": {
-            "description": "Resource operation accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/CloudError"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location",
-          "final-state-schema": "#/definitions/PhysicalPartitionThroughputInfoResult"
-        },
-        "x-ms-long-running-operation": true
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/collections/{collectionName}/throughputSettings/default/retrieveThroughputDistribution": {
-      "post": {
-        "operationId": "MongoDBResources_MongoDBContainerRetrieveThroughputDistribution",
-        "description": "Retrieve throughput distribution for an Azure Cosmos DB MongoDB container",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "databaseName",
-            "in": "path",
-            "description": "Cosmos DB database name.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "collectionName",
-            "in": "path",
-            "description": "Cosmos DB collection name.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "retrieveThroughputParameters",
-            "in": "body",
-            "description": "The parameters to provide for retrieving throughput distribution for the current MongoDB container.",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/RetrieveThroughputParameters"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/PhysicalPartitionThroughputInfoResult"
-            }
-          },
-          "202": {
-            "description": "Resource operation accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/CloudError"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location",
-          "final-state-schema": "#/definitions/PhysicalPartitionThroughputInfoResult"
-        },
-        "x-ms-long-running-operation": true
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/partitionMerge": {
-      "post": {
-        "operationId": "MongoDBResources_MongoDBDatabasePartitionMerge",
-        "description": "Merges the partitions of a MongoDB database",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "databaseName",
-            "in": "path",
-            "description": "Cosmos DB database name.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "mergeParameters",
-            "in": "body",
-            "description": "The parameters for the merge operation.",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/MergeParameters"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/PhysicalPartitionStorageInfoCollection"
-            }
-          },
-          "202": {
-            "description": "Resource operation accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/CloudError"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location",
-          "final-state-schema": "#/definitions/PhysicalPartitionStorageInfoCollection"
         },
         "x-ms-long-running-operation": true
       }
@@ -9770,6 +6525,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBMongoDBDatabaseThroughputGet": {
+            "$ref": "./examples/CosmosDBMongoDBDatabaseThroughputGet.json"
           }
         }
       },
@@ -9846,6 +6606,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBMongoDBDatabaseThroughputUpdate": {
+            "$ref": "./examples/CosmosDBMongoDBDatabaseThroughputUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
@@ -9916,6 +6681,11 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBMongoDBDatabaseMigrateToAutoscale": {
+            "$ref": "./examples/CosmosDBMongoDBDatabaseMigrateToAutoscale.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -9990,171 +6760,14 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBMongoDBDatabaseMigrateToManualThroughput": {
+            "$ref": "./examples/CosmosDBMongoDBDatabaseMigrateToManualThroughput.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
-        },
-        "x-ms-long-running-operation": true
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/throughputSettings/default/redistributeThroughput": {
-      "post": {
-        "operationId": "MongoDBResources_MongoDBDatabaseRedistributeThroughput",
-        "description": "Redistribute throughput for an Azure Cosmos DB MongoDB database",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "databaseName",
-            "in": "path",
-            "description": "Cosmos DB database name.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "redistributeThroughputParameters",
-            "in": "body",
-            "description": "The parameters to provide for redistributing throughput for the current MongoDB database.",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/RedistributeThroughputParameters"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/PhysicalPartitionThroughputInfoResult"
-            }
-          },
-          "202": {
-            "description": "Resource operation accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/CloudError"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location",
-          "final-state-schema": "#/definitions/PhysicalPartitionThroughputInfoResult"
-        },
-        "x-ms-long-running-operation": true
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/mongodbDatabases/{databaseName}/throughputSettings/default/retrieveThroughputDistribution": {
-      "post": {
-        "operationId": "MongoDBResources_MongoDBDatabaseRetrieveThroughputDistribution",
-        "description": "Retrieve throughput distribution for an Azure Cosmos DB MongoDB database",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "databaseName",
-            "in": "path",
-            "description": "Cosmos DB database name.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "retrieveThroughputParameters",
-            "in": "body",
-            "description": "The parameters to provide for retrieving throughput distribution for the current MongoDB database.",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/RetrieveThroughputParameters"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/PhysicalPartitionThroughputInfoResult"
-            }
-          },
-          "202": {
-            "description": "Resource operation accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/CloudError"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location",
-          "final-state-schema": "#/definitions/PhysicalPartitionThroughputInfoResult"
         },
         "x-ms-long-running-operation": true
       }
@@ -10196,6 +6809,11 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBMongoDBRoleDefinitionList": {
+            "$ref": "./examples/CosmosDBMongoDBRoleDefinitionList.json"
           }
         },
         "x-ms-pageable": {
@@ -10247,6 +6865,11 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBMongoRoleDefinitionGet": {
+            "$ref": "./examples/CosmosDBMongoDBRoleDefinitionGet.json"
           }
         }
       },
@@ -10318,6 +6941,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBMongoDBRoleDefinitionCreateUpdate": {
+            "$ref": "./examples/CosmosDBMongoDBRoleDefinitionCreateUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/MongoRoleDefinitionGetResults"
@@ -10383,6 +7011,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBMongoDBRoleDefinitionDelete": {
+            "$ref": "./examples/CosmosDBMongoDBRoleDefinitionDelete.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -10426,6 +7059,11 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBMongoDBUserDefinitionList": {
+            "$ref": "./examples/CosmosDBMongoDBUserDefinitionList.json"
           }
         },
         "x-ms-pageable": {
@@ -10477,6 +7115,11 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBMongoDBUserDefinitionGet": {
+            "$ref": "./examples/CosmosDBMongoDBUserDefinitionGet.json"
           }
         }
       },
@@ -10548,6 +7191,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBMongoDBUserDefinitionCreateUpdate": {
+            "$ref": "./examples/CosmosDBMongoDBUserDefinitionCreateUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/MongoUserDefinitionGetResults"
@@ -10613,167 +7261,9 @@
             }
           }
         },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
-        },
-        "x-ms-long-running-operation": true
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/networkSecurityPerimeterConfigurations": {
-      "get": {
-        "operationId": "NetworkSecurityPerimeterConfigurations_List",
-        "tags": [
-          "NetworkSecurityPerimeterConfigurations"
-        ],
-        "description": "Gets list of effective Network Security Perimeter Configuration for cosmos db account",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationListResult"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-pageable": {
-          "nextLinkName": "nextLink"
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/networkSecurityPerimeterConfigurations/{networkSecurityPerimeterConfigurationName}": {
-      "get": {
-        "operationId": "NetworkSecurityPerimeterConfigurations_Get",
-        "tags": [
-          "NetworkSecurityPerimeterConfigurations"
-        ],
-        "description": "Gets effective Network Security Perimeter Configuration for association",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "networkSecurityPerimeterConfigurationName",
-            "in": "path",
-            "description": "The name for Network Security Perimeter configuration",
-            "required": true,
-            "type": "string",
-            "pattern": "^.*$"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/NetworkSecurityPerimeterConfiguration"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/networkSecurityPerimeterConfigurations/{networkSecurityPerimeterConfigurationName}/reconcile": {
-      "post": {
-        "operationId": "NetworkSecurityPerimeterConfigurations_Reconcile",
-        "tags": [
-          "NetworkSecurityPerimeterConfigurations"
-        ],
-        "description": "Refreshes any information about the association.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "networkSecurityPerimeterConfigurationName",
-            "in": "path",
-            "description": "The name for Network Security Perimeter configuration",
-            "required": true,
-            "type": "string",
-            "pattern": "^.*$"
-          }
-        ],
-        "responses": {
-          "202": {
-            "description": "Resource operation accepted.",
-            "headers": {
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
+        "x-ms-examples": {
+          "CosmosDBMongoDBUserDefinitionDelete": {
+            "$ref": "./examples/CosmosDBMongoDBUserDefinitionDelete.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -10822,6 +7312,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBNotebookWorkspaceList": {
+            "$ref": "./examples/CosmosDBNotebookWorkspaceList.json"
           }
         },
         "x-ms-pageable": {
@@ -10889,6 +7384,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBNotebookWorkspaceGet": {
+            "$ref": "./examples/CosmosDBNotebookWorkspaceGet.json"
           }
         }
       },
@@ -10966,6 +7466,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBNotebookWorkspaceCreate": {
+            "$ref": "./examples/CosmosDBNotebookWorkspaceCreate.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -11046,6 +7551,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBNotebookWorkspaceDelete": {
+            "$ref": "./examples/CosmosDBNotebookWorkspaceDelete.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -11112,6 +7622,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBNotebookWorkspaceListConnectionInfo": {
+            "$ref": "./examples/CosmosDBNotebookWorkspaceListConnectionInfo.json"
           }
         }
       }
@@ -11187,6 +7702,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBNotebookWorkspaceRegenerateAuthToken": {
+            "$ref": "./examples/CosmosDBNotebookWorkspaceRegenerateAuthToken.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -11268,6 +7788,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBNotebookWorkspaceStart": {
+            "$ref": "./examples/CosmosDBNotebookWorkspaceStart.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -11336,6 +7861,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBDatabaseAccountOfflineRegion": {
+            "$ref": "./examples/CosmosDBDatabaseAccountOfflineRegion.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -11408,6 +7938,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBDatabaseAccountOnlineRegion": {
+            "$ref": "./examples/CosmosDBDatabaseAccountOnlineRegion.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -11460,6 +7995,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBDatabaseAccountRegionGetMetrics": {
+            "$ref": "./examples/CosmosDBPercentileGetMetrics.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -11505,6 +8045,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Gets private endpoint connection.": {
+            "$ref": "./examples/CosmosDBPrivateEndpointConnectionListGet.json"
           }
         },
         "x-ms-pageable": {
@@ -11559,6 +8104,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Gets private endpoint connection.": {
+            "$ref": "./examples/CosmosDBPrivateEndpointConnectionGet.json"
           }
         }
       },
@@ -11633,6 +8183,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Approve or reject a private endpoint connection with a given name.": {
+            "$ref": "./examples/CosmosDBPrivateEndpointConnectionUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/PrivateEndpointConnection"
@@ -11698,6 +8253,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Deletes a private endpoint connection with a given name.": {
+            "$ref": "./examples/CosmosDBPrivateEndpointConnectionDelete.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -11744,6 +8304,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Gets private endpoint connection.": {
+            "$ref": "./examples/CosmosDBPrivateLinkResourceListGet.json"
           }
         },
         "x-ms-pageable": {
@@ -11799,6 +8364,11 @@
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "Gets private endpoint connection.": {
+            "$ref": "./examples/CosmosDBPrivateLinkResourceGet.json"
+          }
         }
       }
     },
@@ -11840,6 +8410,11 @@
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "CosmosDBDatabaseAccountListReadOnlyKeys": {
+            "$ref": "./examples/CosmosDBDatabaseAccountListReadOnlyKeys_GetReadOnlyKeys.json"
+          }
         }
       },
       "post": {
@@ -11878,6 +8453,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBDatabaseAccountListReadOnlyKeys": {
+            "$ref": "./examples/CosmosDBDatabaseAccountListReadOnlyKeys.json"
           }
         }
       }
@@ -11944,6 +8524,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBDatabaseAccountRegenerateKey": {
+            "$ref": "./examples/CosmosDBDatabaseAccountRegenerateKey.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -12017,6 +8602,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBRegionCollectionGetMetrics": {
+            "$ref": "./examples/CosmosDBRegionCollectionGetMetrics.json"
           }
         },
         "x-ms-pageable": {
@@ -12098,6 +8688,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBDatabaseAccountRegionGetMetrics": {
+            "$ref": "./examples/CosmosDBPKeyRangeIdRegionGetMetrics.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -12170,6 +8765,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBDatabaseAccountRegionGetMetrics": {
+            "$ref": "./examples/CosmosDBCollectionPartitionRegionGetMetrics.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -12228,6 +8828,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBDatabaseAccountRegionGetMetrics": {
+            "$ref": "./examples/CosmosDBDatabaseAccountRegionGetMetrics.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -12270,6 +8875,11 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBServicesList": {
+            "$ref": "./examples/CosmosDBServicesList.json"
           }
         },
         "x-ms-pageable": {
@@ -12329,6 +8939,20 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
+          }
+        },
+        "x-ms-examples": {
+          "DataTransferServiceGet": {
+            "$ref": "./examples/CosmosDBDataTransferServiceGet.json"
+          },
+          "GraphAPIComputeServiceGet": {
+            "$ref": "./examples/CosmosDBGraphAPIComputeServiceGet.json"
+          },
+          "MaterializedViewsBuilderServiceGet": {
+            "$ref": "./examples/CosmosDBMaterializedViewsBuilderServiceGet.json"
+          },
+          "SqlDedicatedGatewayServiceGet": {
+            "$ref": "./examples/services/sqldedicatedgateway/CosmosDBSqlDedicatedGatewayServiceGet.json"
           }
         }
       },
@@ -12408,6 +9032,20 @@
             }
           }
         },
+        "x-ms-examples": {
+          "DataTransferServiceCreate": {
+            "$ref": "./examples/CosmosDBDataTransferServiceCreate.json"
+          },
+          "GraphAPIComputeServiceCreate": {
+            "$ref": "./examples/CosmosDBGraphAPIComputeServiceCreate.json"
+          },
+          "MaterializedViewsBuilderServiceCreate": {
+            "$ref": "./examples/CosmosDBMaterializedViewsBuilderServiceCreate.json"
+          },
+          "SqlDedicatedGatewayServiceCreate": {
+            "$ref": "./examples/services/sqldedicatedgateway/CosmosDBSqlDedicatedGatewayServiceCreate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ServiceResource"
@@ -12481,6 +9119,20 @@
             }
           }
         },
+        "x-ms-examples": {
+          "DataTransferServiceDelete": {
+            "$ref": "./examples/CosmosDBDataTransferServiceDelete.json"
+          },
+          "GraphAPIComputeServiceDelete": {
+            "$ref": "./examples/CosmosDBGraphAPIComputeServiceDelete.json"
+          },
+          "MaterializedViewsBuilderServiceDelete": {
+            "$ref": "./examples/CosmosDBMaterializedViewsBuilderServiceDelete.json"
+          },
+          "SqlDedicatedGatewayServiceDelete": {
+            "$ref": "./examples/services/sqldedicatedgateway/CosmosDBSqlDedicatedGatewayServiceDelete.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -12547,6 +9199,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBDatabaseAccountRegionGetMetrics": {
+            "$ref": "./examples/CosmosDBPercentileSourceTargetGetMetrics.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -12589,6 +9246,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBSqlDatabaseList": {
+            "$ref": "./examples/CosmosDBSqlDatabaseList.json"
           }
         },
         "x-ms-pageable": {
@@ -12640,6 +9302,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBSqlDatabaseGet": {
+            "$ref": "./examples/CosmosDBSqlDatabaseGet.json"
           }
         }
       },
@@ -12716,6 +9383,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBSqlDatabaseCreateUpdate": {
+            "$ref": "./examples/CosmosDBSqlDatabaseCreateUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/SqlDatabaseGetResults"
@@ -12778,6 +9450,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBSqlDatabaseDelete": {
+            "$ref": "./examples/CosmosDBSqlDatabaseDelete.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -12828,6 +9505,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBClientEncryptionKeysList": {
+            "$ref": "./examples/CosmosDBSqlClientEncryptionKeysList.json"
           }
         },
         "x-ms-pageable": {
@@ -12886,6 +9568,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBClientEncryptionKeyGet": {
+            "$ref": "./examples/CosmosDBSqlClientEncryptionKeyGet.json"
           }
         }
       },
@@ -12969,6 +9656,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBClientEncryptionKeyCreateUpdate": {
+            "$ref": "./examples/CosmosDBSqlClientEncryptionKeyCreateUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ClientEncryptionKeyGetResults"
@@ -13020,6 +9712,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBSqlContainerList": {
+            "$ref": "./examples/CosmosDBSqlContainerList.json"
           }
         },
         "x-ms-pageable": {
@@ -13078,6 +9775,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBSqlContainerGet": {
+            "$ref": "./examples/CosmosDBSqlContainerGet.json"
           }
         }
       },
@@ -13161,6 +9863,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBSqlContainerCreateUpdate": {
+            "$ref": "./examples/CosmosDBSqlContainerCreateUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/SqlContainerGetResults"
@@ -13230,91 +9937,13 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBSqlContainerDelete": {
+            "$ref": "./examples/CosmosDBSqlContainerDelete.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
-        },
-        "x-ms-long-running-operation": true
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/partitionMerge": {
-      "post": {
-        "operationId": "SqlResources_ListSqlContainerPartitionMerge",
-        "description": "Merges the partitions of a SQL Container",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "databaseName",
-            "in": "path",
-            "description": "Cosmos DB database name.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "containerName",
-            "in": "path",
-            "description": "Cosmos DB container name.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "mergeParameters",
-            "in": "body",
-            "description": "The parameters for the merge operation.",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/MergeParameters"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/PhysicalPartitionStorageInfoCollection"
-            }
-          },
-          "202": {
-            "description": "Resource operation accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/CloudError"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location",
-          "final-state-schema": "#/definitions/PhysicalPartitionStorageInfoCollection"
         },
         "x-ms-long-running-operation": true
       }
@@ -13395,6 +10024,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBSqlContainerBackupInformation": {
+            "$ref": "./examples/CosmosDBSqlContainerBackupInformation.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/BackupInformation"
@@ -13453,6 +10087,11 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBSqlStoredProcedureList": {
+            "$ref": "./examples/CosmosDBSqlStoredProcedureList.json"
           }
         },
         "x-ms-pageable": {
@@ -13518,6 +10157,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBSqlStoredProcedureGet": {
+            "$ref": "./examples/CosmosDBSqlStoredProcedureGet.json"
           }
         }
       },
@@ -13608,6 +10252,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBSqlStoredProcedureCreateUpdate": {
+            "$ref": "./examples/CosmosDBSqlStoredProcedureCreateUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/SqlStoredProcedureGetResults"
@@ -13684,6 +10333,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBSqlStoredProcedureDelete": {
+            "$ref": "./examples/CosmosDBSqlStoredProcedureDelete.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -13741,6 +10395,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBSqlContainerThroughputGet": {
+            "$ref": "./examples/CosmosDBSqlContainerThroughputGet.json"
           }
         }
       },
@@ -13824,6 +10483,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBSqlContainerThroughputUpdate": {
+            "$ref": "./examples/CosmosDBSqlContainerThroughputUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
@@ -13896,6 +10560,11 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBSqlContainerMigrateToAutoscale": {
+            "$ref": "./examples/CosmosDBSqlContainerMigrateToAutoscale.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -13972,175 +10641,14 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBSqlContainerMigrateToManualThroughput": {
+            "$ref": "./examples/CosmosDBSqlContainerMigrateToManualThroughput.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
-        },
-        "x-ms-long-running-operation": true
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/throughputSettings/default/redistributeThroughput": {
-      "post": {
-        "operationId": "SqlResources_SqlContainerRedistributeThroughput",
-        "description": "Redistribute throughput for an Azure Cosmos DB SQL container",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "databaseName",
-            "in": "path",
-            "description": "Cosmos DB database name.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "containerName",
-            "in": "path",
-            "description": "Cosmos DB container name.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "redistributeThroughputParameters",
-            "in": "body",
-            "description": "The parameters to provide for redistributing throughput for the current SQL container.",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/RedistributeThroughputParameters"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/PhysicalPartitionThroughputInfoResult"
-            }
-          },
-          "202": {
-            "description": "Resource operation accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/CloudError"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location",
-          "final-state-schema": "#/definitions/PhysicalPartitionThroughputInfoResult"
-        },
-        "x-ms-long-running-operation": true
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/containers/{containerName}/throughputSettings/default/retrieveThroughputDistribution": {
-      "post": {
-        "operationId": "SqlResources_SqlContainerRetrieveThroughputDistribution",
-        "description": "Retrieve throughput distribution for an Azure Cosmos DB SQL container",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "databaseName",
-            "in": "path",
-            "description": "Cosmos DB database name.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "containerName",
-            "in": "path",
-            "description": "Cosmos DB container name.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "retrieveThroughputParameters",
-            "in": "body",
-            "description": "The parameters to provide for retrieving throughput distribution for the current SQL container.",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/RetrieveThroughputParameters"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/PhysicalPartitionThroughputInfoResult"
-            }
-          },
-          "202": {
-            "description": "Resource operation accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/CloudError"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location",
-          "final-state-schema": "#/definitions/PhysicalPartitionThroughputInfoResult"
         },
         "x-ms-long-running-operation": true
       }
@@ -14196,6 +10704,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBSqlTriggerList": {
+            "$ref": "./examples/CosmosDBSqlTriggerList.json"
           }
         },
         "x-ms-pageable": {
@@ -14261,6 +10774,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBSqlTriggerGet": {
+            "$ref": "./examples/CosmosDBSqlTriggerGet.json"
           }
         }
       },
@@ -14351,6 +10869,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBSqlTriggerCreateUpdate": {
+            "$ref": "./examples/CosmosDBSqlTriggerCreateUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/SqlTriggerGetResults"
@@ -14427,6 +10950,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBSqlTriggerDelete": {
+            "$ref": "./examples/CosmosDBSqlTriggerDelete.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -14484,6 +11012,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBSqlUserDefinedFunctionList": {
+            "$ref": "./examples/CosmosDBSqlUserDefinedFunctionList.json"
           }
         },
         "x-ms-pageable": {
@@ -14549,6 +11082,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBSqlUserDefinedFunctionGet": {
+            "$ref": "./examples/CosmosDBSqlUserDefinedFunctionGet.json"
           }
         }
       },
@@ -14639,6 +11177,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBSqlUserDefinedFunctionCreateUpdate": {
+            "$ref": "./examples/CosmosDBSqlUserDefinedFunctionCreateUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/SqlUserDefinedFunctionGetResults"
@@ -14715,89 +11258,13 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBSqlUserDefinedFunctionDelete": {
+            "$ref": "./examples/CosmosDBSqlUserDefinedFunctionDelete.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
-        },
-        "x-ms-long-running-operation": true
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/partitionMerge": {
-      "post": {
-        "operationId": "SqlResources_SqlDatabasePartitionMerge",
-        "description": "Merges the partitions of a SQL database",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "databaseName",
-            "in": "path",
-            "description": "Cosmos DB database name.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "mergeParameters",
-            "in": "body",
-            "description": "The parameters for the merge operation.",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/MergeParameters"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/PhysicalPartitionStorageInfoCollection"
-            }
-          },
-          "202": {
-            "description": "Resource operation accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/CloudError"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location",
-          "final-state-schema": "#/definitions/PhysicalPartitionStorageInfoCollection"
         },
         "x-ms-long-running-operation": true
       }
@@ -14846,6 +11313,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBSqlDatabaseThroughputGet": {
+            "$ref": "./examples/CosmosDBSqlDatabaseThroughputGet.json"
           }
         }
       },
@@ -14922,6 +11394,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBSqlDatabaseThroughputUpdate": {
+            "$ref": "./examples/CosmosDBSqlDatabaseThroughputUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
@@ -14992,6 +11469,11 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBSqlDatabaseMigrateToAutoscale": {
+            "$ref": "./examples/CosmosDBSqlDatabaseMigrateToAutoscale.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -15066,171 +11548,14 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBSqlDatabaseMigrateToManualThroughput": {
+            "$ref": "./examples/CosmosDBSqlDatabaseMigrateToManualThroughput.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
-        },
-        "x-ms-long-running-operation": true
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/throughputSettings/default/redistributeThroughput": {
-      "post": {
-        "operationId": "SqlResources_SqlDatabaseRedistributeThroughput",
-        "description": "Redistribute throughput for an Azure Cosmos DB SQL database",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "databaseName",
-            "in": "path",
-            "description": "Cosmos DB database name.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "redistributeThroughputParameters",
-            "in": "body",
-            "description": "The parameters to provide for redistributing throughput for the current SQL database.",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/RedistributeThroughputParameters"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/PhysicalPartitionThroughputInfoResult"
-            }
-          },
-          "202": {
-            "description": "Resource operation accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/CloudError"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location",
-          "final-state-schema": "#/definitions/PhysicalPartitionThroughputInfoResult"
-        },
-        "x-ms-long-running-operation": true
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/sqlDatabases/{databaseName}/throughputSettings/default/retrieveThroughputDistribution": {
-      "post": {
-        "operationId": "SqlResources_SqlDatabaseRetrieveThroughputDistribution",
-        "description": "Retrieve throughput distribution for an Azure Cosmos DB SQL database",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "databaseName",
-            "in": "path",
-            "description": "Cosmos DB database name.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "retrieveThroughputParameters",
-            "in": "body",
-            "description": "The parameters to provide for retrieving throughput distribution for the current SQL database.",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/RetrieveThroughputParameters"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/PhysicalPartitionThroughputInfoResult"
-            }
-          },
-          "202": {
-            "description": "Resource operation accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/CloudError"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location",
-          "final-state-schema": "#/definitions/PhysicalPartitionThroughputInfoResult"
         },
         "x-ms-long-running-operation": true
       }
@@ -15272,6 +11597,11 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBSqlRoleAssignmentList": {
+            "$ref": "./examples/CosmosDBSqlRoleAssignmentList.json"
           }
         },
         "x-ms-pageable": {
@@ -15323,6 +11653,11 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBSqlRoleAssignmentGet": {
+            "$ref": "./examples/CosmosDBSqlRoleAssignmentGet.json"
           }
         }
       },
@@ -15394,6 +11729,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBSqlRoleAssignmentCreateUpdate": {
+            "$ref": "./examples/CosmosDBSqlRoleAssignmentCreateUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/SqlRoleAssignmentGetResults"
@@ -15459,6 +11799,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBSqlRoleAssignmentDelete": {
+            "$ref": "./examples/CosmosDBSqlRoleAssignmentDelete.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -15502,6 +11847,11 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBSqlRoleDefinitionList": {
+            "$ref": "./examples/CosmosDBSqlRoleDefinitionList.json"
           }
         },
         "x-ms-pageable": {
@@ -15553,6 +11903,11 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBSqlRoleDefinitionGet": {
+            "$ref": "./examples/CosmosDBSqlRoleDefinitionGet.json"
           }
         }
       },
@@ -15624,6 +11979,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBSqlRoleDefinitionCreateUpdate": {
+            "$ref": "./examples/CosmosDBSqlRoleDefinitionCreateUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/SqlRoleDefinitionGetResults"
@@ -15689,469 +12049,9 @@
             }
           }
         },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
-        },
-        "x-ms-long-running-operation": true
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/tableRoleAssignments": {
-      "get": {
-        "operationId": "TableResources_ListTableRoleAssignments",
-        "description": "Retrieves the list of all Azure Cosmos DB Table Role Assignments.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "The request has succeeded.",
-            "schema": {
-              "$ref": "#/definitions/TableRoleAssignmentListResult"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-pageable": {
-          "nextLinkName": "nextLink"
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/tableRoleAssignments/{roleAssignmentId}": {
-      "get": {
-        "operationId": "TableResources_GetTableRoleAssignment",
-        "description": "Retrieves the properties of an existing Azure Cosmos DB Table Role Assignment with the given Id.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "roleAssignmentId",
-            "in": "path",
-            "description": "The GUID for the Role Assignment.",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/TableRoleAssignmentResource"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        }
-      },
-      "put": {
-        "operationId": "TableResources_CreateUpdateTableRoleAssignment",
-        "description": "Creates or updates an Azure Cosmos DB Table Role Assignment.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "roleAssignmentId",
-            "in": "path",
-            "description": "The GUID for the Role Assignment.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "createUpdateTableRoleAssignmentParameters",
-            "in": "body",
-            "description": "The properties required to create or update a Role Assignment.",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/TableRoleAssignmentResource"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Resource 'TableRoleAssignmentResource' update operation succeeded",
-            "schema": {
-              "$ref": "#/definitions/TableRoleAssignmentResource"
-            }
-          },
-          "202": {
-            "description": "Resource operation accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location",
-          "final-state-schema": "#/definitions/TableRoleAssignmentResource"
-        },
-        "x-ms-long-running-operation": true
-      },
-      "delete": {
-        "operationId": "TableResources_DeleteTableRoleAssignment",
-        "description": "Deletes an existing Azure Cosmos DB Table Role Assignment.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "roleAssignmentId",
-            "in": "path",
-            "description": "The GUID for the Role Assignment.",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Resource deleted successfully."
-          },
-          "202": {
-            "description": "Resource deletion accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              }
-            }
-          },
-          "204": {
-            "description": "Resource does not exist."
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
-        },
-        "x-ms-long-running-operation": true
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/tableRoleDefinitions": {
-      "get": {
-        "operationId": "TableResources_ListTableRoleDefinitions",
-        "description": "Retrieves the list of all Azure Cosmos DB Table Role Definitions.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "The request has succeeded.",
-            "schema": {
-              "$ref": "#/definitions/TableRoleDefinitionListResult"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-pageable": {
-          "nextLinkName": "nextLink"
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/tableRoleDefinitions/{roleDefinitionId}": {
-      "get": {
-        "operationId": "TableResources_GetTableRoleDefinition",
-        "description": "Retrieves the properties of an existing Azure Cosmos DB Table Role Definition with the given Id.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "roleDefinitionId",
-            "in": "path",
-            "description": "The GUID for the Role Definition.",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/TableRoleDefinitionResource"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        }
-      },
-      "put": {
-        "operationId": "TableResources_CreateUpdateTableRoleDefinition",
-        "description": "Creates or updates an Azure Cosmos DB Table Role Definition.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "roleDefinitionId",
-            "in": "path",
-            "description": "The GUID for the Role Definition.",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "createUpdateTableRoleDefinitionParameters",
-            "in": "body",
-            "description": "The properties required to create or update a Role Definition.",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/TableRoleDefinitionResource"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Resource 'TableRoleDefinitionResource' update operation succeeded",
-            "schema": {
-              "$ref": "#/definitions/TableRoleDefinitionResource"
-            }
-          },
-          "202": {
-            "description": "Resource operation accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location",
-          "final-state-schema": "#/definitions/TableRoleDefinitionResource"
-        },
-        "x-ms-long-running-operation": true
-      },
-      "delete": {
-        "operationId": "TableResources_DeleteTableRoleDefinition",
-        "description": "Deletes an existing Azure Cosmos DB Table Role Definition.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "roleDefinitionId",
-            "in": "path",
-            "description": "The GUID for the Role Definition.",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Resource deleted successfully."
-          },
-          "202": {
-            "description": "Resource deletion accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              }
-            }
-          },
-          "204": {
-            "description": "Resource does not exist."
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
+        "x-ms-examples": {
+          "CosmosDBSqlRoleDefinitionDelete": {
+            "$ref": "./examples/CosmosDBSqlRoleDefinitionDelete.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -16197,6 +12097,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBTableList": {
+            "$ref": "./examples/CosmosDBTableList.json"
           }
         },
         "x-ms-pageable": {
@@ -16248,6 +12153,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBTableGet": {
+            "$ref": "./examples/CosmosDBTableGet.json"
           }
         }
       },
@@ -16324,6 +12234,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBTableReplace": {
+            "$ref": "./examples/CosmosDBTableCreateUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/TableGetResults"
@@ -16384,6 +12299,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBTableDelete": {
+            "$ref": "./examples/CosmosDBTableDelete.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -16461,6 +12381,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBTableCollectionBackupInformation": {
+            "$ref": "./examples/CosmosDBTableBackupInformation.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/BackupInformation"
@@ -16512,6 +12437,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBTableThroughputGet": {
+            "$ref": "./examples/CosmosDBTableThroughputGet.json"
           }
         }
       },
@@ -16588,6 +12518,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBTableThroughputUpdate": {
+            "$ref": "./examples/CosmosDBTableThroughputUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
@@ -16658,6 +12593,11 @@
             "schema": {
               "$ref": "#/definitions/CloudError"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBTableMigrateToAutoscale": {
+            "$ref": "./examples/CosmosDBTableMigrateToAutoscale.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -16732,6 +12672,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBTableMigrateToManualThroughput": {
+            "$ref": "./examples/CosmosDBTableMigrateToManualThroughput.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ThroughputSettingsGetResults"
@@ -16792,6 +12737,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBDatabaseAccountRegionGetMetrics": {
+            "$ref": "./examples/CosmosDBPercentileTargetGetMetrics.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -16843,6 +12793,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDBDatabaseAccountGetUsages": {
+            "$ref": "./examples/CosmosDBDatabaseAccountGetUsages.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -16878,6 +12833,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDB Fleet List by Resource Group": {
+            "$ref": "./examples/fleet/CosmosDBFleetList_ListByResourceGroup.json"
           }
         },
         "x-ms-pageable": {
@@ -16922,6 +12882,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDB Fleet Get": {
+            "$ref": "./examples/fleet/CosmosDBFleetGet.json"
           }
         }
       },
@@ -16977,6 +12942,11 @@
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "CosmosDB Fleet Create": {
+            "$ref": "./examples/fleet/CosmosDBFleetCreate.json"
+          }
         }
       },
       "patch": {
@@ -17024,6 +12994,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDB Fleet Update": {
+            "$ref": "./examples/fleet/CosmosDBFleetUpdate.json"
           }
         }
       },
@@ -17081,232 +13056,9 @@
             }
           }
         },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "azure-async-operation"
-        },
-        "x-ms-long-running-operation": true
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/fleets/{fleetName}/fleetAnalytics": {
-      "get": {
-        "operationId": "FleetAnalytics_List",
-        "description": "Lists all the FleetAnalytics under a fleet.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "fleetName",
-            "in": "path",
-            "description": "Cosmos DB fleet name. Needs to be unique under a subscription.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "The request has succeeded.",
-            "schema": {
-              "$ref": "#/definitions/FleetAnalyticsListResult"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-pageable": {
-          "nextLinkName": "nextLink"
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/fleets/{fleetName}/fleetAnalytics/{fleetAnalyticsName}": {
-      "get": {
-        "operationId": "FleetAnalytics_Get",
-        "description": "Retrieves the properties of an existing Azure Cosmos DB FleetAnalytics under a fleet",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "fleetName",
-            "in": "path",
-            "description": "Cosmos DB fleet name. Needs to be unique under a subscription.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "fleetAnalyticsName",
-            "in": "path",
-            "description": "Cosmos DB fleetAnalytics name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/FleetAnalyticsResource"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        }
-      },
-      "put": {
-        "operationId": "FleetAnalytics_Create",
-        "description": "Creates an Azure Cosmos DB FleetAnalytics under a fleet.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "fleetName",
-            "in": "path",
-            "description": "Cosmos DB fleet name. Needs to be unique under a subscription.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "fleetAnalyticsName",
-            "in": "path",
-            "description": "Cosmos DB fleetAnalytics name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "description": "The parameters to provide for the current FleetAnalytics.",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/FleetAnalyticsResource"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Resource 'FleetAnalyticsResource' update operation succeeded",
-            "schema": {
-              "$ref": "#/definitions/FleetAnalyticsResource"
-            }
-          },
-          "201": {
-            "description": "Resource 'FleetAnalyticsResource' create operation succeeded",
-            "schema": {
-              "$ref": "#/definitions/FleetAnalyticsResource"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        }
-      },
-      "delete": {
-        "operationId": "FleetAnalytics_Delete",
-        "description": "Deletes an existing Azure Cosmos DB FleetAnalytics.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "fleetName",
-            "in": "path",
-            "description": "Cosmos DB fleet name. Needs to be unique under a subscription.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "fleetAnalyticsName",
-            "in": "path",
-            "description": "Cosmos DB fleetAnalytics name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          }
-        ],
-        "responses": {
-          "202": {
-            "description": "Resource deletion accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
-          },
-          "204": {
-            "description": "Resource does not exist."
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
+        "x-ms-examples": {
+          "CosmosDB Fleet Delete": {
+            "$ref": "./examples/fleet/CosmosDBFleetDelete.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -17352,6 +13104,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDB Fleetspace List": {
+            "$ref": "./examples/fleet/CosmosDBFleetspaceList.json"
           }
         },
         "x-ms-pageable": {
@@ -17406,6 +13163,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDB Fleetspace Get": {
+            "$ref": "./examples/fleet/CosmosDBFleetspaceGet.json"
           }
         }
       },
@@ -17481,6 +13243,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDB Fleetspace Create": {
+            "$ref": "./examples/fleet/CosmosDBFleetspaceCreate.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -17565,6 +13332,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDB Fleetspace Update": {
+            "$ref": "./examples/fleet/CosmosDBFleetspaceUpdate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "azure-async-operation",
           "final-state-schema": "#/definitions/FleetspaceResource"
@@ -17635,6 +13407,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDB Fleetspace Delete": {
+            "$ref": "./examples/fleet/CosmosDBFleetspaceDelete.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "azure-async-operation"
         },
@@ -17688,6 +13465,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDB FleetspaceAccount List": {
+            "$ref": "./examples/fleet/CosmosDBFleetspaceAccountList.json"
           }
         },
         "x-ms-pageable": {
@@ -17752,6 +13534,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDB FleetspaceAccount Get": {
+            "$ref": "./examples/fleet/CosmosDBFleetspaceAccountGet.json"
           }
         }
       },
@@ -17839,6 +13626,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDB FleetspaceAccount Create": {
+            "$ref": "./examples/fleet/CosmosDBFleetspaceAccountCreate.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "azure-async-operation",
           "final-state-schema": "#/definitions/FleetspaceAccountResource"
@@ -17919,797 +13711,13 @@
             }
           }
         },
+        "x-ms-examples": {
+          "CosmosDB FleetspaceAccount Delete": {
+            "$ref": "./examples/fleet/CosmosDBFleetspaceAccountDelete.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "azure-async-operation"
-        },
-        "x-ms-long-running-operation": true
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/garnetClusters": {
-      "get": {
-        "operationId": "GarnetClusters_ListByResourceGroup",
-        "description": "List all Garnet clusters in this resource group.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/ListGarnetClusters"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-pageable": {
-          "nextLinkName": "nextLink"
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/garnetClusters/{clusterName}": {
-      "get": {
-        "operationId": "GarnetClusters_Get",
-        "description": "Get the properties of a Garnet cache cluster.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "clusterName",
-            "in": "path",
-            "description": "The name of the GarnetClusterResource",
-            "required": true,
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 100,
-            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/GarnetClusterResource"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        }
-      },
-      "put": {
-        "operationId": "GarnetClusters_CreateUpdate",
-        "description": "Create or update a Garnet cache cluster. When updating, you must specify all writable properties.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "clusterName",
-            "in": "path",
-            "description": "The name of the GarnetClusterResource",
-            "required": true,
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 100,
-            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "description": "Resource create parameters.",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/GarnetClusterResource"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Resource 'GarnetClusterResource' update operation succeeded",
-            "schema": {
-              "$ref": "#/definitions/GarnetClusterResource"
-            }
-          },
-          "201": {
-            "description": "Resource 'GarnetClusterResource' create operation succeeded",
-            "schema": {
-              "$ref": "#/definitions/GarnetClusterResource"
-            },
-            "headers": {
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location",
-          "final-state-schema": "#/definitions/GarnetClusterResource"
-        },
-        "x-ms-long-running-operation": true
-      },
-      "patch": {
-        "operationId": "GarnetClusters_Update",
-        "description": "Updates some of the properties of a garnet cluster.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "clusterName",
-            "in": "path",
-            "description": "The name of the GarnetClusterResource",
-            "required": true,
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 100,
-            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "description": "The resource properties to be updated.",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/GarnetClusterResourcePatch"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/GarnetClusterResource"
-            }
-          },
-          "202": {
-            "description": "Resource operation accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location",
-          "final-state-schema": "#/definitions/GarnetClusterResource"
-        },
-        "x-ms-long-running-operation": true
-      },
-      "delete": {
-        "operationId": "GarnetClusters_Delete",
-        "description": "Deletes a Garnet cluster.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "clusterName",
-            "in": "path",
-            "description": "The name of the GarnetClusterResource",
-            "required": true,
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 100,
-            "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$"
-          }
-        ],
-        "responses": {
-          "202": {
-            "description": "Resource deletion accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
-          },
-          "204": {
-            "description": "Resource does not exist."
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
-        },
-        "x-ms-long-running-operation": true
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/throughputPools": {
-      "get": {
-        "operationId": "ThroughputPools_ListByResourceGroup",
-        "tags": [
-          "ThroughputPools"
-        ],
-        "description": "List all the ThroughputPools in a given resource group.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/ThroughputPoolsListResult"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-pageable": {
-          "nextLinkName": "nextLink"
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/throughputPools/{throughputPoolName}": {
-      "get": {
-        "operationId": "ThroughputPool_Get",
-        "description": "Retrieves the properties of an existing Azure Cosmos DB Throughput Pool",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "throughputPoolName",
-            "in": "path",
-            "description": "Cosmos DB Throughput Pool name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/ThroughputPoolResource"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        }
-      },
-      "put": {
-        "operationId": "ThroughputPool_CreateOrUpdate",
-        "description": "Creates or updates an Azure Cosmos DB ThroughputPool account. The \"Update\" method is preferred when performing updates on an account.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "throughputPoolName",
-            "in": "path",
-            "description": "Cosmos DB Throughput Pool name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "description": "The parameters to provide for the current ThroughputPool.",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/ThroughputPoolResource"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Resource 'ThroughputPoolResource' update operation succeeded",
-            "schema": {
-              "$ref": "#/definitions/ThroughputPoolResource"
-            }
-          },
-          "201": {
-            "description": "Resource 'ThroughputPoolResource' create operation succeeded",
-            "schema": {
-              "$ref": "#/definitions/ThroughputPoolResource"
-            },
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "description": "A link to the status monitor"
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "azure-async-operation",
-          "final-state-schema": "#/definitions/ThroughputPoolResource"
-        },
-        "x-ms-long-running-operation": true
-      },
-      "patch": {
-        "operationId": "ThroughputPool_Update",
-        "description": "Updates the properties of an existing Azure Cosmos DB Throughput Pool.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "throughputPoolName",
-            "in": "path",
-            "description": "Cosmos DB Throughput Pool name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "description": "The parameters to provide for the current Throughput Pool.",
-            "required": false,
-            "schema": {
-              "$ref": "#/definitions/ThroughputPoolUpdate"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/ThroughputPoolResource"
-            }
-          },
-          "202": {
-            "description": "Resource update request accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "azure-async-operation",
-          "final-state-schema": "#/definitions/ThroughputPoolResource"
-        },
-        "x-ms-long-running-operation": true
-      },
-      "delete": {
-        "operationId": "ThroughputPool_Delete",
-        "description": "Deletes an existing Azure Cosmos DB Throughput Pool.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "throughputPoolName",
-            "in": "path",
-            "description": "Cosmos DB Throughput Pool name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          }
-        ],
-        "responses": {
-          "202": {
-            "description": "Resource deletion accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              }
-            }
-          },
-          "204": {
-            "description": "Resource does not exist."
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
-        },
-        "x-ms-long-running-operation": true
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/throughputPools/{throughputPoolName}/throughputPoolAccounts": {
-      "get": {
-        "operationId": "ThroughputPoolAccounts_List",
-        "description": "Lists all the Azure Cosmos DB accounts available under the subscription.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "throughputPoolName",
-            "in": "path",
-            "description": "Cosmos DB Throughput Pool name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "The request has succeeded.",
-            "schema": {
-              "$ref": "#/definitions/ThroughputPoolAccountsListResult"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-pageable": {
-          "nextLinkName": "nextLink"
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/throughputPools/{throughputPoolName}/throughputPoolAccounts/{throughputPoolAccountName}": {
-      "get": {
-        "operationId": "ThroughputPoolAccount_Get",
-        "description": "Retrieves the properties of an existing Azure Cosmos DB Throughput Pool",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "throughputPoolName",
-            "in": "path",
-            "description": "Cosmos DB Throughput Pool name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "throughputPoolAccountName",
-            "in": "path",
-            "description": "Cosmos DB global database account in a Throughput Pool",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
-            "schema": {
-              "$ref": "#/definitions/ThroughputPoolAccountResource"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        }
-      },
-      "put": {
-        "operationId": "ThroughputPoolAccount_Create",
-        "description": "Creates or updates an Azure Cosmos DB ThroughputPool account. The \"Update\" method is preferred when performing updates on an account.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "throughputPoolName",
-            "in": "path",
-            "description": "Cosmos DB Throughput Pool name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "throughputPoolAccountName",
-            "in": "path",
-            "description": "Cosmos DB global database account in a Throughput Pool",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "description": "The parameters to provide for the current ThroughputPoolAccount.",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/ThroughputPoolAccountResource"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Resource 'ThroughputPoolAccountResource' update operation succeeded",
-            "schema": {
-              "$ref": "#/definitions/ThroughputPoolAccountResource"
-            }
-          },
-          "201": {
-            "description": "Resource 'ThroughputPoolAccountResource' create operation succeeded",
-            "schema": {
-              "$ref": "#/definitions/ThroughputPoolAccountResource"
-            },
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "description": "A link to the status monitor"
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "azure-async-operation",
-          "final-state-schema": "#/definitions/ThroughputPoolAccountResource"
-        },
-        "x-ms-long-running-operation": true
-      },
-      "delete": {
-        "operationId": "ThroughputPoolAccount_Delete",
-        "description": "Removes an existing Azure Cosmos DB database account from a throughput pool.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "throughputPoolName",
-            "in": "path",
-            "description": "Cosmos DB Throughput Pool name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "throughputPoolAccountName",
-            "in": "path",
-            "description": "Cosmos DB global database account in a Throughput Pool",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          }
-        ],
-        "responses": {
-          "202": {
-            "description": "Resource deletion accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              }
-            }
-          },
-          "204": {
-            "description": "Resource does not exist."
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
         },
         "x-ms-long-running-operation": true
       }
@@ -18783,30 +13791,6 @@
           "description": "Generation time in UTC of the key in ISO-8601 format. If the value is missing from the object, it means that the last key regeneration was triggered before 2022-06-18.",
           "readOnly": true
         }
-      }
-    },
-    "AllocationState": {
-      "type": "string",
-      "description": "Allocation state of the cluster and data center resources.",
-      "enum": [
-        "Active",
-        "Deallocated"
-      ],
-      "x-ms-enum": {
-        "name": "AllocationState",
-        "modelAsString": true,
-        "values": [
-          {
-            "name": "Active",
-            "value": "Active",
-            "description": "Active implies the virtual machines of the cluster are allocated."
-          },
-          {
-            "name": "Deallocated",
-            "value": "Deallocated",
-            "description": "Deallocated implies virtual machines and resources are deallocated."
-          }
-        ]
       }
     },
     "AnalyticalStorageConfiguration": {
@@ -19033,54 +14017,6 @@
         "maxThroughput"
       ]
     },
-    "AzureBlobContainer": {
-      "type": "object",
-      "description": "An Azure Blob container",
-      "properties": {
-        "containerName": {
-          "type": "string",
-          "description": "Azure Blob container."
-        }
-      },
-      "required": [
-        "containerName"
-      ]
-    },
-    "AzureBlobDataTransferDataSourceSink": {
-      "type": "object",
-      "description": "An Azure Blob Storage data source/sink",
-      "properties": {
-        "containerName": {
-          "type": "string"
-        },
-        "endpointUrl": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "containerName"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/DataTransferDataSourceSink"
-        }
-      ],
-      "x-ms-discriminator-value": "AzureBlobStorage"
-    },
-    "AzureBlobSourceSinkDetails": {
-      "type": "object",
-      "description": "An Azure Blob Storage data source/sink",
-      "properties": {
-        "endpointUrl": {
-          "type": "string",
-          "description": "Azure Blob container endpoint.",
-          "pattern": "^https?://[^/$.?# ]+.[^ ]*$"
-        }
-      },
-      "required": [
-        "endpointUrl"
-      ]
-    },
     "AzureConnectionType": {
       "type": "string",
       "description": "How to connect to the azure services needed for running the cluster",
@@ -19204,35 +14140,6 @@
         ]
       }
     },
-    "BackupResource": {
-      "type": "object",
-      "description": "A restorable backup of a Cassandra cluster.",
-      "properties": {
-        "backupId": {
-          "type": "string",
-          "description": "The unique identifier of backup."
-        },
-        "backupState": {
-          "$ref": "#/definitions/BackupState",
-          "description": "The current state of the backup."
-        },
-        "backupStartTimestamp": {
-          "type": "string",
-          "format": "date-time",
-          "description": "The time at which the backup process begins."
-        },
-        "backupStopTimestamp": {
-          "type": "string",
-          "format": "date-time",
-          "description": "The time at which the backup process ends."
-        },
-        "backupExpiryTimestamp": {
-          "type": "string",
-          "format": "date-time",
-          "description": "The time at which the backup will expire."
-        }
-      }
-    },
     "BackupSchedule": {
       "type": "object",
       "properties": {
@@ -19249,38 +14156,6 @@
           "format": "int32",
           "description": "The retention period (hours) of the backups. If you want to retain data forever, set retention to 0."
         }
-      }
-    },
-    "BackupState": {
-      "type": "string",
-      "description": "The current state of the backup.",
-      "enum": [
-        "Initiated",
-        "InProgress",
-        "Succeeded",
-        "Failed"
-      ],
-      "x-ms-enum": {
-        "name": "BackupState",
-        "modelAsString": true,
-        "values": [
-          {
-            "name": "Initiated",
-            "value": "Initiated"
-          },
-          {
-            "name": "InProgress",
-            "value": "InProgress"
-          },
-          {
-            "name": "Succeeded",
-            "value": "Succeeded"
-          },
-          {
-            "name": "Failed",
-            "value": "Failed"
-          }
-        ]
       }
     },
     "BackupStorageRedundancy": {
@@ -19309,146 +14184,6 @@
           }
         ]
       }
-    },
-    "BaseCopyJobProperties": {
-      "type": "object",
-      "description": "Base copy job properties",
-      "properties": {
-        "jobType": {
-          "type": "string",
-          "description": "Copy Job Type",
-          "default": "NoSqlRUToNoSqlRU",
-          "enum": [
-            "CassandraRUToCassandraRU",
-            "CassandraRUToAzureBlobStorage",
-            "AzureBlobStorageToCassandraRU",
-            "MongoRUToMongoRU",
-            "MongoRUToMongoVCore",
-            "NoSqlRUToNoSqlRU"
-          ],
-          "x-ms-enum": {
-            "name": "CopyJobType",
-            "modelAsString": true,
-            "values": [
-              {
-                "name": "CassandraRUToCassandraRU",
-                "value": "CassandraRUToCassandraRU"
-              },
-              {
-                "name": "CassandraRUToAzureBlobStorage",
-                "value": "CassandraRUToAzureBlobStorage"
-              },
-              {
-                "name": "AzureBlobStorageToCassandraRU",
-                "value": "AzureBlobStorageToCassandraRU"
-              },
-              {
-                "name": "MongoRUToMongoRU",
-                "value": "MongoRUToMongoRU"
-              },
-              {
-                "name": "MongoRUToMongoVCore",
-                "value": "MongoRUToMongoVCore"
-              },
-              {
-                "name": "NoSqlRUToNoSqlRU",
-                "value": "NoSqlRUToNoSqlRU"
-              }
-            ]
-          }
-        }
-      },
-      "discriminator": "jobType",
-      "required": [
-        "jobType"
-      ]
-    },
-    "BaseCopyJobTask": {
-      "type": "object",
-      "description": "The properties of a Copy Job Task",
-      "properties": {
-        "totalCount": {
-          "type": "integer",
-          "format": "int64",
-          "description": "Task level Total Count.",
-          "readOnly": true
-        },
-        "processedCount": {
-          "type": "integer",
-          "format": "int64",
-          "description": "Task level Processed Count.",
-          "readOnly": true
-        }
-      }
-    },
-    "BaseCosmosDataTransferDataSourceSink": {
-      "type": "object",
-      "description": "A base CosmosDB data source/sink",
-      "properties": {
-        "remoteAccountName": {
-          "type": "string"
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/DataTransferDataSourceSink"
-        }
-      ],
-      "x-ms-discriminator-value": "BaseCosmosDataTransferDataSourceSink"
-    },
-    "BlobToCassandraRUCopyJobProperties": {
-      "type": "object",
-      "description": "Source Azure Blob Storage to Destination Cassandra copy job properties",
-      "properties": {
-        "sourceDetails": {
-          "$ref": "#/definitions/AzureBlobSourceSinkDetails",
-          "description": "Azure Storage container DataStore details"
-        },
-        "destinationDetails": {
-          "$ref": "#/definitions/CosmosDBSourceSinkDetails",
-          "description": "Destination Cassandra DataStore details"
-        },
-        "tasks": {
-          "type": "array",
-          "description": "Copy Job tasks.",
-          "items": {
-            "$ref": "#/definitions/BlobToCassandraRUCopyJobTask"
-          },
-          "x-ms-identifiers": []
-        }
-      },
-      "required": [
-        "sourceDetails",
-        "tasks"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/BaseCopyJobProperties"
-        }
-      ],
-      "x-ms-discriminator-value": "AzureBlobStorageToCassandraRU"
-    },
-    "BlobToCassandraRUCopyJobTask": {
-      "type": "object",
-      "properties": {
-        "source": {
-          "$ref": "#/definitions/AzureBlobContainer",
-          "description": "Source Azure Blob container"
-        },
-        "destination": {
-          "$ref": "#/definitions/CosmosDBCassandraTable",
-          "description": "Destination Cassandra table"
-        }
-      },
-      "required": [
-        "source",
-        "destination"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/BaseCopyJobTask"
-        }
-      ]
     },
     "Capability": {
       "type": "object",
@@ -19809,242 +14544,6 @@
         }
       }
     },
-    "CassandraRUToBlobCopyJobProperties": {
-      "type": "object",
-      "description": "Source Cassandra to Destination Azure Blob Storage copy job properties",
-      "properties": {
-        "sourceDetails": {
-          "$ref": "#/definitions/CosmosDBSourceSinkDetails",
-          "description": "Source Cassandra DataStore details"
-        },
-        "destinationDetails": {
-          "$ref": "#/definitions/AzureBlobSourceSinkDetails",
-          "description": "Destination Cassandra DataStore details"
-        },
-        "tasks": {
-          "type": "array",
-          "description": "Copy Job tasks.",
-          "items": {
-            "$ref": "#/definitions/CassandraRUToBlobCopyJobTask"
-          },
-          "x-ms-identifiers": []
-        }
-      },
-      "required": [
-        "destinationDetails",
-        "tasks"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/BaseCopyJobProperties"
-        }
-      ],
-      "x-ms-discriminator-value": "CassandraRUToAzureBlobStorage"
-    },
-    "CassandraRUToBlobCopyJobTask": {
-      "type": "object",
-      "properties": {
-        "source": {
-          "$ref": "#/definitions/CosmosDBCassandraTable",
-          "description": "Source Cassandra table"
-        },
-        "destination": {
-          "$ref": "#/definitions/AzureBlobContainer",
-          "description": "Destination Azure Blob container"
-        }
-      },
-      "required": [
-        "source",
-        "destination"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/BaseCopyJobTask"
-        }
-      ]
-    },
-    "CassandraRUToCassandraRUCopyJobProperties": {
-      "type": "object",
-      "description": "Source Cassandra to Destination Cassandra copy job properties",
-      "properties": {
-        "sourceDetails": {
-          "$ref": "#/definitions/CosmosDBSourceSinkDetails",
-          "description": "Source Cassandra DataStore details"
-        },
-        "destinationDetails": {
-          "$ref": "#/definitions/CosmosDBSourceSinkDetails",
-          "description": "Destination Cassandra DataStore details"
-        },
-        "tasks": {
-          "type": "array",
-          "description": "Copy Job tasks.",
-          "items": {
-            "$ref": "#/definitions/CassandraRUToCassandraRUCopyJobTask"
-          },
-          "x-ms-identifiers": []
-        }
-      },
-      "required": [
-        "tasks"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/BaseCopyJobProperties"
-        }
-      ],
-      "x-ms-discriminator-value": "CassandraRUToCassandraRU"
-    },
-    "CassandraRUToCassandraRUCopyJobTask": {
-      "type": "object",
-      "properties": {
-        "source": {
-          "$ref": "#/definitions/CosmosDBCassandraTable",
-          "description": "Source Cassandra table"
-        },
-        "destination": {
-          "$ref": "#/definitions/CosmosDBCassandraTable",
-          "description": "Destination Cassandra table"
-        }
-      },
-      "required": [
-        "source",
-        "destination"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/BaseCopyJobTask"
-        }
-      ]
-    },
-    "CassandraRoleAssignmentListResult": {
-      "type": "object",
-      "description": "The response of a CassandraRoleAssignmentResource list operation.",
-      "properties": {
-        "value": {
-          "type": "array",
-          "description": "The CassandraRoleAssignmentResource items on this page",
-          "items": {
-            "$ref": "#/definitions/CassandraRoleAssignmentResource"
-          }
-        },
-        "nextLink": {
-          "type": "string",
-          "format": "uri",
-          "description": "The link to the next page of items"
-        }
-      },
-      "required": [
-        "value"
-      ]
-    },
-    "CassandraRoleAssignmentResource": {
-      "type": "object",
-      "description": "Parameters to create and update an Azure Cosmos DB Cassandra Role Assignment.",
-      "properties": {
-        "properties": {
-          "$ref": "#/definitions/CassandraRoleAssignmentResourceProperties",
-          "description": "Properties to create and update an Azure Cosmos DB Cassandra Role Assignment.",
-          "x-ms-client-flatten": true
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
-        }
-      ]
-    },
-    "CassandraRoleAssignmentResourceProperties": {
-      "type": "object",
-      "description": "Azure Cosmos DB Cassandra Role Assignment resource object.",
-      "properties": {
-        "roleDefinitionId": {
-          "type": "string",
-          "description": "The unique identifier for the associated Role Definition."
-        },
-        "scope": {
-          "type": "string",
-          "description": "The data plane resource path for which access is being granted through this Cassandra Role Assignment."
-        },
-        "principalId": {
-          "type": "string",
-          "description": "The unique identifier for the associated AAD principal in the AAD graph to which access is being granted through this Cassandra Role Assignment. Tenant ID for the principal is inferred using the tenant associated with the subscription."
-        },
-        "provisioningState": {
-          "type": "string",
-          "description": "Provisioning state of the resource.",
-          "readOnly": true
-        }
-      }
-    },
-    "CassandraRoleDefinitionListResult": {
-      "type": "object",
-      "description": "The response of a CassandraRoleDefinitionResource list operation.",
-      "properties": {
-        "value": {
-          "type": "array",
-          "description": "The CassandraRoleDefinitionResource items on this page",
-          "items": {
-            "$ref": "#/definitions/CassandraRoleDefinitionResource"
-          }
-        },
-        "nextLink": {
-          "type": "string",
-          "format": "uri",
-          "description": "The link to the next page of items"
-        }
-      },
-      "required": [
-        "value"
-      ]
-    },
-    "CassandraRoleDefinitionResource": {
-      "type": "object",
-      "description": "Parameters to create and update an Azure Cosmos DB Cassandra Role Definition.",
-      "properties": {
-        "properties": {
-          "$ref": "#/definitions/CassandraRoleDefinitionResourceProperties",
-          "description": "Properties to create and update an Azure Cosmos DB Cassandra Role Definition.",
-          "x-ms-client-flatten": true
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
-        }
-      ]
-    },
-    "CassandraRoleDefinitionResourceProperties": {
-      "type": "object",
-      "description": "Azure Cosmos DB Cassandra Role Definition resource object.",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "The path id for the Role Definition."
-        },
-        "roleName": {
-          "type": "string",
-          "description": "A user-friendly name for the Role Definition. Must be unique for the database account."
-        },
-        "type": {
-          "$ref": "#/definitions/RoleDefinitionType",
-          "description": "Indicates whether the Role Definition was built-in or user created."
-        },
-        "assignableScopes": {
-          "type": "array",
-          "description": "A set of fully qualified Scopes at or below which Cassandra Role Assignments may be created using this Role Definition. This will allow application of this Role Definition on the entire database account or any underlying Database / Collection. Must have at least one element. Scopes higher than Database account are not enforceable as assignable Scopes. Note that resources referenced in assignable Scopes need not exist.",
-          "items": {
-            "type": "string"
-          }
-        },
-        "permissions": {
-          "type": "array",
-          "description": "The set of operations allowed through this Role Definition.",
-          "items": {
-            "$ref": "#/definitions/Permission"
-          }
-        }
-      }
-    },
     "CassandraSchema": {
       "type": "object",
       "description": "Cosmos DB Cassandra table schema",
@@ -20232,159 +14731,6 @@
       },
       "required": [
         "id"
-      ]
-    },
-    "CassandraViewCreateUpdateParameters": {
-      "type": "object",
-      "description": "Parameters to create and update Cosmos DB Cassandra view.",
-      "properties": {
-        "properties": {
-          "$ref": "#/definitions/CassandraViewCreateUpdateProperties",
-          "description": "Properties to create and update Azure Cosmos DB Cassandra view.",
-          "x-ms-client-flatten": true
-        }
-      },
-      "required": [
-        "properties"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/ARMResourceProperties"
-        }
-      ]
-    },
-    "CassandraViewCreateUpdateProperties": {
-      "type": "object",
-      "description": "Properties to create and update Azure Cosmos DB Cassandra view.",
-      "properties": {
-        "resource": {
-          "$ref": "#/definitions/CassandraViewResource",
-          "description": "The standard JSON format of a Cassandra view"
-        },
-        "options": {
-          "$ref": "#/definitions/CreateUpdateOptions",
-          "description": "A key-value pair of options to be applied for the request. This corresponds to the headers sent with the request."
-        }
-      },
-      "required": [
-        "resource"
-      ]
-    },
-    "CassandraViewGetProperties": {
-      "type": "object",
-      "description": "The properties of an Azure Cosmos DB Cassandra view",
-      "properties": {
-        "resource": {
-          "$ref": "#/definitions/CassandraViewGetPropertiesResource"
-        },
-        "options": {
-          "$ref": "#/definitions/CassandraViewGetPropertiesOptions"
-        }
-      }
-    },
-    "CassandraViewGetPropertiesOptions": {
-      "type": "object",
-      "allOf": [
-        {
-          "$ref": "#/definitions/OptionsResource"
-        }
-      ]
-    },
-    "CassandraViewGetPropertiesResource": {
-      "type": "object",
-      "properties": {
-        "_rid": {
-          "type": "string",
-          "description": "A system generated property. A unique identifier.",
-          "readOnly": true
-        },
-        "_ts": {
-          "type": "number",
-          "format": "float",
-          "description": "A system generated property that denotes the last updated timestamp of the resource.",
-          "readOnly": true
-        },
-        "_etag": {
-          "type": "string",
-          "description": "A system generated property representing the resource etag required for optimistic concurrency control.",
-          "readOnly": true
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/CassandraViewResource"
-        }
-      ]
-    },
-    "CassandraViewGetResults": {
-      "type": "object",
-      "description": "An Azure Cosmos DB Cassandra view.",
-      "properties": {
-        "properties": {
-          "$ref": "#/definitions/CassandraViewGetProperties",
-          "description": "The properties of an Azure Cosmos DB Cassandra view",
-          "x-ms-client-flatten": true
-        },
-        "tags": {
-          "type": "object",
-          "description": "Resource tags.",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "location": {
-          "type": "string",
-          "description": "The geo-location where the resource lives",
-          "x-ms-mutability": [
-            "read",
-            "update",
-            "create"
-          ]
-        },
-        "identity": {
-          "$ref": "#/definitions/ManagedServiceIdentity",
-          "description": "Identity for the resource."
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/Resource"
-        }
-      ]
-    },
-    "CassandraViewListResult": {
-      "type": "object",
-      "description": "The List operation response, that contains the Cassandra views and their properties.",
-      "properties": {
-        "value": {
-          "type": "array",
-          "description": "List of Cassandra views and their properties.",
-          "items": {
-            "$ref": "#/definitions/CassandraViewGetResults"
-          },
-          "readOnly": true
-        },
-        "nextLink": {
-          "type": "string"
-        }
-      }
-    },
-    "CassandraViewResource": {
-      "type": "object",
-      "description": "Cosmos DB Cassandra view resource object",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "Name of the Cosmos DB Cassandra view"
-        },
-        "viewDefinition": {
-          "type": "string",
-          "description": "View Definition of the Cosmos DB Cassandra view"
-        }
-      },
-      "required": [
-        "id",
-        "viewDefinition"
       ]
     },
     "Certificate": {
@@ -20749,10 +15095,6 @@
           "type": "boolean",
           "description": "Whether Cassandra audit logging is enabled"
         },
-        "clusterType": {
-          "$ref": "#/definitions/ClusterType",
-          "description": "Type of the cluster. If set to Production, some operations might not be permitted on cluster."
-        },
         "provisionError": {
           "$ref": "#/definitions/CassandraError",
           "description": "Error related to resource provisioning."
@@ -20795,28 +15137,6 @@
         }
       }
     },
-    "ClusterType": {
-      "type": "string",
-      "description": "Type of the cluster. If set to Production, some operations might not be permitted on cluster.",
-      "enum": [
-        "Production",
-        "NonProduction"
-      ],
-      "x-ms-enum": {
-        "name": "ClusterType",
-        "modelAsString": true,
-        "values": [
-          {
-            "name": "Production",
-            "value": "Production"
-          },
-          {
-            "name": "NonProduction",
-            "value": "NonProduction"
-          }
-        ]
-      }
-    },
     "Column": {
       "type": "object",
       "description": "Cosmos DB Cassandra table column",
@@ -20830,35 +15150,6 @@
           "description": "Type of the Cosmos DB Cassandra table column"
         }
       }
-    },
-    "CommandAsyncPostBody": {
-      "type": "object",
-      "description": "Specification of which command to run where",
-      "properties": {
-        "command": {
-          "type": "string",
-          "description": "The command which should be run"
-        },
-        "arguments": {
-          "description": "The arguments for the command to be run"
-        },
-        "host": {
-          "type": "string",
-          "description": "IP address of the cassandra host to run the command on"
-        },
-        "cassandra-stop-start": {
-          "type": "boolean",
-          "description": "If true, stops cassandra before executing the command and then start it again"
-        },
-        "readWrite": {
-          "type": "boolean",
-          "description": "If true, allows the command to *write* to the cassandra directory, otherwise read-only."
-        }
-      },
-      "required": [
-        "command",
-        "host"
-      ]
     },
     "CommandOutput": {
       "type": "object",
@@ -20902,93 +15193,6 @@
         "command",
         "host"
       ]
-    },
-    "CommandPublicResource": {
-      "type": "object",
-      "description": "resource representing a command",
-      "properties": {
-        "command": {
-          "type": "string",
-          "description": "The command which should be run"
-        },
-        "commandId": {
-          "type": "string",
-          "description": "The unique id of command"
-        },
-        "arguments": {
-          "description": "The arguments for the command to be run"
-        },
-        "host": {
-          "type": "string",
-          "description": "IP address of the cassandra host to run the command on"
-        },
-        "isAdmin": {
-          "type": "boolean",
-          "description": "Whether command has admin privileges"
-        },
-        "cassandraStopStart": {
-          "type": "boolean",
-          "description": "If true, stops cassandra before executing the command and then start it again"
-        },
-        "readWrite": {
-          "type": "boolean",
-          "description": "If true, allows the command to *write* to the cassandra directory, otherwise read-only."
-        },
-        "result": {
-          "type": "string",
-          "description": "Result output of the command."
-        },
-        "status": {
-          "$ref": "#/definitions/CommandStatus",
-          "description": "Status of the command."
-        },
-        "outputFile": {
-          "type": "string",
-          "description": "The name of the file where the result is written."
-        }
-      }
-    },
-    "CommandStatus": {
-      "type": "string",
-      "description": "Status of the command.",
-      "enum": [
-        "Done",
-        "Running",
-        "Enqueue",
-        "Processing",
-        "Finished",
-        "Failed"
-      ],
-      "x-ms-enum": {
-        "name": "CommandStatus",
-        "modelAsString": true,
-        "values": [
-          {
-            "name": "Done",
-            "value": "Done"
-          },
-          {
-            "name": "Running",
-            "value": "Running"
-          },
-          {
-            "name": "Enqueue",
-            "value": "Enqueue"
-          },
-          {
-            "name": "Processing",
-            "value": "Processing"
-          },
-          {
-            "name": "Finished",
-            "value": "Finished"
-          },
-          {
-            "name": "Failed",
-            "value": "Failed"
-          }
-        ]
-      }
     },
     "ComponentsM9L909SchemasCassandraclusterpublicstatusPropertiesDatacentersItemsPropertiesNodesItems": {
       "type": "object",
@@ -21395,171 +15599,6 @@
         ]
       }
     },
-    "CopyJobFeedResults": {
-      "type": "object",
-      "description": "The List operation response, that contains the Copy Jobs and their properties.",
-      "properties": {
-        "value": {
-          "type": "array",
-          "description": "The CopyJobGetResults items on this page",
-          "items": {
-            "$ref": "#/definitions/CopyJobGetResults"
-          }
-        },
-        "nextLink": {
-          "type": "string",
-          "format": "uri",
-          "description": "The link to the next page of items"
-        }
-      },
-      "required": [
-        "value"
-      ]
-    },
-    "CopyJobGetResults": {
-      "type": "object",
-      "description": "A Cosmos DB Copy Job",
-      "properties": {
-        "properties": {
-          "$ref": "#/definitions/CopyJobProperties",
-          "description": "The properties of a Copy Job"
-        }
-      },
-      "required": [
-        "properties"
-      ],
-      "allOf": [
-        {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
-        }
-      ]
-    },
-    "CopyJobMode": {
-      "type": "string",
-      "description": "Mode of job execution",
-      "enum": [
-        "Offline",
-        "Online"
-      ],
-      "x-ms-enum": {
-        "name": "CopyJobMode",
-        "modelAsString": true,
-        "values": [
-          {
-            "name": "Offline",
-            "value": "Offline"
-          },
-          {
-            "name": "Online",
-            "value": "Online"
-          }
-        ]
-      }
-    },
-    "CopyJobProperties": {
-      "type": "object",
-      "description": "The properties of a Copy Job",
-      "properties": {
-        "jobProperties": {
-          "$ref": "#/definitions/BaseCopyJobProperties",
-          "description": "Job Properties"
-        },
-        "status": {
-          "$ref": "#/definitions/CopyJobStatus",
-          "description": "Job Status",
-          "readOnly": true
-        },
-        "processedCount": {
-          "type": "integer",
-          "format": "int64",
-          "description": "Processed Count",
-          "readOnly": true
-        },
-        "totalCount": {
-          "type": "integer",
-          "format": "int64",
-          "description": "Total Count",
-          "readOnly": true
-        },
-        "lastUpdatedUtcTime": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last Updated Time (ISO-8601 format)",
-          "readOnly": true
-        },
-        "workerCount": {
-          "type": "integer",
-          "format": "int32",
-          "description": "Worker count",
-          "minimum": 0
-        },
-        "error": {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse",
-          "description": "Error response for Faulted job",
-          "readOnly": true
-        },
-        "duration": {
-          "type": "string",
-          "format": "duration-constant",
-          "description": "Total Duration of Job",
-          "readOnly": true
-        },
-        "mode": {
-          "$ref": "#/definitions/CopyJobMode",
-          "description": "Mode of job execution"
-        }
-      },
-      "required": [
-        "jobProperties"
-      ]
-    },
-    "CopyJobStatus": {
-      "type": "string",
-      "description": "Job Status",
-      "enum": [
-        "Pending",
-        "Partitioning",
-        "Running",
-        "Paused",
-        "Completed",
-        "Faulted",
-        "Cancelled"
-      ],
-      "x-ms-enum": {
-        "name": "CopyJobStatus",
-        "modelAsString": true,
-        "values": [
-          {
-            "name": "Pending",
-            "value": "Pending"
-          },
-          {
-            "name": "Partitioning",
-            "value": "Partitioning"
-          },
-          {
-            "name": "Running",
-            "value": "Running"
-          },
-          {
-            "name": "Paused",
-            "value": "Paused"
-          },
-          {
-            "name": "Completed",
-            "value": "Completed"
-          },
-          {
-            "name": "Faulted",
-            "value": "Faulted"
-          },
-          {
-            "name": "Cancelled",
-            "value": "Cancelled"
-          }
-        ]
-      }
-    },
     "CorsPolicy": {
       "type": "object",
       "description": "The CORS policy for the Cosmos DB database account.",
@@ -21590,200 +15629,6 @@
       },
       "required": [
         "allowedOrigins"
-      ]
-    },
-    "CosmosCassandraDataTransferDataSourceSink": {
-      "type": "object",
-      "description": "A CosmosDB Cassandra API data source/sink",
-      "properties": {
-        "keyspaceName": {
-          "type": "string"
-        },
-        "tableName": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "keyspaceName",
-        "tableName"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/BaseCosmosDataTransferDataSourceSink"
-        }
-      ],
-      "x-ms-discriminator-value": "CosmosDBCassandra"
-    },
-    "CosmosDBCassandraTable": {
-      "type": "object",
-      "description": "A CosmosDB Cassandra table",
-      "properties": {
-        "keyspaceName": {
-          "type": "string",
-          "description": "Azure Cosmos DB for Apache Cassandra keyspace."
-        },
-        "tableName": {
-          "type": "string",
-          "description": "Azure Cosmos DB for Apache Cassandra table."
-        }
-      },
-      "required": [
-        "keyspaceName",
-        "tableName"
-      ]
-    },
-    "CosmosDBMongoCollection": {
-      "type": "object",
-      "description": "A CosmosDB Mongo collection",
-      "properties": {
-        "databaseName": {
-          "type": "string",
-          "description": "Azure Cosmos DB for MongoDB (RU) database."
-        },
-        "collectionName": {
-          "type": "string",
-          "description": "Azure Cosmos DB for MongoDB (RU) collection."
-        }
-      },
-      "required": [
-        "databaseName",
-        "collectionName"
-      ]
-    },
-    "CosmosDBMongoVCoreCollection": {
-      "type": "object",
-      "description": "A CosmosDB Mongo vCore collection",
-      "properties": {
-        "databaseName": {
-          "type": "string",
-          "description": "Azure Cosmos DB for MongoDB (vCore) database."
-        },
-        "collectionName": {
-          "type": "string",
-          "description": "Azure Cosmos DB for MongoDB (vCore) collection."
-        }
-      },
-      "required": [
-        "databaseName",
-        "collectionName"
-      ]
-    },
-    "CosmosDBNoSqlContainer": {
-      "type": "object",
-      "description": "A CosmosDB NoSQL container",
-      "properties": {
-        "databaseName": {
-          "type": "string",
-          "description": "Azure Cosmos DB for NoSQL database."
-        },
-        "containerName": {
-          "type": "string",
-          "description": "Azure Cosmos DB for NoSQL container."
-        }
-      },
-      "required": [
-        "databaseName",
-        "containerName"
-      ]
-    },
-    "CosmosDBSourceSinkDetails": {
-      "type": "object",
-      "description": "A CosmosDB data source/sink details",
-      "properties": {
-        "remoteAccountName": {
-          "type": "string",
-          "description": "Name of remote account in case of cross-account data transfer."
-        }
-      }
-    },
-    "CosmosMongoDataTransferDataSourceSink": {
-      "type": "object",
-      "description": "A CosmosDB Mongo API data source/sink",
-      "properties": {
-        "databaseName": {
-          "type": "string"
-        },
-        "collectionName": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "databaseName",
-        "collectionName"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/BaseCosmosDataTransferDataSourceSink"
-        }
-      ],
-      "x-ms-discriminator-value": "CosmosDBMongo"
-    },
-    "CosmosMongoVCoreDataTransferDataSourceSink": {
-      "type": "object",
-      "description": "A CosmosDB Mongo vCore API data source/sink",
-      "properties": {
-        "databaseName": {
-          "type": "string"
-        },
-        "collectionName": {
-          "type": "string"
-        },
-        "hostName": {
-          "type": "string"
-        },
-        "connectionStringKeyVaultUri": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "databaseName",
-        "collectionName"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/DataTransferDataSourceSink"
-        }
-      ],
-      "x-ms-discriminator-value": "CosmosDBMongoVCore"
-    },
-    "CosmosSqlDataTransferDataSourceSink": {
-      "type": "object",
-      "description": "A CosmosDB No Sql API data source/sink",
-      "properties": {
-        "databaseName": {
-          "type": "string"
-        },
-        "containerName": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "databaseName",
-        "containerName"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/BaseCosmosDataTransferDataSourceSink"
-        }
-      ],
-      "x-ms-discriminator-value": "CosmosDBSql"
-    },
-    "CreateJobRequest": {
-      "type": "object",
-      "description": "Parameters to create Data Transfer Job",
-      "properties": {
-        "properties": {
-          "$ref": "#/definitions/DataTransferJobProperties",
-          "description": "Data Transfer Create Job Properties"
-        }
-      },
-      "required": [
-        "properties"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/ARMProxyResource"
-        }
       ]
     },
     "CreateUpdateOptions": {
@@ -21965,184 +15810,6 @@
       },
       "required": [
         "path"
-      ]
-    },
-    "DataTransferDataSourceSink": {
-      "type": "object",
-      "description": "Base class for all DataTransfer source/sink",
-      "properties": {
-        "component": {
-          "type": "string",
-          "default": "CosmosDBCassandra",
-          "enum": [
-            "CosmosDBCassandra",
-            "CosmosDBMongo",
-            "CosmosDBMongoVCore",
-            "CosmosDBSql",
-            "AzureBlobStorage",
-            "BaseCosmosDataTransferDataSourceSink"
-          ],
-          "x-ms-enum": {
-            "name": "DataTransferComponent",
-            "modelAsString": true,
-            "values": [
-              {
-                "name": "CosmosDBCassandra",
-                "value": "CosmosDBCassandra"
-              },
-              {
-                "name": "CosmosDBMongo",
-                "value": "CosmosDBMongo"
-              },
-              {
-                "name": "CosmosDBMongoVCore",
-                "value": "CosmosDBMongoVCore"
-              },
-              {
-                "name": "CosmosDBSql",
-                "value": "CosmosDBSql"
-              },
-              {
-                "name": "AzureBlobStorage",
-                "value": "AzureBlobStorage"
-              },
-              {
-                "name": "BaseCosmosDataTransferDataSourceSink",
-                "value": "BaseCosmosDataTransferDataSourceSink"
-              }
-            ]
-          }
-        }
-      },
-      "discriminator": "component",
-      "required": [
-        "component"
-      ]
-    },
-    "DataTransferJobFeedResults": {
-      "type": "object",
-      "description": "The List operation response, that contains the Data Transfer jobs and their properties.",
-      "properties": {
-        "value": {
-          "type": "array",
-          "description": "The DataTransferJobGetResults items on this page",
-          "items": {
-            "$ref": "#/definitions/DataTransferJobGetResults"
-          }
-        },
-        "nextLink": {
-          "type": "string",
-          "format": "uri",
-          "description": "The link to the next page of items"
-        }
-      },
-      "required": [
-        "value"
-      ]
-    },
-    "DataTransferJobGetResults": {
-      "type": "object",
-      "description": "A Cosmos DB Data Transfer Job",
-      "properties": {
-        "properties": {
-          "$ref": "#/definitions/DataTransferJobProperties",
-          "description": "The properties of a DataTransfer Job",
-          "x-ms-client-flatten": true
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
-        }
-      ]
-    },
-    "DataTransferJobMode": {
-      "type": "string",
-      "description": "Mode of job execution",
-      "enum": [
-        "Offline",
-        "Online"
-      ],
-      "x-ms-enum": {
-        "name": "DataTransferJobMode",
-        "modelAsString": true,
-        "values": [
-          {
-            "name": "Offline",
-            "value": "Offline"
-          },
-          {
-            "name": "Online",
-            "value": "Online"
-          }
-        ]
-      }
-    },
-    "DataTransferJobProperties": {
-      "type": "object",
-      "description": "The properties of a DataTransfer Job",
-      "properties": {
-        "jobName": {
-          "type": "string",
-          "description": "Job Name",
-          "readOnly": true
-        },
-        "source": {
-          "$ref": "#/definitions/DataTransferDataSourceSink",
-          "description": "Source DataStore details"
-        },
-        "destination": {
-          "$ref": "#/definitions/DataTransferDataSourceSink",
-          "description": "Destination DataStore details"
-        },
-        "status": {
-          "type": "string",
-          "description": "Job Status",
-          "readOnly": true
-        },
-        "processedCount": {
-          "type": "integer",
-          "format": "int64",
-          "description": "Processed Count.",
-          "readOnly": true
-        },
-        "totalCount": {
-          "type": "integer",
-          "format": "int64",
-          "description": "Total Count.",
-          "readOnly": true
-        },
-        "lastUpdatedUtcTime": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last Updated Time (ISO-8601 format).",
-          "readOnly": true
-        },
-        "workerCount": {
-          "type": "integer",
-          "format": "int32",
-          "description": "Worker count",
-          "minimum": 0
-        },
-        "error": {
-          "$ref": "#/definitions/ErrorResponse",
-          "description": "Error response for Faulted job",
-          "readOnly": true
-        },
-        "duration": {
-          "type": "string",
-          "format": "duration-constant",
-          "description": "Total Duration of Job",
-          "readOnly": true
-        },
-        "mode": {
-          "$ref": "#/definitions/DataTransferJobMode",
-          "description": "Mode of job execution"
-        }
-      },
-      "required": [
-        "source",
-        "destination"
       ]
     },
     "DataTransferRegionalServiceResource": {
@@ -23317,82 +16984,6 @@
         }
       }
     },
-    "FleetAnalyticsListResult": {
-      "type": "object",
-      "description": "The response of a FleetAnalyticsResource list operation.",
-      "properties": {
-        "value": {
-          "type": "array",
-          "description": "The FleetAnalyticsResource items on this page",
-          "items": {
-            "$ref": "#/definitions/FleetAnalyticsResource"
-          }
-        },
-        "nextLink": {
-          "type": "string",
-          "format": "uri",
-          "description": "The link to the next page of items"
-        }
-      },
-      "required": [
-        "value"
-      ]
-    },
-    "FleetAnalyticsProperties": {
-      "type": "object",
-      "properties": {
-        "provisioningState": {
-          "$ref": "#/definitions/Status",
-          "description": "A provisioning state of the FleetAnalytics.",
-          "readOnly": true
-        },
-        "storageLocationType": {
-          "$ref": "#/definitions/FleetAnalyticsPropertiesStorageLocationType",
-          "description": "The type of the fleet analytics resource."
-        },
-        "storageLocationUri": {
-          "type": "string",
-          "description": "The unique identifier of the fleet analytics resource."
-        }
-      }
-    },
-    "FleetAnalyticsPropertiesStorageLocationType": {
-      "type": "string",
-      "description": "The type of the fleet analytics resource.",
-      "enum": [
-        "StorageAccount",
-        "FabricLakehouse"
-      ],
-      "x-ms-enum": {
-        "name": "FleetAnalyticsPropertiesStorageLocationType",
-        "modelAsString": true,
-        "values": [
-          {
-            "name": "StorageAccount",
-            "value": "StorageAccount"
-          },
-          {
-            "name": "FabricLakehouse",
-            "value": "FabricLakehouse"
-          }
-        ]
-      }
-    },
-    "FleetAnalyticsResource": {
-      "type": "object",
-      "description": "An Azure Cosmos DB FleetAnalytics.",
-      "properties": {
-        "properties": {
-          "$ref": "#/definitions/FleetAnalyticsProperties",
-          "x-ms-client-flatten": true
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
-        }
-      ]
-    },
     "FleetListResult": {
       "type": "object",
       "description": "The response of a FleetResource list operation.",
@@ -23710,187 +17301,6 @@
         }
       }
     },
-    "GarnetCacheProvisioningState": {
-      "type": "string",
-      "description": "The status of the resource at the time the operation was called.",
-      "enum": [
-        "Creating",
-        "Updating",
-        "Deleting",
-        "Succeeded",
-        "Failed",
-        "Canceled"
-      ],
-      "x-ms-enum": {
-        "name": "GarnetCacheProvisioningState",
-        "modelAsString": true,
-        "values": [
-          {
-            "name": "Creating",
-            "value": "Creating",
-            "description": "Creating"
-          },
-          {
-            "name": "Updating",
-            "value": "Updating",
-            "description": "Updating"
-          },
-          {
-            "name": "Deleting",
-            "value": "Deleting",
-            "description": "Deleting"
-          },
-          {
-            "name": "Succeeded",
-            "value": "Succeeded",
-            "description": "Succeeded"
-          },
-          {
-            "name": "Failed",
-            "value": "Failed",
-            "description": "Failed"
-          },
-          {
-            "name": "Canceled",
-            "value": "Canceled",
-            "description": "Canceled"
-          }
-        ]
-      }
-    },
-    "GarnetClusterResource": {
-      "type": "object",
-      "description": "Representation of a Garnet cache cluster.",
-      "properties": {
-        "properties": {
-          "$ref": "#/definitions/GarnetClusterResourceProperties",
-          "description": "The resource-specific properties for this resource."
-        },
-        "identity": {
-          "$ref": "#/definitions/ManagedCassandraManagedServiceIdentity",
-          "description": "Identity for the resource."
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/TrackedResource"
-        }
-      ]
-    },
-    "GarnetClusterResourcePatch": {
-      "type": "object",
-      "description": "Representation of a Garnet cache cluster for updates.",
-      "properties": {
-        "properties": {
-          "$ref": "#/definitions/GarnetClusterResourcePatchProperties",
-          "description": "Properties of a Garnet cache cluster for updates."
-        }
-      }
-    },
-    "GarnetClusterResourcePatchProperties": {
-      "type": "object",
-      "description": "Properties of a Garnet cache cluster for updates.",
-      "properties": {
-        "clusterType": {
-          "$ref": "#/definitions/ClusterType",
-          "description": "Type of the cluster. If set to Production, some operations might not be permitted on cluster."
-        },
-        "extensions": {
-          "type": "array",
-          "description": "Extensions to be added or updated on cluster.",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "GarnetClusterResourceProperties": {
-      "type": "object",
-      "description": "Properties of a Garnet cache cluster.",
-      "properties": {
-        "provisioningState": {
-          "$ref": "#/definitions/GarnetCacheProvisioningState",
-          "description": "The provisioning state of the resource.",
-          "readOnly": true
-        },
-        "subnetId": {
-          "type": "string",
-          "format": "arm-id",
-          "description": "Resource id of a subnet that this cluster's management service should have its network interface attached to. The subnet must be routable to all subnets that will be delegated to data centers. The resource id must be of the form '/subscriptions/<subscription id>/resourceGroups/<resource group>/providers/Microsoft.Network/virtualNetworks/<virtual network>/subnets/<subnet>'",
-          "x-ms-mutability": [
-            "read",
-            "create"
-          ],
-          "x-ms-arm-id-details": {
-            "allowedResources": [
-              {
-                "type": "Microsoft.Network/virtualNetworks/subnets"
-              }
-            ]
-          }
-        },
-        "endPoints": {
-          "type": "array",
-          "description": "Endpoints for clients to connect to the cluster.",
-          "items": {
-            "$ref": "#/definitions/GarnetClusterResourcePropertiesEndPointsItem"
-          },
-          "readOnly": true
-        },
-        "replicationFactor": {
-          "type": "integer",
-          "format": "int32",
-          "description": "Number of copies of data maintained by the cluster."
-        },
-        "nodeCount": {
-          "type": "integer",
-          "format": "int32",
-          "description": "Number of nodes."
-        },
-        "nodeSku": {
-          "type": "string",
-          "description": "Virtual Machine SKU used for clusters. Default value is Standard_DS14_v2."
-        },
-        "availabilityZone": {
-          "type": "boolean",
-          "description": "If the data center has Availability Zone support, apply it to the Virtual Machine ScaleSet that host the garnet cluster virtual machines."
-        },
-        "allocationState": {
-          "$ref": "#/definitions/AllocationState",
-          "description": "Allocation state of the cluster and data center resources. Active implies the virtual machines of the cluster are allocated, deallocated implies virtual machines and resources are deallocated."
-        },
-        "clusterType": {
-          "$ref": "#/definitions/ClusterType",
-          "description": "Type of the cluster. If set to Production, some operations might not be permitted on cluster."
-        },
-        "provisionError": {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorDetail",
-          "description": "Error related to resource provisioning."
-        },
-        "extensions": {
-          "type": "array",
-          "description": "Extensions to be added or updated on cluster.",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "GarnetClusterResourcePropertiesEndPointsItem": {
-      "type": "object",
-      "description": "Endpoint for clients to connect to the cluster.",
-      "properties": {
-        "ipAddress": {
-          "type": "string",
-          "description": "Ipv4 address of the endpoint."
-        },
-        "port": {
-          "type": "integer",
-          "format": "int32",
-          "description": "Port number."
-        }
-      }
-    },
     "GraphAPIComputeRegionalServiceResource": {
       "type": "object",
       "description": "Resource for a regional service location.",
@@ -23940,136 +17350,6 @@
         }
       ],
       "x-ms-discriminator-value": "GraphAPICompute"
-    },
-    "GraphResource": {
-      "type": "object",
-      "description": "Cosmos DB Graph resource object",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "Name of the Cosmos DB Graph"
-        }
-      },
-      "required": [
-        "id"
-      ]
-    },
-    "GraphResourceCreateUpdateParameters": {
-      "type": "object",
-      "description": "Parameters to create and update Cosmos DB Graph resource.",
-      "properties": {
-        "properties": {
-          "$ref": "#/definitions/GraphResourceCreateUpdateProperties",
-          "description": "Properties to create and update Azure Cosmos DB Graph resource.",
-          "x-ms-client-flatten": true
-        }
-      },
-      "required": [
-        "properties"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/ARMResourceProperties"
-        }
-      ]
-    },
-    "GraphResourceCreateUpdateProperties": {
-      "type": "object",
-      "description": "Properties to create and update Azure Cosmos DB Graph resource.",
-      "properties": {
-        "resource": {
-          "$ref": "#/definitions/GraphResource",
-          "description": "The standard JSON format of a Graph resource"
-        },
-        "options": {
-          "$ref": "#/definitions/CreateUpdateOptions",
-          "description": "A key-value pair of options to be applied for the request. This corresponds to the headers sent with the request."
-        }
-      },
-      "required": [
-        "resource"
-      ]
-    },
-    "GraphResourceGetProperties": {
-      "type": "object",
-      "description": "The properties of an Azure Cosmos DB SQL database",
-      "properties": {
-        "resource": {
-          "$ref": "#/definitions/GraphResourceGetPropertiesResource"
-        },
-        "options": {
-          "$ref": "#/definitions/GraphResourceGetPropertiesOptions"
-        }
-      }
-    },
-    "GraphResourceGetPropertiesOptions": {
-      "type": "object",
-      "allOf": [
-        {
-          "$ref": "#/definitions/OptionsResource"
-        }
-      ]
-    },
-    "GraphResourceGetPropertiesResource": {
-      "type": "object",
-      "allOf": [
-        {
-          "$ref": "#/definitions/GraphResource"
-        }
-      ]
-    },
-    "GraphResourceGetResults": {
-      "type": "object",
-      "description": "An Azure Cosmos DB Graph resource.",
-      "properties": {
-        "properties": {
-          "$ref": "#/definitions/GraphResourceGetProperties",
-          "description": "The properties of an Azure Cosmos DB Graph resource.",
-          "x-ms-client-flatten": true
-        },
-        "tags": {
-          "type": "object",
-          "description": "Resource tags.",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "location": {
-          "type": "string",
-          "description": "The geo-location where the resource lives",
-          "x-ms-mutability": [
-            "read",
-            "update",
-            "create"
-          ]
-        },
-        "identity": {
-          "$ref": "#/definitions/ManagedServiceIdentity",
-          "description": "Identity for the resource."
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/Resource"
-        }
-      ]
-    },
-    "GraphResourcesListResult": {
-      "type": "object",
-      "description": "The List operation response, that contains the Graph resource and their properties.",
-      "properties": {
-        "value": {
-          "type": "array",
-          "description": "List of Graph resource and their properties.",
-          "items": {
-            "$ref": "#/definitions/GraphResourceGetResults"
-          },
-          "readOnly": true
-        },
-        "nextLink": {
-          "type": "string"
-        }
-      }
     },
     "GremlinDatabaseCreateUpdateParameters": {
       "type": "object",
@@ -24464,135 +17744,6 @@
         "id"
       ]
     },
-    "GremlinRoleAssignmentListResult": {
-      "type": "object",
-      "description": "The response of a GremlinRoleAssignmentResource list operation.",
-      "properties": {
-        "value": {
-          "type": "array",
-          "description": "The GremlinRoleAssignmentResource items on this page",
-          "items": {
-            "$ref": "#/definitions/GremlinRoleAssignmentResource"
-          }
-        },
-        "nextLink": {
-          "type": "string",
-          "format": "uri",
-          "description": "The link to the next page of items"
-        }
-      },
-      "required": [
-        "value"
-      ]
-    },
-    "GremlinRoleAssignmentResource": {
-      "type": "object",
-      "description": "Parameters to create and update an Azure Cosmos DB Gremlin Role Assignment.",
-      "properties": {
-        "properties": {
-          "$ref": "#/definitions/GremlinRoleAssignmentResourceProperties",
-          "description": "Properties to create and update an Azure Cosmos DB Gremlin Role Assignment.",
-          "x-ms-client-flatten": true
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
-        }
-      ]
-    },
-    "GremlinRoleAssignmentResourceProperties": {
-      "type": "object",
-      "description": "Azure Cosmos DB Gremlin Role Assignment resource object.",
-      "properties": {
-        "roleDefinitionId": {
-          "type": "string",
-          "description": "The unique identifier for the associated Role Definition."
-        },
-        "scope": {
-          "type": "string",
-          "description": "The data plane resource path for which access is being granted through this Gremlin Role Assignment."
-        },
-        "principalId": {
-          "type": "string",
-          "description": "The unique identifier for the associated AAD principal in the AAD graph to which access is being granted through this Gremlin Role Assignment. Tenant ID for the principal is inferred using the tenant associated with the subscription."
-        },
-        "provisioningState": {
-          "type": "string",
-          "description": "Provisioning state of the resource.",
-          "readOnly": true
-        }
-      }
-    },
-    "GremlinRoleDefinitionListResult": {
-      "type": "object",
-      "description": "The response of a GremlinRoleDefinitionResource list operation.",
-      "properties": {
-        "value": {
-          "type": "array",
-          "description": "The GremlinRoleDefinitionResource items on this page",
-          "items": {
-            "$ref": "#/definitions/GremlinRoleDefinitionResource"
-          }
-        },
-        "nextLink": {
-          "type": "string",
-          "format": "uri",
-          "description": "The link to the next page of items"
-        }
-      },
-      "required": [
-        "value"
-      ]
-    },
-    "GremlinRoleDefinitionResource": {
-      "type": "object",
-      "description": "Parameters to create and update an Azure Cosmos DB Gremlin Role Definition.",
-      "properties": {
-        "properties": {
-          "$ref": "#/definitions/GremlinRoleDefinitionResourceProperties",
-          "description": "Properties to create and update an Azure Cosmos DB Gremlin Role Definition.",
-          "x-ms-client-flatten": true
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
-        }
-      ]
-    },
-    "GremlinRoleDefinitionResourceProperties": {
-      "type": "object",
-      "description": "Azure Cosmos DB Gremlin Role Definition resource object.",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "The path id for the Role Definition."
-        },
-        "roleName": {
-          "type": "string",
-          "description": "A user-friendly name for the Role Definition. Must be unique for the database account."
-        },
-        "type": {
-          "$ref": "#/definitions/RoleDefinitionType",
-          "description": "Indicates whether the Role Definition was built-in or user created."
-        },
-        "assignableScopes": {
-          "type": "array",
-          "description": "A set of fully qualified Scopes at or below which Gremlin Role Assignments may be created using this Role Definition. This will allow application of this Role Definition on the entire database account or any underlying Database / Collection. Must have at least one element. Scopes higher than Database account are not enforceable as assignable Scopes. Note that resources referenced in assignable Scopes need not exist.",
-          "items": {
-            "type": "string"
-          }
-        },
-        "permissions": {
-          "type": "array",
-          "description": "The set of operations allowed through this Role Definition.",
-          "items": {
-            "$ref": "#/definitions/Permission"
-          }
-        }
-      }
-    },
     "IncludedPath": {
       "type": "object",
       "description": "The paths that are included in indexing",
@@ -24878,24 +18029,6 @@
         ]
       }
     },
-    "ListBackups": {
-      "type": "object",
-      "description": "List of restorable backups for a Cassandra cluster.",
-      "properties": {
-        "value": {
-          "type": "array",
-          "description": "Container for array of backups.",
-          "items": {
-            "$ref": "#/definitions/BackupResource"
-          },
-          "readOnly": true,
-          "x-ms-identifiers": []
-        },
-        "nextLink": {
-          "type": "string"
-        }
-      }
-    },
     "ListClusters": {
       "type": "object",
       "description": "List of managed Cassandra clusters.",
@@ -24906,24 +18039,6 @@
           "items": {
             "$ref": "#/definitions/ClusterResource"
           }
-        },
-        "nextLink": {
-          "type": "string"
-        }
-      }
-    },
-    "ListCommands": {
-      "type": "object",
-      "description": "List of commands for cluster.",
-      "properties": {
-        "value": {
-          "type": "array",
-          "description": "Container for array of commands.",
-          "items": {
-            "$ref": "#/definitions/CommandPublicResource"
-          },
-          "readOnly": true,
-          "x-ms-identifiers": []
         },
         "nextLink": {
           "type": "string"
@@ -24944,23 +18059,6 @@
         },
         "nextLink": {
           "type": "string"
-        }
-      }
-    },
-    "ListGarnetClusters": {
-      "type": "object",
-      "description": "List of Garnet clusters.",
-      "properties": {
-        "value": {
-          "type": "array",
-          "description": "Container for the array of clusters.",
-          "items": {
-            "$ref": "#/definitions/GarnetClusterResource"
-          }
-        },
-        "nextLink": {
-          "type": "string",
-          "description": "The link used to get the next page of results."
         }
       }
     },
@@ -25307,16 +18405,6 @@
           "type": "integer",
           "format": "int32",
           "description": "Throughput bucket assigned for the materialized view operations on source container."
-        }
-      }
-    },
-    "MergeParameters": {
-      "type": "object",
-      "description": "The properties of an Azure Cosmos DB merge operations",
-      "properties": {
-        "isDryRun": {
-          "type": "boolean",
-          "description": "Specifies whether the operation is a real merge operation or a simulation."
         }
       }
     },
@@ -25944,242 +19032,6 @@
         }
       }
     },
-    "MongoMIRoleAssignmentListResult": {
-      "type": "object",
-      "description": "The response of a MongoMIRoleAssignmentResource list operation.",
-      "properties": {
-        "value": {
-          "type": "array",
-          "description": "The MongoMIRoleAssignmentResource items on this page",
-          "items": {
-            "$ref": "#/definitions/MongoMIRoleAssignmentResource"
-          }
-        },
-        "nextLink": {
-          "type": "string",
-          "format": "uri",
-          "description": "The link to the next page of items"
-        }
-      },
-      "required": [
-        "value"
-      ]
-    },
-    "MongoMIRoleAssignmentResource": {
-      "type": "object",
-      "description": "Parameters to create and update an Azure Cosmos DB MongoMI Role Assignment.",
-      "properties": {
-        "properties": {
-          "$ref": "#/definitions/MongoMIRoleAssignmentResourceProperties",
-          "description": "Properties to create and update an Azure Cosmos DB MongoMI Role Assignment.",
-          "x-ms-client-flatten": true
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
-        }
-      ]
-    },
-    "MongoMIRoleAssignmentResourceProperties": {
-      "type": "object",
-      "description": "Azure Cosmos DB MongoMI Role Assignment resource object.",
-      "properties": {
-        "roleDefinitionId": {
-          "type": "string",
-          "description": "The unique identifier for the associated Role Definition."
-        },
-        "scope": {
-          "type": "string",
-          "description": "The data plane resource path for which access is being granted through this MongoMI Role Assignment."
-        },
-        "principalId": {
-          "type": "string",
-          "description": "The unique identifier for the associated AAD principal in the AAD graph to which access is being granted through this MongoMI Role Assignment. Tenant ID for the principal is inferred using the tenant associated with the subscription."
-        },
-        "provisioningState": {
-          "type": "string",
-          "description": "Provisioning state of the resource.",
-          "readOnly": true
-        }
-      }
-    },
-    "MongoMIRoleDefinitionListResult": {
-      "type": "object",
-      "description": "The response of a MongoMIRoleDefinitionResource list operation.",
-      "properties": {
-        "value": {
-          "type": "array",
-          "description": "The MongoMIRoleDefinitionResource items on this page",
-          "items": {
-            "$ref": "#/definitions/MongoMIRoleDefinitionResource"
-          }
-        },
-        "nextLink": {
-          "type": "string",
-          "format": "uri",
-          "description": "The link to the next page of items"
-        }
-      },
-      "required": [
-        "value"
-      ]
-    },
-    "MongoMIRoleDefinitionResource": {
-      "type": "object",
-      "description": "Parameters to create and update an Azure Cosmos DB MongoMI Role Definition.",
-      "properties": {
-        "properties": {
-          "$ref": "#/definitions/MongoMIRoleDefinitionResourceProperties",
-          "description": "Properties to create and update an Azure Cosmos DB MongoMI Role Definition.",
-          "x-ms-client-flatten": true
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
-        }
-      ]
-    },
-    "MongoMIRoleDefinitionResourceProperties": {
-      "type": "object",
-      "description": "Azure Cosmos DB MongoMI Role Definition resource object.",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "The path id for the Role Definition."
-        },
-        "roleName": {
-          "type": "string",
-          "description": "A user-friendly name for the Role Definition. Must be unique for the database account."
-        },
-        "type": {
-          "$ref": "#/definitions/RoleDefinitionType",
-          "description": "Indicates whether the Role Definition was built-in or user created."
-        },
-        "assignableScopes": {
-          "type": "array",
-          "description": "A set of fully qualified Scopes at or below which MongoMI Role Assignments may be created using this Role Definition. This will allow application of this Role Definition on the entire database account or any underlying Database / Collection. Must have at least one element. Scopes higher than Database account are not enforceable as assignable Scopes. Note that resources referenced in assignable Scopes need not exist.",
-          "items": {
-            "type": "string"
-          }
-        },
-        "permissions": {
-          "type": "array",
-          "description": "The set of operations allowed through this Role Definition.",
-          "items": {
-            "$ref": "#/definitions/Permission"
-          }
-        }
-      }
-    },
-    "MongoRUToMongoRUCopyJobProperties": {
-      "type": "object",
-      "description": "Source Mongo to Destination Mongo copy job properties",
-      "properties": {
-        "sourceDetails": {
-          "$ref": "#/definitions/CosmosDBSourceSinkDetails",
-          "description": "Source Mongo DataStore details"
-        },
-        "destinationDetails": {
-          "$ref": "#/definitions/CosmosDBSourceSinkDetails",
-          "description": "Destination Mongo DataStore details"
-        },
-        "tasks": {
-          "type": "array",
-          "description": "Copy Job tasks.",
-          "items": {
-            "$ref": "#/definitions/MongoRUToMongoRUCopyJobTask"
-          },
-          "x-ms-identifiers": []
-        }
-      },
-      "required": [
-        "tasks"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/BaseCopyJobProperties"
-        }
-      ],
-      "x-ms-discriminator-value": "MongoRUToMongoRU"
-    },
-    "MongoRUToMongoRUCopyJobTask": {
-      "type": "object",
-      "properties": {
-        "source": {
-          "$ref": "#/definitions/CosmosDBMongoCollection",
-          "description": "Source Mongo (RU) collection"
-        },
-        "destination": {
-          "$ref": "#/definitions/CosmosDBMongoCollection",
-          "description": "Destination Mongo (RU) collection"
-        }
-      },
-      "required": [
-        "source",
-        "destination"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/BaseCopyJobTask"
-        }
-      ]
-    },
-    "MongoRUToMongoVCoreCopyJobProperties": {
-      "type": "object",
-      "description": "Source Mongo to Destination Mongo vCore copy job properties",
-      "properties": {
-        "sourceDetails": {
-          "$ref": "#/definitions/CosmosDBSourceSinkDetails",
-          "description": "Source Mongo (RU) DataStore details"
-        },
-        "destinationDetails": {
-          "$ref": "#/definitions/MongoVCoreSourceSinkDetails",
-          "description": "Destination Mongo (vCore) DataStore details"
-        },
-        "tasks": {
-          "type": "array",
-          "description": "Copy Job tasks.",
-          "items": {
-            "$ref": "#/definitions/MongoRUToMongoVCoreCopyJobTask"
-          },
-          "x-ms-identifiers": []
-        }
-      },
-      "required": [
-        "destinationDetails",
-        "tasks"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/BaseCopyJobProperties"
-        }
-      ],
-      "x-ms-discriminator-value": "MongoRUToMongoVCore"
-    },
-    "MongoRUToMongoVCoreCopyJobTask": {
-      "type": "object",
-      "properties": {
-        "source": {
-          "$ref": "#/definitions/CosmosDBMongoCollection",
-          "description": "Source Mongo (RU) collection"
-        },
-        "destination": {
-          "$ref": "#/definitions/CosmosDBMongoVCoreCollection",
-          "description": "Destination Mongo (vCore) collection"
-        }
-      },
-      "required": [
-        "source",
-        "destination"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/BaseCopyJobTask"
-        }
-      ]
-    },
     "MongoRoleDefinitionCreateUpdateParameters": {
       "type": "object",
       "description": "Parameters to create and update an Azure Cosmos DB Mongo Role Definition.",
@@ -26348,20 +19200,6 @@
         }
       }
     },
-    "MongoVCoreSourceSinkDetails": {
-      "type": "object",
-      "description": "A CosmosDB Mongo vCore data source/sink details",
-      "properties": {
-        "hostName": {
-          "type": "string"
-        },
-        "connectionStringKeyVaultUri": {
-          "type": "string",
-          "description": "URI of Azure KeyVault secret containing connection string.",
-          "pattern": "^https?://[^/$.?# ]+.[^ ]*$"
-        }
-      }
-    },
     "NetworkAclBypass": {
       "type": "string",
       "description": "Indicates what services are allowed to bypass firewall checks.",
@@ -26373,95 +19211,6 @@
         "name": "NetworkAclBypass",
         "modelAsString": false
       }
-    },
-    "NetworkSecurityPerimeterConfiguration": {
-      "type": "object",
-      "description": "Network security perimeter (NSP) configuration resource",
-      "properties": {
-        "properties": {
-          "$ref": "../../../../../../common-types/resource-management/v6/networksecurityperimeter.json#/definitions/NetworkSecurityPerimeterConfigurationProperties",
-          "description": "Network security configuration properties."
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
-        }
-      ]
-    },
-    "NetworkSecurityPerimeterConfigurationListResult": {
-      "type": "object",
-      "description": "The response of a NetworkSecurityPerimeterConfiguration list operation.",
-      "properties": {
-        "value": {
-          "type": "array",
-          "description": "The NetworkSecurityPerimeterConfiguration items on this page",
-          "items": {
-            "$ref": "#/definitions/NetworkSecurityPerimeterConfiguration"
-          }
-        },
-        "nextLink": {
-          "type": "string",
-          "format": "uri",
-          "description": "The link to the next page of items"
-        }
-      },
-      "required": [
-        "value"
-      ]
-    },
-    "NoSqlRUToNoSqlRUCopyJobProperties": {
-      "type": "object",
-      "description": "Source SQL to Destination SQL copy job properties",
-      "properties": {
-        "sourceDetails": {
-          "$ref": "#/definitions/CosmosDBSourceSinkDetails",
-          "description": "Source SQL DataStore details"
-        },
-        "destinationDetails": {
-          "$ref": "#/definitions/CosmosDBSourceSinkDetails",
-          "description": "Destination SQL DataStore details"
-        },
-        "tasks": {
-          "type": "array",
-          "description": "Copy Job tasks.",
-          "items": {
-            "$ref": "#/definitions/NoSqlRUToNoSqlRUCopyJobTask"
-          },
-          "x-ms-identifiers": []
-        }
-      },
-      "required": [
-        "tasks"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/BaseCopyJobProperties"
-        }
-      ],
-      "x-ms-discriminator-value": "NoSqlRUToNoSqlRU"
-    },
-    "NoSqlRUToNoSqlRUCopyJobTask": {
-      "type": "object",
-      "properties": {
-        "source": {
-          "$ref": "#/definitions/CosmosDBNoSqlContainer",
-          "description": "Source SQL container"
-        },
-        "destination": {
-          "$ref": "#/definitions/CosmosDBNoSqlContainer",
-          "description": "Destination SQL container"
-        }
-      },
-      "required": [
-        "source",
-        "destination"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/BaseCopyJobTask"
-        }
-      ]
     },
     "NodeState": {
       "type": "string",
@@ -26931,104 +19680,6 @@
         }
       }
     },
-    "PhysicalPartitionId": {
-      "type": "object",
-      "description": "PhysicalPartitionId object",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "Id of a physical partition"
-        }
-      },
-      "required": [
-        "id"
-      ]
-    },
-    "PhysicalPartitionStorageInfoCollection": {
-      "type": "object",
-      "description": "List of physical partitions and their properties returned by a merge operation.",
-      "properties": {
-        "physicalPartitionStorageInfoCollection": {
-          "type": "array",
-          "description": "List of physical partitions and their properties.",
-          "items": {
-            "$ref": "#/definitions/physicalPartitionStorageInfo"
-          },
-          "readOnly": true
-        }
-      }
-    },
-    "PhysicalPartitionThroughputInfoProperties": {
-      "type": "object",
-      "description": "The properties of an Azure Cosmos DB PhysicalPartitionThroughputInfoProperties object",
-      "properties": {
-        "physicalPartitionThroughputInfo": {
-          "type": "array",
-          "description": "Array of physical partition throughput info objects",
-          "items": {
-            "$ref": "#/definitions/PhysicalPartitionThroughputInfoResource"
-          }
-        }
-      }
-    },
-    "PhysicalPartitionThroughputInfoResource": {
-      "type": "object",
-      "description": "PhysicalPartitionThroughputInfo object",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "Id of a physical partition"
-        },
-        "throughput": {
-          "type": "number",
-          "format": "double",
-          "description": "Throughput of a physical partition"
-        },
-        "targetThroughput": {
-          "type": "number",
-          "format": "double",
-          "description": "Target throughput of a physical partition"
-        }
-      },
-      "required": [
-        "id"
-      ]
-    },
-    "PhysicalPartitionThroughputInfoResult": {
-      "type": "object",
-      "description": "An Azure Cosmos DB PhysicalPartitionThroughputInfoResult object.",
-      "properties": {
-        "properties": {
-          "$ref": "#/definitions/PhysicalPartitionThroughputInfoResultProperties",
-          "description": "The properties of an Azure Cosmos DB PhysicalPartitionThroughputInfoResult object",
-          "x-ms-client-flatten": true
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/ARMResourceProperties"
-        }
-      ]
-    },
-    "PhysicalPartitionThroughputInfoResultProperties": {
-      "type": "object",
-      "description": "The properties of an Azure Cosmos DB PhysicalPartitionThroughputInfoResult object",
-      "properties": {
-        "resource": {
-          "$ref": "#/definitions/PhysicalPartitionThroughputInfoResultPropertiesResource",
-          "description": "properties of physical partition throughput info"
-        }
-      }
-    },
-    "PhysicalPartitionThroughputInfoResultPropertiesResource": {
-      "type": "object",
-      "description": "properties of physical partition throughput info",
-      "allOf": [
-        {
-          "$ref": "#/definitions/PhysicalPartitionThroughputInfoProperties"
-        }
-      ]
-    },
     "PrimaryAggregationType": {
       "type": "string",
       "description": "The primary aggregation type of the metric.",
@@ -27270,67 +19921,6 @@
           }
         ]
       }
-    },
-    "RedistributeThroughputParameters": {
-      "type": "object",
-      "description": "Cosmos DB redistribute throughput parameters object",
-      "properties": {
-        "properties": {
-          "$ref": "#/definitions/RedistributeThroughputProperties",
-          "description": "Properties to redistribute throughput parameters object",
-          "x-ms-client-flatten": true
-        }
-      },
-      "required": [
-        "properties"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/ARMResourceProperties"
-        }
-      ]
-    },
-    "RedistributeThroughputProperties": {
-      "type": "object",
-      "description": "Properties to redistribute throughput for Azure Cosmos DB resource.",
-      "properties": {
-        "resource": {
-          "$ref": "#/definitions/RedistributeThroughputPropertiesResource",
-          "description": "The standard JSON format of a resource throughput"
-        }
-      },
-      "required": [
-        "resource"
-      ]
-    },
-    "RedistributeThroughputPropertiesResource": {
-      "type": "object",
-      "description": "Resource to redistribute throughput for Azure Cosmos DB resource",
-      "properties": {
-        "throughputPolicy": {
-          "$ref": "#/definitions/ThroughputPolicyType",
-          "description": "ThroughputPolicy to apply for throughput redistribution"
-        },
-        "targetPhysicalPartitionThroughputInfo": {
-          "type": "array",
-          "description": "Array of PhysicalPartitionThroughputInfoResource objects.",
-          "items": {
-            "$ref": "#/definitions/PhysicalPartitionThroughputInfoResource"
-          }
-        },
-        "sourcePhysicalPartitionThroughputInfo": {
-          "type": "array",
-          "description": "Array of PhysicalPartitionThroughputInfoResource objects.",
-          "items": {
-            "$ref": "#/definitions/PhysicalPartitionThroughputInfoResource"
-          }
-        }
-      },
-      "required": [
-        "throughputPolicy",
-        "targetPhysicalPartitionThroughputInfo",
-        "sourcePhysicalPartitionThroughputInfo"
-      ]
     },
     "RegionForOnlineOffline": {
       "type": "object",
@@ -28522,54 +21112,6 @@
           "description": "Specifies whether the restored account will have Time-To-Live disabled upon the successful restore."
         }
       }
-    },
-    "RetrieveThroughputParameters": {
-      "type": "object",
-      "description": "Cosmos DB retrieve throughput parameters object",
-      "properties": {
-        "properties": {
-          "$ref": "#/definitions/RetrieveThroughputProperties",
-          "description": "Properties to retrieve throughput parameters object",
-          "x-ms-client-flatten": true
-        }
-      },
-      "required": [
-        "properties"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/ARMResourceProperties"
-        }
-      ]
-    },
-    "RetrieveThroughputProperties": {
-      "type": "object",
-      "description": "Properties to retrieve throughput for Azure Cosmos DB resource.",
-      "properties": {
-        "resource": {
-          "$ref": "#/definitions/RetrieveThroughputPropertiesResource",
-          "description": "The standard JSON format of a resource throughput"
-        }
-      },
-      "required": [
-        "resource"
-      ]
-    },
-    "RetrieveThroughputPropertiesResource": {
-      "type": "object",
-      "description": "Resource to retrieve throughput information for Cosmos DB resource",
-      "properties": {
-        "physicalPartitionIds": {
-          "type": "array",
-          "description": "Array of PhysicalPartitionId objects.",
-          "items": {
-            "$ref": "#/definitions/PhysicalPartitionId"
-          }
-        }
-      },
-      "required": [
-        "physicalPartitionIds"
-      ]
     },
     "Role": {
       "type": "object",
@@ -30041,18 +22583,6 @@
         ]
       }
     },
-    "SupportedActions": {
-      "type": "string",
-      "description": "Indicates whether what action to take for the Chaos Fault.",
-      "enum": [
-        "Enable",
-        "Disable"
-      ],
-      "x-ms-enum": {
-        "name": "SupportedActions",
-        "modelAsString": false
-      }
-    },
     "TableCreateUpdateParameters": {
       "type": "object",
       "description": "Parameters to create and update Cosmos DB Table.",
@@ -30228,135 +22758,6 @@
         "id"
       ]
     },
-    "TableRoleAssignmentListResult": {
-      "type": "object",
-      "description": "The response of a TableRoleAssignmentResource list operation.",
-      "properties": {
-        "value": {
-          "type": "array",
-          "description": "The TableRoleAssignmentResource items on this page",
-          "items": {
-            "$ref": "#/definitions/TableRoleAssignmentResource"
-          }
-        },
-        "nextLink": {
-          "type": "string",
-          "format": "uri",
-          "description": "The link to the next page of items"
-        }
-      },
-      "required": [
-        "value"
-      ]
-    },
-    "TableRoleAssignmentResource": {
-      "type": "object",
-      "description": "Parameters to create and update an Azure Cosmos DB Table Role Assignment.",
-      "properties": {
-        "properties": {
-          "$ref": "#/definitions/TableRoleAssignmentResourceProperties",
-          "description": "Properties to create and update an Azure Cosmos DB Table Role Assignment.",
-          "x-ms-client-flatten": true
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
-        }
-      ]
-    },
-    "TableRoleAssignmentResourceProperties": {
-      "type": "object",
-      "description": "Azure Cosmos DB Table Role Assignment resource object.",
-      "properties": {
-        "roleDefinitionId": {
-          "type": "string",
-          "description": "The unique identifier for the associated Role Definition."
-        },
-        "scope": {
-          "type": "string",
-          "description": "The data plane resource path for which access is being granted through this Table Role Assignment."
-        },
-        "principalId": {
-          "type": "string",
-          "description": "The unique identifier for the associated AAD principal in the AAD graph to which access is being granted through this Table Role Assignment. Tenant ID for the principal is inferred using the tenant associated with the subscription."
-        },
-        "provisioningState": {
-          "type": "string",
-          "description": "Provisioning state of the resource.",
-          "readOnly": true
-        }
-      }
-    },
-    "TableRoleDefinitionListResult": {
-      "type": "object",
-      "description": "The response of a TableRoleDefinitionResource list operation.",
-      "properties": {
-        "value": {
-          "type": "array",
-          "description": "The TableRoleDefinitionResource items on this page",
-          "items": {
-            "$ref": "#/definitions/TableRoleDefinitionResource"
-          }
-        },
-        "nextLink": {
-          "type": "string",
-          "format": "uri",
-          "description": "The link to the next page of items"
-        }
-      },
-      "required": [
-        "value"
-      ]
-    },
-    "TableRoleDefinitionResource": {
-      "type": "object",
-      "description": "Parameters to create and update an Azure Cosmos DB Table Role Definition.",
-      "properties": {
-        "properties": {
-          "$ref": "#/definitions/TableRoleDefinitionResourceProperties",
-          "description": "Properties to create and update an Azure Cosmos DB Table Role Definition.",
-          "x-ms-client-flatten": true
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
-        }
-      ]
-    },
-    "TableRoleDefinitionResourceProperties": {
-      "type": "object",
-      "description": "Azure Cosmos DB Table Role Definition resource object.",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "The path id for the Role Definition."
-        },
-        "roleName": {
-          "type": "string",
-          "description": "A user-friendly name for the Role Definition. Must be unique for the database account."
-        },
-        "type": {
-          "$ref": "#/definitions/RoleDefinitionType",
-          "description": "Indicates whether the Role Definition was built-in or user created."
-        },
-        "assignableScopes": {
-          "type": "array",
-          "description": "A set of fully qualified Scopes at or below which Table Role Assignments may be created using this Role Definition. This will allow application of this Role Definition on the entire database account or any underlying Database / Collection. Must have at least one element. Scopes higher than Database account are not enforceable as assignable Scopes. Note that resources referenced in assignable Scopes need not exist.",
-          "items": {
-            "type": "string"
-          }
-        },
-        "permissions": {
-          "type": "array",
-          "description": "The set of operations allowed through this Role Definition.",
-          "items": {
-            "$ref": "#/definitions/Permission"
-          }
-        }
-      }
-    },
     "ThroughputBucketResource": {
       "type": "object",
       "description": "Cosmos DB throughput bucket object",
@@ -30395,157 +22796,6 @@
           "description": "Represents the percentage by which throughput can increase every time throughput policy kicks in."
         }
       }
-    },
-    "ThroughputPolicyType": {
-      "type": "string",
-      "description": "ThroughputPolicy to apply for throughput redistribution",
-      "enum": [
-        "none",
-        "equal",
-        "custom"
-      ],
-      "x-ms-enum": {
-        "name": "ThroughputPolicyType",
-        "modelAsString": true,
-        "values": [
-          {
-            "name": "None",
-            "value": "none"
-          },
-          {
-            "name": "Equal",
-            "value": "equal"
-          },
-          {
-            "name": "Custom",
-            "value": "custom"
-          }
-        ]
-      }
-    },
-    "ThroughputPoolAccountProperties": {
-      "type": "object",
-      "description": "An Azure Cosmos DB Global Database Account which is part of a Throughputpool.",
-      "properties": {
-        "provisioningState": {
-          "$ref": "#/definitions/Status",
-          "description": "A provisioning state of the ThroughputPool Account.",
-          "readOnly": true
-        },
-        "accountResourceIdentifier": {
-          "type": "string",
-          "description": "The resource identifier of global database account in the throughputPool."
-        },
-        "accountLocation": {
-          "type": "string",
-          "description": "The location of  global database account in the throughputPool."
-        },
-        "accountInstanceId": {
-          "type": "string",
-          "description": "The instance id of global database account in the throughputPool.",
-          "readOnly": true
-        }
-      }
-    },
-    "ThroughputPoolAccountResource": {
-      "type": "object",
-      "description": "An Azure Cosmos DB Throughputpool Account",
-      "properties": {
-        "properties": {
-          "$ref": "#/definitions/ThroughputPoolAccountProperties",
-          "description": "An Azure Cosmos DB Global Database Account which is part of a Throughputpool.",
-          "x-ms-client-flatten": true
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
-        }
-      ]
-    },
-    "ThroughputPoolAccountsListResult": {
-      "type": "object",
-      "description": "The response of a ThroughputPoolAccountResource list operation.",
-      "properties": {
-        "value": {
-          "type": "array",
-          "description": "The ThroughputPoolAccountResource items on this page",
-          "items": {
-            "$ref": "#/definitions/ThroughputPoolAccountResource"
-          }
-        },
-        "nextLink": {
-          "type": "string",
-          "format": "uri",
-          "description": "The link to the next page of items"
-        }
-      },
-      "required": [
-        "value"
-      ]
-    },
-    "ThroughputPoolProperties": {
-      "type": "object",
-      "description": "Properties to update Azure Cosmos DB throughput pool.",
-      "properties": {
-        "provisioningState": {
-          "$ref": "#/definitions/Status",
-          "description": "A provisioning state of the ThroughputPool."
-        },
-        "maxThroughput": {
-          "type": "integer",
-          "format": "int32",
-          "description": "Value for throughput to be shared among CosmosDB resources in the pool."
-        }
-      }
-    },
-    "ThroughputPoolResource": {
-      "type": "object",
-      "description": "An Azure Cosmos DB Throughputpool.",
-      "properties": {
-        "properties": {
-          "$ref": "#/definitions/ThroughputPoolProperties",
-          "description": "Properties to update Azure Cosmos DB throughput pool.",
-          "x-ms-client-flatten": true
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/TrackedResource"
-        }
-      ]
-    },
-    "ThroughputPoolUpdate": {
-      "type": "object",
-      "description": "Represents a throughput pool resource for updates.",
-      "properties": {
-        "properties": {
-          "$ref": "#/definitions/ThroughputPoolProperties",
-          "description": "Properties of the throughput pool.",
-          "x-ms-client-flatten": true
-        }
-      }
-    },
-    "ThroughputPoolsListResult": {
-      "type": "object",
-      "description": "The response of a ThroughputPoolResource list operation.",
-      "properties": {
-        "value": {
-          "type": "array",
-          "description": "The ThroughputPoolResource items on this page",
-          "items": {
-            "$ref": "#/definitions/ThroughputPoolResource"
-          }
-        },
-        "nextLink": {
-          "type": "string",
-          "format": "uri",
-          "description": "The link to the next page of items"
-        }
-      },
-      "required": [
-        "value"
-      ]
     },
     "ThroughputSettingsGetProperties": {
       "type": "object",
@@ -31091,87 +23341,6 @@
         "ignoreMissingVNetServiceEndpoint": {
           "type": "boolean",
           "description": "Create firewall rule before the virtual network has vnet service endpoint enabled."
-        }
-      }
-    },
-    "chaosFaultListResponse": {
-      "type": "object",
-      "description": "Chaos Fault List Response.",
-      "properties": {
-        "value": {
-          "type": "array",
-          "description": "The chaosFaultResource items on this page",
-          "items": {
-            "$ref": "#/definitions/chaosFaultResource"
-          }
-        },
-        "nextLink": {
-          "type": "string",
-          "format": "uri",
-          "description": "The link to the next page of items"
-        }
-      },
-      "required": [
-        "value"
-      ]
-    },
-    "chaosFaultProperties": {
-      "type": "object",
-      "description": "A request object to enable/disable the chaos fault.",
-      "properties": {
-        "action": {
-          "$ref": "#/definitions/SupportedActions",
-          "description": "Indicates whether what action to take for the Chaos Fault."
-        },
-        "region": {
-          "type": "string",
-          "description": "Region of the account where the Chaos Fault is to be enabled/disabled."
-        },
-        "databaseName": {
-          "type": "string",
-          "description": "Database name."
-        },
-        "containerName": {
-          "type": "string",
-          "description": "Container name."
-        },
-        "provisioningState": {
-          "type": "string",
-          "description": "A provisioning state of the Chaos Fault.",
-          "readOnly": true
-        }
-      }
-    },
-    "chaosFaultResource": {
-      "type": "object",
-      "description": "A request object to enable/disable the chaos fault",
-      "properties": {
-        "properties": {
-          "$ref": "#/definitions/chaosFaultProperties",
-          "description": "A request object to enable/disable the chaos fault.",
-          "x-ms-client-flatten": true
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
-        }
-      ]
-    },
-    "physicalPartitionStorageInfo": {
-      "type": "object",
-      "description": "The storage of a physical partition",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "The unique identifier of the partition.",
-          "readOnly": true
-        },
-        "storageInKB": {
-          "type": "number",
-          "format": "double",
-          "description": "The storage in KB for the physical partition.",
-          "readOnly": true
         }
       }
     }


### PR DESCRIPTION
… 2026-03-15

Add optional boolean property to enable/disable hierarchical partition key ID last level enforcement on the Cosmos DB database account. Property is scoped to 2026-03-15 stable only (excluded from 2026-04-01-preview).

Added to: DatabaseAccountGetProperties, DatabaseAccountUpdateProperties, DatabaseAccountCreateUpdateProperties.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
