### PR TITLE
[keyvault] Fix SubjectAlternativeNames.uris client name to use uris (Python + JavaScript)

### DIFF
--- a/specification/keyvault/data-plane/Certificates/client.tsp
+++ b/specification/keyvault/data-plane/Certificates/client.tsp
@@ -246,17 +246,11 @@ op listDeletedCertificateProperties is KeyVaultOperation<
 @@alternateType(CertificateOperation.error, string, "go");
 
 // Python configuration
-@@clientName(SubjectAlternativeNames.uris,
-  "uniform_resource_identifiers",
-  "python"
-);
+@@clientName(SubjectAlternativeNames.uris, "uris", "python");
 @@clientName(SubjectAlternativeNames.ipAddresses, "ip_addresses", "python");
 
 // JavaScript configuration
-@@clientName(SubjectAlternativeNames.uris,
-  "uniformResourceIdentifiers",
-  "javascript"
-);
+@@clientName(SubjectAlternativeNames.uris, "uris", "javascript");
 @@clientName(SubjectAlternativeNames.ipAddresses, "ipAddresses", "javascript");
 
 // Rust configuration


### PR DESCRIPTION
The [SubjectAlternativeNames](vscode-file://vscode-app/c:/Users/singhalrohit/AppData/Local/Programs/Microsoft%20VS%20Code/cfbea10c5f/resources/app/out/vs/code/electron-browser/workbench/workbench.html) model has a [uris](vscode-file://vscode-app/c:/Users/singhalrohit/AppData/Local/Programs/Microsoft%20VS%20Code/cfbea10c5f/resources/app/out/vs/code/electron-browser/workbench/workbench.html) property (added in API version 2025-07-01) whose Python and JavaScript client names were overridden to verbose forms:

Python: [uris](vscode-file://vscode-app/c:/Users/singhalrohit/AppData/Local/Programs/Microsoft%20VS%20Code/cfbea10c5f/resources/app/out/vs/code/electron-browser/workbench/workbench.html) → [uniform_resource_identifiers](vscode-file://vscode-app/c:/Users/singhalrohit/AppData/Local/Programs/Microsoft%20VS%20Code/cfbea10c5f/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
JavaScript: [uris](vscode-file://vscode-app/c:/Users/singhalrohit/AppData/Local/Programs/Microsoft%20VS%20Code/cfbea10c5f/resources/app/out/vs/code/electron-browser/workbench/workbench.html) → uniformResourceIdentifiers
This is inconsistent with how the [upns](vscode-file://vscode-app/c:/Users/singhalrohit/AppData/Local/Programs/Microsoft%20VS%20Code/cfbea10c5f/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (User Principal Names) property is handled — [upns](vscode-file://vscode-app/c:/Users/singhalrohit/AppData/Local/Programs/Microsoft%20VS%20Code/cfbea10c5f/resources/app/out/vs/code/electron-browser/workbench/workbench.html) keeps its short acronym name in both languages with no override.

This PR updates the @@clientName overrides in [client.tsp](vscode-file://vscode-app/c:/Users/singhalrohit/AppData/Local/Programs/Microsoft%20VS%20Code/cfbea10c5f/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to explicitly use ["uris"](vscode-file://vscode-app/c:/Users/singhalrohit/AppData/Local/Programs/Microsoft%20VS%20Code/cfbea10c5f/resources/app/out/vs/code/electron-browser/workbench/workbench.html) for both Python and JavaScript, making it consistent with the [upns](vscode-file://vscode-app/c:/Users/singhalrohit/AppData/Local/Programs/Microsoft%20VS%20Code/cfbea10c5f/resources/app/out/vs/code/electron-browser/workbench/workbench.html) naming pattern.

Changes
[client.tsp](vscode-file://vscode-app/c:/Users/singhalrohit/AppData/Local/Programs/Microsoft%20VS%20Code/cfbea10c5f/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Updated @@clientName for [SubjectAlternativeNames.uris](vscode-file://vscode-app/c:/Users/singhalrohit/AppData/Local/Programs/Microsoft%20VS%20Code/cfbea10c5f/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to use ["uris"](vscode-file://vscode-app/c:/Users/singhalrohit/AppData/Local/Programs/Microsoft%20VS%20Code/cfbea10c5f/resources/app/out/vs/code/electron-browser/workbench/workbench.html) instead of ["uniform_resource_identifiers"](vscode-file://vscode-app/c:/Users/singhalrohit/AppData/Local/Programs/Microsoft%20VS%20Code/cfbea10c5f/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (Python) and "uniformResourceIdentifiers" (JavaScript).
Related
Raised in review of [#45842](vscode-file://vscode-app/c:/Users/singhalrohit/AppData/Local/Programs/Microsoft%20VS%20Code/cfbea10c5f/resources/app/out/vs/code/electron-browser/workbench/workbench.html) by @melissamserv