### PR TITLE
Update AgentEndpoint typespec

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -11415,18 +11415,6 @@
               ]
             }
           },
-          "m365_card": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/M365Card"
-              }
-            ],
-            "x-ms-foundry-meta": {
-              "required_previews": [
-                "AgentEndpoints=V1Preview"
-              ]
-            }
-          },
           "agent_card": {
             "allOf": [
               {
@@ -11452,21 +11440,6 @@
               "activity_protocol",
               "responses",
               "invocations"
-            ]
-          }
-        ]
-      },
-      "AgentPublishScope": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "Individual",
-              "Shared",
-              "Organization"
             ]
           }
         ]
@@ -17490,67 +17463,6 @@
           }
         ],
         "description": "The types of parameters for red team item generation."
-      },
-      "M365Card": {
-        "type": "object",
-        "required": [
-          "display_name",
-          "version",
-          "short_description",
-          "full_description",
-          "developer_name",
-          "website",
-          "terms_of_use",
-          "privacy_statement",
-          "publish_scope",
-          "is_digital_worker"
-        ],
-        "properties": {
-          "display_name": {
-            "type": "string",
-            "description": "The display name of the agent as it will appear in Teams/M365"
-          },
-          "version": {
-            "type": "string",
-            "description": "The user-facing version of the agent"
-          },
-          "short_description": {
-            "type": "string",
-            "description": "A one sentence description of what your agent does"
-          },
-          "full_description": {
-            "type": "string",
-            "description": "Longer description of your agent's responsibilities and the actions it can take"
-          },
-          "developer_name": {
-            "type": "string",
-            "description": "The organization or agent developer's name"
-          },
-          "website": {
-            "type": "string",
-            "description": "URL to the website of the developer"
-          },
-          "terms_of_use": {
-            "type": "string",
-            "description": "URL to the terms of use for the agent"
-          },
-          "privacy_statement": {
-            "type": "string",
-            "description": "URL to the privacy policy for the agent"
-          },
-          "publish_scope": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/AgentPublishScope"
-              }
-            ],
-            "description": "The scope at which the agent is available"
-          },
-          "is_digital_worker": {
-            "type": "boolean",
-            "description": "Whether the agent is a digital worker or regular published agent"
-          }
-        }
       },
       "ManagedAgentIdentityBlueprint": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -433,7 +433,7 @@
         ]
       },
       "patch": {
-        "operationId": "Agents_updateAgentEndpointObject",
+        "operationId": "Agents_patchAgentObject",
         "description": "Updates an agent endpoint.",
         "parameters": [
           {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -431,9 +431,7 @@
         "tags": [
           "Agents"
         ]
-      }
-    },
-    "/agents/{agent_name}/endpoint": {
+      },
       "patch": {
         "operationId": "Agents_updateAgentEndpointObject",
         "description": "Updates an agent endpoint.",
@@ -500,7 +498,7 @@
           "content": {
             "application/merge-patch+json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateAgentEndpointRequest"
+                "$ref": "#/components/schemas/PatchAgentRequest"
               }
             }
           }
@@ -10998,14 +10996,6 @@
               "$ref": "#/components/schemas/AgentEndpointAuthorizationScheme"
             },
             "description": "The authorization schemes supported by the agent endpoint"
-          },
-          "agent_card": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/AgentCard"
-              }
-            ],
-            "description": "The agent card"
           }
         },
         "x-ms-foundry-meta": {
@@ -11073,6 +11063,38 @@
             ]
           }
         ]
+      },
+      "AgentEndpointUpdate": {
+        "type": "object",
+        "properties": {
+          "version_selector": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VersionSelectorUpdate"
+              }
+            ],
+            "description": "The version selector of the agent endpoint determines how traffic is routed to different versions of the agent."
+          },
+          "protocols": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentEndpointProtocol"
+            },
+            "description": "The protocols that the agent supports"
+          },
+          "authorization_schemes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentEndpointAuthorizationScheme"
+            },
+            "description": "The authorization schemes supported by the agent endpoint"
+          }
+        },
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentEndpoints=V1Preview"
+          ]
+        }
       },
       "AgentEvaluation": {
         "type": "object",
@@ -11365,8 +11387,7 @@
               "required_previews": [
                 "AgentEndpoints=V1Preview"
               ]
-            },
-            "readOnly": true
+            }
           },
           "blueprint": {
             "allOf": [
@@ -11379,8 +11400,7 @@
               "required_previews": [
                 "AgentEndpoints=V1Preview"
               ]
-            },
-            "readOnly": true
+            }
           },
           "blueprint_reference": {
             "allOf": [
@@ -11393,8 +11413,31 @@
               "required_previews": [
                 "AgentEndpoints=V1Preview"
               ]
-            },
-            "readOnly": true
+            }
+          },
+          "m365_card": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/M365Card"
+              }
+            ],
+            "x-ms-foundry-meta": {
+              "required_previews": [
+                "AgentEndpoints=V1Preview"
+              ]
+            }
+          },
+          "agent_card": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentCard"
+              }
+            ],
+            "x-ms-foundry-meta": {
+              "required_previews": [
+                "AgentEndpoints=V1Preview"
+              ]
+            }
           }
         }
       },
