### PR TITLE
Add threshold field to EvaluatorMetric model

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -13536,6 +13536,11 @@
             "format": "float",
             "description": "Maximum value for the metric. If not specified, it is assumed to be unbounded."
           },
+          "threshold": {
+            "type": "number",
+            "format": "float",
+            "description": "Default pass/fail threshold for this metric. When set, this value is used as the evaluator-authored default instead of computing from min/max midpoint."
+          },
           "is_primary": {
             "type": "boolean",
             "description": "Indicates if this metric is primary when there are multiple metrics."

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -13539,7 +13539,7 @@
           "threshold": {
             "type": "number",
             "format": "float",
-            "description": "Default pass/fail threshold for this metric. When set, this value is used as the evaluator-authored default instead of computing from min/max midpoint."
+            "description": "Default pass/fail threshold for this metric."
           },
           "is_primary": {
             "type": "boolean",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -17730,7 +17730,7 @@
           "threshold": {
             "type": "number",
             "format": "float",
-            "description": "Default pass/fail threshold for this metric. When set, this value is used as the evaluator-authored default instead of computing from min/max midpoint."
+            "description": "Default pass/fail threshold for this metric."
           },
           "is_primary": {
             "type": "boolean",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -17727,6 +17727,11 @@
             "format": "float",
             "description": "Maximum value for the metric. If not specified, it is assumed to be unbounded."
           },
+          "threshold": {
+            "type": "number",
+            "format": "float",
+            "description": "Default pass/fail threshold for this metric. When set, this value is used as the evaluator-authored default instead of computing from min/max midpoint."
+          },
           "is_primary": {
             "type": "boolean",
             "description": "Indicates if this metric is primary when there are multiple metrics."

--- a/specification/ai-foundry/data-plane/Foundry/src/evaluators/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/evaluators/models.tsp
@@ -146,6 +146,9 @@ model EvaluatorMetric {
   @doc("Maximum value for the metric. If not specified, it is assumed to be unbounded.")
   max_value?: float32;
 
+  @doc("Default pass/fail threshold for this metric. When set, this value is used as the evaluator-authored default instead of computing from min/max midpoint.")
+  threshold?: float32;
+
   @doc("Indicates if this metric is primary when there are multiple metrics.")
   is_primary?: boolean;
 }

--- a/specification/ai-foundry/data-plane/Foundry/src/evaluators/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/evaluators/models.tsp
@@ -146,7 +146,7 @@ model EvaluatorMetric {
   @doc("Maximum value for the metric. If not specified, it is assumed to be unbounded.")
   max_value?: float32;
 
-  @doc("Default pass/fail threshold for this metric. When set, this value is used as the evaluator-authored default instead of computing from min/max midpoint.")
+  @doc("Default pass/fail threshold for this metric.")
   threshold?: float32;
 
   @doc("Indicates if this metric is primary when there are multiple metrics.")


### PR DESCRIPTION
## Summary
Add optional 	hreshold (float32) property to the EvaluatorMetric TypeSpec model.

## Motivation
Evaluator authors need to specify a default pass/fail threshold per metric, rather than relying on a generic midpoint computation algorithm. This enables more precise default thresholds for custom evaluators.

## Changes
- **specification/ai-foundry/data-plane/Foundry/src/evaluators/models.tsp** — Added 	hreshold?: float32 to EvaluatorMetric model, positioned between max_value and is_primary.

## Companion PR
- RAISvc implementation: https://msdata.visualstudio.com/Vienna/_git/vienna/pullrequest/2021425

## Notes
- Swagger regeneration via `npx tsv .` should be run as part of the review process.