### PR TITLE
Copilot hooks

### DIFF
--- a/.github/hooks/hooks.json
+++ b/.github/hooks/hooks.json
@@ -9,7 +9,6 @@
         ],
         "SessionStart": [
             {
-                //Install MCP tool
                 "type": "command",
                 "command": "pwsh eng/common/mcp/azure-sdk-mcp.ps1",
                 "timeoutSec": 30

--- a/.github/hooks/hooks.json
+++ b/.github/hooks/hooks.json
@@ -1,18 +1,11 @@
 {
-    "hooks": {
-        "PostToolUse": [
-            {
-                "type": "command",
-                "command": "pwsh eng/common/scripts/azsdk_tool_telemetry.ps1",
-                "timeoutSec": 5
-            }
-        ],
-        "SessionStart": [
-            {
-                "type": "command",
-                "command": "pwsh eng/common/mcp/azure-sdk-mcp.ps1",
-                "timeoutSec": 30
-            }
-        ]
-    }
+  "hooks": {
+    "PostToolUse": [
+      {
+        "type": "command",
+        "command": "pwsh eng/common/scripts/azsdk_tool_telemetry.ps1",
+        "timeoutSec": 5
+      }
+    ]
+  }
 }

--- a/.github/hooks/hooks.json
+++ b/.github/hooks/hooks.json
@@ -1,0 +1,19 @@
+{
+    "hooks": {
+        "PostToolUse": [
+            {
+                "type": "command",
+                "command": "pwsh eng/common/scripts/azsdk_tool_telemetry.ps1",
+                "timeoutSec": 5
+            }
+        ],
+        "SessionStart": [
+            {
+                //Install MCP tool
+                "type": "command",
+                "command": "pwsh eng/common/mcp/azure-sdk-mcp.ps1",
+                "timeoutSec": 30
+            }
+        ]
+    }
+}


### PR DESCRIPTION
This PR adds a Copilot hook to trigger telemetry script as a post tool trigger. This will also install Azure SDK tools MCP server when session start event is triggered.