@@ -11409,6 +11452,21 @@
               "activity_protocol",
               "responses",
               "invocations"
+            ]
+          }
+        ]
+      },
+      "AgentPublishScope": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "Individual",
+              "Shared",
+              "Organization"
             ]
           }
         ]
@@ -13834,6 +13892,32 @@
               }
             ],
             "description": "The blueprint reference for the agent.",
+            "x-ms-foundry-meta": {
+              "required_previews": [
+                "AgentEndpoints=V1Preview"
+              ]
+            }
+          },
+          "agent_endpoint": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentEndpoint"
+              }
+            ],
+            "description": "An optional endpoint configuration. If not specified, a default endpoint configuration will be set for the agent",
+            "x-ms-foundry-meta": {
+              "required_previews": [
+                "AgentEndpoints=V1Preview"
+              ]
+            }
+          },
+          "agent_card": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentCard"
+              }
+            ],
+            "description": "Optional agent card for the agent",
             "x-ms-foundry-meta": {
               "required_previews": [
                 "AgentEndpoints=V1Preview"
@@ -17406,6 +17490,67 @@
           }
         ],
         "description": "The types of parameters for red team item generation."
+      },
+      "M365Card": {
+        "type": "object",
+        "required": [
+          "display_name",
+          "version",
+          "short_description",
+          "full_description",
+          "developer_name",
+          "website",
+          "terms_of_use",
+          "privacy_statement",
+          "publish_scope",
+          "is_digital_worker"
+        ],
+        "properties": {
+          "display_name": {
+            "type": "string",
+            "description": "The display name of the agent as it will appear in Teams/M365"
+          },
+          "version": {
+            "type": "string",
+            "description": "The user-facing version of the agent"
+          },
+          "short_description": {
+            "type": "string",
+            "description": "A one sentence description of what your agent does"
+          },
+          "full_description": {
+            "type": "string",
+            "description": "Longer description of your agent's responsibilities and the actions it can take"
+          },
+          "developer_name": {
+            "type": "string",
+            "description": "The organization or agent developer's name"
+          },
+          "website": {
+            "type": "string",
+            "description": "URL to the website of the developer"
+          },
+          "terms_of_use": {
+            "type": "string",
+            "description": "URL to the terms of use for the agent"
+          },
+          "privacy_statement": {
+            "type": "string",
+            "description": "URL to the privacy policy for the agent"
+          },
+          "publish_scope": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentPublishScope"
+              }
+            ],
+            "description": "The scope at which the agent is available"
+          },
+          "is_digital_worker": {
+            "type": "boolean",
+            "description": "Whether the agent is a digital worker or regular published agent"
+          }
+        }
       },
       "ManagedAgentIdentityBlueprint": {
         "type": "object",
@@ -38590,6 +38735,45 @@
         },
         "description": "Paged collection of ScheduleRun items"
       },
+      "PatchAgentRequest": {
+        "type": "object",
+        "properties": {
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Set of 16 key-value pairs that can be attached to an object. This can be\nuseful for storing additional information about the object in a structured\nformat, and querying for objects via API or the dashboard.\n\nKeys are strings with a maximum length of 64 characters. Values are strings\nwith a maximum length of 512 characters.",
+            "x-oaiTypeLabel": "map"
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 512,
+            "description": "A human-readable description of the agent."
+          },
+          "agent_endpoint": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentEndpointUpdate"
+              }
+            ],
+            "description": "The endpoint configuration for the agent"
+          },
+          "agent_card": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentCardUpdate"
+              }
+            ],
+            "description": "Optional agent card for the agent"
+          }
+        },
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentEndpoints=V1Preview"
+          ]
+        }
+      },
       "PendingUploadRequest": {
         "type": "object",
         "required": [
@@ -40435,46 +40619,6 @@
           }
         ],
         "description": "Type of the trigger."
