### PR TITLE
[AppService] Fix Java naming compatibility for TypeSpec migration

### DIFF
--- a/specification/web/resource-manager/Microsoft.Web/AppService/client.tsp
+++ b/specification/web/resource-manager/Microsoft.Web/AppService/client.tsp
@@ -2897,6 +2897,11 @@ op webAppsUpdateVnetConnectionSlotCustomized(
 );
 
 @@clientName(Microsoft.Web, "WebSiteManagementClient", "java");
+@@clientName(listBillingMeters, "list", "java");
+@@clientName(listSiteIdentifiersAssignedToHostName,
+  "listSiteIdentifiersAssignedToHostname",
+  "java"
+);
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Swagger bug. Function App on ACA is LRO."
 @@Azure.ClientGenerator.Core.Legacy.markAsLro(Sites.updateApplicationSettings,
   "java"


### PR DESCRIPTION
Fix Java client naming to maintain backward compatibility after TypeSpec migration:

- clientName for listBillingMeters to list (restores old list() method name)
- clientName for listAseRegions to listAseRegions (prevents it from becoming list)
- clientName for listSiteIdentifiersAssignedToHostName to listSiteIdentifiersAssignedToHostname (restores lowercase n casing)
- Added NameIdentifier to remove-inner in tspconfig.yaml