### PR TITLE
[CosmosDB][TypeSpec] Add keysMetadata.approximateLastUsageTime for 2026-04-01-preview

### DIFF
--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBDatabaseAccountCreateMax.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBDatabaseAccountCreateMax.json
@@ -227,16 +227,20 @@
           "minimalTlsVersion": "Tls12",
           "keysMetadata": {
             "primaryMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             },
             "secondaryMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             },
             "primaryReadonlyMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             },
             "secondaryReadonlyMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             }
           },
           "enablePriorityBasedExecution": true,

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBDatabaseAccountCreateMin.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBDatabaseAccountCreateMin.json
@@ -94,16 +94,20 @@
           "minimalTlsVersion": "Tls",
           "keysMetadata": {
             "primaryMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             },
             "secondaryMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             },
             "primaryReadonlyMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             },
             "secondaryReadonlyMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             }
           },
           "throughputPoolDedicatedRUs": 0,

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBDatabaseAccountGet.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBDatabaseAccountGet.json
@@ -118,16 +118,20 @@
           "enableMaterializedViews": false,
           "keysMetadata": {
             "primaryMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             },
             "secondaryMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             },
             "primaryReadonlyMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             },
             "secondaryReadonlyMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             }
           },
           "enablePriorityBasedExecution": true,

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBDatabaseAccountList.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBDatabaseAccountList.json
@@ -108,16 +108,20 @@
               "enableMaterializedViews": false,
               "keysMetadata": {
                 "primaryMasterKey": {
-                  "generationTime": "2022-02-25T20:30:11Z"
+                  "generationTime": "2022-02-25T20:30:11Z",
+                  "approximateLastUsageTime": "2024-10-09T11:45:33Z"
                 },
                 "secondaryMasterKey": {
-                  "generationTime": "2022-02-25T20:30:11Z"
+                  "generationTime": "2022-02-25T20:30:11Z",
+                  "approximateLastUsageTime": "2024-10-09T11:45:33Z"
                 },
                 "primaryReadonlyMasterKey": {
-                  "generationTime": "2022-02-25T20:30:11Z"
+                  "generationTime": "2022-02-25T20:30:11Z",
+                  "approximateLastUsageTime": "2024-10-09T11:45:33Z"
                 },
                 "secondaryReadonlyMasterKey": {
-                  "generationTime": "2022-02-25T20:30:11Z"
+                  "generationTime": "2022-02-25T20:30:11Z",
+                  "approximateLastUsageTime": "2024-10-09T11:45:33Z"
                 }
               },
               "enablePriorityBasedExecution": true,

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBDatabaseAccountListByResourceGroup.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBDatabaseAccountListByResourceGroup.json
@@ -88,16 +88,20 @@
               "minimalTlsVersion": "Tls",
               "keysMetadata": {
                 "primaryMasterKey": {
-                  "generationTime": "2022-02-25T20:30:11Z"
+                  "generationTime": "2022-02-25T20:30:11Z",
+                  "approximateLastUsageTime": "2024-10-09T11:45:33Z"
                 },
                 "secondaryMasterKey": {
-                  "generationTime": "2022-02-25T20:30:11Z"
+                  "generationTime": "2022-02-25T20:30:11Z",
+                  "approximateLastUsageTime": "2024-10-09T11:45:33Z"
                 },
                 "primaryReadonlyMasterKey": {
-                  "generationTime": "2022-02-25T20:30:11Z"
+                  "generationTime": "2022-02-25T20:30:11Z",
+                  "approximateLastUsageTime": "2024-10-09T11:45:33Z"
                 },
                 "secondaryReadonlyMasterKey": {
-                  "generationTime": "2022-02-25T20:30:11Z"
+                  "generationTime": "2022-02-25T20:30:11Z",
+                  "approximateLastUsageTime": "2024-10-09T11:45:33Z"
                 }
               },
               "throughputPoolDedicatedRUs": 300000,

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBDatabaseAccountPatch.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBDatabaseAccountPatch.json
@@ -207,16 +207,20 @@
           "minimalTlsVersion": "Tls",
           "keysMetadata": {
             "primaryMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             },
             "secondaryMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             },
             "primaryReadonlyMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             },
             "secondaryReadonlyMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             }
           },
           "enablePriorityBasedExecution": true,

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBRestoreDatabaseAccountCreateUpdate.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBRestoreDatabaseAccountCreateUpdate.json
@@ -103,16 +103,20 @@
           "ipRules": [],
           "keysMetadata": {
             "primaryMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             },
             "primaryReadonlyMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             },
             "secondaryMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             },
             "secondaryReadonlyMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             }
           },
           "locations": [

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/models.tsp
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/models.tsp
@@ -2194,6 +2194,16 @@ model AccountKeyMetadata {
   @visibility(Lifecycle.Read)
   // FIXME: (utcDateTime) Please double check that this is the correct type for your scenario.
   generationTime?: utcDateTime;
+
+  /**
+   * Approximate time in UTC of the most recent usage of the key in ISO-8601 format.
+   * If the value is missing from the object, it means there is no recorded data plane
+   * usage for this key.
+   */
+  @visibility(Lifecycle.Read)
+  @added(Versions.v2026_04_01_preview)
+  // FIXME: (utcDateTime) Please double check that this is the correct type for your scenario.
+  approximateLastUsageTime?: utcDateTime;
 }
 
 /**

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBDatabaseAccountCreateMax.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBDatabaseAccountCreateMax.json
@@ -227,16 +227,20 @@
           "minimalTlsVersion": "Tls12",
           "keysMetadata": {
             "primaryMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             },
             "secondaryMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             },
             "primaryReadonlyMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             },
             "secondaryReadonlyMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             }
           },
           "enablePriorityBasedExecution": true,

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBDatabaseAccountCreateMin.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBDatabaseAccountCreateMin.json
@@ -94,16 +94,20 @@
           "minimalTlsVersion": "Tls",
           "keysMetadata": {
             "primaryMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             },
             "secondaryMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             },
             "primaryReadonlyMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             },
             "secondaryReadonlyMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             }
           },
           "throughputPoolDedicatedRUs": 0,

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBDatabaseAccountGet.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBDatabaseAccountGet.json
@@ -118,16 +118,20 @@
           "enableMaterializedViews": false,
           "keysMetadata": {
             "primaryMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             },
             "secondaryMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             },
             "primaryReadonlyMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             },
             "secondaryReadonlyMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             }
           },
           "enablePriorityBasedExecution": true,

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBDatabaseAccountList.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBDatabaseAccountList.json
@@ -108,16 +108,20 @@
               "enableMaterializedViews": false,
               "keysMetadata": {
                 "primaryMasterKey": {
-                  "generationTime": "2022-02-25T20:30:11Z"
+                  "generationTime": "2022-02-25T20:30:11Z",
+                  "approximateLastUsageTime": "2024-10-09T11:45:33Z"
                 },
                 "secondaryMasterKey": {
-                  "generationTime": "2022-02-25T20:30:11Z"
+                  "generationTime": "2022-02-25T20:30:11Z",
+                  "approximateLastUsageTime": "2024-10-09T11:45:33Z"
                 },
                 "primaryReadonlyMasterKey": {
-                  "generationTime": "2022-02-25T20:30:11Z"
+                  "generationTime": "2022-02-25T20:30:11Z",
+                  "approximateLastUsageTime": "2024-10-09T11:45:33Z"
                 },
                 "secondaryReadonlyMasterKey": {
-                  "generationTime": "2022-02-25T20:30:11Z"
+                  "generationTime": "2022-02-25T20:30:11Z",
+                  "approximateLastUsageTime": "2024-10-09T11:45:33Z"
                 }
               },
               "enablePriorityBasedExecution": true,

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBDatabaseAccountListByResourceGroup.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBDatabaseAccountListByResourceGroup.json
@@ -88,16 +88,20 @@
               "minimalTlsVersion": "Tls",
               "keysMetadata": {
                 "primaryMasterKey": {
-                  "generationTime": "2022-02-25T20:30:11Z"
+                  "generationTime": "2022-02-25T20:30:11Z",
+                  "approximateLastUsageTime": "2024-10-09T11:45:33Z"
                 },
                 "secondaryMasterKey": {
-                  "generationTime": "2022-02-25T20:30:11Z"
+                  "generationTime": "2022-02-25T20:30:11Z",
+                  "approximateLastUsageTime": "2024-10-09T11:45:33Z"
                 },
                 "primaryReadonlyMasterKey": {
-                  "generationTime": "2022-02-25T20:30:11Z"
+                  "generationTime": "2022-02-25T20:30:11Z",
+                  "approximateLastUsageTime": "2024-10-09T11:45:33Z"
                 },
                 "secondaryReadonlyMasterKey": {
-                  "generationTime": "2022-02-25T20:30:11Z"
+                  "generationTime": "2022-02-25T20:30:11Z",
+                  "approximateLastUsageTime": "2024-10-09T11:45:33Z"
                 }
               },
               "throughputPoolDedicatedRUs": 300000,

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBDatabaseAccountPatch.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBDatabaseAccountPatch.json
@@ -207,16 +207,20 @@
           "minimalTlsVersion": "Tls",
           "keysMetadata": {
             "primaryMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             },
             "secondaryMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             },
             "primaryReadonlyMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             },
             "secondaryReadonlyMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             }
           },
           "enablePriorityBasedExecution": true,

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBRestoreDatabaseAccountCreateUpdate.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBRestoreDatabaseAccountCreateUpdate.json
@@ -103,16 +103,20 @@
           "ipRules": [],
           "keysMetadata": {
             "primaryMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             },
             "primaryReadonlyMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             },
             "secondaryMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             },
             "secondaryReadonlyMasterKey": {
-              "generationTime": "2022-02-25T20:30:11Z"
+              "generationTime": "2022-02-25T20:30:11Z",
+              "approximateLastUsageTime": "2024-10-09T11:45:33Z"
             }
           },
           "locations": [

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/openapi.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/openapi.json
@@ -20363,6 +20363,12 @@
           "format": "date-time",
           "description": "Generation time in UTC of the key in ISO-8601 format. If the value is missing from the object, it means that the last key regeneration was triggered before 2022-06-18.",
           "readOnly": true
+        },
+        "approximateLastUsageTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Approximate time in UTC of the most recent usage of the key in ISO-8601 format.\nIf the value is missing from the object, it means there is no recorded data plane\nusage for this key.",
+          "readOnly": true
         }
       }
     },


### PR DESCRIPTION
## Summary
 This PR publishes `approximateLastUsageTime` for Cosmos DB account key metadata in TypeSpec for `2026-04-01-preview`, aligning spec output with the RP behavior already propagated for newer preview API flow.
 
 ## Changes made
 - Added `approximateLastUsageTime?: utcDateTime` to `AccountKeyMetadata` in `models.tsp`.
 - Decorated with `@visibility(Lifecycle.Read)` and `@added(Versions.v2026_04_01_preview)`.
 - Updated `examples/2026-04-01-preview` account examples so all four key metadata objects include `approximateLastUsageTime`.
 - Regenerated `preview/2026-04-01-preview/openapi.json` and generated preview examples.
 
 ## Validation
 - ✅ `npx tsp compile specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB` succeeded.
 - ⚠️ `npx tsv ...` is blocked by existing branch baseline/tooling behavior (missing `examples/2026-03-15` and clean-tree enforcement), not by this feature change.