### PR TITLE
[Communication.Messages] Specify namespace for models so it doesn't get under root namespace

### DIFF
--- a/specification/communication/Communication.Messages/client.tsp
+++ b/specification/communication/Communication.Messages/client.tsp
@@ -76,3 +76,28 @@ interface ConversationThreadClient
   "mediaUrl",
   "java"
 );
+
+@@clientNamespace(Azure.Communication.MessagesService.WhatsAppMessageButtonSubType,
+  "Azure.Communication.Messages.Models.Channels",
+  "csharp"
+);
+
+@@clientNamespace(Azure.Communication.MessagesService.WhatsAppMessageTemplateBindings,
+  "Azure.Communication.Messages.Models.Channels",
+  "csharp"
+);
+
+@@clientNamespace(Azure.Communication.MessagesService.WhatsAppMessageTemplateBindingsButton,
+  "Azure.Communication.Messages.Models.Channels",
+  "csharp"
+);
+
+@@clientNamespace(Azure.Communication.MessagesService.WhatsAppMessageTemplateBindingsComponent,
+  "Azure.Communication.Messages.Models.Channels",
+  "csharp"
+);
+
+@@clientNamespace(Azure.Communication.MessagesService.WhatsAppMessageTemplateItem,
+  "Azure.Communication.Messages.Models.Channels",
+  "csharp"
+);


### PR DESCRIPTION
The old generator put these 5 models under `namespace Azure.Communication.Messages.Models.Channels` with swagger configuration. Adding `@@clientNamespace` so these models get generated under the same namespace with the new generator as well instead of root namespace.