### PR TITLE
Add C# clientName decorators for AppLink EastWestGatewayVisibility and AKS acronym

### DIFF
--- a/specification/applink/AppLink.Management/client.tsp
+++ b/specification/applink/AppLink.Management/client.tsp
@@ -7,23 +7,23 @@ namespace Microsoft.AppLink;
 
 @@clientName(Microsoft.AppLink, "AppNetworkMgmtClient", "python");
 
-// Fix selfManagedVersions flattening name collision in C#
 @@clientName(AvailableVersionProperties.selfManagedVersions,
   "selfManagedVersionDetail",
   "csharp"
 );
 
-// Contextual naming: add AppLink prefix to avoid cross-SDK collisions in C#
 @@clientName(ProvisioningState, "AppLinkProvisioningState", "csharp");
 @@clientName(ClusterType, "AppLinkClusterType", "csharp");
+@@clientName(EastWestGatewayVisibility,
+  "AppLinkEastWestGatewayVisibility",
+  "csharp"
+);
 @@clientName(UpgradeMode, "AppLinkUpgradeMode", "csharp");
 @@clientName(UpgradeReleaseChannel, "AppLinkUpgradeReleaseChannel", "csharp");
 @@clientName(ConnectivityProfile, "AppLinkConnectivityProfile", "csharp");
 @@clientName(UpgradeProfile, "AppLinkUpgradeProfile", "csharp");
 @@clientName(ReleaseChannelInfo, "AppLinkReleaseChannelInfo", "csharp");
 @@clientName(VersionInfo, "AppLinkVersionInfo", "csharp");
-
-// Contextual naming: add AppLink prefix to resource types
 @@clientName(AvailableVersion, "AppLinkAvailableVersion", "csharp");
 @@clientName(AvailableVersionProperties,
   "AppLinkAvailableVersionProperties",
@@ -35,7 +35,6 @@ namespace Microsoft.AppLink;
   "csharp"
 );
 
-// Operation renames: method names should clearly indicate what is listed
 @@clientName(AvailableVersions.listByLocation,
   "GetAppLinkAvailableVersionsByLocation",
   "csharp"
@@ -45,9 +44,10 @@ namespace Microsoft.AppLink;
   "csharp"
 );
 
-// DateTimeOffset properties should follow *On naming convention in C#
 @@clientName(UpgradeHistoryProperties.startTimestamp, "startOn", "csharp");
 @@clientName(UpgradeHistoryProperties.endTimestamp, "endOn", "csharp");
+
+@@clientName(ClusterType.AKS, "Aks", "csharp");
 
 @doc("The type used for update operations of the AppLink.")
 model AppLinkUpdate {


### PR DESCRIPTION
## Changes

Add two `@@clientName` decorators in `client.tsp` for the C# SDK to follow Azure SDK naming conventions:

### Contextual naming (add `AppLink` prefix)
- `EastWestGatewayVisibility` → `AppLinkEastWestGatewayVisibility`
  Per the API review guidelines, all types must include sufficient context in their name. `EastWestGatewayVisibility` could apply to any service with east-west gateways.

### PascalCase acronym convention
- `ClusterType.AKS` → `Aks`
  Per the Azure SDK naming guidelines, acronyms of 3+ letters should use PascalCase (capitalize first letter only), e.g., `Aes`, `Tcp`, `Http`.

## Motivation

These changes address remaining naming issues identified during the C# SDK review of [Azure/azure-sdk-for-net#57448](https://github.com/Azure/azure-sdk-for-net/pull/57448). This is a follow-up to [#41754](https://github.com/Azure/azure-rest-api-specs/pull/41754) which addressed the initial batch of naming fixes.

The renames only affect the C# SDK via `@@clientName(..., "csharp")` and do not impact other languages or the wire format.