### PR TITLE
Fix unintended rename of ".beta.insights.get() input argument

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/client.tsp
@@ -168,6 +168,7 @@ using Azure.AI.Projects;
 // Insights sub‐client
 // --------------------------------------------------------------------------------
 @@clientName(Azure.AI.Projects.Insight.id, "insight_id");
+@@clientName(InsightsGetParams.id, "insight_id");
 
 // --------------------------------------------------------------------------------
 // Datasets sub‐client

--- a/specification/ai-foundry/data-plane/Foundry/src/insights/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/insights/routes.tsp
@@ -1,6 +1,7 @@
 import "./models.tsp";
 
 using TypeSpec.Http;
+using Azure.ClientGenerator.Core;
 
 namespace Azure.AI.Projects;
 
@@ -63,6 +64,7 @@ interface Insights {
       ...IncludeCoordinatesTrait;
 
       /** The unique identifier for the insights report. */
+      @clientName("insight_id")
       @path id: string;
     },
     Insight

--- a/specification/ai-foundry/data-plane/Foundry/src/insights/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/insights/routes.tsp
@@ -1,7 +1,6 @@
 import "./models.tsp";
 
 using TypeSpec.Http;
-using Azure.ClientGenerator.Core;
 
 namespace Azure.AI.Projects;
 
@@ -29,6 +28,13 @@ alias FilterQueryParamsTraits = {
   agentName?: string;
 
   ...IncludeCoordinatesTrait;
+};
+
+alias InsightsGetParams = {
+  ...IncludeCoordinatesTrait;
+
+  /** The unique identifier for the insights report. */
+  @path id: string;
 };
 
 @tag("Insights")
@@ -60,13 +66,7 @@ interface Insights {
   @route("/{id}")
   get is FoundryDataPlanePreviewOperation<
     FoundryFeaturesOptInKeys.insights_v1_preview,
-    {
-      ...IncludeCoordinatesTrait;
-
-      /** The unique identifier for the insights report. */
-      @clientName("insight_id")
-      @path id: string;
-    },
+    InsightsGetParams,
     Insight
   >;
 


### PR DESCRIPTION
There is no change in REST API protocol in this PR, just emitted SDKs. The swagger has not changed.

Gerardo's minor TypeSpec refactor two weeks ago ([this commit](https://github.com/Azure/azure-rest-api-specs/commit/07b4b1c5f6e1dd3f21d4c14820b074c80666041f)) had a side effect of changing the input argument name in the Python and JS emitted method ".beta.insights.get()", from "insight_id" to "id".

This PR adds client customization to get back to emitting "insight_id" we had before.

Thank you Howie for calling this out!

