### PR TITLE
[SDK Validation] Flip .net data plane required setting

### DIFF
--- a/eng/tools/spec-gen-sdk-runner/src/types.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/types.ts
@@ -117,7 +117,7 @@ export const SpecGenSdkRequiredSettings: Record<SdkName, PlaneTypeSettings> = {
     managementPlane: true,
   },
   "azure-sdk-for-net": {
-    dataPlane: false,
+    dataPlane: true,
     managementPlane: true,
   },
   "azure-sdk-for-python": {

--- a/eng/tools/spec-gen-sdk-runner/test/command-helpers.test.ts
+++ b/eng/tools/spec-gen-sdk-runner/test/command-helpers.test.ts
@@ -622,12 +622,12 @@ describe("commands.ts", () => {
       expect(result).toBe(true);
 
       const result2 = getRequiredSettingValue(false, true, "azure-sdk-for-js");
-      // Based on the constants in types.ts, JS SDK does not require check for data plane
+      // Based on the constants in types.ts, JS SDK requires check for data plane
       expect(result2).toBe(true);
 
       const result3 = getRequiredSettingValue(false, true, "azure-sdk-for-net");
-      // .NET SDK set (dataplane: false)
-      expect(result3).toBe(false);
+      // .NET SDK set (dataPlane: true)
+      expect(result3).toBe(true);
     });
 
     test("should return false for azure-sdk-for-net when hasTypeSpecProjects is false", () => {

--- a/eng/tools/spec-gen-sdk-runner/test/commands.test.ts
+++ b/eng/tools/spec-gen-sdk-runner/test/commands.test.ts
@@ -432,7 +432,7 @@ describe("generateSdkForSpecPr", () => {
       // mock implementation intentionally left blank
     });
 
-    const statusCode = await generateSdkForSpecPr();
+    const { statusCode } = await generateSdkForSpecPr();
 
     expect(statusCode).toBe(0);
     // Verify hasTypeSpecProjects is false because executionResult is "notEnabled"
@@ -492,7 +492,7 @@ describe("generateSdkForSpecPr", () => {
       // mock implementation intentionally left blank
     });
 
-    const statusCode = await generateSdkForSpecPr();
+    const { statusCode } = await generateSdkForSpecPr();
 
     expect(statusCode).toBe(0);
     // Verify hasTypeSpecProjects is true because executionResult is "succeeded"


### PR DESCRIPTION
This pull request updates the required settings for the .NET SDK in the `spec-gen-sdk-runner` tool to indicate that it now requires a data plane check. Corresponding test cases have also been updated to reflect this change.

SDK settings update:

* Changed `dataPlane` for `azure-sdk-for-net` from `false` to `true` in `SpecGenSdkRequiredSettings` within `types.ts`, indicating that the .NET SDK now requires a data plane check.

Test updates:

* Updated comments and assertions in `command-helpers.test.ts` to match the new requirement that the .NET SDK requires a data plane check.