### PR TITLE
[Python] Mitigate breaking changes for azure-mgmt-cognitiveservices

### DIFF
--- a/specification/cognitiveservices/CognitiveServices.Management/client.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/client.tsp
@@ -93,6 +93,8 @@ op calculateModelCapacityCustom(
   "java"
 );
 
+@@clientName(ResourceSkuRestrictions.values, "values", "python");
+
 @@clientLocation(checkDomainAvailability, "ManagementClient", "go");
 @@clientLocation(checkSkuAvailability, "ManagementClient", "go");
 @@clientLocation(calculateModelCapacity, "ManagementClient", "go");


### PR DESCRIPTION
# [Python] Mitigate breaking changes for azure-mgmt-cognitiveservices

## Summary

This PR adds Python SDK breaking change mitigations for the `azure-mgmt-cognitiveservices` package TypeSpec migration.

### Mitigation Applied

| Breaking Change | Classification | Mitigation |
|---|---|---|
| `ResourceSkuRestrictions.values` renamed to `values_property` | MITIGATE | `@@clientName(ResourceSkuRestrictions.values, "values", "python")` |

### Changes

- Added `@@clientName(ResourceSkuRestrictions.values, "values", "python")` to `client.tsp` to preserve the original property name in the Python SDK.
