### PR TITLE
TypeSpec changes to remove foundry_features from public Python SDK API surface,

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/client.tsp
@@ -240,11 +240,12 @@ using Azure.AI.Projects;
 // To support custom client-side handling of "opt-in" to preview features.
 // --------------------------------------------------------------------------------
 
-// Remove preview opt-in union types from the public PythonSDK surface.
-@@access(AgentDefinitionOptInKeys, Access.internal, "python");  // Why doesn't this have any effect?
-@@access(FoundryFeaturesOptInKeys, Access.internal, "python");  // Why doesn't this have any effect?
+// Remove foundry_features input arguments from public methods, as they are set internally.
 @@scope(WithConditionalFoundryPreviewHeader.foundry_features, "!python");
 @@scope(WithRequiredFoundryPreviewHeader.foundry_features, "!python");
+// These two lines are commented out since they have no effect. Emitted Python code needs to be edited to make these internal.
+//@@access(AgentDefinitionOptInKeys, Access.internal, "python");
+//@@access(FoundryFeaturesOptInKeys, Access.internal, "python");
 
 // Add optional boolean "allow_preview" client initialization parameter
 // See: https://azure.github.io/typespec-azure/docs/howtos/generate-client-libraries/03client/#adding-client-initialization-parameters

--- a/specification/ai-foundry/data-plane/Foundry/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/client.tsp
@@ -241,8 +241,8 @@ using Azure.AI.Projects;
 // --------------------------------------------------------------------------------
 
 // Remove preview opt-in union types from the public PythonSDK surface.
-@@access(AgentDefinitionOptInKeys, Access.internal, "python");
-@@access(FoundryFeaturesOptInKeys, Access.internal, "python");
+@@access(AgentDefinitionOptInKeys, Access.internal, "python");  // Why doesn't this have any effect?
+@@access(FoundryFeaturesOptInKeys, Access.internal, "python");  // Why doesn't this have any effect?
 @@scope(WithConditionalFoundryPreviewHeader.foundry_features, "!python");
 @@scope(WithRequiredFoundryPreviewHeader.foundry_features, "!python");
 

--- a/specification/ai-foundry/data-plane/Foundry/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/client.tsp
@@ -241,16 +241,10 @@ using Azure.AI.Projects;
 // --------------------------------------------------------------------------------
 
 // Remove preview opt-in union types from the public PythonSDK surface.
-//
-// TODO: These do not work. Follow up with the Python emitter team.
-// What does work: Adding @scope("!python") to `CreateAgentVersionRequest` above any of the
-// proprties there. But it does not seem to work I add @scope("!python") above `foundry_features`?
-// in alias WithConditionalFoundryPreviewHeader.
-//
-//@@access(AgentDefinitionOptInKeys, Access.internal, "python");
-//@@access(FoundryFeaturesOptInKeys, Access.internal, "python");
-//@@scope(WithConditionalFoundryPreviewHeader.foundry_features, "!python");
-//@@scope(WithRequiredFoundryPreviewHeader.foundry_features, "!python");
+@@access(AgentDefinitionOptInKeys, Access.internal, "python");
+@@access(FoundryFeaturesOptInKeys, Access.internal, "python");
+@@scope(WithConditionalFoundryPreviewHeader.foundry_features, "!python");
+@@scope(WithRequiredFoundryPreviewHeader.foundry_features, "!python");
 
 // Add optional boolean "allow_preview" client initialization parameter
 // See: https://azure.github.io/typespec-azure/docs/howtos/generate-client-libraries/03client/#adding-client-initialization-parameters

--- a/specification/ai-foundry/data-plane/Foundry/src/common/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/common/models.tsp
@@ -1,5 +1,4 @@
 namespace Azure.AI.Projects;
-using Azure.ClientGenerator.Core;
 using Azure.Core.Experimental;
 using Azure.Core.Traits;
 using TypeSpec.OpenAPI;

--- a/specification/ai-foundry/data-plane/Foundry/src/common/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/common/models.tsp
@@ -1,4 +1,5 @@
 namespace Azure.AI.Projects;
+
 using Azure.Core.Experimental;
 using Azure.Core.Traits;
 using TypeSpec.OpenAPI;

--- a/specification/ai-foundry/data-plane/Foundry/src/common/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/common/models.tsp
@@ -73,7 +73,6 @@ alias WithRequiredFoundryPreviewHeader<RequiredPreviewOptInHeader extends Foundr
    * A feature flag opt-in required when using preview operations or modifying persisted preview resources.
    */
   @header("Foundry-Features")
-  @scope("!python")
   foundry_features: RequiredPreviewOptInHeader;
 };
 
@@ -82,7 +81,6 @@ alias WithConditionalFoundryPreviewHeader<OptionalPreviewOptInHeader extends Fou
    * A feature flag opt-in required when using preview operations or modifying persisted preview resources.
    */
   @header("Foundry-Features")
-  @scope("!python")
   foundry_features?: OptionalPreviewOptInHeader;
 };
 

--- a/specification/ai-foundry/data-plane/Foundry/src/common/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/common/models.tsp
@@ -1,5 +1,5 @@
 namespace Azure.AI.Projects;
-
+using Azure.ClientGenerator.Core;
 using Azure.Core.Experimental;
 using Azure.Core.Traits;
 using TypeSpec.OpenAPI;
@@ -73,6 +73,7 @@ alias WithRequiredFoundryPreviewHeader<RequiredPreviewOptInHeader extends Foundr
    * A feature flag opt-in required when using preview operations or modifying persisted preview resources.
    */
   @header("Foundry-Features")
+  @scope("!python")
   foundry_features: RequiredPreviewOptInHeader;
 };
 
@@ -81,6 +82,7 @@ alias WithConditionalFoundryPreviewHeader<OptionalPreviewOptInHeader extends Fou
    * A feature flag opt-in required when using preview operations or modifying persisted preview resources.
    */
   @header("Foundry-Features")
+  @scope("!python")
   foundry_features?: OptionalPreviewOptInHeader;
 };
 


### PR DESCRIPTION
For the emitter to work as intended, this requires dev package `@azure-tools/typespec-client-generator-core": "0.67.0-dev.12"`, which include a fix from Isabella. This package will be in stable release in a few days.