### PR TITLE
[Python] Mitigate breaking changes for azure-mgmt-redisenterprise

### DIFF
--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/client.tsp
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/client.tsp
@@ -14,6 +14,9 @@ using Microsoft.Cache;
   "python"
 );
 
+// Rename `args` to `module_args` for Python to avoid collision with Python's *args syntax
+@@clientName(Module.args, "module_args", "python");
+
 // csharp configurations
 @@clientName(AccessKeys, "RedisEnterpriseDataAccessKeys", "csharp");
 @@clientName(AccessKeyType, "RedisEnterpriseAccessKeyType", "csharp");


### PR DESCRIPTION
## Python SDK Breaking Changes Mitigation for azure-mgmt-redisenterprise

### Summary

| Classification | Count |
|---|---|
| **ACCEPT** (no code change needed) | 56 |
| **MITIGATE** (decorator added) | 2 |

### Mitigations Applied

| Breaking Change | Classification | Mitigation |
|---|---|---|
| `Module.__init__` parameter `args` changed from `keyword_only` to `var_positional` | MITIGATE | `@@clientName(Module.args, "module_args", "python")` |
| `Module.__init__` removed default value `None` from parameter `args` | MITIGATE | (covered by same fix above) |

### Accepted Breaking Changes (no mitigation needed)

**Category 11 - Removal of multi-level flattened properties (52 items):**
Properties on `Cluster`, `ClusterUpdate`, `Database`, `DatabaseUpdate`, `Migration` moved under `.properties` wrapper. TypeSpec preserves the actual REST API hierarchy.

**Category 8 - Removal of Pageable Models (4 items):**
`AccessPolicyAssignmentList`, `ClusterList`, `DatabaseList`, `MigrationList`

**Category 7 - Removal of Unreferenced Models (4 items):**
`ErrorDetailAutoGenerated`, `ErrorResponseAutoGenerated`, `ProxyResourceAutoGenerated`, `ResourceAutoGenerated`

### Pre-migration swagger source
[specification/redisenterprise/resource-manager @ 8a34a1be](https://github.com/Azure/azure-rest-api-specs/tree/8a34a1be47eeb4ccc185d5961bb4b53a27ebb98c/specification/redisenterprise/resource-manager)
