### PR TITLE
[Compute] Update tspconfig.yaml and client.tsp for Java

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/back-compatible.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/back-compatible.tsp
@@ -349,7 +349,6 @@ using Common;
 @@clientName(VirtualMachineScaleSetVMS.update::parameters.resource,
   "parameters"
 );
-@@clientName(AvailabilitySetSkuTypes, "AvailabilitySetSkuType", "java");
 @@clientName(VirtualMachineExtensions.createOrUpdate::parameters.resource,
   "extensionParameters"
 );

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/client.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/client.tsp
@@ -1,4 +1,6 @@
 import "./main.tsp";
+import "../ComputeGallery/main.tsp";
+import "../ComputeSku/main.tsp";
 import "@azure-tools/typespec-client-generator-core";
 
 using Azure.ClientGenerator.Core;
@@ -191,3 +193,16 @@ using Compute;
   Azure.ClientGenerator.Core.Usage.input | Azure.ClientGenerator.Core.Usage.output,
   "java"
 );
+
+// TODO: maximumDuration type changed from String to Duration, revert to String to avoid breaking change
+@@alternateType(VirtualMachineInstallPatchesParameters.maximumDuration,
+  string,
+  "java"
+);
+
+// Property name changes: retain old Java names for ComputeGallery and ComputeSku models
+@@clientName(ComputeGallery.AccessControlRulesIdentity.userName,
+  "username",
+  "java"
+);
+@@clientName(ComputeSku.ResourceSkuCosts.meterID, "meterId", "java");

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/client.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/client.tsp
@@ -1,6 +1,4 @@
 import "./main.tsp";
-import "../ComputeGallery/main.tsp";
-import "../ComputeSku/main.tsp";
 import "@azure-tools/typespec-client-generator-core";
 
 using Azure.ClientGenerator.Core;
@@ -180,29 +178,3 @@ using Compute;
   "publicIpAllocationMethod",
   "java"
 );
-
-// VirtualMachineInstanceView needs input usage for premium layer constructor and setters
-@@usage(VirtualMachineInstanceView,
-  Azure.ClientGenerator.Core.Usage.input,
-  "java"
-);
-
-// AvailabilitySetSkuTypes needs public access and input+output usage for premium layer
-@@access(AvailabilitySetSkuTypes, Access.public, "java");
-@@usage(AvailabilitySetSkuTypes,
-  Azure.ClientGenerator.Core.Usage.input | Azure.ClientGenerator.Core.Usage.output,
-  "java"
-);
-
-// TODO: maximumDuration type changed from String to Duration, revert to String to avoid breaking change
-@@alternateType(VirtualMachineInstallPatchesParameters.maximumDuration,
-  string,
-  "java"
-);
-
-// Property name changes: retain old Java names for ComputeGallery and ComputeSku models
-@@clientName(ComputeGallery.AccessControlRulesIdentity.userName,
-  "username",
-  "java"
-);
-@@clientName(ComputeSku.ResourceSkuCosts.meterID, "meterId", "java");

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/client.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/client.tsp
@@ -178,3 +178,9 @@ using Compute;
   "publicIpAllocationMethod",
   "java"
 );
+
+// VirtualMachineInstanceView needs input usage for premium layer constructor and setters
+@@usage(VirtualMachineInstanceView,
+  Azure.ClientGenerator.Core.Usage.input,
+  "java"
+);

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/client.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/client.tsp
@@ -184,3 +184,10 @@ using Compute;
   Azure.ClientGenerator.Core.Usage.input,
   "java"
 );
+
+// AvailabilitySetSkuTypes needs public access and input+output usage for premium layer
+@@access(AvailabilitySetSkuTypes, Access.public, "java");
+@@usage(AvailabilitySetSkuTypes,
+  Azure.ClientGenerator.Core.Usage.input | Azure.ClientGenerator.Core.Usage.output,
+  "java"
+);

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/client.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/client.tsp
@@ -5,6 +5,10 @@ import "./ComputeGallery/main.tsp";
 import "./ComputeSku/main.tsp";
 
 using Azure.ClientGenerator.Core;
+using Compute;
+using ComputeGallery;
+using ComputeSku;
+
 /**
  * Compute Client
  */
@@ -13,4 +17,29 @@ using Azure.ClientGenerator.Core;
   service: [Compute, ComputeDisk, ComputeGallery, ComputeSku],
   autoMergeService: true,
 })
-namespace ComputeCombine;
+namespace ComputeCombine {
+
+}
+
+// VirtualMachineInstanceView needs input usage for premium layer constructor and setters
+@@usage(VirtualMachineInstanceView,
+  Azure.ClientGenerator.Core.Usage.input,
+  "java"
+);
+
+// AvailabilitySetSkuTypes needs public access and input+output usage for premium layer
+@@access(AvailabilitySetSkuTypes, Access.public, "java");
+@@usage(AvailabilitySetSkuTypes,
+  Azure.ClientGenerator.Core.Usage.input | Azure.ClientGenerator.Core.Usage.output,
+  "java"
+);
+
+// TODO: maximumDuration type changed from String to Duration, revert to String to avoid breaking change
+@@alternateType(VirtualMachineInstallPatchesParameters.maximumDuration,
+  string,
+  "java"
+);
+
+// Property name changes: retain old Java names for ComputeGallery and ComputeSku models
+@@clientName(AccessControlRulesIdentity.userName, "username", "java");
+@@clientName(ResourceSkuCosts.meterID, "meterId", "java");

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/client.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/client.tsp
@@ -5,6 +5,7 @@ import "./ComputeGallery/main.tsp";
 import "./ComputeSku/main.tsp";
 
 using Azure.ClientGenerator.Core;