-      },
-      "UpdateAgentEndpointRequest": {
-        "type": "object",
-        "properties": {
-          "version_selector": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/VersionSelectorUpdate"
-              }
-            ],
-            "description": "The version selector of the agent endpoint determines how traffic is routed to different versions of the agent."
-          },
-          "protocols": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/AgentEndpointProtocol"
-            },
-            "description": "The protocols that the agent supports"
-          },
-          "authorization_schemes": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/AgentEndpointAuthorizationScheme"
-            },
-            "description": "The authorization schemes supported by the agent endpoint"
-          },
-          "agent_card": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/AgentCardUpdate"
-              }
-            ],
-            "description": "The agent card"
-          }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
       },
       "UpdateAgentFromManifestRequest": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -296,14 +296,6 @@ union AgentProtocol {
 }
 
 @removed(Versions.v1)
-union AgentPublishScope {
-  string,
-  individual: "Individual",
-  shared: "Shared",
-  organization: "Organization",
-}
-
-@removed(Versions.v1)
 union AgentEndpointProtocol {
   string,
   activity: "activity",

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -80,6 +80,26 @@ model CreateAgentRequest {
   name: string;
 
   ...CreateAgentVersionRequest;
+
+  @removed(Versions.v1)
+  @extension(
+    "x-ms-foundry-meta",
+    #{
+      required_previews: #[FoundryFeaturesOptInKeys.agent_endpoint_v1_preview],
+    }
+  )
+  @doc("An optional endpoint configuration. If not specified, a default endpoint configuration will be set for the agent")
+  agent_endpoint?: AgentEndpoint;
+
+  @removed(Versions.v1)
+  @extension(
+    "x-ms-foundry-meta",
+    #{
+      required_previews: #[FoundryFeaturesOptInKeys.agent_endpoint_v1_preview],
+    }
+  )
+  @doc("Optional agent card for the agent")
+  agent_card?: AgentCard;
 }
 
 model UpdateAgentRequest {
@@ -91,8 +111,18 @@ model UpdateAgentRequest {
   "x-ms-foundry-meta",
   #{ required_previews: #[FoundryFeaturesOptInKeys.agent_endpoint_v1_preview] }
 )
-model UpdateAgentEndpointRequest {
-  ...AgentEndpoint;
+model PatchAgentRequest {
+  ...MetadataPropertyForRequest;
+
+  @doc("A human-readable description of the agent.")
+  @maxLength(512)
+  description?: string;
+
+  @doc("The endpoint configuration for the agent")
+  agent_endpoint?: AgentEndpoint;
+
+  @doc("Optional agent card for the agent")
+  agent_card?: AgentCard;
 }
 
 union AgentObjectType {
@@ -137,7 +167,6 @@ model AgentObject {
     }
   )
   @doc("The instance identity of the agent")
-  @visibility(Lifecycle.Read)
   instance_identity?: AgentIdentity;
 
   @removed(Versions.v1)
@@ -148,7 +177,6 @@ model AgentObject {
     }
   )
   @doc("The blueprint for the agent")
-  @visibility(Lifecycle.Read)
   blueprint?: AgentIdentity;
 
   @removed(Versions.v1)
@@ -159,8 +187,25 @@ model AgentObject {
     }
   )
   @doc("The blueprint for the agent")
-  @visibility(Lifecycle.Read)
   blueprint_reference?: AgentBlueprintReference;
