### PR TITLE
[Python] Mitigate breaking changes for azure-mgmt-containerinstance

### DIFF
--- a/specification/containerinstance/resource-manager/Microsoft.ContainerInstance/ContainerInstance/back-compatible.tsp
+++ b/specification/containerinstance/resource-manager/Microsoft.ContainerInstance/ContainerInstance/back-compatible.tsp
@@ -67,3 +67,6 @@ using Microsoft.ContainerInstance;
 @@clientLocation(SubnetServiceAssociationLinkOperationGroup.delete,
   "SubnetServiceAssociationLink"
 );
+
+@@clientName(Azure.ResourceManager.CommonTypes.Resource, "ArmResource", "python");
+@@clientName(Microsoft.ContainerInstance, "ContainerInstanceManagementClient", "python");


### PR DESCRIPTION
## Python SDK Breaking Changes Mitigation for azure-mgmt-containerinstance

This PR mitigates Python SDK breaking changes detected during the TypeSpec migration in PR #41602.

### Breaking Change Summary

| # | Breaking Change | Classification | Action |
|---|----------------|---------------|--------|
| 1 | Client renamed from `ContainerInstanceManagementClient` to `ContainerInstanceClient` | Client Naming (Cat 4) | **MITIGATE** |
| 2-23 | `ContainerGroup` lost 22 flattened properties (moved to `.properties`) | Flatten removal (Cat 11) | ACCEPT |
| 24-45 | `ListResultContainerGroup` lost 22 flattened properties (moved to `.properties`) | Flatten removal (Cat 11) | ACCEPT |
| 46-51 | `InitContainerDefinition` lost 6 flattened properties (moved to `.properties`) | Flatten removal (Cat 11) | ACCEPT |
| 52-56 | `NGroupPatch` lost 5 flattened properties (moved to `.properties`) | Flatten removal (Cat 11) | ACCEPT |
| 57-59 | Deleted models: `ContainerGroupProperties`, `ContainerGroupPropertiesInstanceView`, `ListResultContainerGroupProperties` | Unreferenced models (Cat 7) | ACCEPT |
| 60-61 | Deleted models: `NGroupSkus`, `NGroupsSkusList` | Unreferenced/Pageable (Cat 7/8) | ACCEPT |
| 62-63 | `ContainersOperations.list_logs` params `tail`/`timestamps` changed to keyword-only | Keyword-only params (Cat 9) | ACCEPT |

### Mitigations Applied

- `@@clientName(Microsoft.ContainerInstance, "ContainerInstanceManagementClient", "python")` — restores original client name
- `@@clientName(Azure.ResourceManager.CommonTypes.Resource, "ArmResource", "python")` — resolves duplicate client name compilation error

### Accepted Breaking Changes (61 items)

These are expected consequences of the TypeSpec migration and are accepted per the SDK breaking changes guide:
- Flattened properties moved to `.properties` sub-object (Category 11)
- Unreferenced/pageable models removed (Category 7/8)
- Query/header parameters changed to keyword-only (Category 9)
