### PR TITLE
Add C# clientName decorators for AppLink SDK naming conventions

### DIFF
--- a/specification/applink/AppLink.Management/client.tsp
+++ b/specification/applink/AppLink.Management/client.tsp
@@ -6,10 +6,26 @@ using Azure.ClientGenerator.Core;
 namespace Microsoft.AppLink;
 
 @@clientName(Microsoft.AppLink, "AppNetworkMgmtClient", "python");
+
+// Fix selfManagedVersions flattening name collision in C#
 @@clientName(AvailableVersionProperties.selfManagedVersions,
   "selfManagedVersionDetail",
   "csharp"
 );
+
+// Contextual naming: add AppLink prefix to avoid cross-SDK collisions in C#
+@@clientName(ProvisioningState, "AppLinkProvisioningState", "csharp");
+@@clientName(ClusterType, "AppLinkClusterType", "csharp");
+@@clientName(UpgradeMode, "AppLinkUpgradeMode", "csharp");
+@@clientName(UpgradeReleaseChannel, "AppLinkUpgradeReleaseChannel", "csharp");
+@@clientName(ConnectivityProfile, "AppLinkConnectivityProfile", "csharp");
+@@clientName(UpgradeProfile, "AppLinkUpgradeProfile", "csharp");
+@@clientName(ReleaseChannelInfo, "AppLinkReleaseChannelInfo", "csharp");
+@@clientName(VersionInfo, "AppLinkVersionInfo", "csharp");
+
+// DateTimeOffset properties should follow *On naming convention in C#
+@@clientName(UpgradeHistoryProperties.startTimestamp, "startOn", "csharp");
+@@clientName(UpgradeHistoryProperties.endTimestamp, "endOn", "csharp");
 
 @doc("The type used for update operations of the AppLink.")
 model AppLinkUpdate {

--- a/specification/applink/AppLink.Management/client.tsp
+++ b/specification/applink/AppLink.Management/client.tsp
@@ -25,13 +25,25 @@ namespace Microsoft.AppLink;
 
 // Contextual naming: add AppLink prefix to resource types
 @@clientName(AvailableVersion, "AppLinkAvailableVersion", "csharp");
-@@clientName(AvailableVersionProperties, "AppLinkAvailableVersionProperties", "csharp");
+@@clientName(AvailableVersionProperties,
+  "AppLinkAvailableVersionProperties",
+  "csharp"
+);
 @@clientName(UpgradeHistory, "AppLinkUpgradeHistory", "csharp");
-@@clientName(UpgradeHistoryProperties, "AppLinkUpgradeHistoryProperties", "csharp");
+@@clientName(UpgradeHistoryProperties,
+  "AppLinkUpgradeHistoryProperties",
+  "csharp"
+);
 
 // Operation renames: method names should clearly indicate what is listed
-@@clientName(AvailableVersions.listByLocation, "GetAppLinkAvailableVersionsByLocation", "csharp");
-@@clientName(UpgradeHistories.listByAppLinkMember, "GetAppLinkUpgradeHistories", "csharp");
+@@clientName(AvailableVersions.listByLocation,
+  "GetAppLinkAvailableVersionsByLocation",
+  "csharp"
+);
+@@clientName(UpgradeHistories.listByAppLinkMember,
+  "GetAppLinkUpgradeHistories",
+  "csharp"
+);
 
 // DateTimeOffset properties should follow *On naming convention in C#
 @@clientName(UpgradeHistoryProperties.startTimestamp, "startOn", "csharp");

--- a/specification/applink/AppLink.Management/client.tsp
+++ b/specification/applink/AppLink.Management/client.tsp
@@ -6,6 +6,10 @@ using Azure.ClientGenerator.Core;
 namespace Microsoft.AppLink;
 
 @@clientName(Microsoft.AppLink, "AppNetworkMgmtClient", "python");
+@@clientName(AvailableVersionProperties.selfManagedVersions,
+  "selfManagedVersionDetail",
+  "csharp"
+);
 
 @doc("The type used for update operations of the AppLink.")
 model AppLinkUpdate {

--- a/specification/applink/AppLink.Management/client.tsp
+++ b/specification/applink/AppLink.Management/client.tsp
@@ -23,6 +23,16 @@ namespace Microsoft.AppLink;
 @@clientName(ReleaseChannelInfo, "AppLinkReleaseChannelInfo", "csharp");
 @@clientName(VersionInfo, "AppLinkVersionInfo", "csharp");
 
+// Contextual naming: add AppLink prefix to resource types
+@@clientName(AvailableVersion, "AppLinkAvailableVersion", "csharp");
+@@clientName(AvailableVersionProperties, "AppLinkAvailableVersionProperties", "csharp");
+@@clientName(UpgradeHistory, "AppLinkUpgradeHistory", "csharp");
+@@clientName(UpgradeHistoryProperties, "AppLinkUpgradeHistoryProperties", "csharp");
+
+// Operation renames: method names should clearly indicate what is listed
+@@clientName(AvailableVersions.listByLocation, "GetAppLinkAvailableVersionsByLocation", "csharp");
+@@clientName(UpgradeHistories.listByAppLinkMember, "GetAppLinkUpgradeHistories", "csharp");
+
 // DateTimeOffset properties should follow *On naming convention in C#
 @@clientName(UpgradeHistoryProperties.startTimestamp, "startOn", "csharp");
 @@clientName(UpgradeHistoryProperties.endTimestamp, "endOn", "csharp");


### PR DESCRIPTION
## Changes

Add `@@clientName` decorators in `client.tsp` for the C# SDK to follow Azure SDK naming conventions:

### Contextual naming (add `AppLink` prefix)
- `ProvisioningState` → `AppLinkProvisioningState`
- `ClusterType` → `AppLinkClusterType`
- `UpgradeMode` → `AppLinkUpgradeMode`
- `UpgradeReleaseChannel` → `AppLinkUpgradeReleaseChannel`
- `ConnectivityProfile` → `AppLinkConnectivityProfile`
- `UpgradeProfile` → `AppLinkUpgradeProfile`
- `ReleaseChannelInfo` → `AppLinkReleaseChannelInfo`
- `VersionInfo` → `AppLinkVersionInfo`

### DateTimeOffset naming convention
- `startTimestamp` → `startOn`
- `endTimestamp` → `endOn`

### Bug fix
- `selfManagedVersions` → `selfManagedVersionDetail` (fixes C# CS0102 compilation error where the flattened property name collided with the internal property name)

## Motivation

These changes address naming issues identified during the C# SDK review of [Azure/azure-sdk-for-net#57448](https://github.com/Azure/azure-sdk-for-net/pull/57448). The renames only affect the C# SDK via `@@clientName(..., "csharp")` and do not impact other languages.