### PR TITLE
Add scenarioFilter query parameter to list evaluations API

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/src/openai-evaluations/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai-evaluations/routes.tsp
@@ -38,6 +38,17 @@ alias EvalListQueryParameters = {
   #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" ""
   @query(#{ explode: true })
   order_by?: "created_at" | "updated_at" = "created_at";
+
+  /**
+   * Filter evaluations by scenario type.
+   * - `evaluation`: Regular evaluations only (default).
+   * - `redteam`: Red team evaluations only.
+   * - `benchmark`: Benchmark evaluations only.
+   * - `default`: Regular evaluations and benchmarks (excludes red team).
+   */
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" ""
+  @query(#{ explode: true })
+  scenarioFilter?: "evaluation" | "redteam" | "benchmark" | "default" = "evaluation";
 };
 
 alias EvalRunOutputItemsQueryParameters = {


### PR DESCRIPTION
## Summary

Add `scenarioFilter` query parameter to the list evaluations TypeSpec (`GET /openai/v1/evals`).

## New enum values

| Value | Description |
|-------|-------------|
| `evaluation` (default) | Regular evaluations only |
| `redteam` | Red team evaluations only |
| `benchmark` | Benchmark evaluations only |
| `default` | Regular evaluations + benchmarks (excludes red team) |

## Why

Benchmark evaluations set `evals_scenario = "benchmark_preview"` in their properties. The existing list API defaults to showing only evals without this property set, making benchmark evals invisible. The `default` filter shows both regular evals and benchmarks together, which is needed for the combined evaluations list view in the UI.

## Related

- Service implementation PR: https://dev.azure.com/msdata/Vienna/_git/vienna/pullrequest/2023147
- Original benchmark TypeSpec PR: #40012