### PR TITLE
[keyvault] Remove Uris and Ipaddress clientName overrides for Python and JavaScript

### DIFF
--- a/specification/keyvault/data-plane/Certificates/client.tsp
+++ b/specification/keyvault/data-plane/Certificates/client.tsp
@@ -97,7 +97,6 @@ op getCertificate is KeyVaultOperation<
   "uniformResourceIdentifiers",
   "java"
 );
-@@clientName(SubjectAlternativeNames.ipAddresses, "ipAddresses", "java");
 
 // Go configuration
 

--- a/specification/keyvault/data-plane/Certificates/client.tsp
+++ b/specification/keyvault/data-plane/Certificates/client.tsp
@@ -245,14 +245,6 @@ op listDeletedCertificateProperties is KeyVaultOperation<
 @@alternateType(CertificateAttributes.recoveryLevel, string, "go");
 @@alternateType(CertificateOperation.error, string, "go");
 
-// Python configuration
-@@clientName(SubjectAlternativeNames.uris, "uris", "python");
-@@clientName(SubjectAlternativeNames.ipAddresses, "ip_addresses", "python");
-
-// JavaScript configuration
-@@clientName(SubjectAlternativeNames.uris, "uris", "javascript");
-@@clientName(SubjectAlternativeNames.ipAddresses, "ipAddresses", "javascript");
-
 // Rust configuration
 @@clientName(setCertificateContacts, "SetContacts", "rust");
 

--- a/specification/keyvault/data-plane/Certificates/client.tsp
+++ b/specification/keyvault/data-plane/Certificates/client.tsp
@@ -246,17 +246,11 @@ op listDeletedCertificateProperties is KeyVaultOperation<
 @@alternateType(CertificateOperation.error, string, "go");
 
 // Python configuration
-@@clientName(SubjectAlternativeNames.uris,
-  "uniform_resource_identifiers",
-  "python"
-);
+@@clientName(SubjectAlternativeNames.uris, "uris", "python");
 @@clientName(SubjectAlternativeNames.ipAddresses, "ip_addresses", "python");
 
 // JavaScript configuration
-@@clientName(SubjectAlternativeNames.uris,
-  "uniformResourceIdentifiers",
-  "javascript"
-);
+@@clientName(SubjectAlternativeNames.uris, "uris", "javascript");
 @@clientName(SubjectAlternativeNames.ipAddresses, "ipAddresses", "javascript");
 
 // Rust configuration


### PR DESCRIPTION
## Summary

Removes the `@@clientName` overrides for `uris and Ipaddress` in Python and JavaScript:

## Related
- Requested in review: Azure/azure-sdk-for-python#45842 by @melissamserv
fix https://github.com/Azure/azure-rest-api-specs/issues/41995