### PR TITLE
 [CosmosDB][TypeSpec] Add optional skipAccountKeysLastUsageCheck to RegenerateKey (2026-04-01-preview)

### DIFF
--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBDatabaseAccountRegenerateKey.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBDatabaseAccountRegenerateKey.json
@@ -3,7 +3,8 @@
     "accountName": "ddb1",
     "api-version": "2026-04-01-preview",
     "keyToRegenerate": {
-      "keyKind": "primary"
+      "keyKind": "primary",
+      "skipAccountKeysLastUsageCheck": false
     },
     "resourceGroupName": "rg1",
     "subscriptionId": "00000000-1111-2222-3333-444444444444"

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/models.tsp
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/models.tsp
@@ -2841,6 +2841,12 @@ model DatabaseAccountRegenerateKeyParameters {
    * The access key to regenerate.
    */
   keyKind: KeyKind;
+
+  /**
+   * Optional flag indicating whether to skip account keys last usage check.
+   */
+  @added(Versions.v2026_04_01_preview)
+  skipAccountKeysLastUsageCheck?: boolean;
 }
 
 /**

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBDatabaseAccountRegenerateKey.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBDatabaseAccountRegenerateKey.json
@@ -3,7 +3,8 @@
     "accountName": "ddb1",
     "api-version": "2026-04-01-preview",
     "keyToRegenerate": {
-      "keyKind": "primary"
+      "keyKind": "primary",
+      "skipAccountKeysLastUsageCheck": false
     },
     "resourceGroupName": "rg1",
     "subscriptionId": "00000000-1111-2222-3333-444444444444"

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/openapi.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/openapi.json
@@ -24485,6 +24485,10 @@
         "keyKind": {
           "$ref": "#/definitions/KeyKind",
           "description": "The access key to regenerate."
+        },
+        "skipAccountKeysLastUsageCheck": {
+          "type": "boolean",
+          "description": "Optional flag indicating whether to skip account keys last usage check."
         }
       },
       "required": [


### PR DESCRIPTION
## Summary
 This PR adds support for the optional `skipAccountKeysLastUsageCheck` input on the Cosmos DB `RegenerateKey` request model for `2026-04-01-preview`, aligning RP-API spec surface with backend request handling behavior.
 
 ## Changes made
 - Added `skipAccountKeysLastUsageCheck?: boolean` to `DatabaseAccountRegenerateKeyParameters` in `models.tsp`.
 - Marked it with `@added(Versions.v2026_04_01_preview)`.
 - Updated `examples/2026-04-01-preview/CosmosDBDatabaseAccountRegenerateKey.json` to include the optional flag.
 - Regenerated `preview/2026-04-01-preview/openapi.json` and generated preview example.
 
 ## Validation
 - ✅ `npx tsp compile specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB` succeeded.
 - ⚠️ `npx tsv specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB` still hits the pre-existing baseline issue (`examples/2026-03-15` missing under `--warn-as-error`), unrelated to this change.