### PR TITLE
[Queues] xml.name additions

### DIFF
--- a/specification/storage/Microsoft.QueueStorage/models.tsp
+++ b/specification/storage/Microsoft.QueueStorage/models.tsp
@@ -254,6 +254,7 @@ model Metrics {
 }
 
 /** CORS is an HTTP feature that enables a web application running under one domain to access resources in another domain. Web browsers implement a security restriction known as same-origin policy that prevents a web page from calling APIs in a different domain; CORS provides a secure way to allow one domain (the origin domain) to call APIs in another domain */
+@Xml.name("CorsRule")
 model CorsRule {
   /** The allowed origins. */
   @Xml.name("AllowedOrigins") allowedOrigins: string;
@@ -411,6 +412,7 @@ model AccessPolicy {
  * The object returned in the QueueMessageList array when calling Get Messages on
  * a Queue.
  */
+@Xml.name("QueueMessage")
 model ReceivedMessage {
   /**
    * The Id of the Message.
@@ -520,6 +522,7 @@ model QueueMessage {
  * The object returned in the QueueMessageList array when calling Put Message on a
  * Queue
  */
+@Xml.name("QueueMessage")
 model SentMessage {
   /**
    * The Id of the Message.
@@ -558,6 +561,7 @@ model SentMessage {
  * The object returned in the QueueMessageList array when calling Peek Messages on
  * a Queue
  */
+@Xml.name("QueueMessage")
 model PeekedMessage {
   /**
    * The Id of the Message.

--- a/specification/storage/data-plane/Microsoft.QueueStorage/stable/2026-04-06/generated_queue.json
+++ b/specification/storage/data-plane/Microsoft.QueueStorage/stable/2026-04-06/generated_queue.json
@@ -2064,7 +2064,10 @@
         "ExpirationTime",
         "DequeueCount",
         "MessageText"
-      ]
+      ],
+      "xml": {
+        "name": "QueueMessage"
+      }
     },
     "PeekedMessages": {
       "type": "object",
@@ -2226,7 +2229,10 @@
         "TimeNextVisible",
         "DequeueCount",
         "MessageText"
-      ]
+      ],
+      "xml": {
+        "name": "QueueMessage"
+      }
     },
     "ReceivedMessages": {
       "type": "object",
@@ -2311,7 +2317,10 @@
         "ExpirationTime",
         "PopReceipt",
         "TimeNextVisible"
-      ]
+      ],
+      "xml": {
+        "name": "QueueMessage"
+      }
     },
     "SignedIdentifier": {
       "type": "object",


### PR DESCRIPTION
Adding `xml.Name` decorators to models. Needed for proper Go generation 

This change also helps match the original swagger more closely. Example: https://github.com/Azure/azure-rest-api-specs/blob/5f1f13276e3bba25876eeabedc765ac987c3b457/specification/storage/data-plane/Microsoft.QueueStorage/preview/2018-03-28/queue.json#L1459