### PR TITLE
Add Microsoft.Devices DeviceProvisioningServices 2026-10-01 GA API version

### DIFF
--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/PrivateEndpointConnection.tsp
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/PrivateEndpointConnection.tsp
@@ -26,7 +26,7 @@ model PrivateEndpointConnection
   >;
 }
 
-#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-interface-requires-decorator" "This is a helper interface for private endpoint connection operations"
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-interface-requires-decorator" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 interface PrivateEndpointConnectionsOps
   extends Azure.ResourceManager.Legacy.LegacyOperations<
       {

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/PrivateEndpointConnection.tsp
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/PrivateEndpointConnection.tsp
@@ -26,7 +26,7 @@ model PrivateEndpointConnection
   >;
 }
 
-#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-interface-requires-decorator" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-interface-requires-decorator" "This is a helper interface for private endpoint connection operations"
 interface PrivateEndpointConnectionsOps
   extends Azure.ResourceManager.Legacy.LegacyOperations<
       {

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSCertificateCreateOrUpdate.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSCertificateCreateOrUpdate.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "certificateDescription": {
+      "properties": {
+        "certificate": "MA=="
+      }
+    },
+    "certificateName": "cert",
+    "provisioningServiceName": "myFirstProvisioningService",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "cert",
+        "type": "Microsoft.Devices/ProvisioningServices/Certificates",
+        "etag": "AAAAAAExpNs=",
+        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServives/myFirstProvisioningService/certificates/cert",
+        "properties": {
+          "certificate": "MA==",
+          "created": "Thu, 12 Oct 2017 19:23:50 GMT",
+          "expiry": "Sat, 31 Dec 2039 23:59:59 GMT",
+          "isVerified": false,
+          "subject": "CN=testdevice1",
+          "thumbprint": "97388663832D0393C9246CAB4FBA2C8677185A25",
+          "updated": "Thu, 12 Oct 2017 19:23:50 GMT"
+        }
+      }
+    }
+  },
+  "operationId": "DpsCertificate_CreateOrUpdate",
+  "title": "DPSCreateOrUpdateCertificate"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSCheckNameAvailability.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSCheckNameAvailability.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "arguments": {
+      "name": "test213123"
+    },
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "message": "name is valid",
+        "nameAvailable": true,
+        "reason": "Invalid"
+      }
+    }
+  },
+  "operationId": "IotDpsResource_CheckProvisioningServiceNameAvailability",
+  "title": "DPSCheckName"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSCreate.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSCreate.json
@@ -1,0 +1,80 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "iotDpsDescription": {
+      "location": "East US",
+      "properties": {
+        "enableDataResidency": false,
+        "disableLocalAuth": false
+      },
+      "sku": {
+        "name": "S1",
+        "capacity": 1
+      },
+      "tags": {}
+    },
+    "provisioningServiceName": "myFirstProvisioningService",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myFirstProvisioningService",
+        "type": "Microsoft.Devices/ProvisioningServices",
+        "etag": "AAAAAAAADGk=",
+        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups//providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService",
+        "location": "eastus",
+        "properties": {
+          "allocationPolicy": "Hashed",
+          "authorizationPolicies": [],
+          "deviceProvisioningHostName": "global.azure-devices-provisioning.net",
+          "disableLocalAuth": false,
+          "enableDataResidency": false,
+          "idScope": "0ne00000012",
+          "portalOperationsHostName": "myFirstProvisioningService.services.azure-devices-provisioning.net",
+          "serviceOperationsHostName": "myFirstProvisioningService.azure-devices-provisioning.net",
+          "state": "Active"
+        },
+        "resourcegroup": "myResourceGroup",
+        "sku": {
+          "name": "S1",
+          "capacity": 1,
+          "tier": "Standard"
+        },
+        "subscriptionid": "91d12660-3dec-467a-be2a-213b5544ddc0",
+        "tags": {}
+      }
+    },
+    "201": {
+      "body": {
+        "name": "myFirstProvisioningService",
+        "type": "Microsoft.Devices/ProvisioningServices",
+        "etag": "AAAAAAAADGk=",
+        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups//providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService",
+        "location": "eastus",
+        "properties": {
+          "allocationPolicy": "Hashed",
+          "authorizationPolicies": [],
+          "deviceProvisioningHostName": "global.azure-devices-provisioning.net",
+          "disableLocalAuth": false,
+          "enableDataResidency": false,
+          "idScope": "0ne00000012",
+          "portalOperationsHostName": "myFirstProvisioningService.services.azure-devices-provisioning.net",
+          "serviceOperationsHostName": "myFirstProvisioningService.azure-devices-provisioning.net",
+          "state": "Active"
+        },
+        "resourcegroup": "myResourceGroup",
+        "sku": {
+          "name": "S1",
+          "capacity": 1,
+          "tier": "Standard"
+        },
+        "subscriptionid": "91d12660-3dec-467a-be2a-213b5544ddc0",
+        "tags": {}
+      }
+    }
+  },
+  "operationId": "IotDpsResource_CreateOrUpdate",
+  "title": "DPSCreate"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSCreateOrUpdatePrivateEndpointConnection.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSCreateOrUpdatePrivateEndpointConnection.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "privateEndpointConnection": {
+      "properties": {
+        "privateLinkServiceConnectionState": {
+          "description": "Approved by johndoe@contoso.com",
+          "status": "Approved"
+        }
+      }
+    },
+    "privateEndpointConnectionName": "myPrivateEndpointConnection",
+    "resourceGroupName": "myResourceGroup",
+    "resourceName": "myFirstProvisioningService",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myPrivateEndpointConnection",
+        "type": "Microsoft.Devices/ProvisioningServices/PrivateEndpointConnections",
+        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService/PrivateEndpointConnections/myPrivateEndpointConnection",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/a9eba280-4734-4d49-878f-b5549d1d0453/resourceGroups/networkResourceGroup/providers/Microsoft.Network/privateEndpoints/myPrivateEndpoint"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Approved by johndoe@contoso.com",
+            "actionsRequired": "None",
+            "status": "Approved"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "myPrivateEndpointConnection",
+        "type": "Microsoft.Devices/ProvisioningServices/PrivateEndpointConnections",
+        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService/PrivateEndpointConnections/myPrivateEndpointConnection",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/a9eba280-4734-4d49-878f-b5549d1d0453/resourceGroups/networkResourceGroup/providers/Microsoft.Network/privateEndpoints/myPrivateEndpoint"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Approved by johndoe@contoso.com",
+            "actionsRequired": "None",
+            "status": "Approved"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "IotDpsResource_CreateOrUpdatePrivateEndpointConnection",
+  "title": "PrivateEndpointConnection_CreateOrUpdate"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSCreateWithIotHub.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSCreateWithIotHub.json
@@ -1,0 +1,130 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "iotDpsDescription": {
+      "location": "East US",
+      "properties": {
+        "enableDataResidency": false,
+        "disableLocalAuth": false,
+        "iotHubs": [
+          {
+            "applyAllocationPolicy": true,
+            "allocationWeight": 1,
+            "hostName": "myFirstIoTHub.azure-devices.net",
+            "authenticationType": "UserAssigned",
+            "selectedUserAssignedIdentityResourceId": "/subscriptions/abcf2d55-764f-419f-974d-f77a55c2ce55/resourcegroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-mi-1",
+            "location": "eastus"
+          }
+        ]
+      },
+      "sku": {
+        "name": "S1",
+        "capacity": 1
+      },
+      "identity": {
+        "type": "SystemAssigned, UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/abcf2d55-764f-419f-974d-f77a55c2ce55/resourcegroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-mi-1": {}
+        }
+      },
+      "tags": {}
+    },
+    "provisioningServiceName": "myFirstProvisioningService",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myFirstProvisioningService",
+        "type": "Microsoft.Devices/ProvisioningServices",
+        "etag": "AAAAAAAADGk=",
+        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService",
+        "location": "eastus",
+        "properties": {
+          "allocationPolicy": "Hashed",
+          "authorizationPolicies": [],
+          "deviceProvisioningHostName": "global.azure-devices-provisioning.net",
+          "disableLocalAuth": false,
+          "enableDataResidency": false,
+          "idScope": "0ne00000012",
+          "iotHubs": [
+            {
+              "applyAllocationPolicy": true,
+              "allocationWeight": 1,
+              "name": "myFirstIoTHub.azure-devices.net",
+              "hostName": "myFirstIoTHub.azure-devices.net",
+              "authenticationType": "UserAssigned",
+              "selectedUserAssignedIdentityResourceId": "/subscriptions/abcf2d55-764f-419f-974d-f77a55c2ce55/resourcegroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-mi-1",
+              "location": "eastus"
+            }
+          ],
+          "portalOperationsHostName": "myFirstProvisioningService.services.azure-devices-provisioning.net",
+          "serviceOperationsHostName": "myFirstProvisioningService.azure-devices-provisioning.net",
+          "state": "Active"
+        },
+        "resourcegroup": "myResourceGroup",
+        "sku": {
+          "name": "S1",
+          "capacity": 1,
+          "tier": "Standard"
+        },
+        "identity": {
+          "type": "SystemAssigned, UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/abcf2d55-764f-419f-974d-f77a55c2ce55/resourcegroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-mi-1": {}
+          }
+        },
+        "subscriptionid": "91d12660-3dec-467a-be2a-213b5544ddc0",
+        "tags": {}
+      }
+    },
+    "201": {
+      "body": {
+        "name": "myFirstProvisioningService",
+        "type": "Microsoft.Devices/ProvisioningServices",
+        "etag": "AAAAAAAADGk=",
+        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService",
+        "location": "eastus",
+        "properties": {
+          "allocationPolicy": "Hashed",
+          "authorizationPolicies": [],
+          "deviceProvisioningHostName": "global.azure-devices-provisioning.net",
+          "disableLocalAuth": false,
+          "enableDataResidency": false,
+          "idScope": "0ne00000012",
+          "iotHubs": [
+            {
+              "applyAllocationPolicy": true,
+              "allocationWeight": 1,
+              "name": "myFirstIoTHub.azure-devices.net",
+              "hostName": "myFirstIoTHub.azure-devices.net",
+              "authenticationType": "UserAssigned",
+              "selectedUserAssignedIdentityResourceId": "/subscriptions/abcf2d55-764f-419f-974d-f77a55c2ce55/resourcegroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-mi-1",
+              "location": "eastus"
+            }
+          ],
+          "portalOperationsHostName": "myFirstProvisioningService.services.azure-devices-provisioning.net",
+          "serviceOperationsHostName": "myFirstProvisioningService.azure-devices-provisioning.net",
+          "state": "Active"
+        },
+        "resourcegroup": "myResourceGroup",
+        "sku": {
+          "name": "S1",
+          "capacity": 1,
+          "tier": "Standard"
+        },
+        "identity": {
+          "type": "SystemAssigned, UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/abcf2d55-764f-419f-974d-f77a55c2ce55/resourcegroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-mi-1": {}
+          }
+        },
+        "subscriptionid": "91d12660-3dec-467a-be2a-213b5544ddc0",
+        "tags": {}
+      }
+    }
+  },
+  "operationId": "IotDpsResource_CreateOrUpdate",
+  "title": "DPSCreateWithIotHub"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSCreateWithNamespace.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSCreateWithNamespace.json
@@ -1,0 +1,103 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "iotDpsDescription": {
+      "location": "East US",
+      "properties": {
+        "enableDataResidency": false
+      },
+      "sku": {
+        "name": "S1",
+        "capacity": 1
+      },
+      "tags": {}
+    },
+    "provisioningServiceName": "myFirstProvisioningService",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myFirstProvisioningService",
+        "type": "Microsoft.Devices/ProvisioningServices",
+        "etag": "AAAAAAAADGk=",
+        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups//providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService",
+        "location": "eastus",
+        "properties": {
+          "allocationPolicy": "Hashed",
+          "authorizationPolicies": [],
+          "deviceProvisioningHostName": "global.azure-devices-provisioning.net",
+              "disableLocalAuth": false,
+          "enableDataResidency": false,
+          "idScope": "0ne00000012",
+          "portalOperationsHostName": "myFirstProvisioningService.services.azure-devices-provisioning.net",
+          "serviceOperationsHostName": "myFirstProvisioningService.azure-devices-provisioning.net",
+          "state": "Active",
+          "deviceRegistryNamespace": {
+            "resourceId": "/subscriptions/8c64812d-6e59-4e65-96b3-14a7cdb1a4e4/resourceGroups/myRg/providers/Microsoft.DeviceRegistry/namespaces/myNamespace",
+            "authenticationType": "UserAssigned",
+            "selectedUserAssignedIdentityResourceId": "/subscriptions/abcf2d55-764f-419f-974d-f77a55c2ce55/resourcegroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-mi-1"
+          }
+        },
+        "resourcegroup": "myResourceGroup",
+        "sku": {
+          "name": "S1",
+          "capacity": 1,
+          "tier": "Standard"
+        },
+        "identity": {
+          "type": "SystemAssigned, UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/abcf2d55-764f-419f-974d-f77a55c2ce55/resourcegroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-mi-1": {},
+            "/subscriptions/abcf2d55-764f-419f-974d-f77a55c2ce55/resourcegroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-mi-2": {}
+          }
+        },
+        "subscriptionid": "91d12660-3dec-467a-be2a-213b5544ddc0",
+        "tags": {}
+      }
+    },
+    "201": {
+      "body": {
+        "name": "myFirstProvisioningService",
+        "type": "Microsoft.Devices/ProvisioningServices",
+        "etag": "AAAAAAAADGk=",
+        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups//providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService",
+        "location": "eastus",
+        "properties": {
+          "allocationPolicy": "Hashed",
+          "authorizationPolicies": [],
+          "deviceProvisioningHostName": "global.azure-devices-provisioning.net",
+              "disableLocalAuth": false,
+          "enableDataResidency": false,
+          "idScope": "0ne00000012",
+          "portalOperationsHostName": "myFirstProvisioningService.services.azure-devices-provisioning.net",
+          "serviceOperationsHostName": "myFirstProvisioningService.azure-devices-provisioning.net",
+          "state": "Active",
+          "deviceRegistryNamespace": {
+            "resourceId": "/subscriptions/8c64812d-6e59-4e65-96b3-14a7cdb1a4e4/resourceGroups/myRg/providers/Microsoft.DeviceRegistry/namespaces/myNamespace",
+            "authenticationType": "UserAssigned",
+            "selectedUserAssignedIdentityResourceId": "/subscriptions/abcf2d55-764f-419f-974d-f77a55c2ce55/resourcegroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-mi-1"
+          }
+        },
+        "resourcegroup": "myResourceGroup",
+        "sku": {
+          "name": "S1",
+          "capacity": 1,
+          "tier": "Standard"
+        },
+        "identity": {
+          "type": "SystemAssigned, UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/abcf2d55-764f-419f-974d-f77a55c2ce55/resourcegroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-mi-1": {},
+            "/subscriptions/abcf2d55-764f-419f-974d-f77a55c2ce55/resourcegroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-mi-2": {}
+          }
+        },
+        "subscriptionid": "91d12660-3dec-467a-be2a-213b5544ddc0",
+        "tags": {}
+      }
+    }
+  },
+  "operationId": "IotDpsResource_CreateOrUpdate",
+  "title": "DPSCreateWithNamespace"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSDelete.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSDelete.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "provisioningServiceName": "myFirstProvisioningService",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService/operationResults/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2015-03-15",
+        "Location": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService/operationResults/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2015-03-15",
+        "Retry-After": "15"
+      }
+    },
+    "204": {},
+    "404": {}
+  },
+  "operationId": "IotDpsResource_Delete",
+  "title": "DPSDelete"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSDeleteCertificate.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSDeleteCertificate.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "If-Match": "AAAAAAAADGk=",
+    "api-version": "2026-10-01",
+    "certificateName": "cert",
+    "provisioningServiceName": "myFirstProvisioningService",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "DpsCertificate_Delete",
+  "title": "DPSDeleteCertificate"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSDeletePrivateEndpointConnection.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSDeletePrivateEndpointConnection.json
@@ -1,0 +1,53 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "privateEndpointConnectionName": "myPrivateEndpointConnection",
+    "resourceGroupName": "myResourceGroup",
+    "resourceName": "myFirstProvisioningService",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myPrivateEndpointConnection",
+        "type": "Microsoft.Devices/ProvisioningServices/PrivateEndpointConnections",
+        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService/PrivateEndpointConnections/myPrivateEndpointConnection",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/a9eba280-4734-4d49-878f-b5549d1d0453/resourceGroups/networkResourceGroup/providers/Microsoft.Network/privateEndpoints/myPrivateEndpoint"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Deleted",
+            "actionsRequired": "None",
+            "status": "Disconnected"
+          }
+        }
+      }
+    },
+    "202": {
+      "body": {
+        "name": "myPrivateEndpointConnection",
+        "type": "Microsoft.Devices/ProvisioningServices/PrivateEndpointConnections",
+        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService/PrivateEndpointConnections/myPrivateEndpointConnection",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/a9eba280-4734-4d49-878f-b5549d1d0453/resourceGroups/networkResourceGroup/providers/Microsoft.Network/privateEndpoints/myPrivateEndpoint"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Deleted",
+            "actionsRequired": "None",
+            "status": "Disconnected"
+          }
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService/operationResults/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2015-03-15",
+        "Location": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService/operationResults/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2015-03-15",
+        "Retry-After": "15"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "IotDpsResource_DeletePrivateEndpointConnection",
+  "title": "PrivateEndpointConnection_Delete"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSGenerateVerificationCode.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSGenerateVerificationCode.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "If-Match": "AAAAAAAADGk=",
+    "api-version": "2026-10-01",
+    "certificateName": "cert",
+    "provisioningServiceName": "myFirstProvisioningService",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "cert",
+        "properties": {
+          "certificate": "MA==",
+          "created": "Thu, 12 Oct 2017 19:23:50 GMT",
+          "expiry": "Sat, 31 Dec 2039 23:59:59 GMT",
+          "isVerified": false,
+          "subject": "CN=andbucdevice1",
+          "thumbprint": "##############################",
+          "updated": "Thu, 12 Oct 2017 19:26:56 GMT",
+          "verificationCode": "##################################"
+        }
+      }
+    }
+  },
+  "operationId": "DpsCertificate_GenerateVerificationCode",
+  "title": "DPSGenerateVerificationCode"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSGet.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSGet.json
@@ -1,0 +1,50 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "provisioningServiceName": "myFirstProvisioningService",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myFirstProvisioningService",
+        "type": "Microsoft.Devices/ProvisioningServices",
+        "etag": "AAAAAAAADGk=",
+        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "aa80bd74-a3f0-4f14-b9da-99c5351cf9d5",
+          "tenantId": "f686d426-8d16-42db-81b7-ab578e110ccd",
+          "userAssignedIdentities": {
+            "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourcegroups/testrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testidentity": {
+              "clientId": "c38f618d-47f6-4260-8b3d-1dd8c130f323",
+              "principalId": "f1b0b133-10dc-4985-966f-a98a04675fe9"
+            }
+          }
+        },
+        "location": "eastus",
+        "properties": {
+          "allocationPolicy": "Hashed",
+          "authorizationPolicies": [],
+          "deviceProvisioningHostName": "global.azure-devices-provisioning.net",
+          "disableLocalAuth": false,
+          "idScope": "0ne00000012",
+          "portalOperationsHostName": "myFirstProvisioningService.services.azure-devices-provisioning.net",
+          "serviceOperationsHostName": "myFirstProvisioningService.azure-devices-provisioning.net",
+          "state": "Active"
+        },
+        "resourcegroup": "myResourceGroup",
+        "sku": {
+          "name": "S1",
+          "capacity": 1,
+          "tier": "Standard"
+        },
+        "subscriptionid": "91d12660-3dec-467a-be2a-213b5544ddc0",
+        "tags": {}
+      }
+    }
+  },
+  "operationId": "IotDpsResource_Get",
+  "title": "DPSGet"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSGetCertificate.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSGetCertificate.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "certificateName": "cert",
+    "provisioningServiceName": "myFirstProvisioningService",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "cert",
+        "type": "Microsoft.Devices/ProvisioningServices/Certificates",
+        "etag": "AAAAAAExpNs=",
+        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/IotHubs/andbuc-hub/certificates/cert",
+        "properties": {
+          "certificate": "MA==",
+          "created": "Thu, 12 Oct 2017 19:23:50 GMT",
+          "expiry": "Sat, 31 Dec 2039 23:59:59 GMT",
+          "isVerified": false,
+          "subject": "CN=testdevice1",
+          "thumbprint": "97388663832D0393C9246CAB4FBA2C8677185A25",
+          "updated": "Thu, 12 Oct 2017 19:23:50 GMT"
+        }
+      }
+    }
+  },
+  "operationId": "DpsCertificate_Get",
+  "title": "DPSGetCertificate"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSGetCertificates.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSGetCertificates.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "provisioningServiceName": "myFirstProvisioningService",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "cert",
+            "type": "Microsoft.Devices/ProvisioningServices/Certificates",
+            "etag": "AAAAAAExpNs=",
+            "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/IotHubs/andbuc-hub/certificates/cert",
+            "properties": {
+              "certificate": "MA==",
+              "created": "Thu, 12 Oct 2017 19:23:50 GMT",
+              "expiry": "Sat, 31 Dec 2039 23:59:59 GMT",
+              "isVerified": false,
+              "subject": "CN=testdevice1",
+              "thumbprint": "97388663832D0393C9246CAB4FBA2C8677185A25",
+              "updated": "Thu, 12 Oct 2017 19:23:50 GMT"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DpsCertificate_List",
+  "title": "DPSGetCertificates"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSGetKey.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSGetKey.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "keyName": "testKey",
+    "provisioningServiceName": "myFirstProvisioningService",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keyName": "testKey",
+        "primaryKey": "##################################",
+        "rights": "RegistrationStatusWrite",
+        "secondaryKey": "################################"
+      }
+    }
+  },
+  "operationId": "IotDpsResource_ListKeysForKeyName",
+  "title": "DPSGetKey"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSGetOperationResult.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSGetOperationResult.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "operationId": "MTY5OTNmZDctODI5Yy00N2E2LTkxNDQtMDU1NGIyYzY1ZjRl",
+    "api-version": "2026-10-01",
+    "asyncinfo": "1508265712453",
+    "provisioningServiceName": "myFirstProvisioningService",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "status": "Succeeded"
+      }
+    }
+  },
+  "operationId": "IotDpsResource_GetOperationResult",
+  "title": "DPSGetOperationResult"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSGetPrivateEndpointConnection.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSGetPrivateEndpointConnection.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "privateEndpointConnectionName": "myPrivateEndpointConnection",
+    "resourceGroupName": "myResourceGroup",
+    "resourceName": "myFirstProvisioningService",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myPrivateEndpointConnection",
+        "type": "Microsoft.Devices/ProvisioningServices/PrivateEndpointConnections",
+        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService/PrivateEndpointConnections/myPrivateEndpointConnection",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/a9eba280-4734-4d49-878f-b5549d1d0453/resourceGroups/networkResourceGroup/providers/Microsoft.Network/privateEndpoints/myPrivateEndpoint"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Please approve my request!",
+            "actionsRequired": "None",
+            "status": "Pending"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "IotDpsResource_GetPrivateEndpointConnection",
+  "title": "PrivateEndpointConnection_Get"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSGetPrivateLinkResources.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSGetPrivateLinkResources.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "groupId": "iotDps",
+    "resourceGroupName": "myResourceGroup",
+    "resourceName": "myFirstProvisioningService",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "iotDps",
+        "type": "Microsoft.Devices/ProvisioningServices/PrivateLinkResources",
+        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService/PrivateLinkResources/iotDps",
+        "properties": {
+          "groupId": "iotDps",
+          "requiredMembers": [
+            "iotDps"
+          ],
+          "requiredZoneNames": [
+            "privatelink.azure-devices-provisioning.net"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "IotDpsResource_GetPrivateLinkResources",
+  "title": "PrivateLinkResources_List"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSGetValidSku.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSGetValidSku.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "provisioningServiceName": "myFirstProvisioningService",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "S1"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "IotDpsResource_listValidSkus",
+  "title": "DPSGetValidSku"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSListByResourceGroup.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSListByResourceGroup.json
@@ -1,0 +1,87 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "myFirstProvisioningService",
+            "type": "Microsoft.Devices/ProvisioningServices",
+            "etag": "AAAAAAAADGk=",
+            "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService",
+            "identity": {
+              "type": "SystemAssigned,UserAssigned",
+              "principalId": "aa80bd74-a3f0-4f14-b9da-99c5351cf9d5",
+              "tenantId": "f686d426-8d16-42db-81b7-ab578e110ccd",
+              "userAssignedIdentities": {
+                "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourcegroups/testrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testidentity": {
+                  "clientId": "c38f618d-47f6-4260-8b3d-1dd8c130f323",
+                  "principalId": "f1b0b133-10dc-4985-966f-a98a04675fe9"
+                }
+              }
+            },
+            "location": "eastus",
+            "properties": {
+              "allocationPolicy": "Hashed",
+              "deviceProvisioningHostName": "global.azure-devices-provisioning.net",
+              "disableLocalAuth": false,
+              "idScope": "0ne00000012",
+              "portalOperationsHostName": "myFirstProvisioningService.services.azure-devices-provisioning.net",
+              "serviceOperationsHostName": "myFirstProvisioningService.azure-devices-provisioning.net",
+              "state": "Active"
+            },
+            "resourcegroup": "myResourceGroup",
+            "sku": {
+              "name": "S1",
+              "capacity": 1,
+              "tier": "Standard"
+            },
+            "subscriptionid": "91d12660-3dec-467a-be2a-213b5544ddc0",
+            "tags": {}
+          },
+          {
+            "name": "mySecondProvisioningService",
+            "type": "Microsoft.Devices/ProvisioningServices",
+            "etag": "AAAAAAAADGk=",
+            "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/mySecondProvisioningService",
+            "identity": {
+              "type": "SystemAssigned,UserAssigned",
+              "principalId": "01341f2b-d497-4117-b5c1-1f1d50b25444",
+              "tenantId": "f686d426-8d16-42db-81b7-ab578e110ccd",
+              "userAssignedIdentities": {
+                "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourcegroups/testrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testidentity2": {
+                  "clientId": "8cd6d250-17dd-4c1b-9847-225237b94c55",
+                  "principalId": "8785a11f-848a-4d5d-a55b-e381b9e15512"
+                }
+              }
+            },
+            "location": "eastus",
+            "properties": {
+              "allocationPolicy": "Hashed",
+              "deviceProvisioningHostName": "global.azure-devices-provisioning.net",
+              "disableLocalAuth": false,
+              "idScope": "0ne00000012",
+              "portalOperationsHostName": "myFirstProvisioningService.services.azure-devices-provisioning.net",
+              "serviceOperationsHostName": "mySecondProvisioningService.azure-devices-provisioning.net",
+              "state": "Active"
+            },
+            "resourcegroup": "myResourceGroup",
+            "sku": {
+              "name": "S1",
+              "capacity": 1,
+              "tier": "Standard"
+            },
+            "subscriptionid": "91d12660-3dec-467a-be2a-213b5544ddc0",
+            "tags": {}
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "IotDpsResource_ListByResourceGroup",
+  "title": "DPSListByResourceGroup"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSListBySubscription.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSListBySubscription.json
@@ -1,0 +1,86 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "myFirstProvisioningService",
+            "type": "Microsoft.Devices/ProvisioningServices",
+            "etag": "AAAAAAAADGk=",
+            "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService",
+            "identity": {
+              "type": "SystemAssigned,UserAssigned",
+              "principalId": "aa80bd74-a3f0-4f14-b9da-99c5351cf9d5",
+              "tenantId": "f686d426-8d16-42db-81b7-ab578e110ccd",
+              "userAssignedIdentities": {
+                "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourcegroups/testrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testidentity": {
+                  "clientId": "c38f618d-47f6-4260-8b3d-1dd8c130f323",
+                  "principalId": "f1b0b133-10dc-4985-966f-a98a04675fe9"
+                }
+              }
+            },
+            "location": "eastus",
+            "properties": {
+              "allocationPolicy": "Hashed",
+              "deviceProvisioningHostName": "global.azure-devices-provisioning.net",
+              "disableLocalAuth": false,
+              "idScope": "0ne00000012",
+              "portalOperationsHostName": "myFirstProvisioningService.services.azure-devices-provisioning.net",
+              "serviceOperationsHostName": "myFirstProvisioningService.azure-devices-provisioning.net",
+              "state": "Active"
+            },
+            "resourcegroup": "myResourceGroup",
+            "sku": {
+              "name": "S1",
+              "capacity": 1,
+              "tier": "Standard"
+            },
+            "subscriptionid": "91d12660-3dec-467a-be2a-213b5544ddc0",
+            "tags": {}
+          },
+          {
+            "name": "mySecondProvisioningService",
+            "type": "Microsoft.Devices/ProvisioningServices",
+            "etag": "AAAAAAAADGk=",
+            "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/mySecondProvisioningService",
+            "identity": {
+              "type": "SystemAssigned,UserAssigned",
+              "principalId": "01341f2b-d497-4117-b5c1-1f1d50b25444",
+              "tenantId": "f686d426-8d16-42db-81b7-ab578e110ccd",
+              "userAssignedIdentities": {
+                "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourcegroups/testrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testidentity2": {
+                  "clientId": "8cd6d250-17dd-4c1b-9847-225237b94c55",
+                  "principalId": "8785a11f-848a-4d5d-a55b-e381b9e15512"
+                }
+              }
+            },
+            "location": "eastus",
+            "properties": {
+              "allocationPolicy": "Hashed",
+              "deviceProvisioningHostName": "global.azure-devices-provisioning.net",
+              "disableLocalAuth": false,
+              "idScope": "0ne00000012",
+              "portalOperationsHostName": "myFirstProvisioningService.services.azure-devices-provisioning.net",
+              "serviceOperationsHostName": "myFirstProvisioningService.azure-devices-provisioning.net",
+              "state": "Active"
+            },
+            "resourcegroup": "myResourceGroup",
+            "sku": {
+              "name": "S1",
+              "capacity": 1,
+              "tier": "Standard"
+            },
+            "subscriptionid": "91d12660-3dec-467a-be2a-213b5544ddc0",
+            "tags": {}
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "IotDpsResource_ListBySubscription",
+  "title": "DPSListBySubscription"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSListKeys.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSListKeys.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "provisioningServiceName": "myFirstProvisioningService",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "keyName": "key1",
+            "primaryKey": "#####################################",
+            "rights": "ServiceConfig",
+            "secondaryKey": "###################################"
+          },
+          {
+            "keyName": "key2",
+            "primaryKey": "#######################################",
+            "rights": "ServiceConfig",
+            "secondaryKey": "####################################="
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "IotDpsResource_ListKeys",
+  "title": "DPSListKeys"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSListPrivateEndpointConnections.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSListPrivateEndpointConnections.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "resourceGroupName": "myResourceGroup",
+    "resourceName": "myFirstProvisioningService",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": [
+        {
+          "name": "myPrivateEndpointConnection",
+          "type": "Microsoft.Devices/ProvisioningServices/PrivateEndpointConnections",
+          "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService/PrivateEndpointConnections/myPrivateEndpointConnection",
+          "properties": {
+            "privateEndpoint": {
+              "id": "/subscriptions/a9eba280-4734-4d49-878f-b5549d1d0453/resourceGroups/networkResourceGroup/providers/Microsoft.Network/privateEndpoints/myPrivateEndpoint"
+            },
+            "privateLinkServiceConnectionState": {
+              "description": "Please approve my request!",
+              "actionsRequired": "None",
+              "status": "Pending"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "operationId": "IotDpsResource_ListPrivateEndpointConnections",
+  "title": "PrivateEndpointConnections_List"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSListPrivateLinkResources.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSListPrivateLinkResources.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "resourceGroupName": "myResourceGroup",
+    "resourceName": "myFirstProvisioningService",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "iotDps",
+            "type": "Microsoft.Devices/ProvisioningServices/PrivateLinkResources",
+            "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService/PrivateLinkResources/iotDps",
+            "properties": {
+              "groupId": "iotDps",
+              "requiredMembers": [
+                "iotDps"
+              ],
+              "requiredZoneNames": [
+                "privatelink.azure-devices-provisioning.net"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "IotDpsResource_ListPrivateLinkResources",
+  "title": "PrivateLinkResources_List"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSOperations.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSOperations.json
@@ -1,0 +1,295 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.Devices/register/action",
+            "display": {
+              "operation": "Register Resource Provider",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/IotHubs/diagnosticSettings/read",
+            "display": {
+              "operation": "Get Diagnostic Setting",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/IotHubs/diagnosticSettings/write",
+            "display": {
+              "operation": "Set Diagnostic Setting",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/IotHubs/metricDefinitions/read",
+            "display": {
+              "operation": "Read IotHub service metric definitions",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/IotHubs/logDefinitions/read",
+            "display": {
+              "operation": "Read IotHub service log definitions",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/operations/Read",
+            "display": {
+              "operation": "Get All ResourceProvider Operations",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/checkNameAvailability/Action",
+            "display": {
+              "operation": "Check If IotHub name is available",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/usages/Read",
+            "display": {
+              "operation": "Get Subscription Usages",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/iotHubs/Read",
+            "display": {
+              "operation": "Get IotHub(s)",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/iotHubs/Write",
+            "display": {
+              "operation": "Create or update IotHub Resource",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/iotHubs/Delete",
+            "display": {
+              "operation": "Delete IotHub Resource",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/iotHubs/iotHubStats/Read",
+            "display": {
+              "operation": "Get IotHub Statistics",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/iotHubs/skus/Read",
+            "display": {
+              "operation": "Get valid IotHub Skus",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/iotHubs/listkeys/Action",
+            "display": {
+              "operation": "Get all IotHub Keys",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/iotHubs/iotHubKeys/listkeys/Action",
+            "display": {
+              "operation": "Get IotHub Key for the given name",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/iotHubs/eventHubEndpoints/consumerGroups/Write",
+            "display": {
+              "operation": "Create EventHub Consumer Group",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/iotHubs/eventHubEndpoints/consumerGroups/Read",
+            "display": {
+              "operation": "Get EventHub Consumer Group(s)",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/iotHubs/eventHubEndpoints/consumerGroups/Delete",
+            "display": {
+              "operation": "Delete EventHub Consumer Group",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/iotHubs/exportDevices/Action",
+            "display": {
+              "operation": "Export Devices",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/iotHubs/importDevices/Action",
+            "display": {
+              "operation": "Import Devices",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/iotHubs/jobs/Read",
+            "display": {
+              "operation": "Get the Job(s) on IotHub",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/iotHubs/quotaMetrics/Read",
+            "display": {
+              "operation": "Get Quota Metrics",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/iotHubs/routing/routes/$testall/Action",
+            "display": {
+              "operation": "Routing Rule Test All",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/iotHubs/routing/routes/$testnew/Action",
+            "display": {
+              "operation": "Routing Rule Test Route",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/iotHubs/routingEndpointsHealth/Read",
+            "display": {
+              "operation": "Get Endpoint Health",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/ProvisioningServices/diagnosticSettings/read",
+            "display": {
+              "operation": "Get Diagnostic Setting",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/ProvisioningServices/diagnosticSettings/write",
+            "display": {
+              "operation": "Set Diagnostic Setting",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/ProvisioningServices/metricDefinitions/read",
+            "display": {
+              "operation": "Read DPS service metric definitions",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/ProvisioningServices/logDefinitions/read",
+            "display": {
+              "operation": "Read DPS service log definitions",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/checkProvisioningServiceNameAvailability/Action",
+            "display": {
+              "operation": "Check If Provisioning Service name is available",
+              "provider": "Microsoft Devices",
+              "resource": "ProvisioningServives"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/provisioningServices/Read",
+            "display": {
+              "operation": "Get Provisioning Service resource",
+              "provider": "Microsoft Devices",
+              "resource": "ProvisioningServices"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/provisioningServices/Write",
+            "display": {
+              "operation": "Create Provisioning Service resource",
+              "provider": "Microsoft Devices",
+              "resource": "ProvisioningServices"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/provisioningServices/Delete",
+            "display": {
+              "operation": "Delete Provisioning Service resource",
+              "provider": "Microsoft Devices",
+              "resource": "ProvisioningServices"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/provisioningServices/skus/Read",
+            "display": {
+              "operation": "Delete Provisioning Service resource",
+              "provider": "Microsoft Devices",
+              "resource": "ProvisioningServices"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/provisioningServices/listkeys/Action",
+            "display": {
+              "operation": "get security related metadata",
+              "provider": "Microsoft Devices",
+              "resource": "ProvisioningServices"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Operations_List",
+  "title": "DPSOperations"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSPatch.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSPatch.json
@@ -1,0 +1,58 @@
+{
+  "parameters": {
+    "type": "Microsoft.Devices/ProvisioningServices",
+    "ProvisioningServiceTags": {
+      "tags": {
+        "foo": "bar"
+      }
+    },
+    "api-version": "2026-10-01",
+    "location": "East US",
+    "provisioningServiceName": "myFirstProvisioningService",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myFirstProvisioningService",
+        "type": "Microsoft.Devices/ProvisioningServices",
+        "etag": "AAAAAAAADGk=",
+        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "aa80bd74-a3f0-4f14-b9da-99c5351cf9d5",
+          "tenantId": "f686d426-8d16-42db-81b7-ab578e110ccd",
+          "userAssignedIdentities": {
+            "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourcegroups/testrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testidentity": {
+              "clientId": "c38f618d-47f6-4260-8b3d-1dd8c130f323",
+              "principalId": "f1b0b133-10dc-4985-966f-a98a04675fe9"
+            }
+          }
+        },
+        "location": "eastus",
+        "properties": {
+          "allocationPolicy": "Hashed",
+          "deviceProvisioningHostName": "global.azure-devices-provisioning.net",
+              "disableLocalAuth": false,
+          "idScope": "0ne00000012",
+          "portalOperationsHostName": "myFirstProvisioningService.services.azure-devices-provisioning.net",
+          "serviceOperationsHostName": "myFirstProvisioningService.azure-devices-provisioning.net",
+          "state": "Active"
+        },
+        "resourcegroup": "myResourceGroup",
+        "sku": {
+          "name": "S1",
+          "capacity": 1,
+          "tier": "Standard"
+        },
+        "subscriptionid": "91d12660-3dec-467a-be2a-213b5544ddc0",
+        "tags": {
+          "foo": "bar"
+        }
+      }
+    }
+  },
+  "operationId": "IotDpsResource_Update",
+  "title": "DPSPatch"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSUpdate.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSUpdate.json
@@ -1,0 +1,108 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "iotDpsDescription": {
+      "identity": {
+        "type": "SystemAssigned,UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourcegroups/testrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testidentity": {}
+        }
+      },
+      "location": "East US",
+      "properties": {
+        "enableDataResidency": false,
+        "disableLocalAuth": false
+      },
+      "sku": {
+        "name": "S1",
+        "capacity": 1
+      },
+      "tags": {}
+    },
+    "provisioningServiceName": "myFirstProvisioningService",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myFirstProvisioningService",
+        "type": "Microsoft.Devices/ProvisioningServices",
+        "etag": "AAAAAAAADGk=",
+        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups//providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "aa80bd74-a3f0-4f14-b9da-99c5351cf9d5",
+          "tenantId": "f686d426-8d16-42db-81b7-ab578e110ccd",
+          "userAssignedIdentities": {
+            "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourcegroups/testrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testidentity": {
+              "clientId": "c38f618d-47f6-4260-8b3d-1dd8c130f323",
+              "principalId": "f1b0b133-10dc-4985-966f-a98a04675fe9"
+            }
+          }
+        },
+        "location": "eastus",
+        "properties": {
+          "allocationPolicy": "Hashed",
+          "authorizationPolicies": [],
+          "deviceProvisioningHostName": "global.azure-devices-provisioning.net",
+          "disableLocalAuth": false,
+          "enableDataResidency": false,
+          "idScope": "0ne00000012",
+          "portalOperationsHostName": "myFirstProvisioningService.services.azure-devices-provisioning.net",
+          "serviceOperationsHostName": "myFirstProvisioningService.azure-devices-provisioning.net",
+          "state": "Active"
+        },
+        "resourcegroup": "myResourceGroup",
+        "sku": {
+          "name": "S1",
+          "capacity": 1,
+          "tier": "Standard"
+        },
+        "subscriptionid": "91d12660-3dec-467a-be2a-213b5544ddc0",
+        "tags": {}
+      }
+    },
+    "201": {
+      "body": {
+        "name": "myFirstProvisioningService",
+        "type": "Microsoft.Devices/ProvisioningServices",
+        "etag": "AAAAAAAADGk=",
+        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups//providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "aa80bd74-a3f0-4f14-b9da-99c5351cf9d5",
+          "tenantId": "f686d426-8d16-42db-81b7-ab578e110ccd",
+          "userAssignedIdentities": {
+            "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourcegroups/testrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testidentity": {
+              "clientId": "c38f618d-47f6-4260-8b3d-1dd8c130f323",
+              "principalId": "f1b0b133-10dc-4985-966f-a98a04675fe9"
+            }
+          }
+        },
+        "location": "eastus",
+        "properties": {
+          "allocationPolicy": "Hashed",
+          "authorizationPolicies": [],
+          "deviceProvisioningHostName": "global.azure-devices-provisioning.net",
+          "disableLocalAuth": false,
+          "enableDataResidency": false,
+          "idScope": "0ne00000012",
+          "portalOperationsHostName": "myFirstProvisioningService.services.azure-devices-provisioning.net",
+          "serviceOperationsHostName": "myFirstProvisioningService.azure-devices-provisioning.net",
+          "state": "Active"
+        },
+        "resourcegroup": "myResourceGroup",
+        "sku": {
+          "name": "S1",
+          "capacity": 1,
+          "tier": "Standard"
+        },
+        "subscriptionid": "91d12660-3dec-467a-be2a-213b5544ddc0",
+        "tags": {}
+      }
+    }
+  },
+  "operationId": "IotDpsResource_CreateOrUpdate",
+  "title": "DPSUpdate"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSVerifyCertificate.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DPSVerifyCertificate.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "If-Match": "AAAAAAAADGk=",
+    "api-version": "2026-10-01",
+    "certificateName": "cert",
+    "provisioningServiceName": "myFirstProvisioningService",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0",
+    "request": {
+      "certificate": "#####################################"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "cert",
+        "type": "Microsoft.Devices/ProvisioningServices/Certificates",
+        "etag": "AAAAAAExpTQ=",
+        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService/certificates/cert",
+        "properties": {
+          "certificate": "MA==",
+          "created": "Thu, 12 Oct 2017 19:23:50 GMT",
+          "expiry": "Sat, 31 Dec 2039 23:59:59 GMT",
+          "isVerified": true,
+          "subject": "CN=andbucdevice1",
+          "thumbprint": "97388663832D0393C9246CAB4FBA2C8677185A25",
+          "updated": "Thu, 12 Oct 2017 19:26:56 GMT"
+        }
+      }
+    }
+  },
+  "operationId": "DpsCertificate_VerifyCertificate",
+  "title": "DPSVerifyCertificate"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/main.tsp
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/main.tsp
@@ -44,6 +44,11 @@ enum Versions {
    * The 2025-02-01-preview API version.
    */
   v2025_02_01_preview: "2025-02-01-preview",
+
+  /**
+   * The 2026-10-01 API version.
+   */
+  v2026_10_01: "2026-10-01",
 }
 
 /**

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/models.tsp
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/models.tsp
@@ -149,28 +149,6 @@ union DeviceRegistryNamespaceAuthenticationType {
 }
 
 /**
- * IotHub MI authentication type: KeyBased, UserAssigned, SystemAssigned.
- */
-union IotHubAuthenticationType {
-  string,
-
-  /**
-   * Key Based authentication type.
-   */
-  KeyBased: "KeyBased",
-
-  /**
-   * User assigned authentication type.
-   */
-  UserAssigned: "UserAssigned",
-
-  /**
-   * System assigned authentication type.
-   */
-  SystemAssigned: "SystemAssigned",
-}
-
-/**
  * Allocation policy to be used by this provisioning service.
  */
 union AllocationPolicy {
@@ -519,32 +497,9 @@ model IotHubDefinitionDescription {
   name?: string;
 
   /**
-   * Host name of the IoT hub. This is required when connectionString is not provided.
-   */
-  @added(Versions.v2026_10_01)
-  hostName?: string;
-
-  /**
-   * IotHub MI authentication type: KeyBased, UserAssigned, SystemAssigned.
-   */
-  @added(Versions.v2026_10_01)
-  authenticationType?: IotHubAuthenticationType;
-
-  /**
-   * The selected user-assigned identity resource Id associated with IoT hub. This is required when authenticationType is UserAssigned.
-   */
-  @added(Versions.v2026_10_01)
-  selectedUserAssignedIdentityResourceId?: Azure.Core.armResourceIdentifier<[
-    {
-      type: "Microsoft.ManagedIdentity/userAssignedIdentities";
-    }
-  ]>;
-
-  /**
    * Connection string of the IoT hub.
    */
-  @madeOptional(Versions.v2026_10_01)
-  connectionString?: string;
+  connectionString: string;
 
   /**
    * ARM region of the IoT hub.

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/models.tsp
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/models.tsp
@@ -1,9 +1,11 @@
 import "@typespec/rest";
 import "@typespec/http";
+import "@typespec/versioning";
 import "@azure-tools/typespec-azure-core";
 import "@azure-tools/typespec-azure-resource-manager";
 
 using Azure.ResourceManager.Foundations;
+using TypeSpec.Versioning;
 
 namespace Microsoft.Devices;
 
@@ -134,6 +136,28 @@ union PrivateLinkServiceConnectionStatus {
  */
 union DeviceRegistryNamespaceAuthenticationType {
   string,
+
+  /**
+   * User assigned authentication type.
+   */
+  UserAssigned: "UserAssigned",
+
+  /**
+   * System assigned authentication type.
+   */
+  SystemAssigned: "SystemAssigned",
+}
+
+/**
+ * IotHub MI authentication type: KeyBased, UserAssigned, SystemAssigned.
+ */
+union IotHubAuthenticationType {
+  string,
+
+  /**
+   * Key Based authentication type.
+   */
+  KeyBased: "KeyBased",
 
   /**
    * User assigned authentication type.
@@ -394,6 +418,12 @@ model IotDpsPropertiesDescription {
    * Portal endpoint to enable CORS for this provisioning service.
    */
   portalOperationsHostName?: string;
+
+  /**
+   * Disables all authentication methods other than Azure RBAC
+   */
+  @added(Versions.v2026_10_01)
+  disableLocalAuth?: boolean = false;
 }
 
 /**
@@ -489,9 +519,32 @@ model IotHubDefinitionDescription {
   name?: string;
 
   /**
+   * Host name of the IoT hub. This is required when connectionString is not provided.
+   */
+  @added(Versions.v2026_10_01)
+  hostName?: string;
+
+  /**
+   * IotHub MI authentication type: KeyBased, UserAssigned, SystemAssigned.
+   */
+  @added(Versions.v2026_10_01)
+  authenticationType?: IotHubAuthenticationType;
+
+  /**
+   * The selected user-assigned identity resource Id associated with IoT hub. This is required when authenticationType is UserAssigned.
+   */
+  @added(Versions.v2026_10_01)
+  selectedUserAssignedIdentityResourceId?: Azure.Core.armResourceIdentifier<[
+    {
+      type: "Microsoft.ManagedIdentity/userAssignedIdentities";
+    }
+  ]>;
+
+  /**
    * Connection string of the IoT hub.
    */
-  connectionString: string;
+  @madeOptional(Versions.v2026_10_01)
+  connectionString?: string;
 
   /**
    * ARM region of the IoT hub.

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/readme.md
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/readme.md
@@ -27,9 +27,17 @@ These are the global settings for the API.
 ``` yaml
 openapi-type: arm
 azure-arm: true
-tag: package-preview-2025-02
+tag: package-2026-10
 ```
 
+### Tag: package-2026-10
+
+These settings apply only when `--tag=package-2026-10` is specified on the command line.
+
+```yaml $(tag) == 'package-2026-10'
+input-file:
+  - stable/2026-10-01/iotdps.json
+```
 
 ### Tag: package-preview-2025-02
 

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSCertificateCreateOrUpdate.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSCertificateCreateOrUpdate.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "certificateDescription": {
+      "properties": {
+        "certificate": "MA=="
+      }
+    },
+    "certificateName": "cert",
+    "provisioningServiceName": "myFirstProvisioningService",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "cert",
+        "type": "Microsoft.Devices/ProvisioningServices/Certificates",
+        "etag": "AAAAAAExpNs=",
+        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServives/myFirstProvisioningService/certificates/cert",
+        "properties": {
+          "certificate": "MA==",
+          "created": "Thu, 12 Oct 2017 19:23:50 GMT",
+          "expiry": "Sat, 31 Dec 2039 23:59:59 GMT",
+          "isVerified": false,
+          "subject": "CN=testdevice1",
+          "thumbprint": "97388663832D0393C9246CAB4FBA2C8677185A25",
+          "updated": "Thu, 12 Oct 2017 19:23:50 GMT"
+        }
+      }
+    }
+  },
+  "operationId": "DpsCertificate_CreateOrUpdate",
+  "title": "DPSCreateOrUpdateCertificate"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSCheckNameAvailability.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSCheckNameAvailability.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "arguments": {
+      "name": "test213123"
+    },
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "message": "name is valid",
+        "nameAvailable": true,
+        "reason": "Invalid"
+      }
+    }
+  },
+  "operationId": "IotDpsResource_CheckProvisioningServiceNameAvailability",
+  "title": "DPSCheckName"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSCreate.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSCreate.json
@@ -1,0 +1,80 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "iotDpsDescription": {
+      "location": "East US",
+      "properties": {
+        "enableDataResidency": false,
+        "disableLocalAuth": false
+      },
+      "sku": {
+        "name": "S1",
+        "capacity": 1
+      },
+      "tags": {}
+    },
+    "provisioningServiceName": "myFirstProvisioningService",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myFirstProvisioningService",
+        "type": "Microsoft.Devices/ProvisioningServices",
+        "etag": "AAAAAAAADGk=",
+        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups//providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService",
+        "location": "eastus",
+        "properties": {
+          "allocationPolicy": "Hashed",
+          "authorizationPolicies": [],
+          "deviceProvisioningHostName": "global.azure-devices-provisioning.net",
+          "disableLocalAuth": false,
+          "enableDataResidency": false,
+          "idScope": "0ne00000012",
+          "portalOperationsHostName": "myFirstProvisioningService.services.azure-devices-provisioning.net",
+          "serviceOperationsHostName": "myFirstProvisioningService.azure-devices-provisioning.net",
+          "state": "Active"
+        },
+        "resourcegroup": "myResourceGroup",
+        "sku": {
+          "name": "S1",
+          "capacity": 1,
+          "tier": "Standard"
+        },
+        "subscriptionid": "91d12660-3dec-467a-be2a-213b5544ddc0",
+        "tags": {}
+      }
+    },
+    "201": {
+      "body": {
+        "name": "myFirstProvisioningService",
+        "type": "Microsoft.Devices/ProvisioningServices",
+        "etag": "AAAAAAAADGk=",
+        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups//providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService",
+        "location": "eastus",
+        "properties": {
+          "allocationPolicy": "Hashed",
+          "authorizationPolicies": [],
+          "deviceProvisioningHostName": "global.azure-devices-provisioning.net",
+          "disableLocalAuth": false,
+          "enableDataResidency": false,
+          "idScope": "0ne00000012",
+          "portalOperationsHostName": "myFirstProvisioningService.services.azure-devices-provisioning.net",
+          "serviceOperationsHostName": "myFirstProvisioningService.azure-devices-provisioning.net",
+          "state": "Active"
+        },
+        "resourcegroup": "myResourceGroup",
+        "sku": {
+          "name": "S1",
+          "capacity": 1,
+          "tier": "Standard"
+        },
+        "subscriptionid": "91d12660-3dec-467a-be2a-213b5544ddc0",
+        "tags": {}
+      }
+    }
+  },
+  "operationId": "IotDpsResource_CreateOrUpdate",
+  "title": "DPSCreate"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSCreateOrUpdatePrivateEndpointConnection.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSCreateOrUpdatePrivateEndpointConnection.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "privateEndpointConnection": {
+      "properties": {
+        "privateLinkServiceConnectionState": {
+          "description": "Approved by johndoe@contoso.com",
+          "status": "Approved"
+        }
+      }
+    },
+    "privateEndpointConnectionName": "myPrivateEndpointConnection",
+    "resourceGroupName": "myResourceGroup",
+    "resourceName": "myFirstProvisioningService",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myPrivateEndpointConnection",
+        "type": "Microsoft.Devices/ProvisioningServices/PrivateEndpointConnections",
+        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService/PrivateEndpointConnections/myPrivateEndpointConnection",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/a9eba280-4734-4d49-878f-b5549d1d0453/resourceGroups/networkResourceGroup/providers/Microsoft.Network/privateEndpoints/myPrivateEndpoint"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Approved by johndoe@contoso.com",
+            "actionsRequired": "None",
+            "status": "Approved"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "myPrivateEndpointConnection",
+        "type": "Microsoft.Devices/ProvisioningServices/PrivateEndpointConnections",
+        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService/PrivateEndpointConnections/myPrivateEndpointConnection",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/a9eba280-4734-4d49-878f-b5549d1d0453/resourceGroups/networkResourceGroup/providers/Microsoft.Network/privateEndpoints/myPrivateEndpoint"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Approved by johndoe@contoso.com",
+            "actionsRequired": "None",
+            "status": "Approved"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "IotDpsResource_CreateOrUpdatePrivateEndpointConnection",
+  "title": "PrivateEndpointConnection_CreateOrUpdate"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSCreateWithIotHub.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSCreateWithIotHub.json
@@ -1,0 +1,130 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "iotDpsDescription": {
+      "location": "East US",
+      "properties": {
+        "enableDataResidency": false,
+        "disableLocalAuth": false,
+        "iotHubs": [
+          {
+            "applyAllocationPolicy": true,
+            "allocationWeight": 1,
+            "hostName": "myFirstIoTHub.azure-devices.net",
+            "authenticationType": "UserAssigned",
+            "selectedUserAssignedIdentityResourceId": "/subscriptions/abcf2d55-764f-419f-974d-f77a55c2ce55/resourcegroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-mi-1",
+            "location": "eastus"
+          }
+        ]
+      },
+      "sku": {
+        "name": "S1",
+        "capacity": 1
+      },
+      "identity": {
+        "type": "SystemAssigned, UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/abcf2d55-764f-419f-974d-f77a55c2ce55/resourcegroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-mi-1": {}
+        }
+      },
+      "tags": {}
+    },
+    "provisioningServiceName": "myFirstProvisioningService",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myFirstProvisioningService",
+        "type": "Microsoft.Devices/ProvisioningServices",
+        "etag": "AAAAAAAADGk=",
+        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService",
+        "location": "eastus",
+        "properties": {
+          "allocationPolicy": "Hashed",
+          "authorizationPolicies": [],
+          "deviceProvisioningHostName": "global.azure-devices-provisioning.net",
+          "disableLocalAuth": false,
+          "enableDataResidency": false,
+          "idScope": "0ne00000012",
+          "iotHubs": [
+            {
+              "applyAllocationPolicy": true,
+              "allocationWeight": 1,
+              "name": "myFirstIoTHub.azure-devices.net",
+              "hostName": "myFirstIoTHub.azure-devices.net",
+              "authenticationType": "UserAssigned",
+              "selectedUserAssignedIdentityResourceId": "/subscriptions/abcf2d55-764f-419f-974d-f77a55c2ce55/resourcegroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-mi-1",
+              "location": "eastus"
+            }
+          ],
+          "portalOperationsHostName": "myFirstProvisioningService.services.azure-devices-provisioning.net",
+          "serviceOperationsHostName": "myFirstProvisioningService.azure-devices-provisioning.net",
+          "state": "Active"
+        },
+        "resourcegroup": "myResourceGroup",
+        "sku": {
+          "name": "S1",
+          "capacity": 1,
+          "tier": "Standard"
+        },
+        "identity": {
+          "type": "SystemAssigned, UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/abcf2d55-764f-419f-974d-f77a55c2ce55/resourcegroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-mi-1": {}
+          }
+        },
+        "subscriptionid": "91d12660-3dec-467a-be2a-213b5544ddc0",
+        "tags": {}
+      }
+    },
+    "201": {
+      "body": {
+        "name": "myFirstProvisioningService",
+        "type": "Microsoft.Devices/ProvisioningServices",
+        "etag": "AAAAAAAADGk=",
+        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService",
+        "location": "eastus",
+        "properties": {
+          "allocationPolicy": "Hashed",
+          "authorizationPolicies": [],
+          "deviceProvisioningHostName": "global.azure-devices-provisioning.net",
+          "disableLocalAuth": false,
+          "enableDataResidency": false,
+          "idScope": "0ne00000012",
+          "iotHubs": [
+            {
+              "applyAllocationPolicy": true,
+              "allocationWeight": 1,
+              "name": "myFirstIoTHub.azure-devices.net",
+              "hostName": "myFirstIoTHub.azure-devices.net",
+              "authenticationType": "UserAssigned",
+              "selectedUserAssignedIdentityResourceId": "/subscriptions/abcf2d55-764f-419f-974d-f77a55c2ce55/resourcegroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-mi-1",
+              "location": "eastus"
+            }
+          ],
+          "portalOperationsHostName": "myFirstProvisioningService.services.azure-devices-provisioning.net",
+          "serviceOperationsHostName": "myFirstProvisioningService.azure-devices-provisioning.net",
+          "state": "Active"
+        },
+        "resourcegroup": "myResourceGroup",
+        "sku": {
+          "name": "S1",
+          "capacity": 1,
+          "tier": "Standard"
+        },
+        "identity": {
+          "type": "SystemAssigned, UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/abcf2d55-764f-419f-974d-f77a55c2ce55/resourcegroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-mi-1": {}
+          }
+        },
+        "subscriptionid": "91d12660-3dec-467a-be2a-213b5544ddc0",
+        "tags": {}
+      }
+    }
+  },
+  "operationId": "IotDpsResource_CreateOrUpdate",
+  "title": "DPSCreateWithIotHub"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSCreateWithNamespace.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSCreateWithNamespace.json
@@ -1,0 +1,103 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "iotDpsDescription": {
+      "location": "East US",
+      "properties": {
+        "enableDataResidency": false
+      },
+      "sku": {
+        "name": "S1",
+        "capacity": 1
+      },
+      "tags": {}
+    },
+    "provisioningServiceName": "myFirstProvisioningService",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myFirstProvisioningService",
+        "type": "Microsoft.Devices/ProvisioningServices",
+        "etag": "AAAAAAAADGk=",
+        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups//providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService",
+        "location": "eastus",
+        "properties": {
+          "allocationPolicy": "Hashed",
+          "authorizationPolicies": [],
+          "deviceProvisioningHostName": "global.azure-devices-provisioning.net",
+              "disableLocalAuth": false,
+          "enableDataResidency": false,
+          "idScope": "0ne00000012",
+          "portalOperationsHostName": "myFirstProvisioningService.services.azure-devices-provisioning.net",
+          "serviceOperationsHostName": "myFirstProvisioningService.azure-devices-provisioning.net",
+          "state": "Active",
+          "deviceRegistryNamespace": {
+            "resourceId": "/subscriptions/8c64812d-6e59-4e65-96b3-14a7cdb1a4e4/resourceGroups/myRg/providers/Microsoft.DeviceRegistry/namespaces/myNamespace",
+            "authenticationType": "UserAssigned",
+            "selectedUserAssignedIdentityResourceId": "/subscriptions/abcf2d55-764f-419f-974d-f77a55c2ce55/resourcegroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-mi-1"
+          }
+        },
+        "resourcegroup": "myResourceGroup",
+        "sku": {
+          "name": "S1",
+          "capacity": 1,
+          "tier": "Standard"
+        },
+        "identity": {
+          "type": "SystemAssigned, UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/abcf2d55-764f-419f-974d-f77a55c2ce55/resourcegroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-mi-1": {},
+            "/subscriptions/abcf2d55-764f-419f-974d-f77a55c2ce55/resourcegroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-mi-2": {}
+          }
+        },
+        "subscriptionid": "91d12660-3dec-467a-be2a-213b5544ddc0",
+        "tags": {}
+      }
+    },
+    "201": {
+      "body": {
+        "name": "myFirstProvisioningService",
+        "type": "Microsoft.Devices/ProvisioningServices",
+        "etag": "AAAAAAAADGk=",
+        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups//providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService",
+        "location": "eastus",
+        "properties": {
+          "allocationPolicy": "Hashed",
+          "authorizationPolicies": [],
+          "deviceProvisioningHostName": "global.azure-devices-provisioning.net",
+              "disableLocalAuth": false,
+          "enableDataResidency": false,
+          "idScope": "0ne00000012",
+          "portalOperationsHostName": "myFirstProvisioningService.services.azure-devices-provisioning.net",
+          "serviceOperationsHostName": "myFirstProvisioningService.azure-devices-provisioning.net",
+          "state": "Active",
+          "deviceRegistryNamespace": {
+            "resourceId": "/subscriptions/8c64812d-6e59-4e65-96b3-14a7cdb1a4e4/resourceGroups/myRg/providers/Microsoft.DeviceRegistry/namespaces/myNamespace",
+            "authenticationType": "UserAssigned",
+            "selectedUserAssignedIdentityResourceId": "/subscriptions/abcf2d55-764f-419f-974d-f77a55c2ce55/resourcegroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-mi-1"
+          }
+        },
+        "resourcegroup": "myResourceGroup",
+        "sku": {
+          "name": "S1",
+          "capacity": 1,
+          "tier": "Standard"
+        },
+        "identity": {
+          "type": "SystemAssigned, UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/abcf2d55-764f-419f-974d-f77a55c2ce55/resourcegroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-mi-1": {},
+            "/subscriptions/abcf2d55-764f-419f-974d-f77a55c2ce55/resourcegroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-mi-2": {}
+          }
+        },
+        "subscriptionid": "91d12660-3dec-467a-be2a-213b5544ddc0",
+        "tags": {}
+      }
+    }
+  },
+  "operationId": "IotDpsResource_CreateOrUpdate",
+  "title": "DPSCreateWithNamespace"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSDelete.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSDelete.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "provisioningServiceName": "myFirstProvisioningService",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService/operationResults/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2015-03-15",
+        "Location": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService/operationResults/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2015-03-15",
+        "Retry-After": "15"
+      }
+    },
+    "204": {},
+    "404": {}
+  },
+  "operationId": "IotDpsResource_Delete",
+  "title": "DPSDelete"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSDeleteCertificate.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSDeleteCertificate.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "If-Match": "AAAAAAAADGk=",
+    "api-version": "2026-10-01",
+    "certificateName": "cert",
+    "provisioningServiceName": "myFirstProvisioningService",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "DpsCertificate_Delete",
+  "title": "DPSDeleteCertificate"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSDeletePrivateEndpointConnection.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSDeletePrivateEndpointConnection.json
@@ -1,0 +1,53 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "privateEndpointConnectionName": "myPrivateEndpointConnection",
+    "resourceGroupName": "myResourceGroup",
+    "resourceName": "myFirstProvisioningService",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myPrivateEndpointConnection",
+        "type": "Microsoft.Devices/ProvisioningServices/PrivateEndpointConnections",
+        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService/PrivateEndpointConnections/myPrivateEndpointConnection",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/a9eba280-4734-4d49-878f-b5549d1d0453/resourceGroups/networkResourceGroup/providers/Microsoft.Network/privateEndpoints/myPrivateEndpoint"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Deleted",
+            "actionsRequired": "None",
+            "status": "Disconnected"
+          }
+        }
+      }
+    },
+    "202": {
+      "body": {
+        "name": "myPrivateEndpointConnection",
+        "type": "Microsoft.Devices/ProvisioningServices/PrivateEndpointConnections",
+        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService/PrivateEndpointConnections/myPrivateEndpointConnection",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/a9eba280-4734-4d49-878f-b5549d1d0453/resourceGroups/networkResourceGroup/providers/Microsoft.Network/privateEndpoints/myPrivateEndpoint"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Deleted",
+            "actionsRequired": "None",
+            "status": "Disconnected"
+          }
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService/operationResults/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2015-03-15",
+        "Location": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService/operationResults/YWUzNDFkMzQtZmM5OS00MmUyLWEzNDMtZGJkMDIxZjlmZjgzOzdmYzBiMzhmLTc2NmItNDM5NS05OWQ1LTVmOGEzNzg4MWQzNA==?api-version=2015-03-15",
+        "Retry-After": "15"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "IotDpsResource_DeletePrivateEndpointConnection",
+  "title": "PrivateEndpointConnection_Delete"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSGenerateVerificationCode.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSGenerateVerificationCode.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "If-Match": "AAAAAAAADGk=",
+    "api-version": "2026-10-01",
+    "certificateName": "cert",
+    "provisioningServiceName": "myFirstProvisioningService",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "cert",
+        "properties": {
+          "certificate": "MA==",
+          "created": "Thu, 12 Oct 2017 19:23:50 GMT",
+          "expiry": "Sat, 31 Dec 2039 23:59:59 GMT",
+          "isVerified": false,
+          "subject": "CN=andbucdevice1",
+          "thumbprint": "##############################",
+          "updated": "Thu, 12 Oct 2017 19:26:56 GMT",
+          "verificationCode": "##################################"
+        }
+      }
+    }
+  },
+  "operationId": "DpsCertificate_GenerateVerificationCode",
+  "title": "DPSGenerateVerificationCode"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSGet.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSGet.json
@@ -1,0 +1,50 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "provisioningServiceName": "myFirstProvisioningService",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myFirstProvisioningService",
+        "type": "Microsoft.Devices/ProvisioningServices",
+        "etag": "AAAAAAAADGk=",
+        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "aa80bd74-a3f0-4f14-b9da-99c5351cf9d5",
+          "tenantId": "f686d426-8d16-42db-81b7-ab578e110ccd",
+          "userAssignedIdentities": {
+            "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourcegroups/testrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testidentity": {
+              "clientId": "c38f618d-47f6-4260-8b3d-1dd8c130f323",
+              "principalId": "f1b0b133-10dc-4985-966f-a98a04675fe9"
+            }
+          }
+        },
+        "location": "eastus",
+        "properties": {
+          "allocationPolicy": "Hashed",
+          "authorizationPolicies": [],
+          "deviceProvisioningHostName": "global.azure-devices-provisioning.net",
+          "disableLocalAuth": false,
+          "idScope": "0ne00000012",
+          "portalOperationsHostName": "myFirstProvisioningService.services.azure-devices-provisioning.net",
+          "serviceOperationsHostName": "myFirstProvisioningService.azure-devices-provisioning.net",
+          "state": "Active"
+        },
+        "resourcegroup": "myResourceGroup",
+        "sku": {
+          "name": "S1",
+          "capacity": 1,
+          "tier": "Standard"
+        },
+        "subscriptionid": "91d12660-3dec-467a-be2a-213b5544ddc0",
+        "tags": {}
+      }
+    }
+  },
+  "operationId": "IotDpsResource_Get",
+  "title": "DPSGet"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSGetCertificate.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSGetCertificate.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "certificateName": "cert",
+    "provisioningServiceName": "myFirstProvisioningService",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "cert",
+        "type": "Microsoft.Devices/ProvisioningServices/Certificates",
+        "etag": "AAAAAAExpNs=",
+        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/IotHubs/andbuc-hub/certificates/cert",
+        "properties": {
+          "certificate": "MA==",
+          "created": "Thu, 12 Oct 2017 19:23:50 GMT",
+          "expiry": "Sat, 31 Dec 2039 23:59:59 GMT",
+          "isVerified": false,
+          "subject": "CN=testdevice1",
+          "thumbprint": "97388663832D0393C9246CAB4FBA2C8677185A25",
+          "updated": "Thu, 12 Oct 2017 19:23:50 GMT"
+        }
+      }
+    }
+  },
+  "operationId": "DpsCertificate_Get",
+  "title": "DPSGetCertificate"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSGetCertificates.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSGetCertificates.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "provisioningServiceName": "myFirstProvisioningService",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "cert",
+            "type": "Microsoft.Devices/ProvisioningServices/Certificates",
+            "etag": "AAAAAAExpNs=",
+            "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/IotHubs/andbuc-hub/certificates/cert",
+            "properties": {
+              "certificate": "MA==",
+              "created": "Thu, 12 Oct 2017 19:23:50 GMT",
+              "expiry": "Sat, 31 Dec 2039 23:59:59 GMT",
+              "isVerified": false,
+              "subject": "CN=testdevice1",
+              "thumbprint": "97388663832D0393C9246CAB4FBA2C8677185A25",
+              "updated": "Thu, 12 Oct 2017 19:23:50 GMT"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DpsCertificate_List",
+  "title": "DPSGetCertificates"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSGetKey.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSGetKey.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "keyName": "testKey",
+    "provisioningServiceName": "myFirstProvisioningService",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keyName": "testKey",
+        "primaryKey": "##################################",
+        "rights": "RegistrationStatusWrite",
+        "secondaryKey": "################################"
+      }
+    }
+  },
+  "operationId": "IotDpsResource_ListKeysForKeyName",
+  "title": "DPSGetKey"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSGetOperationResult.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSGetOperationResult.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "operationId": "MTY5OTNmZDctODI5Yy00N2E2LTkxNDQtMDU1NGIyYzY1ZjRl",
+    "api-version": "2026-10-01",
+    "asyncinfo": "1508265712453",
+    "provisioningServiceName": "myFirstProvisioningService",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "status": "Succeeded"
+      }
+    }
+  },
+  "operationId": "IotDpsResource_GetOperationResult",
+  "title": "DPSGetOperationResult"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSGetPrivateEndpointConnection.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSGetPrivateEndpointConnection.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "privateEndpointConnectionName": "myPrivateEndpointConnection",
+    "resourceGroupName": "myResourceGroup",
+    "resourceName": "myFirstProvisioningService",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myPrivateEndpointConnection",
+        "type": "Microsoft.Devices/ProvisioningServices/PrivateEndpointConnections",
+        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService/PrivateEndpointConnections/myPrivateEndpointConnection",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/a9eba280-4734-4d49-878f-b5549d1d0453/resourceGroups/networkResourceGroup/providers/Microsoft.Network/privateEndpoints/myPrivateEndpoint"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Please approve my request!",
+            "actionsRequired": "None",
+            "status": "Pending"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "IotDpsResource_GetPrivateEndpointConnection",
+  "title": "PrivateEndpointConnection_Get"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSGetPrivateLinkResources.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSGetPrivateLinkResources.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "groupId": "iotDps",
+    "resourceGroupName": "myResourceGroup",
+    "resourceName": "myFirstProvisioningService",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "iotDps",
+        "type": "Microsoft.Devices/ProvisioningServices/PrivateLinkResources",
+        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService/PrivateLinkResources/iotDps",
+        "properties": {
+          "groupId": "iotDps",
+          "requiredMembers": [
+            "iotDps"
+          ],
+          "requiredZoneNames": [
+            "privatelink.azure-devices-provisioning.net"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "IotDpsResource_GetPrivateLinkResources",
+  "title": "PrivateLinkResources_List"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSGetValidSku.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSGetValidSku.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "provisioningServiceName": "myFirstProvisioningService",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "S1"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "IotDpsResource_listValidSkus",
+  "title": "DPSGetValidSku"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSListByResourceGroup.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSListByResourceGroup.json
@@ -1,0 +1,87 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "myFirstProvisioningService",
+            "type": "Microsoft.Devices/ProvisioningServices",
+            "etag": "AAAAAAAADGk=",
+            "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService",
+            "identity": {
+              "type": "SystemAssigned,UserAssigned",
+              "principalId": "aa80bd74-a3f0-4f14-b9da-99c5351cf9d5",
+              "tenantId": "f686d426-8d16-42db-81b7-ab578e110ccd",
+              "userAssignedIdentities": {
+                "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourcegroups/testrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testidentity": {
+                  "clientId": "c38f618d-47f6-4260-8b3d-1dd8c130f323",
+                  "principalId": "f1b0b133-10dc-4985-966f-a98a04675fe9"
+                }
+              }
+            },
+            "location": "eastus",
+            "properties": {
+              "allocationPolicy": "Hashed",
+              "deviceProvisioningHostName": "global.azure-devices-provisioning.net",
+              "disableLocalAuth": false,
+              "idScope": "0ne00000012",
+              "portalOperationsHostName": "myFirstProvisioningService.services.azure-devices-provisioning.net",
+              "serviceOperationsHostName": "myFirstProvisioningService.azure-devices-provisioning.net",
+              "state": "Active"
+            },
+            "resourcegroup": "myResourceGroup",
+            "sku": {
+              "name": "S1",
+              "capacity": 1,
+              "tier": "Standard"
+            },
+            "subscriptionid": "91d12660-3dec-467a-be2a-213b5544ddc0",
+            "tags": {}
+          },
+          {
+            "name": "mySecondProvisioningService",
+            "type": "Microsoft.Devices/ProvisioningServices",
+            "etag": "AAAAAAAADGk=",
+            "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/mySecondProvisioningService",
+            "identity": {
+              "type": "SystemAssigned,UserAssigned",
+              "principalId": "01341f2b-d497-4117-b5c1-1f1d50b25444",
+              "tenantId": "f686d426-8d16-42db-81b7-ab578e110ccd",
+              "userAssignedIdentities": {
+                "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourcegroups/testrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testidentity2": {
+                  "clientId": "8cd6d250-17dd-4c1b-9847-225237b94c55",
+                  "principalId": "8785a11f-848a-4d5d-a55b-e381b9e15512"
+                }
+              }
+            },
+            "location": "eastus",
+            "properties": {
+              "allocationPolicy": "Hashed",
+              "deviceProvisioningHostName": "global.azure-devices-provisioning.net",
+              "disableLocalAuth": false,
+              "idScope": "0ne00000012",
+              "portalOperationsHostName": "myFirstProvisioningService.services.azure-devices-provisioning.net",
+              "serviceOperationsHostName": "mySecondProvisioningService.azure-devices-provisioning.net",
+              "state": "Active"
+            },
+            "resourcegroup": "myResourceGroup",
+            "sku": {
+              "name": "S1",
+              "capacity": 1,
+              "tier": "Standard"
+            },
+            "subscriptionid": "91d12660-3dec-467a-be2a-213b5544ddc0",
+            "tags": {}
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "IotDpsResource_ListByResourceGroup",
+  "title": "DPSListByResourceGroup"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSListBySubscription.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSListBySubscription.json
@@ -1,0 +1,86 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "myFirstProvisioningService",
+            "type": "Microsoft.Devices/ProvisioningServices",
+            "etag": "AAAAAAAADGk=",
+            "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService",
+            "identity": {
+              "type": "SystemAssigned,UserAssigned",
+              "principalId": "aa80bd74-a3f0-4f14-b9da-99c5351cf9d5",
+              "tenantId": "f686d426-8d16-42db-81b7-ab578e110ccd",
+              "userAssignedIdentities": {
+                "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourcegroups/testrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testidentity": {
+                  "clientId": "c38f618d-47f6-4260-8b3d-1dd8c130f323",
+                  "principalId": "f1b0b133-10dc-4985-966f-a98a04675fe9"
+                }
+              }
+            },
+            "location": "eastus",
+            "properties": {
+              "allocationPolicy": "Hashed",
+              "deviceProvisioningHostName": "global.azure-devices-provisioning.net",
+              "disableLocalAuth": false,
+              "idScope": "0ne00000012",
+              "portalOperationsHostName": "myFirstProvisioningService.services.azure-devices-provisioning.net",
+              "serviceOperationsHostName": "myFirstProvisioningService.azure-devices-provisioning.net",
+              "state": "Active"
+            },
+            "resourcegroup": "myResourceGroup",
+            "sku": {
+              "name": "S1",
+              "capacity": 1,
+              "tier": "Standard"
+            },
+            "subscriptionid": "91d12660-3dec-467a-be2a-213b5544ddc0",
+            "tags": {}
+          },
+          {
+            "name": "mySecondProvisioningService",
+            "type": "Microsoft.Devices/ProvisioningServices",
+            "etag": "AAAAAAAADGk=",
+            "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/mySecondProvisioningService",
+            "identity": {
+              "type": "SystemAssigned,UserAssigned",
+              "principalId": "01341f2b-d497-4117-b5c1-1f1d50b25444",
+              "tenantId": "f686d426-8d16-42db-81b7-ab578e110ccd",
+              "userAssignedIdentities": {
+                "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourcegroups/testrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testidentity2": {
+                  "clientId": "8cd6d250-17dd-4c1b-9847-225237b94c55",
+                  "principalId": "8785a11f-848a-4d5d-a55b-e381b9e15512"
+                }
+              }
+            },
+            "location": "eastus",
+            "properties": {
+              "allocationPolicy": "Hashed",
+              "deviceProvisioningHostName": "global.azure-devices-provisioning.net",
+              "disableLocalAuth": false,
+              "idScope": "0ne00000012",
+              "portalOperationsHostName": "myFirstProvisioningService.services.azure-devices-provisioning.net",
+              "serviceOperationsHostName": "myFirstProvisioningService.azure-devices-provisioning.net",
+              "state": "Active"
+            },
+            "resourcegroup": "myResourceGroup",
+            "sku": {
+              "name": "S1",
+              "capacity": 1,
+              "tier": "Standard"
+            },
+            "subscriptionid": "91d12660-3dec-467a-be2a-213b5544ddc0",
+            "tags": {}
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "IotDpsResource_ListBySubscription",
+  "title": "DPSListBySubscription"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSListKeys.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSListKeys.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "provisioningServiceName": "myFirstProvisioningService",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "keyName": "key1",
+            "primaryKey": "#####################################",
+            "rights": "ServiceConfig",
+            "secondaryKey": "###################################"
+          },
+          {
+            "keyName": "key2",
+            "primaryKey": "#######################################",
+            "rights": "ServiceConfig",
+            "secondaryKey": "####################################="
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "IotDpsResource_ListKeys",
+  "title": "DPSListKeys"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSListPrivateEndpointConnections.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSListPrivateEndpointConnections.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "resourceGroupName": "myResourceGroup",
+    "resourceName": "myFirstProvisioningService",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": [
+        {
+          "name": "myPrivateEndpointConnection",
+          "type": "Microsoft.Devices/ProvisioningServices/PrivateEndpointConnections",
+          "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService/PrivateEndpointConnections/myPrivateEndpointConnection",
+          "properties": {
+            "privateEndpoint": {
+              "id": "/subscriptions/a9eba280-4734-4d49-878f-b5549d1d0453/resourceGroups/networkResourceGroup/providers/Microsoft.Network/privateEndpoints/myPrivateEndpoint"
+            },
+            "privateLinkServiceConnectionState": {
+              "description": "Please approve my request!",
+              "actionsRequired": "None",
+              "status": "Pending"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "operationId": "IotDpsResource_ListPrivateEndpointConnections",
+  "title": "PrivateEndpointConnections_List"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSListPrivateLinkResources.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSListPrivateLinkResources.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "resourceGroupName": "myResourceGroup",
+    "resourceName": "myFirstProvisioningService",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "iotDps",
+            "type": "Microsoft.Devices/ProvisioningServices/PrivateLinkResources",
+            "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService/PrivateLinkResources/iotDps",
+            "properties": {
+              "groupId": "iotDps",
+              "requiredMembers": [
+                "iotDps"
+              ],
+              "requiredZoneNames": [
+                "privatelink.azure-devices-provisioning.net"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "IotDpsResource_ListPrivateLinkResources",
+  "title": "PrivateLinkResources_List"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSOperations.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSOperations.json
@@ -1,0 +1,295 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.Devices/register/action",
+            "display": {
+              "operation": "Register Resource Provider",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/IotHubs/diagnosticSettings/read",
+            "display": {
+              "operation": "Get Diagnostic Setting",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/IotHubs/diagnosticSettings/write",
+            "display": {
+              "operation": "Set Diagnostic Setting",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/IotHubs/metricDefinitions/read",
+            "display": {
+              "operation": "Read IotHub service metric definitions",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/IotHubs/logDefinitions/read",
+            "display": {
+              "operation": "Read IotHub service log definitions",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/operations/Read",
+            "display": {
+              "operation": "Get All ResourceProvider Operations",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/checkNameAvailability/Action",
+            "display": {
+              "operation": "Check If IotHub name is available",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/usages/Read",
+            "display": {
+              "operation": "Get Subscription Usages",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/iotHubs/Read",
+            "display": {
+              "operation": "Get IotHub(s)",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/iotHubs/Write",
+            "display": {
+              "operation": "Create or update IotHub Resource",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/iotHubs/Delete",
+            "display": {
+              "operation": "Delete IotHub Resource",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/iotHubs/iotHubStats/Read",
+            "display": {
+              "operation": "Get IotHub Statistics",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/iotHubs/skus/Read",
+            "display": {
+              "operation": "Get valid IotHub Skus",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/iotHubs/listkeys/Action",
+            "display": {
+              "operation": "Get all IotHub Keys",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/iotHubs/iotHubKeys/listkeys/Action",
+            "display": {
+              "operation": "Get IotHub Key for the given name",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/iotHubs/eventHubEndpoints/consumerGroups/Write",
+            "display": {
+              "operation": "Create EventHub Consumer Group",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/iotHubs/eventHubEndpoints/consumerGroups/Read",
+            "display": {
+              "operation": "Get EventHub Consumer Group(s)",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/iotHubs/eventHubEndpoints/consumerGroups/Delete",
+            "display": {
+              "operation": "Delete EventHub Consumer Group",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/iotHubs/exportDevices/Action",
+            "display": {
+              "operation": "Export Devices",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/iotHubs/importDevices/Action",
+            "display": {
+              "operation": "Import Devices",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/iotHubs/jobs/Read",
+            "display": {
+              "operation": "Get the Job(s) on IotHub",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/iotHubs/quotaMetrics/Read",
+            "display": {
+              "operation": "Get Quota Metrics",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/iotHubs/routing/routes/$testall/Action",
+            "display": {
+              "operation": "Routing Rule Test All",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/iotHubs/routing/routes/$testnew/Action",
+            "display": {
+              "operation": "Routing Rule Test Route",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/iotHubs/routingEndpointsHealth/Read",
+            "display": {
+              "operation": "Get Endpoint Health",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/ProvisioningServices/diagnosticSettings/read",
+            "display": {
+              "operation": "Get Diagnostic Setting",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/ProvisioningServices/diagnosticSettings/write",
+            "display": {
+              "operation": "Set Diagnostic Setting",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/ProvisioningServices/metricDefinitions/read",
+            "display": {
+              "operation": "Read DPS service metric definitions",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/ProvisioningServices/logDefinitions/read",
+            "display": {
+              "operation": "Read DPS service log definitions",
+              "provider": "Microsoft Devices",
+              "resource": "IotHubs"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/checkProvisioningServiceNameAvailability/Action",
+            "display": {
+              "operation": "Check If Provisioning Service name is available",
+              "provider": "Microsoft Devices",
+              "resource": "ProvisioningServives"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/provisioningServices/Read",
+            "display": {
+              "operation": "Get Provisioning Service resource",
+              "provider": "Microsoft Devices",
+              "resource": "ProvisioningServices"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/provisioningServices/Write",
+            "display": {
+              "operation": "Create Provisioning Service resource",
+              "provider": "Microsoft Devices",
+              "resource": "ProvisioningServices"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/provisioningServices/Delete",
+            "display": {
+              "operation": "Delete Provisioning Service resource",
+              "provider": "Microsoft Devices",
+              "resource": "ProvisioningServices"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/provisioningServices/skus/Read",
+            "display": {
+              "operation": "Delete Provisioning Service resource",
+              "provider": "Microsoft Devices",
+              "resource": "ProvisioningServices"
+            }
+          },
+          {
+            "name": "Microsoft.Devices/provisioningServices/listkeys/Action",
+            "display": {
+              "operation": "get security related metadata",
+              "provider": "Microsoft Devices",
+              "resource": "ProvisioningServices"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Operations_List",
+  "title": "DPSOperations"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSPatch.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSPatch.json
@@ -1,0 +1,58 @@
+{
+  "parameters": {
+    "type": "Microsoft.Devices/ProvisioningServices",
+    "ProvisioningServiceTags": {
+      "tags": {
+        "foo": "bar"
+      }
+    },
+    "api-version": "2026-10-01",
+    "location": "East US",
+    "provisioningServiceName": "myFirstProvisioningService",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myFirstProvisioningService",
+        "type": "Microsoft.Devices/ProvisioningServices",
+        "etag": "AAAAAAAADGk=",
+        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "aa80bd74-a3f0-4f14-b9da-99c5351cf9d5",
+          "tenantId": "f686d426-8d16-42db-81b7-ab578e110ccd",
+          "userAssignedIdentities": {
+            "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourcegroups/testrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testidentity": {
+              "clientId": "c38f618d-47f6-4260-8b3d-1dd8c130f323",
+              "principalId": "f1b0b133-10dc-4985-966f-a98a04675fe9"
+            }
+          }
+        },
+        "location": "eastus",
+        "properties": {
+          "allocationPolicy": "Hashed",
+          "deviceProvisioningHostName": "global.azure-devices-provisioning.net",
+              "disableLocalAuth": false,
+          "idScope": "0ne00000012",
+          "portalOperationsHostName": "myFirstProvisioningService.services.azure-devices-provisioning.net",
+          "serviceOperationsHostName": "myFirstProvisioningService.azure-devices-provisioning.net",
+          "state": "Active"
+        },
+        "resourcegroup": "myResourceGroup",
+        "sku": {
+          "name": "S1",
+          "capacity": 1,
+          "tier": "Standard"
+        },
+        "subscriptionid": "91d12660-3dec-467a-be2a-213b5544ddc0",
+        "tags": {
+          "foo": "bar"
+        }
+      }
+    }
+  },
+  "operationId": "IotDpsResource_Update",
+  "title": "DPSPatch"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSUpdate.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSUpdate.json
@@ -1,0 +1,108 @@
+{
+  "parameters": {
+    "api-version": "2026-10-01",
+    "iotDpsDescription": {
+      "identity": {
+        "type": "SystemAssigned,UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourcegroups/testrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testidentity": {}
+        }
+      },
+      "location": "East US",
+      "properties": {
+        "enableDataResidency": false,
+        "disableLocalAuth": false
+      },
+      "sku": {
+        "name": "S1",
+        "capacity": 1
+      },
+      "tags": {}
+    },
+    "provisioningServiceName": "myFirstProvisioningService",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myFirstProvisioningService",
+        "type": "Microsoft.Devices/ProvisioningServices",
+        "etag": "AAAAAAAADGk=",
+        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups//providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "aa80bd74-a3f0-4f14-b9da-99c5351cf9d5",
+          "tenantId": "f686d426-8d16-42db-81b7-ab578e110ccd",
+          "userAssignedIdentities": {
+            "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourcegroups/testrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testidentity": {
+              "clientId": "c38f618d-47f6-4260-8b3d-1dd8c130f323",
+              "principalId": "f1b0b133-10dc-4985-966f-a98a04675fe9"
+            }
+          }
+        },
+        "location": "eastus",
+        "properties": {
+          "allocationPolicy": "Hashed",
+          "authorizationPolicies": [],
+          "deviceProvisioningHostName": "global.azure-devices-provisioning.net",
+          "disableLocalAuth": false,
+          "enableDataResidency": false,
+          "idScope": "0ne00000012",
+          "portalOperationsHostName": "myFirstProvisioningService.services.azure-devices-provisioning.net",
+          "serviceOperationsHostName": "myFirstProvisioningService.azure-devices-provisioning.net",
+          "state": "Active"
+        },
+        "resourcegroup": "myResourceGroup",
+        "sku": {
+          "name": "S1",
+          "capacity": 1,
+          "tier": "Standard"
+        },
+        "subscriptionid": "91d12660-3dec-467a-be2a-213b5544ddc0",
+        "tags": {}
+      }
+    },
+    "201": {
+      "body": {
+        "name": "myFirstProvisioningService",
+        "type": "Microsoft.Devices/ProvisioningServices",
+        "etag": "AAAAAAAADGk=",
+        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups//providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "aa80bd74-a3f0-4f14-b9da-99c5351cf9d5",
+          "tenantId": "f686d426-8d16-42db-81b7-ab578e110ccd",
+          "userAssignedIdentities": {
+            "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourcegroups/testrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testidentity": {
+              "clientId": "c38f618d-47f6-4260-8b3d-1dd8c130f323",
+              "principalId": "f1b0b133-10dc-4985-966f-a98a04675fe9"
+            }
+          }
+        },
+        "location": "eastus",
+        "properties": {
+          "allocationPolicy": "Hashed",
+          "authorizationPolicies": [],
+          "deviceProvisioningHostName": "global.azure-devices-provisioning.net",
+          "disableLocalAuth": false,
+          "enableDataResidency": false,
+          "idScope": "0ne00000012",
+          "portalOperationsHostName": "myFirstProvisioningService.services.azure-devices-provisioning.net",
+          "serviceOperationsHostName": "myFirstProvisioningService.azure-devices-provisioning.net",
+          "state": "Active"
+        },
+        "resourcegroup": "myResourceGroup",
+        "sku": {
+          "name": "S1",
+          "capacity": 1,
+          "tier": "Standard"
+        },
+        "subscriptionid": "91d12660-3dec-467a-be2a-213b5544ddc0",
+        "tags": {}
+      }
+    }
+  },
+  "operationId": "IotDpsResource_CreateOrUpdate",
+  "title": "DPSUpdate"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSVerifyCertificate.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/examples/DPSVerifyCertificate.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "If-Match": "AAAAAAAADGk=",
+    "api-version": "2026-10-01",
+    "certificateName": "cert",
+    "provisioningServiceName": "myFirstProvisioningService",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "91d12660-3dec-467a-be2a-213b5544ddc0",
+    "request": {
+      "certificate": "#####################################"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "cert",
+        "type": "Microsoft.Devices/ProvisioningServices/Certificates",
+        "etag": "AAAAAAExpTQ=",
+        "id": "/subscriptions/91d12660-3dec-467a-be2a-213b5544ddc0/resourceGroups/myResourceGroup/providers/Microsoft.Devices/ProvisioningServices/myFirstProvisioningService/certificates/cert",
+        "properties": {
+          "certificate": "MA==",
+          "created": "Thu, 12 Oct 2017 19:23:50 GMT",
+          "expiry": "Sat, 31 Dec 2039 23:59:59 GMT",
+          "isVerified": true,
+          "subject": "CN=andbucdevice1",
+          "thumbprint": "97388663832D0393C9246CAB4FBA2C8677185A25",
+          "updated": "Thu, 12 Oct 2017 19:26:56 GMT"
+        }
+      }
+    }
+  },
+  "operationId": "DpsCertificate_VerifyCertificate",
+  "title": "DPSVerifyCertificate"
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/iotdps.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/iotdps.json
@@ -1,0 +1,2767 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "iotDpsClient",
+    "version": "2026-10-01",
+    "description": "API for using the Azure IoT Hub Device Provisioning Service features.",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Operations"
+    },
+    {
+      "name": "CertificateResponses"
+    },
+    {
+      "name": "ProvisioningServiceDescriptions"
+    },
+    {
+      "name": "GroupIdInformations"
+    },
+    {
+      "name": "PrivateEndpointConnections"
+    }
+  ],
+  "paths": {
+    "/providers/Microsoft.Devices/operations": {
+      "get": {
+        "operationId": "Operations_List",
+        "tags": [
+          "Operations"
+        ],
+        "description": "List the operations for the provider",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/OperationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DPSOperations": {
+            "$ref": "./examples/DPSOperations.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Devices/checkProvisioningServiceNameAvailability": {
+      "post": {
+        "operationId": "IotDpsResource_CheckProvisioningServiceNameAvailability",
+        "summary": "Check if a provisioning service name is available.",
+        "description": "Check if a provisioning service name is available. This will validate if the name is syntactically valid and if the name is usable",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "arguments",
+            "in": "body",
+            "description": "The request body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OperationInputs"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/NameAvailabilityInfo"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DPSCheckName": {
+            "$ref": "./examples/DPSCheckNameAvailability.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Devices/provisioningServices": {
+      "get": {
+        "operationId": "IotDpsResource_ListBySubscription",
+        "tags": [
+          "ProvisioningServiceDescriptions"
+        ],
+        "description": "List all the provisioning services for a given subscription id.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ProvisioningServiceDescriptionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DPSListBySubscription": {
+            "$ref": "./examples/DPSListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/provisioningServices": {
+      "get": {
+        "operationId": "IotDpsResource_ListByResourceGroup",
+        "tags": [
+          "ProvisioningServiceDescriptions"
+        ],
+        "description": "Get a list of all provisioning services in the given resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ProvisioningServiceDescriptionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DPSListByResourceGroup": {
+            "$ref": "./examples/DPSListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/provisioningServices/{provisioningServiceName}": {
+      "get": {
+        "operationId": "IotDpsResource_Get",
+        "tags": [
+          "ProvisioningServiceDescriptions"
+        ],
+        "description": "Get the metadata of the provisioning service without SAS keys.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "provisioningServiceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ProvisioningServiceDescription"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DPSGet": {
+            "$ref": "./examples/DPSGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "IotDpsResource_CreateOrUpdate",
+        "tags": [
+          "ProvisioningServiceDescriptions"
+        ],
+        "description": "Create or update the metadata of the provisioning service. The usual pattern to modify a property is to retrieve the provisioning service metadata and security metadata, and then combine them with the modified values in a new body to update the provisioning service.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "provisioningServiceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "iotDpsDescription",
+            "in": "body",
+            "description": "Description of the provisioning service to create or update.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ProvisioningServiceDescription"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ProvisioningServiceDescription' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ProvisioningServiceDescription"
+            }
+          },
+          "201": {
+            "description": "Resource 'ProvisioningServiceDescription' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ProvisioningServiceDescription"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DPSCreate": {
+            "$ref": "./examples/DPSCreate.json"
+          },
+          "DPSCreateWithIotHub": {
+            "$ref": "./examples/DPSCreateWithIotHub.json"
+          },
+          "DPSCreateWithNamespace": {
+            "$ref": "./examples/DPSCreateWithNamespace.json"
+          },
+          "DPSUpdate": {
+            "$ref": "./examples/DPSUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "IotDpsResource_Update",
+        "tags": [
+          "ProvisioningServiceDescriptions"
+        ],
+        "description": "Update an existing provisioning service's tags. to update other fields use the CreateOrUpdate method",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "provisioningServiceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ProvisioningServiceTags",
+            "in": "body",
+            "description": "Updated tag information to set into the provisioning service instance.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/TagsResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ProvisioningServiceDescription"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DPSPatch": {
+            "$ref": "./examples/DPSPatch.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "IotDpsResource_Delete",
+        "tags": [
+          "ProvisioningServiceDescriptions"
+        ],
+        "description": "Deletes the Provisioning Service.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "provisioningServiceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "404": {
+            "description": "The Azure resource is not found"
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DPSDelete": {
+            "$ref": "./examples/DPSDelete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/provisioningServices/{provisioningServiceName}/certificates": {
+      "get": {
+        "operationId": "DpsCertificate_List",
+        "tags": [
+          "CertificateResponses"
+        ],
+        "description": "Get all the certificates tied to the provisioning service.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "provisioningServiceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CertificateListDescription"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DPSGetCertificates": {
+            "$ref": "./examples/DPSGetCertificates.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/provisioningServices/{provisioningServiceName}/certificates/{certificateName}": {
+      "get": {
+        "operationId": "DpsCertificate_Get",
+        "tags": [
+          "CertificateResponses"
+        ],
+        "description": "Get the certificate from the provisioning service.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "provisioningServiceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "certificateName",
+            "in": "path",
+            "description": "Name of the certificate to retrieve.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag of the certificate.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "ifMatch"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CertificateResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DPSGetCertificate": {
+            "$ref": "./examples/DPSGetCertificate.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "DpsCertificate_CreateOrUpdate",
+        "tags": [
+          "CertificateResponses"
+        ],
+        "description": "Add new certificate or update an existing certificate.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "provisioningServiceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "certificateName",
+            "in": "path",
+            "description": "Name of the certificate to retrieve.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag of the certificate. This is required to update an existing certificate, and ignored while creating a brand new certificate.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "ifMatch"
+          },
+          {
+            "name": "certificateDescription",
+            "in": "body",
+            "description": "The certificate body.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CertificateResponse"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'CertificateResponse' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/CertificateResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DPSCreateOrUpdateCertificate": {
+            "$ref": "./examples/DPSCertificateCreateOrUpdate.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "DpsCertificate_Delete",
+        "tags": [
+          "CertificateResponses"
+        ],
+        "description": "Deletes the specified certificate associated with the Provisioning Service",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "provisioningServiceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "certificateName",
+            "in": "path",
+            "description": "Name of the certificate to retrieve.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag of the certificate",
+            "required": true,
+            "type": "string",
+            "x-ms-client-name": "ifMatch"
+          },
+          {
+            "name": "certificate.name",
+            "in": "query",
+            "description": "This is optional, and it is the Common Name of the certificate.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "certificate.rawBytes",
+            "in": "query",
+            "description": "Raw data within the certificate.",
+            "required": false,
+            "type": "string",
+            "format": "byte",
+            "x-ms-client-name": "certificateRawBytes"
+          },
+          {
+            "name": "certificate.isVerified",
+            "in": "query",
+            "description": "Indicates if certificate has been verified by owner of the private key.",
+            "required": false,
+            "type": "boolean",
+            "x-ms-client-name": "certificateIsVerified"
+          },
+          {
+            "name": "certificate.purpose",
+            "in": "query",
+            "description": "A description that mentions the purpose of the certificate.",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "clientAuthentication",
+              "serverAuthentication"
+            ],
+            "x-ms-enum": {
+              "name": "CertificatePurpose",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "clientAuthentication",
+                  "value": "clientAuthentication"
+                },
+                {
+                  "name": "serverAuthentication",
+                  "value": "serverAuthentication"
+                }
+              ]
+            },
+            "x-ms-client-name": "certificatePurpose"
+          },
+          {
+            "name": "certificate.created",
+            "in": "query",
+            "description": "Time the certificate is created.",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "x-ms-client-name": "certificateCreated"
+          },
+          {
+            "name": "certificate.lastUpdated",
+            "in": "query",
+            "description": "Certificate last updated time.",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "x-ms-client-name": "certificateLastUpdated"
+          },
+          {
+            "name": "certificate.hasPrivateKey",
+            "in": "query",
+            "description": "Indicates if the certificate contains a private key.",
+            "required": false,
+            "type": "boolean",
+            "x-ms-client-name": "certificateHasPrivateKey"
+          },
+          {
+            "name": "certificate.nonce",
+            "in": "query",
+            "description": "Random number generated to indicate Proof of Possession.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "certificateNonce"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DPSDeleteCertificate": {
+            "$ref": "./examples/DPSDeleteCertificate.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/provisioningServices/{provisioningServiceName}/certificates/{certificateName}/generateVerificationCode": {
+      "post": {
+        "operationId": "DpsCertificate_GenerateVerificationCode",
+        "tags": [
+          "CertificateResponses"
+        ],
+        "description": "Generate verification code for Proof of Possession.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "provisioningServiceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "certificateName",
+            "in": "path",
+            "description": "Name of the certificate to retrieve.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag of the certificate. This is required to update an existing certificate, and ignored while creating a brand new certificate.",
+            "required": true,
+            "type": "string",
+            "x-ms-client-name": "ifMatch"
+          },
+          {
+            "name": "certificate.name",
+            "in": "query",
+            "description": "Common Name for the certificate.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "certificate.rawBytes",
+            "in": "query",
+            "description": "Raw data of certificate.",
+            "required": false,
+            "type": "string",
+            "format": "byte",
+            "x-ms-client-name": "certificateRawBytes"
+          },
+          {
+            "name": "certificate.isVerified",
+            "in": "query",
+            "description": "Indicates if the certificate has been verified by owner of the private key.",
+            "required": false,
+            "type": "boolean",
+            "x-ms-client-name": "certificateIsVerified"
+          },
+          {
+            "name": "certificate.purpose",
+            "in": "query",
+            "description": "Description mentioning the purpose of the certificate.",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "clientAuthentication",
+              "serverAuthentication"
+            ],
+            "x-ms-enum": {
+              "name": "CertificatePurpose",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "clientAuthentication",
+                  "value": "clientAuthentication"
+                },
+                {
+                  "name": "serverAuthentication",
+                  "value": "serverAuthentication"
+                }
+              ]
+            },
+            "x-ms-client-name": "certificatePurpose"
+          },
+          {
+            "name": "certificate.created",
+            "in": "query",
+            "description": "Time the certificate is created.",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "x-ms-client-name": "certificateCreated"
+          },
+          {
+            "name": "certificate.lastUpdated",
+            "in": "query",
+            "description": "Certificate last updated time.",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "x-ms-client-name": "certificateLastUpdated"
+          },
+          {
+            "name": "certificate.hasPrivateKey",
+            "in": "query",
+            "description": "Indicates if the certificate contains private key.",
+            "required": false,
+            "type": "boolean",
+            "x-ms-client-name": "certificateHasPrivateKey"
+          },
+          {
+            "name": "certificate.nonce",
+            "in": "query",
+            "description": "Random number generated to indicate Proof of Possession.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "certificateNonce"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VerificationCodeResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DPSGenerateVerificationCode": {
+            "$ref": "./examples/DPSGenerateVerificationCode.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/provisioningServices/{provisioningServiceName}/certificates/{certificateName}/verify": {
+      "post": {
+        "operationId": "DpsCertificate_VerifyCertificate",
+        "tags": [
+          "CertificateResponses"
+        ],
+        "description": "Verifies the certificate's private key possession by providing the leaf cert issued by the verifying pre uploaded certificate.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "provisioningServiceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "certificateName",
+            "in": "path",
+            "description": "Name of the certificate to retrieve.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag of the certificate.",
+            "required": true,
+            "type": "string",
+            "x-ms-client-name": "ifMatch"
+          },
+          {
+            "name": "certificate.name",
+            "in": "query",
+            "description": "Common Name for the certificate.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "certificate.rawBytes",
+            "in": "query",
+            "description": "Raw data of certificate.",
+            "required": false,
+            "type": "string",
+            "format": "byte",
+            "x-ms-client-name": "certificateRawBytes"
+          },
+          {
+            "name": "certificate.isVerified",
+            "in": "query",
+            "description": "Indicates if the certificate has been verified by owner of the private key.",
+            "required": false,
+            "type": "boolean",
+            "x-ms-client-name": "certificateIsVerified"
+          },
+          {
+            "name": "certificate.purpose",
+            "in": "query",
+            "description": "Describe the purpose of the certificate.",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "clientAuthentication",
+              "serverAuthentication"
+            ],
+            "x-ms-enum": {
+              "name": "CertificatePurpose",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "clientAuthentication",
+                  "value": "clientAuthentication"
+                },
+                {
+                  "name": "serverAuthentication",
+                  "value": "serverAuthentication"
+                }
+              ]
+            },
+            "x-ms-client-name": "certificatePurpose"
+          },
+          {
+            "name": "certificate.created",
+            "in": "query",
+            "description": "Time the certificate is created.",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "x-ms-client-name": "certificateCreated"
+          },
+          {
+            "name": "certificate.lastUpdated",
+            "in": "query",
+            "description": "Certificate last updated time.",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "x-ms-client-name": "certificateLastUpdated"
+          },
+          {
+            "name": "certificate.hasPrivateKey",
+            "in": "query",
+            "description": "Indicates if the certificate contains private key.",
+            "required": false,
+            "type": "boolean",
+            "x-ms-client-name": "certificateHasPrivateKey"
+          },
+          {
+            "name": "certificate.nonce",
+            "in": "query",
+            "description": "Random number generated to indicate Proof of Possession.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "certificateNonce"
+          },
+          {
+            "name": "request",
+            "in": "body",
+            "description": "The name of the certificate",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VerificationCodeRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CertificateResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DPSVerifyCertificate": {
+            "$ref": "./examples/DPSVerifyCertificate.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/provisioningServices/{provisioningServiceName}/keys/{keyName}/listkeys": {
+      "post": {
+        "operationId": "IotDpsResource_ListKeysForKeyName",
+        "tags": [
+          "ProvisioningServiceDescriptions"
+        ],
+        "description": "List primary and secondary keys for a specific key name",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "provisioningServiceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "keyName",
+            "in": "path",
+            "description": "Logical key name to get key-values for.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SharedAccessSignatureAuthorizationRuleAccessRightsDescription"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DPSGetKey": {
+            "$ref": "./examples/DPSGetKey.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/provisioningServices/{provisioningServiceName}/listkeys": {
+      "post": {
+        "operationId": "IotDpsResource_ListKeys",
+        "tags": [
+          "ProvisioningServiceDescriptions"
+        ],
+        "description": "List the primary and secondary keys for a provisioning service.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "provisioningServiceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SharedAccessSignatureAuthorizationRuleListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DPSListKeys": {
+            "$ref": "./examples/DPSListKeys.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/provisioningServices/{provisioningServiceName}/operationresults/{operationId}": {
+      "get": {
+        "operationId": "IotDpsResource_GetOperationResult",
+        "description": "Gets the status of a long running operation, such as create, update or delete a provisioning service.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "provisioningServiceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "operationId",
+            "in": "path",
+            "description": "Operation id corresponding to long running operation. Use this to poll for the status.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "asyncinfo",
+            "in": "query",
+            "description": "Async header used to poll on the status of the operation, obtained while creating the long running operation.",
+            "required": true,
+            "type": "string",
+            "default": "true"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AsyncOperationResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DPSGetOperationResult": {
+            "$ref": "./examples/DPSGetOperationResult.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/provisioningServices/{resourceName}/privateEndpointConnections": {
+      "get": {
+        "operationId": "IotDpsResource_ListPrivateEndpointConnections",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "List private endpoint connection properties",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnectionsList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PrivateEndpointConnections_List": {
+            "$ref": "./examples/DPSListPrivateEndpointConnections.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/provisioningServices/{resourceName}/privateEndpointConnections/{privateEndpointConnectionName}": {
+      "get": {
+        "operationId": "IotDpsResource_GetPrivateEndpointConnection",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "Get private endpoint connection properties",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The name of the private endpoint connection",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PrivateEndpointConnection_Get": {
+            "$ref": "./examples/DPSGetPrivateEndpointConnection.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "IotDpsResource_CreateOrUpdatePrivateEndpointConnection",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "Create or update the status of a private endpoint connection with the specified name",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The name of the private endpoint connection",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "privateEndpointConnection",
+            "in": "body",
+            "description": "The private endpoint connection with updated properties",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'PrivateEndpointConnection' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "201": {
+            "description": "Resource 'PrivateEndpointConnection' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PrivateEndpointConnection_CreateOrUpdate": {
+            "$ref": "./examples/DPSCreateOrUpdatePrivateEndpointConnection.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "IotDpsResource_DeletePrivateEndpointConnection",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "Delete private endpoint connection with the specified name",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The name of the private endpoint connection",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PrivateEndpointConnection_Delete": {
+            "$ref": "./examples/DPSDeletePrivateEndpointConnection.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/provisioningServices/{resourceName}/privateLinkResources": {
+      "get": {
+        "operationId": "IotDpsResource_ListPrivateLinkResources",
+        "tags": [
+          "GroupIdInformations"
+        ],
+        "description": "List private link resources for the given provisioning service",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateLinkResources"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PrivateLinkResources_List": {
+            "$ref": "./examples/DPSListPrivateLinkResources.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/provisioningServices/{resourceName}/privateLinkResources/{groupId}": {
+      "get": {
+        "operationId": "IotDpsResource_GetPrivateLinkResources",
+        "tags": [
+          "GroupIdInformations"
+        ],
+        "description": "Get the specified private link resource for the given provisioning service",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "groupId",
+            "in": "path",
+            "description": "The name of the private link resource",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/GroupIdInformation"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PrivateLinkResources_List": {
+            "$ref": "./examples/DPSGetPrivateLinkResources.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/provisioningServices/{provisioningServiceName}/skus": {
+      "get": {
+        "operationId": "IotDpsResource_listValidSkus",
+        "tags": [
+          "ProvisioningServiceDescriptions"
+        ],
+        "description": "Gets the list of valid SKUs and tiers for a provisioning service.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "provisioningServiceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/IotDpsSkuDefinitionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DPSGetValidSku": {
+            "$ref": "./examples/DPSGetValidSku.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "AccessRightsDescription": {
+      "type": "string",
+      "description": "Rights that this key has.",
+      "enum": [
+        "ServiceConfig",
+        "EnrollmentRead",
+        "EnrollmentWrite",
+        "DeviceConnect",
+        "RegistrationStatusRead",
+        "RegistrationStatusWrite"
+      ],
+      "x-ms-enum": {
+        "name": "AccessRightsDescription",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ServiceConfig",
+            "value": "ServiceConfig"
+          },
+          {
+            "name": "EnrollmentRead",
+            "value": "EnrollmentRead"
+          },
+          {
+            "name": "EnrollmentWrite",
+            "value": "EnrollmentWrite"
+          },
+          {
+            "name": "DeviceConnect",
+            "value": "DeviceConnect"
+          },
+          {
+            "name": "RegistrationStatusRead",
+            "value": "RegistrationStatusRead"
+          },
+          {
+            "name": "RegistrationStatusWrite",
+            "value": "RegistrationStatusWrite"
+          }
+        ]
+      }
+    },
+    "AllocationPolicy": {
+      "type": "string",
+      "description": "Allocation policy to be used by this provisioning service.",
+      "enum": [
+        "Hashed",
+        "GeoLatency",
+        "Static"
+      ],
+      "x-ms-enum": {
+        "name": "AllocationPolicy",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Hashed",
+            "value": "Hashed"
+          },
+          {
+            "name": "GeoLatency",
+            "value": "GeoLatency"
+          },
+          {
+            "name": "Static",
+            "value": "Static"
+          }
+        ]
+      }
+    },
+    "AsyncOperationResult": {
+      "type": "object",
+      "description": "Result of a long running operation.",
+      "properties": {
+        "status": {
+          "type": "string",
+          "description": "current status of a long running operation."
+        },
+        "error": {
+          "$ref": "#/definitions/ErrorMessage",
+          "description": "Error message containing code, description and details"
+        }
+      }
+    },
+    "CertificateListDescription": {
+      "type": "object",
+      "description": "The JSON-serialized array of Certificate objects.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The array of Certificate objects.",
+          "items": {
+            "$ref": "#/definitions/CertificateResponse"
+          }
+        }
+      }
+    },
+    "CertificateProperties": {
+      "type": "object",
+      "description": "The description of an X509 CA Certificate.",
+      "properties": {
+        "subject": {
+          "type": "string",
+          "description": "The certificate's subject name.",
+          "readOnly": true
+        },
+        "expiry": {
+          "type": "string",
+          "format": "date-time-rfc7231",
+          "description": "The certificate's expiration date and time.",
+          "readOnly": true
+        },
+        "thumbprint": {
+          "type": "string",
+          "description": "The certificate's thumbprint.",
+          "readOnly": true
+        },
+        "isVerified": {
+          "type": "boolean",
+          "description": "Determines whether certificate has been verified."
+        },
+        "certificate": {
+          "type": "string",
+          "format": "byte",
+          "description": "base-64 representation of X509 certificate .cer file or just .pem file content."
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time-rfc7231",
+          "description": "The certificate's creation date and time.",
+          "readOnly": true
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time-rfc7231",
+          "description": "The certificate's last update date and time.",
+          "readOnly": true
+        }
+      }
+    },
+    "CertificateResponse": {
+      "type": "object",
+      "description": "The X509 Certificate.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/CertificateProperties",
+          "description": "properties of a certificate"
+        },
+        "etag": {
+          "type": "string",
+          "description": "The entity tag.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "DeviceRegistryNamespaceAuthenticationType": {
+      "type": "string",
+      "description": "Device Registry Namespace MI authentication type: UserAssigned, SystemAssigned.",
+      "enum": [
+        "UserAssigned",
+        "SystemAssigned"
+      ],
+      "x-ms-enum": {
+        "name": "DeviceRegistryNamespaceAuthenticationType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "UserAssigned",
+            "value": "UserAssigned",
+            "description": "User assigned authentication type."
+          },
+          {
+            "name": "SystemAssigned",
+            "value": "SystemAssigned",
+            "description": "System assigned authentication type."
+          }
+        ]
+      }
+    },
+    "DeviceRegistryNamespaceDescription": {
+      "type": "object",
+      "description": "Description of the Device Registry namespace that is linked to the provisioning service.",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The ARM resource ID of the Device Registry namespace.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.DeviceRegistry/namespaces"
+              }
+            ]
+          }
+        },
+        "authenticationType": {
+          "$ref": "#/definitions/DeviceRegistryNamespaceAuthenticationType",
+          "description": "Device Registry Namespace MI authentication type: UserAssigned, SystemAssigned."
+        },
+        "selectedUserAssignedIdentityResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The selected user-assigned identity resource Id associated with Device Registry namespace. This is required when authenticationType is UserAssigned.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.ManagedIdentity/userAssignedIdentities"
+              }
+            ]
+          }
+        }
+      },
+      "required": [
+        "resourceId",
+        "authenticationType"
+      ]
+    },
+    "ErrorDetails": {
+      "type": "object",
+      "description": "Error details.",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The error code.",
+          "readOnly": true
+        },
+        "httpStatusCode": {
+          "type": "string",
+          "description": "The HTTP status code.",
+          "readOnly": true
+        },
+        "message": {
+          "type": "string",
+          "description": "The error message.",
+          "readOnly": true
+        },
+        "details": {
+          "type": "string",
+          "description": "The error details.",
+          "readOnly": true
+        }
+      }
+    },
+    "ErrorMessage": {
+      "type": "object",
+      "description": "Error response containing message and code.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "standard error code"
+        },
+        "message": {
+          "type": "string",
+          "description": "standard error description"
+        },
+        "details": {
+          "type": "string",
+          "description": "detailed summary of error"
+        }
+      }
+    },
+    "GroupIdInformation": {
+      "type": "object",
+      "description": "The group information for creating a private endpoint on a provisioning service",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/GroupIdInformationProperties",
+          "description": "The properties for a group information object"
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "GroupIdInformationProperties": {
+      "type": "object",
+      "description": "The properties for a group information object",
+      "properties": {
+        "groupId": {
+          "type": "string",
+          "description": "The group id"
+        },
+        "requiredMembers": {
+          "type": "array",
+          "description": "The required members for a specific group id",
+          "items": {
+            "type": "string"
+          }
+        },
+        "requiredZoneNames": {
+          "type": "array",
+          "description": "The required DNS zones for a specific group id",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "IotDpsPropertiesDescription": {
+      "type": "object",
+      "description": "the service specific properties of a provisioning service, including keys, linked iot hubs, current state, and system generated properties such as hostname and idScope",
+      "properties": {
+        "state": {
+          "$ref": "#/definitions/State",
+          "description": "Current state of the provisioning service."
+        },
+        "publicNetworkAccess": {
+          "$ref": "#/definitions/PublicNetworkAccess",
+          "description": "Whether requests from Public Network are allowed"
+        },
+        "ipFilterRules": {
+          "type": "array",
+          "description": "The IP filter rules.",
+          "items": {
+            "$ref": "#/definitions/IpFilterRule"
+          }
+        },
+        "privateEndpointConnections": {
+          "type": "array",
+          "description": "Private endpoint connections created on this IotHub",
+          "items": {
+            "$ref": "#/definitions/PrivateEndpointConnection"
+          }
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "The ARM provisioning state of the provisioning service."
+        },
+        "iotHubs": {
+          "type": "array",
+          "description": "List of IoT hubs associated with this provisioning service.",
+          "items": {
+            "$ref": "#/definitions/IotHubDefinitionDescription"
+          }
+        },
+        "deviceRegistryNamespace": {
+          "$ref": "#/definitions/DeviceRegistryNamespaceDescription",
+          "description": "The Device Registry namespace that is linked to the provisioning service."
+        },
+        "allocationPolicy": {
+          "$ref": "#/definitions/AllocationPolicy",
+          "description": "Allocation policy to be used by this provisioning service."
+        },
+        "serviceOperationsHostName": {
+          "type": "string",
+          "description": "Service endpoint for provisioning service.",
+          "readOnly": true
+        },
+        "deviceProvisioningHostName": {
+          "type": "string",
+          "description": "Device endpoint for this provisioning service.",
+          "readOnly": true
+        },
+        "idScope": {
+          "type": "string",
+          "description": "Unique identifier of this provisioning service.",
+          "readOnly": true
+        },
+        "authorizationPolicies": {
+          "type": "array",
+          "description": "List of authorization keys for a provisioning service.",
+          "items": {
+            "$ref": "#/definitions/SharedAccessSignatureAuthorizationRuleAccessRightsDescription"
+          }
+        },
+        "enableDataResidency": {
+          "type": "boolean",
+          "description": "Optional.\nIndicates if the DPS instance has Data Residency enabled, removing the cross geo-pair disaster recovery."
+        },
+        "portalOperationsHostName": {
+          "type": "string",
+          "description": "Portal endpoint to enable CORS for this provisioning service."
+        },
+        "disableLocalAuth": {
+          "type": "boolean",
+          "description": "Disables all authentication methods other than Azure RBAC",
+          "default": false
+        }
+      }
+    },
+    "IotDpsSku": {
+      "type": "string",
+      "description": "Sku name.",
+      "enum": [
+        "S1"
+      ],
+      "x-ms-enum": {
+        "name": "IotDpsSku",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "S1",
+            "value": "S1"
+          }
+        ]
+      }
+    },
+    "IotDpsSkuDefinition": {
+      "type": "object",
+      "description": "Available SKUs of tier and units.",
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/IotDpsSku",
+          "description": "Sku name."
+        }
+      }
+    },
+    "IotDpsSkuDefinitionListResult": {
+      "type": "object",
+      "description": "List of available SKUs.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The IotDpsSkuDefinition items on this page",
+          "items": {
+            "$ref": "#/definitions/IotDpsSkuDefinition"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "IotDpsSkuInfo": {
+      "type": "object",
+      "description": "List of possible provisioning service SKUs.",
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/IotDpsSku",
+          "description": "Sku name."
+        },
+        "tier": {
+          "type": "string",
+          "description": "Pricing tier name of the provisioning service.",
+          "readOnly": true
+        },
+        "capacity": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The number of units to provision"
+        }
+      }
+    },
+    "IotHubAuthenticationType": {
+      "type": "string",
+      "description": "IotHub MI authentication type: KeyBased, UserAssigned, SystemAssigned.",
+      "enum": [
+        "KeyBased",
+        "UserAssigned",
+        "SystemAssigned"
+      ],
+      "x-ms-enum": {
+        "name": "IotHubAuthenticationType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "KeyBased",
+            "value": "KeyBased",
+            "description": "Key Based authentication type."
+          },
+          {
+            "name": "UserAssigned",
+            "value": "UserAssigned",
+            "description": "User assigned authentication type."
+          },
+          {
+            "name": "SystemAssigned",
+            "value": "SystemAssigned",
+            "description": "System assigned authentication type."
+          }
+        ]
+      }
+    },
+    "IotHubDefinitionDescription": {
+      "type": "object",
+      "description": "Description of the IoT hub.",
+      "properties": {
+        "applyAllocationPolicy": {
+          "type": "boolean",
+          "description": "flag for applying allocationPolicy or not for a given iot hub."
+        },
+        "allocationWeight": {
+          "type": "integer",
+          "format": "int32",
+          "description": "weight to apply for a given iot h."
+        },
+        "name": {
+          "type": "string",
+          "description": "Host name of the IoT hub.",
+          "readOnly": true
+        },
+        "hostName": {
+          "type": "string",
+          "description": "Host name of the IoT hub. This is required when connectionString is not provided."
+        },
+        "authenticationType": {
+          "$ref": "#/definitions/IotHubAuthenticationType",
+          "description": "IotHub MI authentication type: KeyBased, UserAssigned, SystemAssigned."
+        },
+        "selectedUserAssignedIdentityResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The selected user-assigned identity resource Id associated with IoT hub. This is required when authenticationType is UserAssigned.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.ManagedIdentity/userAssignedIdentities"
+              }
+            ]
+          }
+        },
+        "connectionString": {
+          "type": "string",
+          "description": "Connection string of the IoT hub."
+        },
+        "location": {
+          "type": "string",
+          "description": "ARM region of the IoT hub."
+        }
+      },
+      "required": [
+        "location"
+      ]
+    },
+    "IpFilterActionType": {
+      "type": "string",
+      "description": "The desired action for requests captured by this rule.",
+      "enum": [
+        "Accept",
+        "Reject"
+      ],
+      "x-ms-enum": {
+        "name": "IpFilterActionType",
+        "modelAsString": false
+      }
+    },
+    "IpFilterRule": {
+      "type": "object",
+      "description": "The IP filter rules for a provisioning Service.",
+      "properties": {
+        "filterName": {
+          "type": "string",
+          "description": "The name of the IP filter rule."
+        },
+        "action": {
+          "$ref": "#/definitions/IpFilterActionType",
+          "description": "The desired action for requests captured by this rule."
+        },
+        "ipMask": {
+          "type": "string",
+          "description": "A string that contains the IP address range in CIDR notation for the rule."
+        },
+        "target": {
+          "$ref": "#/definitions/IpFilterTargetType",
+          "description": "Target for requests captured by this rule."
+        }
+      },
+      "required": [
+        "filterName",
+        "action",
+        "ipMask"
+      ]
+    },
+    "IpFilterTargetType": {
+      "type": "string",
+      "description": "Target for requests captured by this rule.",
+      "enum": [
+        "all",
+        "serviceApi",
+        "deviceApi"
+      ],
+      "x-ms-enum": {
+        "name": "IpFilterTargetType",
+        "modelAsString": false
+      }
+    },
+    "NameAvailabilityInfo": {
+      "type": "object",
+      "description": "Description of name availability.",
+      "properties": {
+        "nameAvailable": {
+          "type": "boolean",
+          "description": "specifies if a name is available or not"
+        },
+        "reason": {
+          "$ref": "#/definitions/NameUnavailabilityReason",
+          "description": "specifies the reason a name is unavailable"
+        },
+        "message": {
+          "type": "string",
+          "description": "message containing a detailed reason name is unavailable"
+        }
+      }
+    },
+    "NameUnavailabilityReason": {
+      "type": "string",
+      "description": "specifies the reason a name is unavailable",
+      "enum": [
+        "Invalid",
+        "AlreadyExists"
+      ],
+      "x-ms-enum": {
+        "name": "NameUnavailabilityReason",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "AlreadyExists",
+            "value": "AlreadyExists"
+          }
+        ]
+      }
+    },
+    "Operation": {
+      "type": "object",
+      "description": "Represents an operation.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the operation.",
+          "readOnly": true
+        },
+        "display": {
+          "type": "object",
+          "description": "The display information for the operation.",
+          "properties": {
+            "provider": {
+              "type": "string",
+              "description": "Service provider: Microsoft Devices.",
+              "readOnly": true
+            },
+            "resource": {
+              "type": "string",
+              "description": "Resource Type: ProvisioningServices.",
+              "readOnly": true
+            },
+            "operation": {
+              "type": "string",
+              "description": "Name of the operation.",
+              "readOnly": true
+            }
+          }
+        }
+      }
+    },
+    "OperationInputs": {
+      "type": "object",
+      "description": "Input values for operation results call.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the Provisioning Service to check."
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "OperationListResult": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "[Placeholder] Description for value property",
+          "items": {
+            "$ref": "#/definitions/Operation"
+          },
+          "readOnly": true
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "[Placeholder] Description for nextLink property."
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PrivateEndpoint": {
+      "type": "object",
+      "description": "The private endpoint property of a private endpoint connection",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The resource identifier.",
+          "readOnly": true
+        }
+      }
+    },
+    "PrivateEndpointConnection": {
+      "type": "object",
+      "description": "The private endpoint connection of a provisioning service",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PrivateEndpointConnectionProperties",
+          "description": "The properties of a private endpoint connection"
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "PrivateEndpointConnectionProperties": {
+      "type": "object",
+      "description": "The properties of a private endpoint connection",
+      "properties": {
+        "privateEndpoint": {
+          "$ref": "#/definitions/PrivateEndpoint",
+          "description": "The private endpoint property of a private endpoint connection"
+        },
+        "privateLinkServiceConnectionState": {
+          "$ref": "#/definitions/PrivateLinkServiceConnectionState",
+          "description": "The current state of a private endpoint connection"
+        }
+      },
+      "required": [
+        "privateLinkServiceConnectionState"
+      ]
+    },
+    "PrivateEndpointConnectionsList": {
+      "type": "array",
+      "description": "Represents a list of private endpoint connections.",
+      "items": {
+        "$ref": "#/definitions/PrivateEndpointConnection"
+      }
+    },
+    "PrivateLinkResources": {
+      "type": "object",
+      "description": "The available private link resources for a provisioning service",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The list of available private link resources for a provisioning service",
+          "items": {
+            "$ref": "#/definitions/GroupIdInformation"
+          }
+        }
+      }
+    },
+    "PrivateLinkServiceConnectionState": {
+      "type": "object",
+      "description": "The current state of a private endpoint connection",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/PrivateLinkServiceConnectionStatus",
+          "description": "The status of a private endpoint connection"
+        },
+        "description": {
+          "type": "string",
+          "description": "The description for the current state of a private endpoint connection"
+        },
+        "actionsRequired": {
+          "type": "string",
+          "description": "Actions required for a private endpoint connection"
+        }
+      },
+      "required": [
+        "status",
+        "description"
+      ]
+    },
+    "PrivateLinkServiceConnectionStatus": {
+      "type": "string",
+      "description": "The status of a private endpoint connection",
+      "enum": [
+        "Pending",
+        "Approved",
+        "Rejected",
+        "Disconnected"
+      ],
+      "x-ms-enum": {
+        "name": "PrivateLinkServiceConnectionStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Pending",
+            "value": "Pending"
+          },
+          {
+            "name": "Approved",
+            "value": "Approved"
+          },
+          {
+            "name": "Rejected",
+            "value": "Rejected"
+          },
+          {
+            "name": "Disconnected",
+            "value": "Disconnected"
+          }
+        ]
+      }
+    },
+    "ProvisioningServiceDescription": {
+      "type": "object",
+      "description": "The description of the provisioning service.",
+      "properties": {
+        "etag": {
+          "type": "string",
+          "description": "The Etag field is *not* required. If it is provided in the response body, it must also be provided as a header per the normal ETag convention."
+        },
+        "resourcegroup": {
+          "type": "string",
+          "description": "The resource group of the resource."
+        },
+        "subscriptionid": {
+          "type": "string",
+          "description": "The subscription id of the resource."
+        },
+        "properties": {
+          "$ref": "#/definitions/IotDpsPropertiesDescription",
+          "description": "Service specific properties for a provisioning service"
+        },
+        "sku": {
+          "$ref": "#/definitions/IotDpsSkuInfo",
+          "description": "Sku info for a provisioning Service."
+        },
+        "identity": {
+          "$ref": "../../../../../../common-types/resource-management/v3/managedidentity.json#/definitions/ManagedServiceIdentity",
+          "description": "The managed service identities assigned to this resource."
+        }
+      },
+      "required": [
+        "properties",
+        "sku"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "ProvisioningServiceDescriptionListResult": {
+      "type": "object",
+      "description": "The response of a ProvisioningServiceDescription list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ProvisioningServiceDescription items on this page",
+          "items": {
+            "$ref": "#/definitions/ProvisioningServiceDescription"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PublicNetworkAccess": {
+      "type": "string",
+      "description": "Whether requests from Public Network are allowed",
+      "enum": [
+        "Enabled",
+        "Disabled"
+      ],
+      "x-ms-enum": {
+        "name": "PublicNetworkAccess",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Enabled",
+            "value": "Enabled"
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled"
+          }
+        ]
+      }
+    },
+    "SharedAccessSignatureAuthorizationRuleAccessRightsDescription": {
+      "type": "object",
+      "description": "Description of the shared access key.",
+      "properties": {
+        "keyName": {
+          "type": "string",
+          "description": "Name of the key."
+        },
+        "primaryKey": {
+          "type": "string",
+          "description": "Primary SAS key value."
+        },
+        "secondaryKey": {
+          "type": "string",
+          "description": "Secondary SAS key value."
+        },
+        "rights": {
+          "$ref": "#/definitions/AccessRightsDescription",
+          "description": "Rights that this key has."
+        }
+      },
+      "required": [
+        "keyName",
+        "rights"
+      ]
+    },
+    "SharedAccessSignatureAuthorizationRuleListResult": {
+      "type": "object",
+      "description": "List of shared access keys.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The SharedAccessSignatureAuthorizationRuleAccessRightsDescription items on this page",
+          "items": {
+            "$ref": "#/definitions/SharedAccessSignatureAuthorizationRuleAccessRightsDescription"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "State": {
+      "type": "string",
+      "description": "Current state of the provisioning service.",
+      "enum": [
+        "Activating",
+        "Active",
+        "Deleting",
+        "Deleted",
+        "ActivationFailed",
+        "DeletionFailed",
+        "Transitioning",
+        "Suspending",
+        "Suspended",
+        "Resuming",
+        "FailingOver",
+        "FailoverFailed"
+      ],
+      "x-ms-enum": {
+        "name": "State",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Activating",
+            "value": "Activating"
+          },
+          {
+            "name": "Active",
+            "value": "Active"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting"
+          },
+          {
+            "name": "Deleted",
+            "value": "Deleted"
+          },
+          {
+            "name": "ActivationFailed",
+            "value": "ActivationFailed"
+          },
+          {
+            "name": "DeletionFailed",
+            "value": "DeletionFailed"
+          },
+          {
+            "name": "Transitioning",
+            "value": "Transitioning"
+          },
+          {
+            "name": "Suspending",
+            "value": "Suspending"
+          },
+          {
+            "name": "Suspended",
+            "value": "Suspended"
+          },
+          {
+            "name": "Resuming",
+            "value": "Resuming"
+          },
+          {
+            "name": "FailingOver",
+            "value": "FailingOver"
+          },
+          {
+            "name": "FailoverFailed",
+            "value": "FailoverFailed"
+          }
+        ]
+      }
+    },
+    "TagsResource": {
+      "type": "object",
+      "description": "A container holding only the Tags for a resource, allowing the user to update the tags on a Provisioning Service instance.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "VerificationCodeRequest": {
+      "type": "object",
+      "description": "The JSON-serialized leaf certificate",
+      "properties": {
+        "certificate": {
+          "type": "string",
+          "description": "base-64 representation of X509 certificate .cer file or just .pem file content."
+        }
+      }
+    },
+    "VerificationCodeResponse": {
+      "type": "object",
+      "description": "Description of the response of the verification code.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of certificate.",
+          "readOnly": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "Request etag.",
+          "readOnly": true
+        },
+        "id": {
+          "type": "string",
+          "description": "The resource identifier.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "The resource type.",
+          "readOnly": true
+        },
+        "properties": {
+          "$ref": "#/definitions/VerificationCodeResponseProperties"
+        }
+      }
+    },
+    "VerificationCodeResponseProperties": {
+      "type": "object",
+      "properties": {
+        "verificationCode": {
+          "type": "string",
+          "description": "Verification code."
+        },
+        "subject": {
+          "type": "string",
+          "description": "Certificate subject."
+        },
+        "expiry": {
+          "type": "string",
+          "description": "Code expiry."
+        },
+        "thumbprint": {
+          "type": "string",
+          "description": "Certificate thumbprint."
+        },
+        "isVerified": {
+          "type": "boolean",
+          "description": "Indicate if the certificate is verified by owner of private key."
+        },
+        "certificate": {
+          "type": "string",
+          "format": "byte",
+          "description": "base-64 representation of X509 certificate .cer file or just .pem file content."
+        },
+        "created": {
+          "type": "string",
+          "description": "Certificate created time."
+        },
+        "updated": {
+          "type": "string",
+          "description": "Certificate updated time."
+        }
+      }
+    }
+  },
+  "parameters": {}
+}


### PR DESCRIPTION
## Summary

This PR adds the GA `2026-10-01` API version for Microsoft.Devices DeviceProvisioningServices.

## Changes

- Add `disableLocalAuth` property to `IotDpsPropertiesDescription` for disabling local authentication
- Add `IotHubAuthenticationType` union (`KeyBased`, `UserAssigned`, `SystemAssigned`) for IoT Hub managed identity authentication
- Add `hostName`, `authenticationType`, `selectedUserAssignedIdentityResourceId` properties to `IotHubDefinitionDescription`
- Make `connectionString` optional in `2026-10-01` to support managed identity authentication as an alternative
- Add `DPSCreateWithIotHub` example demonstrating IoT Hub managed identity authentication
- Update `readme.md` with `package-2026-10` as default tag

## Prerequisite PR

This PR depends on and builds upon the preview version changes in:
- https://github.com/Azure/azure-rest-api-specs/pull/40007 (Microsoft.Devices DeviceProvisioningServices 2026-03-01-preview)