+
+  @removed(Versions.v1)
+  @extension(
+    "x-ms-foundry-meta",
+    #{
+      required_previews: #[FoundryFeaturesOptInKeys.agent_endpoint_v1_preview],
+    }
+  )
+  m365_card?: M365Card;
+
+  @removed(Versions.v1)
+  @extension(
+    "x-ms-foundry-meta",
+    #{
+      required_previews: #[FoundryFeaturesOptInKeys.agent_endpoint_v1_preview],
+    }
+  )
+  agent_card?: AgentCard;
 }
 
 model AgentVersionObject {
@@ -257,6 +302,47 @@ union AgentProtocol {
 
   @removed(Versions.v1)
   invocations: "invocations",
+}
+
+@removed(Versions.v1)
+union AgentPublishScope {
+  string,
+  individual: "Individual",
+  shared: "Shared",
+  organization: "Organization",
+}
+
+@removed(Versions.v1)
+model M365Card {
+  @doc("The display name of the agent as it will appear in Teams/M365")
+  display_name: string;
+
+  @doc("The user-facing version of the agent")
+  version: string;
+
+  @doc("A one sentence description of what your agent does")
+  short_description: string;
+
+  @doc("Longer description of your agent's responsibilities and the actions it can take")
+  full_description: string;
+
+  @doc("The organization or agent developer's name")
+  developer_name: string;
+
+  @doc("URL to the website of the developer")
+  website: string;
+
+  @doc("URL to the terms of use for the agent")
+  terms_of_use: string;
+
+  @doc("URL to the privacy policy for the agent")
+  privacy_statement: string;
+
+  @doc("The scope at which the agent is available")
+  publish_scope: AgentPublishScope;
+
+  @doc("Whether the agent is a digital worker or regular published agent")
+  is_digital_worker: boolean;
 }
 
 @removed(Versions.v1)
@@ -822,10 +908,6 @@ model AgentEndpoint {
 
   @doc("The authorization schemes supported by the agent endpoint")
   authorization_schemes?: AgentEndpointAuthorizationScheme[];
-
-  // TODO: move this out to the agent object. This is under preview so for fast iteration putting it here
-  @doc("The agent card")
-  agent_card?: AgentCard;
 }
 
 @removed(Versions.v1)

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -196,15 +196,6 @@ model AgentObject {
       required_previews: #[FoundryFeaturesOptInKeys.agent_endpoint_v1_preview],
     }
   )
-  m365_card?: M365Card;
-
-  @removed(Versions.v1)
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[FoundryFeaturesOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
   agent_card?: AgentCard;
 }
 
@@ -310,39 +301,6 @@ union AgentPublishScope {
   individual: "Individual",
   shared: "Shared",
   organization: "Organization",
-}
-
-@removed(Versions.v1)
-model M365Card {
-  @doc("The display name of the agent as it will appear in Teams/M365")
-  display_name: string;
-
-  @doc("The user-facing version of the agent")
-  version: string;
-
-  @doc("A one sentence description of what your agent does")
-  short_description: string;
-
-  @doc("Longer description of your agent's responsibilities and the actions it can take")
-  full_description: string;
-
-  @doc("The organization or agent developer's name")
-  developer_name: string;
-
-  @doc("URL to the website of the developer")
-  website: string;
-
-  @doc("URL to the terms of use for the agent")
-  terms_of_use: string;
-
-  @doc("URL to the privacy policy for the agent")
-  privacy_statement: string;
-
-  @doc("The scope at which the agent is available")
-  publish_scope: AgentPublishScope;
-
-  @doc("Whether the agent is a digital worker or regular published agent")
-  is_digital_worker: boolean;
 }
 
 @removed(Versions.v1)

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
@@ -202,7 +202,7 @@ interface Agents {
    */
   #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" ""
   @patch(#{ implicitOptionality: true })
-  @route("/agents/{agent_name}/endpoint")
+  @route("/agents/{agent_name}")
   @extension(
     "x-ms-foundry-meta",
     #{
@@ -217,7 +217,7 @@ interface Agents {
       @path agent_name: string;
 
       @header("Content-Type") contentType: "application/merge-patch+json";
-      ...UpdateAgentEndpointRequest;
+      ...PatchAgentRequest;
     },
     AgentObject
   >;

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
@@ -210,7 +210,7 @@ interface Agents {
     }
   )
   @removed(Versions.v1)
-  updateAgentEndpointObject is FoundryDataPlanePreviewOperation<
+  patchAgentObject is FoundryDataPlanePreviewOperation<
     FoundryFeaturesOptInKeys.agent_endpoint_v1_preview,
     {
       /** The name of the agent to retrieve. */


### PR DESCRIPTION
Introduce M365Card class on AgentObject
Move AgentCard from AgentEndpoint to AgentObject
Introduce a new PatchAgentRequest and PATCH agents/{agent_name} URL that allows you to modify the agent object settings (description, metadata, agentcard, agentendpoint)
add agentCard, AgentEndpoint configuration on CreateAgentRequest