+using Common;
 using Compute;
 using ComputeGallery;
 using ComputeSku;
@@ -44,3 +45,9 @@ namespace ComputeCombine;
 // Property name changes: retain old Java names for ComputeGallery and ComputeSku models
 @@clientName(AccessControlRulesIdentity.userName, "username", "java");
 @@clientName(ResourceSkuCosts.meterID, "meterId", "java");
+
+// Rename model to match old Swagger-generated name
+@@clientName(UserAssignedIdentitiesValue,
+  "VirtualMachineIdentityUserAssignedIdentities",
+  "java"
+);

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/client.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/client.tsp
@@ -38,6 +38,9 @@ namespace ComputeCombine;
   "java"
 );
 
+// PurchasePlan needs input usage for premium layer constructor and setters
+@@usage(PurchasePlan, Azure.ClientGenerator.Core.Usage.input, "java");
+
 // Property name changes: retain old Java names for ComputeGallery and ComputeSku models
 @@clientName(AccessControlRulesIdentity.userName, "username", "java");
 @@clientName(ResourceSkuCosts.meterID, "meterId", "java");

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/client.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/client.tsp
@@ -17,9 +17,7 @@ using ComputeSku;
   service: [Compute, ComputeDisk, ComputeGallery, ComputeSku],
   autoMergeService: true,
 })
-namespace ComputeCombine {
-
-}
+namespace ComputeCombine;
 
 // VirtualMachineInstanceView needs input usage for premium layer constructor and setters
 @@usage(VirtualMachineInstanceView,

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/tspconfig.yaml
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/tspconfig.yaml
@@ -48,8 +48,10 @@ options:
     rename-model:
       UserAssignedIdentitiesValue: VirtualMachineIdentityUserAssignedIdentities
       VirtualMachineScaleSetIdentityUserAssignedIdentitiesValue: VirtualMachineScaleSetIdentityUserAssignedIdentities
-    preserve-model: AvailabilitySetSkuTypes
-    remove-inner: StorageProfile
+    preserve-model:
+      - AvailabilitySetSkuTypes
+    remove-inner:
+      - StorageProfile
 
 linter:
   extends:

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/tspconfig.yaml
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/tspconfig.yaml
@@ -35,11 +35,20 @@ options:
       name: "@azure/arm-compute"
   "@azure-tools/typespec-java":
     service-dir: "sdk/compute"
-    emitter-output-dir: "{output-dir}/{service-dir}/azure-resourcemanager-compute-generated"
-    namespace: "com.azure.resourcemanager.compute.generated"
+    emitter-output-dir: "{output-dir}/{service-dir}/azure-resourcemanager-compute"
+    namespace: "com.azure.resourcemanager.compute"
     service-name: "Compute"
     flavor: azure
+    premium: true
+    generate-tests: false
     client-side-validations: true
+    enable-sync-stack: false
+    use-object-for-unknown: true
+    rename-model:
+      UserAssignedIdentitiesValue: VirtualMachineIdentityUserAssignedIdentities
+      VirtualMachineScaleSetIdentityUserAssignedIdentitiesValue: VirtualMachineScaleSetIdentityUserAssignedIdentities
+    preserve-model: AvailabilitySetSkuTypes
+    remove-inner: StorageProfile
 
 linter:
   extends:

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/tspconfig.yaml
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/tspconfig.yaml
@@ -44,6 +44,7 @@ options:
     client-side-validations: true
     enable-sync-stack: false
     use-object-for-unknown: true
+    float32-as-double: false
     rename-model:
       UserAssignedIdentitiesValue: VirtualMachineIdentityUserAssignedIdentities
       VirtualMachineScaleSetIdentityUserAssignedIdentitiesValue: VirtualMachineScaleSetIdentityUserAssignedIdentities

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/tspconfig.yaml
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/tspconfig.yaml
@@ -45,9 +45,6 @@ options:
     enable-sync-stack: false
     use-object-for-unknown: true
     float32-as-double: false
-    rename-model:
-      UserAssignedIdentitiesValue: VirtualMachineIdentityUserAssignedIdentities
-      VirtualMachineScaleSetIdentityUserAssignedIdentitiesValue: VirtualMachineScaleSetIdentityUserAssignedIdentities
     preserve-model:
       - AvailabilitySetSkuTypes
     remove-inner:


### PR DESCRIPTION
Update tspconfig.yaml and client.tsp for Java compute premium SDK migration from Swagger to TypeSpec.

### Changes in client.tsp
- \\@@clientName\\ for AccessControlRulesIdentity.userName, ResourceSkuCosts.meterID
- \\@@alternateType\\ for VirtualMachineInstallPatchesParameters.maximumDuration (duration -> string)
- \\@@access\\ and \\@@usage\\ for AvailabilitySetSkuTypes
- \\@@usage(input)\\ for VirtualMachineInstanceView

### Changes in tspconfig.yaml
- Updated emitter-output-dir and namespace (removed .generated)
- Added premium, generate-tests, enable-sync-stack, use-object-for-unknown, float32-as-double options
- Added rename-model, preserve-model, remove-inner from readme.java.md

### Changes in back-compatible.tsp
- Removed @@clientName rename of AvailabilitySetSkuTypes to AvailabilitySetSkuType