### PR TITLE
Add v2026-05-01-preview API version with dynamic threshold support

### DIFF
--- a/specification/cloudhealth/CloudHealth.Management/client.tsp
+++ b/specification/cloudhealth/CloudHealth.Management/client.tsp
@@ -48,3 +48,8 @@ using Microsoft.CloudHealth;
 @@clientName(SignalOperator, "EntitySignalOperator", "csharp");
 
 @@clientName(SignalOperator.Equals, "EqualsValue", "csharp");
+
+@@clientName(DynamicThresholdSensitivity,
+  "EntityDynamicThresholdSensitivity",
+  "csharp"
+);

--- a/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/AuthenticationSettings_CreateOrUpdate.json
+++ b/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/AuthenticationSettings_CreateOrUpdate.json
@@ -1,0 +1,62 @@
+{
+  "title": "AuthenticationSettings_CreateOrUpdate",
+  "operationId": "AuthenticationSettings_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "myResourceGroup",
+    "healthModelName": "myHealthModel",
+    "authenticationSettingName": "myAuthSetting",
+    "resource": {
+      "properties": {
+        "managedIdentityName": "SystemAssigned",
+        "displayName": "myDisplayName",
+        "authenticationKind": "ManagedIdentity"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "managedIdentityName": "SystemAssigned",
+          "provisioningState": "Succeeded",
+          "displayName": "myDisplayName",
+          "authenticationKind": "ManagedIdentity"
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.CloudHealth/healthModels/myHealthModel/authenticationSettings/myAuthSetting",
+        "name": "myAuthSetting",
+        "type": "Microsoft.CloudHealth/healthModels/authenticationSettings",
+        "systemData": {
+          "createdBy": "myCreatedBy",
+          "createdByType": "User",
+          "createdAt": "2023-09-18T14:04:09.327Z",
+          "lastModifiedBy": "myLastModifiedBy",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "properties": {
+          "managedIdentityName": "SystemAssigned",
+          "provisioningState": "Succeeded",
+          "displayName": "myDisplayName",
+          "authenticationKind": "ManagedIdentity"
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.CloudHealth/healthModels/myHealthModel/authenticationSettings/myAuthSetting",
+        "name": "myAuthSetting",
+        "type": "Microsoft.CloudHealth/healthModels/authenticationSettings",
+        "systemData": {
+          "createdBy": "myCreatedBy",
+          "createdByType": "User",
+          "createdAt": "2023-09-18T14:04:09.327Z",
+          "lastModifiedBy": "myLastModifiedBy",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/AuthenticationSettings_Delete.json
+++ b/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/AuthenticationSettings_Delete.json
@@ -1,0 +1,19 @@
+{
+  "title": "AuthenticationSettings_Delete",
+  "operationId": "AuthenticationSettings_Delete",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "my-resource-group",
+    "healthModelName": "my-health-model",
+    "authenticationSettingName": "my-auth-setting"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/AuthenticationSettings_Get.json
+++ b/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/AuthenticationSettings_Get.json
@@ -1,0 +1,34 @@
+{
+  "title": "AuthenticationSettings_Get",
+  "operationId": "AuthenticationSettings_Get",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "my-resource-group",
+    "healthModelName": "my-health-model",
+    "authenticationSettingName": "my-auth-setting"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "managedIdentityName": "SystemAssigned",
+          "provisioningState": "Succeeded",
+          "displayName": "my-display-name",
+          "authenticationKind": "ManagedIdentity"
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-resource-group/providers/Microsoft.CloudHealth/healthmodels/my-health-model/authenticationSettings/my-auth-setting",
+        "name": "my-name",
+        "type": "Microsoft.CloudHealth/healthmodels/authenticationSettings",
+        "systemData": {
+          "createdBy": "my-username",
+          "createdByType": "User",
+          "createdAt": "2023-09-18T14:04:09.327Z",
+          "lastModifiedBy": "my-username",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/AuthenticationSettings_ListByHealthModel.json
+++ b/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/AuthenticationSettings_ListByHealthModel.json
@@ -1,0 +1,38 @@
+{
+  "title": "AuthenticationSettings_ListByHealthModel",
+  "operationId": "AuthenticationSettings_ListByHealthModel",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "my-resource-group",
+    "healthModelName": "my-health-model"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "managedIdentityName": "SystemAssigned",
+              "provisioningState": "Succeeded",
+              "displayName": "my-display-name",
+              "authenticationKind": "ManagedIdentity"
+            },
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-resource-group/providers/Microsoft.CloudHealth/healthModels/my-health-model/authenticationSettings/my-name",
+            "name": "my-name",
+            "type": "Microsoft.CloudHealth/healthModels/authenticationSettings",
+            "systemData": {
+              "createdBy": "my-user",
+              "createdByType": "User",
+              "createdAt": "2023-09-18T14:04:09.327Z",
+              "lastModifiedBy": "my-user",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/ahgxpg"
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/DiscoveryRules_CreateOrUpdate.json
+++ b/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/DiscoveryRules_CreateOrUpdate.json
@@ -1,0 +1,79 @@
+{
+  "title": "DiscoveryRules_CreateOrUpdate",
+  "operationId": "DiscoveryRules_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "myResourceGroup",
+    "healthModelName": "myHealthModel",
+    "discoveryRuleName": "myDiscoveryRule",
+    "resource": {
+      "properties": {
+        "authenticationSetting": "authSetting1",
+        "displayName": "myDisplayName",
+        "discoverRelationships": "Enabled",
+        "addRecommendedSignals": "Enabled",
+        "specification": {
+          "kind": "ResourceGraphQuery",
+          "resourceGraphQuery": "resources | where subscriptionId == '7ddfffd7-9b32-40df-1234-828cbd55d6f4' | where resourceGroup == 'my-rg'"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "authenticationSetting": "authSetting1",
+          "provisioningState": "Succeeded",
+          "displayName": "myDisplayName",
+          "discoverRelationships": "Enabled",
+          "addRecommendedSignals": "Enabled",
+          "specification": {
+            "kind": "ResourceGraphQuery",
+            "resourceGraphQuery": "resources | where subscriptionId == '7ddfffd7-9b32-40df-1234-828cbd55d6f4' | where resourceGroup == 'my-rg'"
+          },
+          "entityName": "f1f0ef5e-a5b5-4d02-b69c-7145f4658829"
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.CloudHealth/healthModels/myHealthModel/discoveryRules/myDiscoveryRule",
+        "name": "myDiscoveryRule",
+        "type": "Microsoft.CloudHealth/healthModels/discoveryRules",
+        "systemData": {
+          "createdBy": "myCreatedBy",
+          "createdByType": "User",
+          "createdAt": "2023-09-18T14:04:09.327Z",
+          "lastModifiedBy": "myLastModifiedBy",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "properties": {
+          "authenticationSetting": "authSetting1",
+          "provisioningState": "Succeeded",
+          "displayName": "myDisplayName",
+          "discoverRelationships": "Enabled",
+          "addRecommendedSignals": "Enabled",
+          "specification": {
+            "kind": "ResourceGraphQuery",
+            "resourceGraphQuery": "resources | where subscriptionId == '7ddfffd7-9b32-40df-1234-828cbd55d6f4' | where resourceGroup == 'my-rg'"
+          },
+          "entityName": "f1f0ef5e-a5b5-4d02-b69c-7145f4658829"
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.CloudHealth/healthModels/myHealthModel/discoveryRules/myDiscoveryRule",
+        "name": "myDiscoveryRule",
+        "type": "Microsoft.CloudHealth/healthModels/discoveryRules",
+        "systemData": {
+          "createdBy": "myCreatedBy",
+          "createdByType": "User",
+          "createdAt": "2023-09-18T14:04:09.327Z",
+          "lastModifiedBy": "myLastModifiedBy",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/DiscoveryRules_Delete.json
+++ b/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/DiscoveryRules_Delete.json
@@ -1,0 +1,19 @@
+{
+  "title": "DiscoveryRules_Delete",
+  "operationId": "DiscoveryRules_Delete",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "my-resource-group",
+    "healthModelName": "my-health-model",
+    "discoveryRuleName": "my-discovery-rule"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/DiscoveryRules_Get.json
+++ b/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/DiscoveryRules_Get.json
@@ -1,0 +1,46 @@
+{
+  "title": "DiscoveryRules_Get",
+  "operationId": "DiscoveryRules_Get",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "myResourceGroup",
+    "healthModelName": "myHealthModel",
+    "discoveryRuleName": "myDiscoveryRule"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "authenticationSetting": "authSetting1",
+          "provisioningState": "Succeeded",
+          "displayName": "myDisplayName",
+          "discoverRelationships": "Enabled",
+          "addRecommendedSignals": "Enabled",
+          "specification": {
+            "kind": "ResourceGraphQuery",
+            "resourceGraphQuery": "resources | where subscriptionId == '7ddfffd7-9b32-40df-1234-828cbd55d6f4' | where resourceGroup == 'my-rg'"
+          },
+          "error": {
+            "message": "Authorization error on execution",
+            "context": [
+              "subscriptionId: 7ddfffd7-9b32-40df-1234-828cbd55d6f4"
+            ]
+          },
+          "entityName": "f1f0ef5e-a5b5-4d02-b69c-7145f4658829"
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.CloudHealth/healthModels/myHealthModel/discoveryRules/myDiscoveryRule",
+        "name": "myDiscoveryRule",
+        "type": "Microsoft.CloudHealth/healthModels/discoveryRules",
+        "systemData": {
+          "createdBy": "myCreatedBy",
+          "createdByType": "User",
+          "createdAt": "2023-09-18T14:04:09.327Z",
+          "lastModifiedBy": "myLastModifiedBy",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/DiscoveryRules_ListByHealthModel.json
+++ b/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/DiscoveryRules_ListByHealthModel.json
@@ -1,0 +1,69 @@
+{
+  "title": "DiscoveryRules_ListByHealthModel",
+  "operationId": "DiscoveryRules_ListByHealthModel",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "my-resource-group",
+    "healthModelName": "my-health-model"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "authenticationSetting": "authSetting1",
+              "provisioningState": "Succeeded",
+              "displayName": "ARG Discovery Rule",
+              "discoverRelationships": "Enabled",
+              "addRecommendedSignals": "Enabled",
+              "specification": {
+                "kind": "ResourceGraphQuery",
+                "resourceGraphQuery": "resources | where subscriptionId == '7ddfffd7-9b32-40df-1234-828cbd55d6f4' | where resourceGroup == 'my-rg'"
+              },
+              "entityName": "f1f0ef5e-a5b5-4d02-b69c-7145f4658829"
+            },
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.CloudHealth/healthModels/myHealthModel/discoveryRules/myArgDiscoveryRule",
+            "name": "myArgDiscoveryRule",
+            "type": "Microsoft.CloudHealth/healthModels/discoveryRules",
+            "systemData": {
+              "createdBy": "myCreatedBy",
+              "createdByType": "User",
+              "createdAt": "2023-09-18T14:04:09.327Z",
+              "lastModifiedBy": "myLastModifiedBy",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+            }
+          },
+          {
+            "properties": {
+              "authenticationSetting": "authSetting1",
+              "provisioningState": "Succeeded",
+              "displayName": "Application Insights Discovery Rule",
+              "discoverRelationships": "Enabled",
+              "addRecommendedSignals": "Enabled",
+              "specification": {
+                "kind": "ApplicationInsightsTopology",
+                "applicationInsightsResourceId": "/subscriptions/7ddfffd7-9b32-40df-1234-828cbd55d6f4/resourceGroups/my-rg/providers/Microsoft.Insights/components/my-app-insights"
+              },
+              "entityName": "a2b3c4d5-e6f7-8901-2345-678901234567"
+            },
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.CloudHealth/healthModels/myHealthModel/discoveryRules/myAppInsightsDiscoveryRule",
+            "name": "myAppInsightsDiscoveryRule",
+            "type": "Microsoft.CloudHealth/healthModels/discoveryRules",
+            "systemData": {
+              "createdBy": "myCreatedBy",
+              "createdByType": "User",
+              "createdAt": "2023-09-20T10:15:30.123Z",
+              "lastModifiedBy": "myLastModifiedBy",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2023-09-20T10:15:30.456Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/ahgxpg"
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/Entities_CreateOrUpdate.json
+++ b/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/Entities_CreateOrUpdate.json
@@ -1,0 +1,453 @@
+{
+  "title": "Entities_CreateOrUpdate",
+  "operationId": "Entities_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi",
+    "healthModelName": "myHealthModel",
+    "entityName": "uszrxbdkxesdrxhmagmzywebgbjj",
+    "resource": {
+      "properties": {
+        "displayName": "My entity",
+        "canvasPosition": {
+          "x": 14,
+          "y": 13
+        },
+        "icon": {
+          "iconName": "Custom",
+          "customData": "rcitntvapruccrhtxmkqjphbxunkz"
+        },
+        "healthObjective": 62,
+        "impact": "Standard",
+        "tags": {
+          "key1376": "sample tag"
+        },
+        "signalGroups": {
+          "azureResource": {
+            "authenticationSetting": "auth123",
+            "azureResourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
+            "azureResourceKind": "functionapp",
+            "signals": [
+              {
+                "name": "uniqueSignalName1",
+                "signalDefinitionName": "sigdef1",
+                "signalKind": "AzureResourceMetric",
+                "metricNamespace": "microsoft.compute/virtualMachines",
+                "metricName": "cpuusage",
+                "aggregationType": "None",
+                "dimension": "nodename",
+                "dimensionFilter": "node1",
+                "displayName": "CPU usage",
+                "refreshInterval": "PT1M",
+                "timeGrain": "PT1M",
+                "dataUnit": "Count",
+                "evaluationRules": {
+                  "degradedRule": {
+                    "operator": "LowerThan",
+                    "threshold": 10
+                  },
+                  "unhealthyRule": {
+                    "operator": "LowerThan",
+                    "threshold": 1
+                  }
+                }
+              }
+            ]
+          },
+          "azureLogAnalytics": {
+            "authenticationSetting": "auth123",
+            "logAnalyticsWorkspaceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.OperationalInsights/workspaces/myworkspace",
+            "signals": [
+              {
+                "name": "uniqueSignalName2",
+                "signalDefinitionName": null,
+                "signalKind": "LogAnalyticsQuery",
+                "evaluationRules": {
+                  "degradedRule": {
+                    "operator": "GreaterThan",
+                    "threshold": 1
+                  },
+                  "unhealthyRule": {
+                    "operator": "GreaterThan",
+                    "threshold": 5
+                  }
+                },
+                "refreshInterval": "PT1M",
+                "queryText": "print 1",
+                "timeGrain": "PT30M",
+                "valueColumnName": "result",
+                "displayName": "Test LA signal",
+                "dataUnit": "my unit"
+              }
+            ]
+          },
+          "azureMonitorWorkspace": {
+            "authenticationSetting": "auth123",
+            "azureMonitorWorkspaceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.OperationalInsights/workspaces/myworkspace",
+            "signals": [
+              {
+                "name": "pod-cpu-usage",
+                "signalDefinitionName": "PodCpuUsageDefinition",
+                "signalKind": "PrometheusMetricsQuery",
+                "displayName": "Pod CPU Usage",
+                "refreshInterval": "PT1M",
+                "dataUnit": "Percent",
+                "queryText": "rate(container_cpu_usage_seconds_total{pod=~\"my-app-.*\"}[5m]) * 100",
+                "timeGrain": "PT5M",
+                "evaluationRules": {
+                  "degradedRule": {
+                    "operator": "GreaterThan",
+                    "threshold": 70
+                  },
+                  "unhealthyRule": {
+                    "operator": "GreaterThan",
+                    "threshold": 90
+                  }
+                }
+              }
+            ]
+          },
+          "dependencies": {
+            "aggregationType": "MinHealthy",
+            "unit": "Percentage",
+            "degradedThreshold": 80,
+            "unhealthyThreshold": 50
+          }
+        },
+        "alerts": {
+          "unhealthy": {
+            "severity": "Sev1",
+            "description": "Alert description",
+            "actionGroupIds": [
+              "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Insights/actionGroups/myactiongroup"
+            ]
+          },
+          "degraded": {
+            "severity": "Sev4",
+            "description": "Alert description",
+            "actionGroupIds": [
+              "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Insights/actionGroups/myactiongroup"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "displayName": "My entity",
+          "canvasPosition": {
+            "x": 14,
+            "y": 13
+          },
+          "icon": {
+            "iconName": "Custom",
+            "customData": "rcitntvapruccrhtxmkqjphbxunkz"
+          },
+          "healthObjective": 62,
+          "impact": "Standard",
+          "tags": {
+            "key1376": "sample tag"
+          },
+          "signalGroups": {
+            "azureResource": {
+              "authenticationSetting": "auth123",
+              "azureResourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
+              "azureResourceKind": "functionapp",
+              "signals": [
+                {
+                  "name": "uniqueSignalName1",
+                  "signalDefinitionName": "sigdef1",
+                  "signalKind": "AzureResourceMetric",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 15,
+                    "reportedAt": "2025-11-26T10:00:00Z",
+                    "error": null
+                  },
+                  "metricNamespace": "microsoft.compute/virtualMachines",
+                  "metricName": "cpuusage",
+                  "aggregationType": "None",
+                  "dimension": "nodename",
+                  "dimensionFilter": "node1",
+                  "displayName": "CPU usage",
+                  "refreshInterval": "PT1M",
+                  "timeGrain": "PT1M",
+                  "dataUnit": "Count",
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "LowerThan",
+                      "threshold": 10
+                    },
+                    "unhealthyRule": {
+                      "operator": "LowerThan",
+                      "threshold": 1
+                    }
+                  }
+                }
+              ]
+            },
+            "azureLogAnalytics": {
+              "authenticationSetting": "auth123",
+              "logAnalyticsWorkspaceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.OperationalInsights/workspaces/myworkspace",
+              "signals": [
+                {
+                  "name": "uniqueSignalName2",
+                  "signalDefinitionName": null,
+                  "signalKind": "LogAnalyticsQuery",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 30,
+                    "reportedAt": "2025-11-26T10:00:00Z",
+                    "error": null
+                  },
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 1
+                    },
+                    "unhealthyRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 5
+                    }
+                  },
+                  "refreshInterval": "PT1M",
+                  "queryText": "print 1",
+                  "timeGrain": "PT30M",
+                  "valueColumnName": "result",
+                  "displayName": "Test LA signal",
+                  "dataUnit": "my unit"
+                }
+              ]
+            },
+            "azureMonitorWorkspace": {
+              "authenticationSetting": "auth123",
+              "azureMonitorWorkspaceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.OperationalInsights/workspaces/myworkspace",
+              "signals": [
+                {
+                  "name": "pod-cpu-usage",
+                  "signalDefinitionName": "PodCpuUsageDefinition",
+                  "signalKind": "PrometheusMetricsQuery",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 45.3,
+                    "reportedAt": "2025-12-11T10:30:00Z"
+                  },
+                  "displayName": "Pod CPU Usage",
+                  "refreshInterval": "PT1M",
+                  "dataUnit": "Percent",
+                  "queryText": "rate(container_cpu_usage_seconds_total{pod=~\"my-app-.*\"}[5m]) * 100",
+                  "timeGrain": "PT5M",
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 70
+                    },
+                    "unhealthyRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 90
+                    }
+                  }
+                }
+              ]
+            },
+            "dependencies": {
+              "aggregationType": "MinHealthy",
+              "unit": "Percentage",
+              "degradedThreshold": 80,
+              "unhealthyThreshold": 50
+            }
+          },
+          "alerts": {
+            "unhealthy": {
+              "severity": "Sev1",
+              "description": "Alert description",
+              "actionGroupIds": [
+                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Insights/actionGroups/myactiongroup"
+              ]
+            },
+            "degraded": {
+              "severity": "Sev4",
+              "description": "Alert description",
+              "actionGroupIds": [
+                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Insights/actionGroups/myactiongroup"
+              ]
+            }
+          }
+        },
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/myResourceGroup/providers/Microsoft.CloudHealth/healthmodels/myHealthModel/entities/uszrxbdkxesdrxhmagmzywebgbjj",
+        "name": "uszrxbdkxesdrxhmagmzywebgbjj",
+        "type": "Microsoft.CloudHealth/healthmodels/entities",
+        "systemData": {
+          "createdBy": "cbhzxxlvkmufetjjjwtk",
+          "createdByType": "User",
+          "createdAt": "2023-09-18T14:04:09.327Z",
+          "lastModifiedBy": "arz",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "displayName": "My entity",
+          "canvasPosition": {
+            "x": 14,
+            "y": 13
+          },
+          "icon": {
+            "iconName": "Custom",
+            "customData": "rcitntvapruccrhtxmkqjphbxunkz"
+          },
+          "healthObjective": 62,
+          "impact": "Standard",
+          "tags": {
+            "key1376": "sample tag"
+          },
+          "signalGroups": {
+            "azureResource": {
+              "authenticationSetting": "auth123",
+              "azureResourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
+              "azureResourceKind": "functionapp",
+              "signals": [
+                {
+                  "name": "uniqueSignalName1",
+                  "signalDefinitionName": "sigdef1",
+                  "signalKind": "AzureResourceMetric",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 15,
+                    "reportedAt": "2025-11-26T10:00:00Z",
+                    "error": null
+                  },
+                  "metricNamespace": "microsoft.compute/virtualMachines",
+                  "metricName": "cpuusage",
+                  "aggregationType": "None",
+                  "dimension": "nodename",
+                  "dimensionFilter": "node1",
+                  "displayName": "CPU usage",
+                  "refreshInterval": "PT1M",
+                  "timeGrain": "PT1M",
+                  "dataUnit": "Count",
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "LowerThan",
+                      "threshold": 10
+                    },
+                    "unhealthyRule": {
+                      "operator": "LowerThan",
+                      "threshold": 1
+                    }
+                  }
+                }
+              ]
+            },
+            "azureLogAnalytics": {
+              "authenticationSetting": "auth123",
+              "logAnalyticsWorkspaceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.OperationalInsights/workspaces/myworkspace",
+              "signals": [
+                {
+                  "name": "uniqueSignalName2",
+                  "signalDefinitionName": null,
+                  "signalKind": "LogAnalyticsQuery",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 30,
+                    "reportedAt": "2025-11-26T10:00:00Z",
+                    "error": null
+                  },
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 1
+                    },
+                    "unhealthyRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 5
+                    }
+                  },
+                  "refreshInterval": "PT1M",
+                  "queryText": "print 1",
+                  "timeGrain": "PT30M",
+                  "valueColumnName": "result",
+                  "displayName": "Test LA signal",
+                  "dataUnit": "my unit"
+                }
+              ]
+            },
+            "azureMonitorWorkspace": {
+              "authenticationSetting": "auth123",
+              "azureMonitorWorkspaceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.OperationalInsights/workspaces/myworkspace",
+              "signals": [
+                {
+                  "name": "pod-cpu-usage",
+                  "signalDefinitionName": "PodCpuUsageDefinition",
+                  "signalKind": "PrometheusMetricsQuery",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 45.3,
+                    "reportedAt": "2025-12-11T10:30:00Z"
+                  },
+                  "displayName": "Pod CPU Usage",
+                  "refreshInterval": "PT1M",
+                  "dataUnit": "Percent",
+                  "queryText": "rate(container_cpu_usage_seconds_total{pod=~\"my-app-.*\"}[5m]) * 100",
+                  "timeGrain": "PT5M",
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 70
+                    },
+                    "unhealthyRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 90
+                    }
+                  }
+                }
+              ]
+            },
+            "dependencies": {
+              "aggregationType": "MinHealthy",
+              "unit": "Percentage",
+              "degradedThreshold": 80,
+              "unhealthyThreshold": 50
+            }
+          },
+          "alerts": {
+            "unhealthy": {
+              "severity": "Sev1",
+              "description": "Alert description",
+              "actionGroupIds": [
+                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Insights/actionGroups/myactiongroup"
+              ]
+            },
+            "degraded": {
+              "severity": "Sev4",
+              "description": "Alert description",
+              "actionGroupIds": [
+                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Insights/actionGroups/myactiongroup"
+              ]
+            }
+          }
+        },
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/myResourceGroup/providers/Microsoft.CloudHealth/healthmodels/myHealthModel/entities/uszrxbdkxesdrxhmagmzywebgbjj",
+        "name": "uszrxbdkxesdrxhmagmzywebgbjj",
+        "type": "Microsoft.CloudHealth/healthmodels/entities",
+        "systemData": {
+          "createdBy": "cbhzxxlvkmufetjjjwtk",
+          "createdByType": "User",
+          "createdAt": "2023-09-18T14:04:09.327Z",
+          "lastModifiedBy": "arz",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/Entities_Delete.json
+++ b/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/Entities_Delete.json
@@ -1,0 +1,19 @@
+{
+  "title": "Entities_Delete",
+  "operationId": "Entities_Delete",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi",
+    "healthModelName": "model1",
+    "entityName": "U4VTRFlUkm9kR6H23-c-6U-XHq7n"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/Entities_Get.json
+++ b/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/Entities_Get.json
@@ -1,0 +1,199 @@
+{
+  "title": "Entities_Get",
+  "operationId": "Entities_Get",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi",
+    "healthModelName": "myHealthModel",
+    "entityName": "entity1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "displayName": "Entity 1",
+          "canvasPosition": {
+            "x": 14,
+            "y": 13
+          },
+          "icon": {
+            "iconName": "UserFlow"
+          },
+          "healthObjective": 62,
+          "impact": "Standard",
+          "tags": {
+            "key1376": "sample tag"
+          },
+          "healthState": "Healthy",
+          "signalGroups": {
+            "azureResource": {
+              "authenticationSetting": "auth123",
+              "azureResourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
+              "azureResourceKind": "functionapp",
+              "signals": [
+                {
+                  "name": "uniqueSignalName1",
+                  "signalDefinitionName": "sigdef1",
+                  "signalKind": "AzureResourceMetric",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 15,
+                    "reportedAt": "2025-11-26T10:00:00Z",
+                    "error": null
+                  },
+                  "metricNamespace": "microsoft.compute/virtualMachines",
+                  "metricName": "cpuusage",
+                  "aggregationType": "None",
+                  "dimension": "nodename",
+                  "dimensionFilter": "node1",
+                  "displayName": "CPU usage",
+                  "refreshInterval": "PT1M",
+                  "timeGrain": "PT1M",
+                  "dataUnit": "Count",
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "LowerThan",
+                      "threshold": 10
+                    },
+                    "unhealthyRule": {
+                      "operator": "LowerThan",
+                      "threshold": 1
+                    }
+                  }
+                },
+                {
+                  "name": "uniqueSignalName2",
+                  "signalDefinitionName": "sigdef1",
+                  "signalKind": "AzureResourceMetric"
+                }
+              ]
+            },
+            "azureLogAnalytics": {
+              "authenticationSetting": "auth123",
+              "logAnalyticsWorkspaceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.OperationalInsights/workspaces/myworkspace",
+              "signals": [
+                {
+                  "name": "uniqueSignalName3",
+                  "signalDefinitionName": null,
+                  "signalKind": "LogAnalyticsQuery",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 30,
+                    "reportedAt": "2025-11-26T10:00:00Z",
+                    "error": null
+                  },
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 1
+                    },
+                    "unhealthyRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 5
+                    }
+                  },
+                  "refreshInterval": "PT1M",
+                  "queryText": "print 1",
+                  "timeGrain": "PT30M",
+                  "valueColumnName": "result",
+                  "displayName": "Test LA signal",
+                  "dataUnit": "my unit"
+                }
+              ]
+            },
+            "azureMonitorWorkspace": {
+              "authenticationSetting": "auth123",
+              "azureMonitorWorkspaceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.OperationalInsights/workspaces/myworkspace",
+              "signals": [
+                {
+                  "name": "pod-cpu-usage",
+                  "signalDefinitionName": "PodCpuUsageDefinition",
+                  "signalKind": "PrometheusMetricsQuery",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 45.3,
+                    "reportedAt": "2025-12-11T10:30:00Z"
+                  },
+                  "displayName": "Pod CPU Usage",
+                  "refreshInterval": "PT1M",
+                  "dataUnit": "Percent",
+                  "queryText": "rate(container_cpu_usage_seconds_total{pod=~\"my-app-.*\"}[5m]) * 100",
+                  "timeGrain": "PT5M",
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 70
+                    },
+                    "unhealthyRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 90
+                    }
+                  }
+                }
+              ]
+            },
+            "dependencies": {
+              "aggregationType": "MinHealthy",
+              "unit": "Percentage",
+              "degradedThreshold": 80,
+              "unhealthyThreshold": 50
+            },
+            "external": {
+              "signals": [
+                {
+                  "name": "external-signal-1",
+                  "signalKind": "External",
+                  "status": {
+                    "healthState": "Degraded",
+                    "value": 75.5,
+                    "reportedAt": "2025-12-15T12:00:00Z"
+                  },
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 70
+                    },
+                    "unhealthyRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 90
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "discoveredBy": "discoveryRule1",
+          "alerts": {
+            "unhealthy": {
+              "severity": "Sev1",
+              "description": "Alert description",
+              "actionGroupIds": [
+                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Insights/actionGroups/myactiongroup"
+              ]
+            },
+            "degraded": {
+              "severity": "Sev4",
+              "description": "Alert description",
+              "actionGroupIds": [
+                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Insights/actionGroups/myactiongroup"
+              ]
+            }
+          }
+        },
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/myResourceGroup/providers/Microsoft.CloudHealth/healthmodels/myHealthModel/entities/entity1",
+        "name": "entity1",
+        "type": "Microsoft.CloudHealth/healthmodels/entities",
+        "systemData": {
+          "createdBy": "cbhzxxlvkmufetjjjwtk",
+          "createdByType": "User",
+          "createdAt": "2023-09-18T14:04:09.327Z",
+          "lastModifiedBy": "arz",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/Entities_GetHistory.json
+++ b/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/Entities_GetHistory.json
@@ -1,0 +1,45 @@
+{
+  "title": "Entities_GetHistory",
+  "operationId": "Entities_GetHistory",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi",
+    "healthModelName": "myHealthModel",
+    "entityName": "entity1",
+    "body": {
+      "startAt": "2025-12-11T10:00:00Z",
+      "endAt": "2025-12-12T10:00:00Z"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "entityName": "entity1",
+        "history": [
+          {
+            "previousState": "Healthy",
+            "newState": "Degraded",
+            "occurredAt": "2025-12-11T14:30:00Z",
+            "reason": "SignalTransition"
+          },
+          {
+            "previousState": "Degraded",
+            "newState": "Unhealthy",
+            "occurredAt": "2025-12-11T18:45:00Z"
+          },
+          {
+            "previousState": "Unhealthy",
+            "newState": "Degraded",
+            "occurredAt": "2025-12-11T22:15:00Z"
+          },
+          {
+            "previousState": "Degraded",
+            "newState": "Healthy",
+            "occurredAt": "2025-12-12T02:30:00Z"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/Entities_GetSignalHistory.json
+++ b/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/Entities_GetSignalHistory.json
@@ -1,0 +1,62 @@
+{
+  "title": "Entities_GetSignalHistory",
+  "operationId": "Entities_GetSignalHistory",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi",
+    "healthModelName": "myHealthModel",
+    "entityName": "entity1",
+    "body": {
+      "signalName": "uniqueSignalName1",
+      "startAt": "2025-12-11T10:00:00Z",
+      "endAt": "2025-12-12T10:00:00Z"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "entityName": "entity1",
+        "signalName": "uniqueSignalName1",
+        "history": [
+          {
+            "occurredAt": "2025-12-11T10:00:00Z",
+            "value": 15.2,
+            "healthState": "Healthy"
+          },
+          {
+            "occurredAt": "2025-12-11T14:00:00Z",
+            "value": 42.8,
+            "healthState": "Healthy",
+            "additionalContext": "Manual submission"
+          },
+          {
+            "occurredAt": "2025-12-11T18:00:00Z",
+            "value": 78.5,
+            "healthState": "Degraded"
+          },
+          {
+            "occurredAt": "2025-12-11T22:00:00Z",
+            "value": 95.3,
+            "healthState": "Unhealthy"
+          },
+          {
+            "occurredAt": "2025-12-12T02:00:00Z",
+            "value": 65.1,
+            "healthState": "Degraded"
+          },
+          {
+            "occurredAt": "2025-12-12T06:00:00Z",
+            "value": 28.4,
+            "healthState": "Healthy"
+          },
+          {
+            "occurredAt": "2025-12-12T10:00:00Z",
+            "value": 12.7,
+            "healthState": "Healthy"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/Entities_IngestHealthReport.json
+++ b/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/Entities_IngestHealthReport.json
@@ -1,0 +1,31 @@
+{
+  "title": "Entities_IngestHealthReport",
+  "operationId": "Entities_IngestHealthReport",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi",
+    "healthModelName": "myHealthModel",
+    "entityName": "entity1",
+    "body": {
+      "signalName": "uniqueSignalName1",
+      "value": 85.5,
+      "healthState": "Degraded",
+      "evaluationRules": {
+        "degradedRule": {
+          "operator": "GreaterThan",
+          "threshold": 70
+        },
+        "unhealthyRule": {
+          "operator": "GreaterThan",
+          "threshold": 90
+        }
+      },
+      "expiresInMinutes": 60,
+      "additionalContext": "CPU usage elevated due to batch processing job"
+    }
+  },
+  "responses": {
+    "204": {}
+  }
+}

--- a/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/Entities_ListByHealthModel.json
+++ b/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/Entities_ListByHealthModel.json
@@ -1,0 +1,198 @@
+{
+  "title": "Entities_ListByHealthModel",
+  "operationId": "Entities_ListByHealthModel",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi",
+    "healthModelName": "gPWT6GP85xRV248L7LhNRTD--2Yc73wu-5Qk-0tS"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "provisioningState": "Succeeded",
+              "displayName": "entity 1",
+              "canvasPosition": {
+                "x": 14,
+                "y": 13
+              },
+              "icon": {
+                "iconName": "SystemComponent"
+              },
+              "healthObjective": 62,
+              "impact": "Standard",
+              "tags": {
+                "key1376": "sample tag"
+              },
+              "healthState": "Degraded",
+              "signalGroups": {
+                "azureResource": {
+                  "authenticationSetting": "auth123",
+                  "azureResourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
+                  "azureResourceKind": "functionapp",
+                  "signals": [
+                    {
+                      "name": "uniqueSignalName1",
+                      "signalDefinitionName": "sigdef1",
+                      "signalKind": "AzureResourceMetric",
+                      "status": {
+                        "healthState": "Healthy",
+                        "value": 15,
+                        "reportedAt": "2025-11-26T10:00:00Z",
+                        "error": null
+                      },
+                      "metricNamespace": "microsoft.compute/virtualMachines",
+                      "metricName": "cpuusage",
+                      "aggregationType": "None",
+                      "dimension": "nodename",
+                      "dimensionFilter": "node1",
+                      "displayName": "CPU usage",
+                      "refreshInterval": "PT1M",
+                      "timeGrain": "PT1M",
+                      "dataUnit": "Count",
+                      "evaluationRules": {
+                        "degradedRule": {
+                          "operator": "LowerThan",
+                          "threshold": 10
+                        },
+                        "unhealthyRule": {
+                          "operator": "LowerThan",
+                          "threshold": 1
+                        }
+                      }
+                    }
+                  ]
+                },
+                "azureLogAnalytics": {
+                  "authenticationSetting": "auth123",
+                  "logAnalyticsWorkspaceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.OperationalInsights/workspaces/myworkspace",
+                  "signals": [
+                    {
+                      "name": "uniqueSignalName2",
+                      "signalDefinitionName": null,
+                      "signalKind": "LogAnalyticsQuery",
+                      "status": {
+                        "healthState": "Healthy",
+                        "value": 30,
+                        "reportedAt": "2025-11-26T10:00:00Z",
+                        "error": null
+                      },
+                      "evaluationRules": {
+                        "degradedRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 1
+                        },
+                        "unhealthyRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 5
+                        }
+                      },
+                      "refreshInterval": "PT1M",
+                      "queryText": "print 1",
+                      "timeGrain": "PT30M",
+                      "valueColumnName": "result",
+                      "displayName": "Test LA signal",
+                      "dataUnit": "my unit"
+                    }
+                  ]
+                },
+                "azureMonitorWorkspace": {
+                  "authenticationSetting": "auth123",
+                  "azureMonitorWorkspaceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.OperationalInsights/workspaces/myworkspace",
+                  "signals": [
+                    {
+                      "name": "pod-cpu-usage",
+                      "signalDefinitionName": "PodCpuUsageDefinition",
+                      "signalKind": "PrometheusMetricsQuery",
+                      "status": {
+                        "healthState": "Healthy",
+                        "value": 45.3,
+                        "reportedAt": "2025-12-11T10:30:00Z"
+                      },
+                      "displayName": "Pod CPU Usage",
+                      "refreshInterval": "PT1M",
+                      "dataUnit": "Percent",
+                      "queryText": "rate(container_cpu_usage_seconds_total{pod=~\"my-app-.*\"}[5m]) * 100",
+                      "timeGrain": "PT5M",
+                      "evaluationRules": {
+                        "degradedRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 70
+                        },
+                        "unhealthyRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 90
+                        }
+                      }
+                    }
+                  ]
+                },
+                "dependencies": {
+                  "aggregationType": "MinHealthy",
+                  "unit": "Percentage",
+                  "degradedThreshold": 80,
+                  "unhealthyThreshold": 50
+                },
+                "external": {
+                  "signals": [
+                    {
+                      "name": "external-signal-1",
+                      "signalKind": "External",
+                      "status": {
+                        "healthState": "Degraded",
+                        "value": 75.5,
+                        "reportedAt": "2025-12-15T12:00:00Z"
+                      },
+                      "evaluationRules": {
+                        "degradedRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 70
+                        },
+                        "unhealthyRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 90
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              "discoveredBy": "discoveryRule1",
+              "alerts": {
+                "unhealthy": {
+                  "severity": "Sev1",
+                  "description": "Alert description",
+                  "actionGroupIds": [
+                    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Insights/actionGroups/myactiongroup"
+                  ]
+                },
+                "degraded": {
+                  "severity": "Sev4",
+                  "description": "Alert description",
+                  "actionGroupIds": [
+                    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Insights/actionGroups/myactiongroup"
+                  ]
+                }
+              }
+            },
+            "id": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/myResourceGroup/providers/Microsoft.CloudHealth/healthmodels/5D334Xv2hy4-Kj48w7b3JO0--51G625B6-m/entities/entity1",
+            "name": "entity1",
+            "type": "Microsoft.CloudHealth/healthmodels/entities",
+            "systemData": {
+              "createdBy": "cbhzxxlvkmufetjjjwtk",
+              "createdByType": "User",
+              "createdAt": "2023-09-18T14:04:09.327Z",
+              "lastModifiedBy": "arz",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/ai"
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/HealthModels_Create.json
+++ b/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/HealthModels_Create.json
@@ -1,0 +1,94 @@
+{
+  "title": "HealthModels_Create",
+  "operationId": "HealthModels_Create",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi",
+    "healthModelName": "model1",
+    "resource": {
+      "properties": {},
+      "identity": {
+        "type": "SystemAssigned, UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ua1": {}
+        }
+      },
+      "tags": {
+        "key2961": "hbljozzkqrpcthsjtfkyozpwyx"
+      },
+      "location": "eastus2"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded"
+        },
+        "identity": {
+          "principalId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a1",
+          "tenantId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a0",
+          "type": "SystemAssigned, UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ua1": {
+              "principalId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a0",
+              "clientId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a0"
+            }
+          }
+        },
+        "tags": {
+          "key2961": "hbljozzkqrpcthsjtfkyozpwyx"
+        },
+        "location": "eastus2",
+        "id": "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.CloudHealth/healthmodels/model1",
+        "name": "model1",
+        "type": "Microsoft.CloudHealth/healthmodels",
+        "systemData": {
+          "createdBy": "cbhzxxlvkmufetjjjwtk",
+          "createdByType": "User",
+          "createdAt": "2023-09-18T14:04:09.327Z",
+          "lastModifiedBy": "arz",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+      },
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded"
+        },
+        "identity": {
+          "principalId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a1",
+          "tenantId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a0",
+          "type": "SystemAssigned, UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ua1": {
+              "principalId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a0",
+              "clientId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a0"
+            }
+          }
+        },
+        "tags": {
+          "key2961": "hbljozzkqrpcthsjtfkyozpwyx"
+        },
+        "location": "eastus2",
+        "id": "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.CloudHealth/healthmodels/model1",
+        "name": "model1",
+        "type": "Microsoft.CloudHealth/healthmodels",
+        "systemData": {
+          "createdBy": "cbhzxxlvkmufetjjjwtk",
+          "createdByType": "User",
+          "createdAt": "2023-09-18T14:04:09.327Z",
+          "lastModifiedBy": "arz",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/HealthModels_Delete.json
+++ b/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/HealthModels_Delete.json
@@ -1,0 +1,18 @@
+{
+  "title": "HealthModels_Delete",
+  "operationId": "HealthModels_Delete",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi",
+    "healthModelName": "model1"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/HealthModels_Get.json
+++ b/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/HealthModels_Get.json
@@ -1,0 +1,45 @@
+{
+  "title": "HealthModels_Get",
+  "operationId": "HealthModels_Get",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi",
+    "healthModelName": "myHealthModel"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded"
+        },
+        "identity": {
+          "principalId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a1",
+          "tenantId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a0",
+          "type": "SystemAssigned, UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ua1": {
+              "principalId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a0",
+              "clientId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a0"
+            }
+          }
+        },
+        "tags": {
+          "key2961": "hbljozzkqrpcthsjtfkyozpwyx"
+        },
+        "location": "eastus2",
+        "id": "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.CloudHealth/healthmodels/myHealthModel",
+        "name": "myHealthModel",
+        "type": "Microsoft.CloudHealth/healthmodels",
+        "systemData": {
+          "createdBy": "cbhzxxlvkmufetjjjwtk",
+          "createdByType": "User",
+          "createdAt": "2023-09-18T14:04:09.327Z",
+          "lastModifiedBy": "arz",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/HealthModels_ListByResourceGroup.json
+++ b/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/HealthModels_ListByResourceGroup.json
@@ -1,0 +1,49 @@
+{
+  "title": "HealthModels_ListByResourceGroup",
+  "operationId": "HealthModels_ListByResourceGroup",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "provisioningState": "Succeeded"
+            },
+            "identity": {
+              "principalId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a1",
+              "tenantId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a0",
+              "type": "SystemAssigned, UserAssigned",
+              "userAssignedIdentities": {
+                "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ua1": {
+                  "principalId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a0",
+                  "clientId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a0"
+                }
+              }
+            },
+            "tags": {
+              "key2961": "hbljozzkqrpcthsjtfkyozpwyx"
+            },
+            "location": "eastus2",
+            "id": "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.CloudHealth/healthmodels/mproankhtrzzlpeqhwwsiibjcv",
+            "name": "ledqwyacixdfszgsxnsxggonrwk",
+            "type": "Microsoft.CloudHealth/healthmodels",
+            "systemData": {
+              "createdBy": "cbhzxxlvkmufetjjjwtk",
+              "createdByType": "User",
+              "createdAt": "2023-09-18T14:04:09.327Z",
+              "lastModifiedBy": "arz",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/HealthModels_ListBySubscription.json
+++ b/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/HealthModels_ListBySubscription.json
@@ -1,0 +1,48 @@
+{
+  "title": "HealthModels_ListBySubscription",
+  "operationId": "HealthModels_ListBySubscription",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "provisioningState": "Succeeded"
+            },
+            "identity": {
+              "principalId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a0",
+              "tenantId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a0",
+              "type": "SystemAssigned, UserAssigned",
+              "userAssignedIdentities": {
+                "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ua1": {
+                  "principalId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a1",
+                  "clientId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a0"
+                }
+              }
+            },
+            "tags": {
+              "key2961": "hbljozzkqrpcthsjtfkyozpwyx"
+            },
+            "location": "eastus2",
+            "id": "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/MyResourceGroup/providers/Microsoft.CloudHealth/healthmodels/mproankhtrzzlpeqhwwsiibjcv",
+            "name": "mproankhtrzzlpeqhwwsiibjcv",
+            "type": "Microsoft.CloudHealth/healthmodels",
+            "systemData": {
+              "createdBy": "cbhzxxlvkmufetjjjwtk",
+              "createdByType": "User",
+              "createdAt": "2023-09-18T14:04:09.327Z",
+              "lastModifiedBy": "arz",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/HealthModels_Update.json
+++ b/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/HealthModels_Update.json
@@ -1,0 +1,61 @@
+{
+  "title": "HealthModels_Update",
+  "operationId": "HealthModels_Update",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi",
+    "healthModelName": "model1",
+    "properties": {
+      "identity": {
+        "type": "SystemAssigned, UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ua1": {}
+        }
+      },
+      "tags": {
+        "key21": "menfkmseplchh"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded"
+        },
+        "identity": {
+          "principalId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a0",
+          "tenantId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a0",
+          "type": "SystemAssigned, UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ua1": {
+              "principalId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a1",
+              "clientId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a0"
+            }
+          }
+        },
+        "tags": {
+          "key2961": "hbljozzkqrpcthsjtfkyozpwyx"
+        },
+        "location": "eastus2",
+        "id": "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.CloudHealth/healthmodels/model1",
+        "name": "model1",
+        "type": "Microsoft.CloudHealth/healthmodels",
+        "systemData": {
+          "createdBy": "cbhzxxlvkmufetjjjwtk",
+          "createdByType": "User",
+          "createdAt": "2023-09-18T14:04:09.327Z",
+          "lastModifiedBy": "arz",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/Operations_List.json
+++ b/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/Operations_List.json
@@ -1,0 +1,28 @@
+{
+  "title": "Operations_List",
+  "operationId": "Operations_List",
+  "parameters": {
+    "api-version": "2026-05-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "xnmopnrytj",
+            "isDataAction": true,
+            "display": {
+              "provider": "hzfhjoyiwiwree",
+              "resource": "oldzgb",
+              "operation": "lykzqcnt",
+              "description": "gec"
+            },
+            "origin": "user",
+            "actionType": "Internal"
+          }
+        ],
+        "nextLink": "https://foo.bar/pagednextlink"
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/Relationships_CreateOrUpdate.json
+++ b/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/Relationships_CreateOrUpdate.json
@@ -1,0 +1,71 @@
+{
+  "title": "Relationships_CreateOrUpdate",
+  "operationId": "Relationships_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi",
+    "healthModelName": "model1",
+    "relationshipName": "rel1",
+    "resource": {
+      "properties": {
+        "displayName": "My relationship",
+        "parentEntityName": "Entity1",
+        "childEntityName": "Entity2",
+        "tags": {
+          "key9681": "ixfvzsfnpvkkbrce"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "displayName": "My relationship",
+          "parentEntityName": "Entity1",
+          "childEntityName": "Entity2",
+          "tags": {
+            "key9681": "ixfvzsfnpvkkbrce"
+          }
+        },
+        "id": "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.CloudHealth/healthmodels/J1-j5J-E4N1r4I7i226K7-6V-B27V1RiF6S5M6-pl7JgD3-lx4CF/relationships/rel1",
+        "name": "rel1",
+        "type": "Microsoft.CloudHealth/healthmodels/relationships",
+        "systemData": {
+          "createdBy": "cbhzxxlvkmufetjjjwtk",
+          "createdByType": "User",
+          "createdAt": "2023-09-18T14:04:09.327Z",
+          "lastModifiedBy": "arz",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "displayName": "My relationship",
+          "parentEntityName": "Entity1",
+          "childEntityName": "Entity2",
+          "tags": {
+            "key9681": "ixfvzsfnpvkkbrce"
+          }
+        },
+        "id": "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.CloudHealth/healthmodels/J1-j5J-E4N1r4I7i226K7-6V-B27V1RiF6S5M6-pl7JgD3-lx4CF/relationships/rel1",
+        "name": "rel1",
+        "type": "Microsoft.CloudHealth/healthmodels/relationships",
+        "systemData": {
+          "createdBy": "cbhzxxlvkmufetjjjwtk",
+          "createdByType": "User",
+          "createdAt": "2023-09-18T14:04:09.327Z",
+          "lastModifiedBy": "arz",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/Relationships_Delete.json
+++ b/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/Relationships_Delete.json
@@ -1,0 +1,19 @@
+{
+  "title": "Relationships_Delete",
+  "operationId": "Relationships_Delete",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi",
+    "healthModelName": "model1",
+    "relationshipName": "rel1"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/Relationships_Get.json
+++ b/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/Relationships_Get.json
@@ -1,0 +1,38 @@
+{
+  "title": "Relationships_Get",
+  "operationId": "Relationships_Get",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi",
+    "healthModelName": "myHealthModel",
+    "relationshipName": "Ue-21-F3M12V3w-13x18F8H-7HOk--kq6tP-HB"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "displayName": "My relationship",
+          "parentEntityName": "Entity1",
+          "childEntityName": "Entity2",
+          "tags": {
+            "key9681": "foo"
+          },
+          "discoveredBy": "discoveryRule1"
+        },
+        "id": "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.CloudHealth/healthmodels/myHealthModel/relationships/Ue-21-F3M12V3w-13x18F8H-7HOk--kq6tP-HB",
+        "name": "Ue-21-F3M12V3w-13x18F8H-7HOk--kq6tP-HB",
+        "type": "Microsoft.CloudHealth/healthmodels/relationships",
+        "systemData": {
+          "createdBy": "cbhzxxlvkmufetjjjwtk",
+          "createdByType": "User",
+          "createdAt": "2023-09-18T14:04:09.327Z",
+          "lastModifiedBy": "arz",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/Relationships_ListByHealthModel.json
+++ b/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/Relationships_ListByHealthModel.json
@@ -1,0 +1,42 @@
+{
+  "title": "Relationships_ListByHealthModel",
+  "operationId": "Relationships_ListByHealthModel",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi",
+    "healthModelName": "model1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "provisioningState": "Succeeded",
+              "displayName": "My relationship",
+              "parentEntityName": "B3P1X3e-FZtZ-4Ak-2VLHGQ-4m4-05DE-XNW5zW3P-46XY-DC3SSX",
+              "childEntityName": "B3P1X3e-FZtZ-4Ak-2VLHGQ-4m4-05DE-XNW5zW3P-46XY-DC3SSX",
+              "tags": {
+                "key9681": "sdfsdfsdfsdfsd"
+              },
+              "discoveredBy": "discoveryRule1"
+            },
+            "id": "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.CloudHealth/healthmodels/model1/relationships/cnsofbwhgcen",
+            "name": "cnsofbwhgcen",
+            "type": "Microsoft.CloudHealth/healthmodels/relationships",
+            "systemData": {
+              "createdBy": "cbhzxxlvkmufetjjjwtk",
+              "createdByType": "User",
+              "createdAt": "2023-09-18T14:04:09.327Z",
+              "lastModifiedBy": "arz",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/SignalDefinitions_CreateOrUpdate.json
+++ b/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/SignalDefinitions_CreateOrUpdate.json
@@ -1,0 +1,123 @@
+{
+  "title": "SignalDefinitions_CreateOrUpdate",
+  "operationId": "SignalDefinitions_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi",
+    "healthModelName": "myHealthModel",
+    "signalDefinitionName": "sig1",
+    "resource": {
+      "properties": {
+        "metricNamespace": "microsoft.compute/virtualMachines",
+        "metricName": "cpuusage",
+        "aggregationType": "None",
+        "dimension": "nodename",
+        "dimensionFilter": "node1",
+        "displayName": "cpu usage",
+        "signalKind": "AzureResourceMetric",
+        "refreshInterval": "PT1M",
+        "tags": {
+          "key4788": "ixfvzsfnpvkkbrce"
+        },
+        "timeGrain": "PT1M",
+        "dataUnit": "byte",
+        "evaluationRules": {
+          "degradedRule": {
+            "operator": "GreaterThan",
+            "threshold": 70
+          },
+          "unhealthyRule": {
+            "operator": "Dynamic",
+            "sensitivity": "Medium",
+            "lookBackWindow": "PT7D"
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "metricNamespace": "microsoft.compute/virtualMachines",
+          "metricName": "cpuusage",
+          "aggregationType": "None",
+          "dimension": "nodename",
+          "dimensionFilter": "node1",
+          "provisioningState": "Succeeded",
+          "displayName": "cpu usage",
+          "signalKind": "AzureResourceMetric",
+          "refreshInterval": "PT1M",
+          "tags": {
+            "key4788": "ixfvzsfnpvkkbrce"
+          },
+          "timeGrain": "PT1M",
+          "dataUnit": "byte",
+          "evaluationRules": {
+            "degradedRule": {
+              "operator": "LowerThan",
+              "threshold": 65
+            },
+            "unhealthyRule": {
+              "operator": "LowerThan",
+              "threshold": 60
+            }
+          }
+        },
+        "id": "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.CloudHealth/healthmodels/myHealthModel/signalDefinitions/sig1",
+        "name": "sig1",
+        "type": "Microsoft.CloudHealth/healthmodels/signalDefinitions",
+        "systemData": {
+          "createdBy": "cbhzxxlvkmufetjjjwtk",
+          "createdByType": "User",
+          "createdAt": "2023-09-18T14:04:09.327Z",
+          "lastModifiedBy": "arz",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "properties": {
+          "metricNamespace": "kujaurtzrdlyexshjcraswhnjrmcjlegmtbzduetqznxieewurnnezcwznjpvufjoypioxtfgrfziqhkfthbdvwbzmcvxmdzxgbzxviwmugayrhdyurhdcmvwhuzmhavbvliskxavzov",
+          "metricName": "xlsswqywkvtiulmxongbafoqksbsltadbggpeubkyiy",
+          "aggregationType": "None",
+          "dimension": "sxxlqypljsttlvuvsogtycoiydgzhjjtmbxu",
+          "dimensionFilter": "yhbqekkrnnippcgbeeimcdcuvuohaajzpqcviyqunqhsorduzecwmeawrpffpljlqeauvnhronbycqyurpqgdcrmeikppwezhvrwtqshomrcptiyvnanlticrlihpzjgttdxkawdujtlnwgg",
+          "provisioningState": "Succeeded",
+          "displayName": "mgrilplginubbvafosnnwwxkwflvsznaplxnlqnfhkcnuttrhskkforavbytgptctphwniskif",
+          "signalKind": "AzureResourceMetric",
+          "refreshInterval": "PT1M",
+          "tags": {
+            "key4788": "ixfvzsfnpvkkbrce"
+          },
+          "timeGrain": "PT1M",
+          "dataUnit": "byte",
+          "evaluationRules": {
+            "degradedRule": {
+              "operator": "LowerThan",
+              "threshold": 65
+            },
+            "unhealthyRule": {
+              "operator": "LowerThan",
+              "threshold": 60
+            }
+          }
+        },
+        "id": "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.CloudHealth/healthmodels/myHealthModel/signalDefinitions/sig1",
+        "name": "sig1",
+        "type": "Microsoft.CloudHealth/healthmodels/signalDefinitions",
+        "systemData": {
+          "createdBy": "cbhzxxlvkmufetjjjwtk",
+          "createdByType": "User",
+          "createdAt": "2023-09-18T14:04:09.327Z",
+          "lastModifiedBy": "arz",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/SignalDefinitions_Delete.json
+++ b/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/SignalDefinitions_Delete.json
@@ -1,0 +1,19 @@
+{
+  "title": "SignalDefinitions_Delete",
+  "operationId": "SignalDefinitions_Delete",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi",
+    "healthModelName": "model1",
+    "signalDefinitionName": "sig"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/SignalDefinitions_Get.json
+++ b/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/SignalDefinitions_Get.json
@@ -1,0 +1,55 @@
+{
+  "title": "SignalDefinitions_Get",
+  "operationId": "SignalDefinitions_Get",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi",
+    "healthModelName": "myHealthModel",
+    "signalDefinitionName": "sig1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "metricNamespace": "microsoft.compute/virtualMachines",
+          "metricName": "cpuusage",
+          "aggregationType": "None",
+          "dimension": "nodename",
+          "dimensionFilter": "node1",
+          "provisioningState": "Succeeded",
+          "displayName": "cpu upsage",
+          "signalKind": "AzureResourceMetric",
+          "refreshInterval": "PT1M",
+          "tags": {
+            "key4788": "foo"
+          },
+          "timeGrain": "PT1M",
+          "dataUnit": "Count",
+          "evaluationRules": {
+            "degradedRule": {
+              "operator": "GreaterThan",
+              "threshold": 70
+            },
+            "unhealthyRule": {
+              "operator": "Dynamic",
+              "sensitivity": "Medium",
+              "lookBackWindow": "PT7D"
+            }
+          }
+        },
+        "id": "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.CloudHealth/healthmodels/myHealthModel/signalDefinitions/sig1",
+        "name": "sig1",
+        "type": "Microsoft.CloudHealth/healthmodels/signalDefinitions",
+        "systemData": {
+          "createdBy": "cbhzxxlvkmufetjjjwtk",
+          "createdByType": "User",
+          "createdAt": "2023-09-18T14:04:09.327Z",
+          "lastModifiedBy": "arz",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/SignalDefinitions_ListByHealthModel.json
+++ b/specification/cloudhealth/CloudHealth.Management/examples/2026-05-01-preview/SignalDefinitions_ListByHealthModel.json
@@ -1,0 +1,96 @@
+{
+  "title": "SignalDefinitions_ListByHealthModel",
+  "operationId": "SignalDefinitions_ListByHealthModel",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi",
+    "healthModelName": "myHealthModel"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "metricNamespace": "microsoft.compute/virtualMachines",
+              "metricName": "cpuusage",
+              "aggregationType": "None",
+              "dimension": "node",
+              "dimensionFilter": "node1",
+              "provisioningState": "Succeeded",
+              "displayName": "cpu usage",
+              "signalKind": "AzureResourceMetric",
+              "refreshInterval": "PT1M",
+              "tags": {
+                "key4788": "bar"
+              },
+              "timeGrain": "PT10M",
+              "dataUnit": "Count",
+              "evaluationRules": {
+                "degradedRule": {
+                  "operator": "GreaterThan",
+                  "threshold": 70
+                },
+                "unhealthyRule": {
+                  "operator": "Dynamic",
+                  "sensitivity": "Medium",
+                  "lookBackWindow": "PT7D"
+                }
+              }
+            },
+            "id": "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.CloudHealth/healthmodels/myHealthModel/signalDefinitions/sig1",
+            "name": "sig1",
+            "type": "Microsoft.CloudHealth/healthmodels/signalDefinitions",
+            "systemData": {
+              "createdBy": "cbhzxxlvkmufetjjjwtk",
+              "createdByType": "User",
+              "createdAt": "2023-09-18T14:04:09.327Z",
+              "lastModifiedBy": "arz",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+            }
+          },
+          {
+            "properties": {
+              "metricNamespace": "microsoft.compute/virtualMachines",
+              "metricName": "memoryusage",
+              "aggregationType": "Average",
+              "provisioningState": "Succeeded",
+              "displayName": "memorey usage",
+              "signalKind": "AzureResourceMetric",
+              "refreshInterval": "PT1M",
+              "tags": {
+                "key4788": "bar"
+              },
+              "timeGrain": "PT10M",
+              "dataUnit": "Count",
+              "evaluationRules": {
+                "degradedRule": {
+                  "operator": "LowerThan",
+                  "threshold": 10
+                },
+                "unhealthyRule": {
+                  "operator": "LowerThan",
+                  "threshold": 1
+                }
+              }
+            },
+            "id": "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.CloudHealth/healthmodels/myHealthModel/signalDefinitions/sig2",
+            "name": "sig2",
+            "type": "Microsoft.CloudHealth/healthmodels/signalDefinitions",
+            "systemData": {
+              "createdBy": "cbhzxxlvkmufetjjjwtk",
+              "createdByType": "User",
+              "createdAt": "2023-09-18T14:04:09.327Z",
+              "lastModifiedBy": "arz",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/aqvdhgvi"
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/CloudHealth.Management/main.tsp
+++ b/specification/cloudhealth/CloudHealth.Management/main.tsp
@@ -24,6 +24,9 @@ enum Versions {
 
   @doc("2026-01-01-preview")
   v2026_01_01_preview: "2026-01-01-preview",
+
+  @doc("2026-05-01-preview")
+  v2026_05_01_preview: "2026-05-01-preview",
 }
 
 alias ProviderName = "Microsoft.CloudHealth";
@@ -200,8 +203,32 @@ model ThresholdRuleV2 {
   @doc("Operator how to compare the signal value with the threshold")
   operator: SignalOperator;
 
-  @doc("Threshold value")
-  threshold: float64;
+  @madeOptional(Versions.v2026_05_01_preview)
+  @doc("Threshold value. Required for static operators. When operator is Dynamic, defaults to the minimum representable value if omitted.")
+  threshold?: float64;
+
+  @added(Versions.v2026_05_01_preview)
+  @doc("Sensitivity level for dynamic threshold detection. Only applicable when operator is Dynamic.")
+  sensitivity?: DynamicThresholdSensitivity;
+
+  @added(Versions.v2026_05_01_preview)
+  @doc("ISO 8601 duration for the historical look-back window used by dynamic threshold computation. Only applicable when operator is Dynamic.")
+  lookBackWindow?: string;
+}
+
+@added(Versions.v2026_05_01_preview)
+@doc("Sensitivity level for dynamic threshold detection")
+union DynamicThresholdSensitivity {
+  string,
+
+  @doc("Low sensitivity — fewer anomalies detected, wider threshold band")
+  Low: "Low",
+
+  @doc("Medium sensitivity — balanced detection")
+  Medium: "Medium",
+
+  @doc("High sensitivity — more anomalies detected, tighter threshold band")
+  High: "High",
 }
 
 @removed(Versions.v2026_01_01_preview)
@@ -385,6 +412,10 @@ union SignalOperator {
   @added(Versions.v2026_01_01_preview)
   @doc("Not equal to")
   NotEqual: "NotEqual",
+
+  @added(Versions.v2026_05_01_preview)
+  @doc("Dynamic threshold — uses statistical analysis of historical signal values")
+  Dynamic: "Dynamic",
 }
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "Self-explanatory"

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/cloudhealth.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/cloudhealth.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "Microsoft.CloudHealth",
-    "version": "2026-01-01-preview",
+    "version": "2026-05-01-preview",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"
@@ -2589,6 +2589,36 @@
         "kind"
       ]
     },
+    "DynamicThresholdSensitivity": {
+      "type": "string",
+      "description": "Sensitivity level for dynamic threshold detection",
+      "enum": [
+        "Low",
+        "Medium",
+        "High"
+      ],
+      "x-ms-enum": {
+        "name": "DynamicThresholdSensitivity",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Low",
+            "value": "Low",
+            "description": "Low sensitivity — fewer anomalies detected, wider threshold band"
+          },
+          {
+            "name": "Medium",
+            "value": "Medium",
+            "description": "Medium sensitivity — balanced detection"
+          },
+          {
+            "name": "High",
+            "value": "High",
+            "description": "High sensitivity — more anomalies detected, tighter threshold band"
+          }
+        ]
+      }
+    },
     "Entity": {
       "type": "object",
       "description": "An entity (aka node) of a health model",
@@ -3903,7 +3933,8 @@
         "LessThanOrEqual",
         "GreaterThanOrEqual",
         "Equal",
-        "NotEqual"
+        "NotEqual",
+        "Dynamic"
       ],
       "x-ms-enum": {
         "name": "SignalOperator",
@@ -3938,6 +3969,11 @@
             "name": "NotEqual",
             "value": "NotEqual",
             "description": "Not equal to"
+          },
+          {
+            "name": "Dynamic",
+            "value": "Dynamic",
+            "description": "Dynamic threshold — uses statistical analysis of historical signal values"
           }
         ]
       }
@@ -3982,11 +4018,18 @@
           "type": "number",
           "format": "double",
           "description": "Threshold value. Required for static operators. When operator is Dynamic, defaults to the minimum representable value if omitted."
+        },
+        "sensitivity": {
+          "$ref": "#/definitions/DynamicThresholdSensitivity",
+          "description": "Sensitivity level for dynamic threshold detection. Only applicable when operator is Dynamic."
+        },
+        "lookBackWindow": {
+          "type": "string",
+          "description": "ISO 8601 duration for the historical look-back window used by dynamic threshold computation. Only applicable when operator is Dynamic."
         }
       },
       "required": [
-        "operator",
-        "threshold"
+        "operator"
       ]
     },
     "authenticationSettingName": {

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/AuthenticationSettings_CreateOrUpdate.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/AuthenticationSettings_CreateOrUpdate.json
@@ -1,0 +1,62 @@
+{
+  "title": "AuthenticationSettings_CreateOrUpdate",
+  "operationId": "AuthenticationSettings_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "myResourceGroup",
+    "healthModelName": "myHealthModel",
+    "authenticationSettingName": "myAuthSetting",
+    "resource": {
+      "properties": {
+        "managedIdentityName": "SystemAssigned",
+        "displayName": "myDisplayName",
+        "authenticationKind": "ManagedIdentity"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "managedIdentityName": "SystemAssigned",
+          "provisioningState": "Succeeded",
+          "displayName": "myDisplayName",
+          "authenticationKind": "ManagedIdentity"
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.CloudHealth/healthModels/myHealthModel/authenticationSettings/myAuthSetting",
+        "name": "myAuthSetting",
+        "type": "Microsoft.CloudHealth/healthModels/authenticationSettings",
+        "systemData": {
+          "createdBy": "myCreatedBy",
+          "createdByType": "User",
+          "createdAt": "2023-09-18T14:04:09.327Z",
+          "lastModifiedBy": "myLastModifiedBy",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "properties": {
+          "managedIdentityName": "SystemAssigned",
+          "provisioningState": "Succeeded",
+          "displayName": "myDisplayName",
+          "authenticationKind": "ManagedIdentity"
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.CloudHealth/healthModels/myHealthModel/authenticationSettings/myAuthSetting",
+        "name": "myAuthSetting",
+        "type": "Microsoft.CloudHealth/healthModels/authenticationSettings",
+        "systemData": {
+          "createdBy": "myCreatedBy",
+          "createdByType": "User",
+          "createdAt": "2023-09-18T14:04:09.327Z",
+          "lastModifiedBy": "myLastModifiedBy",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/AuthenticationSettings_Delete.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/AuthenticationSettings_Delete.json
@@ -1,0 +1,19 @@
+{
+  "title": "AuthenticationSettings_Delete",
+  "operationId": "AuthenticationSettings_Delete",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "my-resource-group",
+    "healthModelName": "my-health-model",
+    "authenticationSettingName": "my-auth-setting"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/AuthenticationSettings_Get.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/AuthenticationSettings_Get.json
@@ -1,0 +1,34 @@
+{
+  "title": "AuthenticationSettings_Get",
+  "operationId": "AuthenticationSettings_Get",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "my-resource-group",
+    "healthModelName": "my-health-model",
+    "authenticationSettingName": "my-auth-setting"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "managedIdentityName": "SystemAssigned",
+          "provisioningState": "Succeeded",
+          "displayName": "my-display-name",
+          "authenticationKind": "ManagedIdentity"
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-resource-group/providers/Microsoft.CloudHealth/healthmodels/my-health-model/authenticationSettings/my-auth-setting",
+        "name": "my-name",
+        "type": "Microsoft.CloudHealth/healthmodels/authenticationSettings",
+        "systemData": {
+          "createdBy": "my-username",
+          "createdByType": "User",
+          "createdAt": "2023-09-18T14:04:09.327Z",
+          "lastModifiedBy": "my-username",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/AuthenticationSettings_ListByHealthModel.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/AuthenticationSettings_ListByHealthModel.json
@@ -1,0 +1,38 @@
+{
+  "title": "AuthenticationSettings_ListByHealthModel",
+  "operationId": "AuthenticationSettings_ListByHealthModel",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "my-resource-group",
+    "healthModelName": "my-health-model"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "managedIdentityName": "SystemAssigned",
+              "provisioningState": "Succeeded",
+              "displayName": "my-display-name",
+              "authenticationKind": "ManagedIdentity"
+            },
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-resource-group/providers/Microsoft.CloudHealth/healthModels/my-health-model/authenticationSettings/my-name",
+            "name": "my-name",
+            "type": "Microsoft.CloudHealth/healthModels/authenticationSettings",
+            "systemData": {
+              "createdBy": "my-user",
+              "createdByType": "User",
+              "createdAt": "2023-09-18T14:04:09.327Z",
+              "lastModifiedBy": "my-user",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/ahgxpg"
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/DiscoveryRules_CreateOrUpdate.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/DiscoveryRules_CreateOrUpdate.json
@@ -1,0 +1,79 @@
+{
+  "title": "DiscoveryRules_CreateOrUpdate",
+  "operationId": "DiscoveryRules_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "myResourceGroup",
+    "healthModelName": "myHealthModel",
+    "discoveryRuleName": "myDiscoveryRule",
+    "resource": {
+      "properties": {
+        "authenticationSetting": "authSetting1",
+        "displayName": "myDisplayName",
+        "discoverRelationships": "Enabled",
+        "addRecommendedSignals": "Enabled",
+        "specification": {
+          "kind": "ResourceGraphQuery",
+          "resourceGraphQuery": "resources | where subscriptionId == '7ddfffd7-9b32-40df-1234-828cbd55d6f4' | where resourceGroup == 'my-rg'"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "authenticationSetting": "authSetting1",
+          "provisioningState": "Succeeded",
+          "displayName": "myDisplayName",
+          "discoverRelationships": "Enabled",
+          "addRecommendedSignals": "Enabled",
+          "specification": {
+            "kind": "ResourceGraphQuery",
+            "resourceGraphQuery": "resources | where subscriptionId == '7ddfffd7-9b32-40df-1234-828cbd55d6f4' | where resourceGroup == 'my-rg'"
+          },
+          "entityName": "f1f0ef5e-a5b5-4d02-b69c-7145f4658829"
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.CloudHealth/healthModels/myHealthModel/discoveryRules/myDiscoveryRule",
+        "name": "myDiscoveryRule",
+        "type": "Microsoft.CloudHealth/healthModels/discoveryRules",
+        "systemData": {
+          "createdBy": "myCreatedBy",
+          "createdByType": "User",
+          "createdAt": "2023-09-18T14:04:09.327Z",
+          "lastModifiedBy": "myLastModifiedBy",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "properties": {
+          "authenticationSetting": "authSetting1",
+          "provisioningState": "Succeeded",
+          "displayName": "myDisplayName",
+          "discoverRelationships": "Enabled",
+          "addRecommendedSignals": "Enabled",
+          "specification": {
+            "kind": "ResourceGraphQuery",
+            "resourceGraphQuery": "resources | where subscriptionId == '7ddfffd7-9b32-40df-1234-828cbd55d6f4' | where resourceGroup == 'my-rg'"
+          },
+          "entityName": "f1f0ef5e-a5b5-4d02-b69c-7145f4658829"
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.CloudHealth/healthModels/myHealthModel/discoveryRules/myDiscoveryRule",
+        "name": "myDiscoveryRule",
+        "type": "Microsoft.CloudHealth/healthModels/discoveryRules",
+        "systemData": {
+          "createdBy": "myCreatedBy",
+          "createdByType": "User",
+          "createdAt": "2023-09-18T14:04:09.327Z",
+          "lastModifiedBy": "myLastModifiedBy",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/DiscoveryRules_Delete.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/DiscoveryRules_Delete.json
@@ -1,0 +1,19 @@
+{
+  "title": "DiscoveryRules_Delete",
+  "operationId": "DiscoveryRules_Delete",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "my-resource-group",
+    "healthModelName": "my-health-model",
+    "discoveryRuleName": "my-discovery-rule"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/DiscoveryRules_Get.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/DiscoveryRules_Get.json
@@ -1,0 +1,46 @@
+{
+  "title": "DiscoveryRules_Get",
+  "operationId": "DiscoveryRules_Get",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "myResourceGroup",
+    "healthModelName": "myHealthModel",
+    "discoveryRuleName": "myDiscoveryRule"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "authenticationSetting": "authSetting1",
+          "provisioningState": "Succeeded",
+          "displayName": "myDisplayName",
+          "discoverRelationships": "Enabled",
+          "addRecommendedSignals": "Enabled",
+          "specification": {
+            "kind": "ResourceGraphQuery",
+            "resourceGraphQuery": "resources | where subscriptionId == '7ddfffd7-9b32-40df-1234-828cbd55d6f4' | where resourceGroup == 'my-rg'"
+          },
+          "error": {
+            "message": "Authorization error on execution",
+            "context": [
+              "subscriptionId: 7ddfffd7-9b32-40df-1234-828cbd55d6f4"
+            ]
+          },
+          "entityName": "f1f0ef5e-a5b5-4d02-b69c-7145f4658829"
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.CloudHealth/healthModels/myHealthModel/discoveryRules/myDiscoveryRule",
+        "name": "myDiscoveryRule",
+        "type": "Microsoft.CloudHealth/healthModels/discoveryRules",
+        "systemData": {
+          "createdBy": "myCreatedBy",
+          "createdByType": "User",
+          "createdAt": "2023-09-18T14:04:09.327Z",
+          "lastModifiedBy": "myLastModifiedBy",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/DiscoveryRules_ListByHealthModel.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/DiscoveryRules_ListByHealthModel.json
@@ -1,0 +1,69 @@
+{
+  "title": "DiscoveryRules_ListByHealthModel",
+  "operationId": "DiscoveryRules_ListByHealthModel",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "my-resource-group",
+    "healthModelName": "my-health-model"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "authenticationSetting": "authSetting1",
+              "provisioningState": "Succeeded",
+              "displayName": "ARG Discovery Rule",
+              "discoverRelationships": "Enabled",
+              "addRecommendedSignals": "Enabled",
+              "specification": {
+                "kind": "ResourceGraphQuery",
+                "resourceGraphQuery": "resources | where subscriptionId == '7ddfffd7-9b32-40df-1234-828cbd55d6f4' | where resourceGroup == 'my-rg'"
+              },
+              "entityName": "f1f0ef5e-a5b5-4d02-b69c-7145f4658829"
+            },
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.CloudHealth/healthModels/myHealthModel/discoveryRules/myArgDiscoveryRule",
+            "name": "myArgDiscoveryRule",
+            "type": "Microsoft.CloudHealth/healthModels/discoveryRules",
+            "systemData": {
+              "createdBy": "myCreatedBy",
+              "createdByType": "User",
+              "createdAt": "2023-09-18T14:04:09.327Z",
+              "lastModifiedBy": "myLastModifiedBy",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+            }
+          },
+          {
+            "properties": {
+              "authenticationSetting": "authSetting1",
+              "provisioningState": "Succeeded",
+              "displayName": "Application Insights Discovery Rule",
+              "discoverRelationships": "Enabled",
+              "addRecommendedSignals": "Enabled",
+              "specification": {
+                "kind": "ApplicationInsightsTopology",
+                "applicationInsightsResourceId": "/subscriptions/7ddfffd7-9b32-40df-1234-828cbd55d6f4/resourceGroups/my-rg/providers/Microsoft.Insights/components/my-app-insights"
+              },
+              "entityName": "a2b3c4d5-e6f7-8901-2345-678901234567"
+            },
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.CloudHealth/healthModels/myHealthModel/discoveryRules/myAppInsightsDiscoveryRule",
+            "name": "myAppInsightsDiscoveryRule",
+            "type": "Microsoft.CloudHealth/healthModels/discoveryRules",
+            "systemData": {
+              "createdBy": "myCreatedBy",
+              "createdByType": "User",
+              "createdAt": "2023-09-20T10:15:30.123Z",
+              "lastModifiedBy": "myLastModifiedBy",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2023-09-20T10:15:30.456Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/ahgxpg"
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/Entities_CreateOrUpdate.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/Entities_CreateOrUpdate.json
@@ -1,0 +1,453 @@
+{
+  "title": "Entities_CreateOrUpdate",
+  "operationId": "Entities_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi",
+    "healthModelName": "myHealthModel",
+    "entityName": "uszrxbdkxesdrxhmagmzywebgbjj",
+    "resource": {
+      "properties": {
+        "displayName": "My entity",
+        "canvasPosition": {
+          "x": 14,
+          "y": 13
+        },
+        "icon": {
+          "iconName": "Custom",
+          "customData": "rcitntvapruccrhtxmkqjphbxunkz"
+        },
+        "healthObjective": 62,
+        "impact": "Standard",
+        "tags": {
+          "key1376": "sample tag"
+        },
+        "signalGroups": {
+          "azureResource": {
+            "authenticationSetting": "auth123",
+            "azureResourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
+            "azureResourceKind": "functionapp",
+            "signals": [
+              {
+                "name": "uniqueSignalName1",
+                "signalDefinitionName": "sigdef1",
+                "signalKind": "AzureResourceMetric",
+                "metricNamespace": "microsoft.compute/virtualMachines",
+                "metricName": "cpuusage",
+                "aggregationType": "None",
+                "dimension": "nodename",
+                "dimensionFilter": "node1",
+                "displayName": "CPU usage",
+                "refreshInterval": "PT1M",
+                "timeGrain": "PT1M",
+                "dataUnit": "Count",
+                "evaluationRules": {
+                  "degradedRule": {
+                    "operator": "LowerThan",
+                    "threshold": 10
+                  },
+                  "unhealthyRule": {
+                    "operator": "LowerThan",
+                    "threshold": 1
+                  }
+                }
+              }
+            ]
+          },
+          "azureLogAnalytics": {
+            "authenticationSetting": "auth123",
+            "logAnalyticsWorkspaceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.OperationalInsights/workspaces/myworkspace",
+            "signals": [
+              {
+                "name": "uniqueSignalName2",
+                "signalDefinitionName": null,
+                "signalKind": "LogAnalyticsQuery",
+                "evaluationRules": {
+                  "degradedRule": {
+                    "operator": "GreaterThan",
+                    "threshold": 1
+                  },
+                  "unhealthyRule": {
+                    "operator": "GreaterThan",
+                    "threshold": 5
+                  }
+                },
+                "refreshInterval": "PT1M",
+                "queryText": "print 1",
+                "timeGrain": "PT30M",
+                "valueColumnName": "result",
+                "displayName": "Test LA signal",
+                "dataUnit": "my unit"
+              }
+            ]
+          },
+          "azureMonitorWorkspace": {
+            "authenticationSetting": "auth123",
+            "azureMonitorWorkspaceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.OperationalInsights/workspaces/myworkspace",
+            "signals": [
+              {
+                "name": "pod-cpu-usage",
+                "signalDefinitionName": "PodCpuUsageDefinition",
+                "signalKind": "PrometheusMetricsQuery",
+                "displayName": "Pod CPU Usage",
+                "refreshInterval": "PT1M",
+                "dataUnit": "Percent",
+                "queryText": "rate(container_cpu_usage_seconds_total{pod=~\"my-app-.*\"}[5m]) * 100",
+                "timeGrain": "PT5M",
+                "evaluationRules": {
+                  "degradedRule": {
+                    "operator": "GreaterThan",
+                    "threshold": 70
+                  },
+                  "unhealthyRule": {
+                    "operator": "GreaterThan",
+                    "threshold": 90
+                  }
+                }
+              }
+            ]
+          },
+          "dependencies": {
+            "aggregationType": "MinHealthy",
+            "unit": "Percentage",
+            "degradedThreshold": 80,
+            "unhealthyThreshold": 50
+          }
+        },
+        "alerts": {
+          "unhealthy": {
+            "severity": "Sev1",
+            "description": "Alert description",
+            "actionGroupIds": [
+              "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Insights/actionGroups/myactiongroup"
+            ]
+          },
+          "degraded": {
+            "severity": "Sev4",
+            "description": "Alert description",
+            "actionGroupIds": [
+              "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Insights/actionGroups/myactiongroup"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "displayName": "My entity",
+          "canvasPosition": {
+            "x": 14,
+            "y": 13
+          },
+          "icon": {
+            "iconName": "Custom",
+            "customData": "rcitntvapruccrhtxmkqjphbxunkz"
+          },
+          "healthObjective": 62,
+          "impact": "Standard",
+          "tags": {
+            "key1376": "sample tag"
+          },
+          "signalGroups": {
+            "azureResource": {
+              "authenticationSetting": "auth123",
+              "azureResourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
+              "azureResourceKind": "functionapp",
+              "signals": [
+                {
+                  "name": "uniqueSignalName1",
+                  "signalDefinitionName": "sigdef1",
+                  "signalKind": "AzureResourceMetric",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 15,
+                    "reportedAt": "2025-11-26T10:00:00Z",
+                    "error": null
+                  },
+                  "metricNamespace": "microsoft.compute/virtualMachines",
+                  "metricName": "cpuusage",
+                  "aggregationType": "None",
+                  "dimension": "nodename",
+                  "dimensionFilter": "node1",
+                  "displayName": "CPU usage",
+                  "refreshInterval": "PT1M",
+                  "timeGrain": "PT1M",
+                  "dataUnit": "Count",
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "LowerThan",
+                      "threshold": 10
+                    },
+                    "unhealthyRule": {
+                      "operator": "LowerThan",
+                      "threshold": 1
+                    }
+                  }
+                }
+              ]
+            },
+            "azureLogAnalytics": {
+              "authenticationSetting": "auth123",
+              "logAnalyticsWorkspaceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.OperationalInsights/workspaces/myworkspace",
+              "signals": [
+                {
+                  "name": "uniqueSignalName2",
+                  "signalDefinitionName": null,
+                  "signalKind": "LogAnalyticsQuery",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 30,
+                    "reportedAt": "2025-11-26T10:00:00Z",
+                    "error": null
+                  },
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 1
+                    },
+                    "unhealthyRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 5
+                    }
+                  },
+                  "refreshInterval": "PT1M",
+                  "queryText": "print 1",
+                  "timeGrain": "PT30M",
+                  "valueColumnName": "result",
+                  "displayName": "Test LA signal",
+                  "dataUnit": "my unit"
+                }
+              ]
+            },
+            "azureMonitorWorkspace": {
+              "authenticationSetting": "auth123",
+              "azureMonitorWorkspaceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.OperationalInsights/workspaces/myworkspace",
+              "signals": [
+                {
+                  "name": "pod-cpu-usage",
+                  "signalDefinitionName": "PodCpuUsageDefinition",
+                  "signalKind": "PrometheusMetricsQuery",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 45.3,
+                    "reportedAt": "2025-12-11T10:30:00Z"
+                  },
+                  "displayName": "Pod CPU Usage",
+                  "refreshInterval": "PT1M",
+                  "dataUnit": "Percent",
+                  "queryText": "rate(container_cpu_usage_seconds_total{pod=~\"my-app-.*\"}[5m]) * 100",
+                  "timeGrain": "PT5M",
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 70
+                    },
+                    "unhealthyRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 90
+                    }
+                  }
+                }
+              ]
+            },
+            "dependencies": {
+              "aggregationType": "MinHealthy",
+              "unit": "Percentage",
+              "degradedThreshold": 80,
+              "unhealthyThreshold": 50
+            }
+          },
+          "alerts": {
+            "unhealthy": {
+              "severity": "Sev1",
+              "description": "Alert description",
+              "actionGroupIds": [
+                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Insights/actionGroups/myactiongroup"
+              ]
+            },
+            "degraded": {
+              "severity": "Sev4",
+              "description": "Alert description",
+              "actionGroupIds": [
+                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Insights/actionGroups/myactiongroup"
+              ]
+            }
+          }
+        },
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/myResourceGroup/providers/Microsoft.CloudHealth/healthmodels/myHealthModel/entities/uszrxbdkxesdrxhmagmzywebgbjj",
+        "name": "uszrxbdkxesdrxhmagmzywebgbjj",
+        "type": "Microsoft.CloudHealth/healthmodels/entities",
+        "systemData": {
+          "createdBy": "cbhzxxlvkmufetjjjwtk",
+          "createdByType": "User",
+          "createdAt": "2023-09-18T14:04:09.327Z",
+          "lastModifiedBy": "arz",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "displayName": "My entity",
+          "canvasPosition": {
+            "x": 14,
+            "y": 13
+          },
+          "icon": {
+            "iconName": "Custom",
+            "customData": "rcitntvapruccrhtxmkqjphbxunkz"
+          },
+          "healthObjective": 62,
+          "impact": "Standard",
+          "tags": {
+            "key1376": "sample tag"
+          },
+          "signalGroups": {
+            "azureResource": {
+              "authenticationSetting": "auth123",
+              "azureResourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
+              "azureResourceKind": "functionapp",
+              "signals": [
+                {
+                  "name": "uniqueSignalName1",
+                  "signalDefinitionName": "sigdef1",
+                  "signalKind": "AzureResourceMetric",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 15,
+                    "reportedAt": "2025-11-26T10:00:00Z",
+                    "error": null
+                  },
+                  "metricNamespace": "microsoft.compute/virtualMachines",
+                  "metricName": "cpuusage",
+                  "aggregationType": "None",
+                  "dimension": "nodename",
+                  "dimensionFilter": "node1",
+                  "displayName": "CPU usage",
+                  "refreshInterval": "PT1M",
+                  "timeGrain": "PT1M",
+                  "dataUnit": "Count",
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "LowerThan",
+                      "threshold": 10
+                    },
+                    "unhealthyRule": {
+                      "operator": "LowerThan",
+                      "threshold": 1
+                    }
+                  }
+                }
+              ]
+            },
+            "azureLogAnalytics": {
+              "authenticationSetting": "auth123",
+              "logAnalyticsWorkspaceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.OperationalInsights/workspaces/myworkspace",
+              "signals": [
+                {
+                  "name": "uniqueSignalName2",
+                  "signalDefinitionName": null,
+                  "signalKind": "LogAnalyticsQuery",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 30,
+                    "reportedAt": "2025-11-26T10:00:00Z",
+                    "error": null
+                  },
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 1
+                    },
+                    "unhealthyRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 5
+                    }
+                  },
+                  "refreshInterval": "PT1M",
+                  "queryText": "print 1",
+                  "timeGrain": "PT30M",
+                  "valueColumnName": "result",
+                  "displayName": "Test LA signal",
+                  "dataUnit": "my unit"
+                }
+              ]
+            },
+            "azureMonitorWorkspace": {
+              "authenticationSetting": "auth123",
+              "azureMonitorWorkspaceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.OperationalInsights/workspaces/myworkspace",
+              "signals": [
+                {
+                  "name": "pod-cpu-usage",
+                  "signalDefinitionName": "PodCpuUsageDefinition",
+                  "signalKind": "PrometheusMetricsQuery",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 45.3,
+                    "reportedAt": "2025-12-11T10:30:00Z"
+                  },
+                  "displayName": "Pod CPU Usage",
+                  "refreshInterval": "PT1M",
+                  "dataUnit": "Percent",
+                  "queryText": "rate(container_cpu_usage_seconds_total{pod=~\"my-app-.*\"}[5m]) * 100",
+                  "timeGrain": "PT5M",
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 70
+                    },
+                    "unhealthyRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 90
+                    }
+                  }
+                }
+              ]
+            },
+            "dependencies": {
+              "aggregationType": "MinHealthy",
+              "unit": "Percentage",
+              "degradedThreshold": 80,
+              "unhealthyThreshold": 50
+            }
+          },
+          "alerts": {
+            "unhealthy": {
+              "severity": "Sev1",
+              "description": "Alert description",
+              "actionGroupIds": [
+                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Insights/actionGroups/myactiongroup"
+              ]
+            },
+            "degraded": {
+              "severity": "Sev4",
+              "description": "Alert description",
+              "actionGroupIds": [
+                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Insights/actionGroups/myactiongroup"
+              ]
+            }
+          }
+        },
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/myResourceGroup/providers/Microsoft.CloudHealth/healthmodels/myHealthModel/entities/uszrxbdkxesdrxhmagmzywebgbjj",
+        "name": "uszrxbdkxesdrxhmagmzywebgbjj",
+        "type": "Microsoft.CloudHealth/healthmodels/entities",
+        "systemData": {
+          "createdBy": "cbhzxxlvkmufetjjjwtk",
+          "createdByType": "User",
+          "createdAt": "2023-09-18T14:04:09.327Z",
+          "lastModifiedBy": "arz",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/Entities_Delete.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/Entities_Delete.json
@@ -1,0 +1,19 @@
+{
+  "title": "Entities_Delete",
+  "operationId": "Entities_Delete",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi",
+    "healthModelName": "model1",
+    "entityName": "U4VTRFlUkm9kR6H23-c-6U-XHq7n"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/Entities_Get.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/Entities_Get.json
@@ -1,0 +1,199 @@
+{
+  "title": "Entities_Get",
+  "operationId": "Entities_Get",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi",
+    "healthModelName": "myHealthModel",
+    "entityName": "entity1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "displayName": "Entity 1",
+          "canvasPosition": {
+            "x": 14,
+            "y": 13
+          },
+          "icon": {
+            "iconName": "UserFlow"
+          },
+          "healthObjective": 62,
+          "impact": "Standard",
+          "tags": {
+            "key1376": "sample tag"
+          },
+          "healthState": "Healthy",
+          "signalGroups": {
+            "azureResource": {
+              "authenticationSetting": "auth123",
+              "azureResourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
+              "azureResourceKind": "functionapp",
+              "signals": [
+                {
+                  "name": "uniqueSignalName1",
+                  "signalDefinitionName": "sigdef1",
+                  "signalKind": "AzureResourceMetric",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 15,
+                    "reportedAt": "2025-11-26T10:00:00Z",
+                    "error": null
+                  },
+                  "metricNamespace": "microsoft.compute/virtualMachines",
+                  "metricName": "cpuusage",
+                  "aggregationType": "None",
+                  "dimension": "nodename",
+                  "dimensionFilter": "node1",
+                  "displayName": "CPU usage",
+                  "refreshInterval": "PT1M",
+                  "timeGrain": "PT1M",
+                  "dataUnit": "Count",
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "LowerThan",
+                      "threshold": 10
+                    },
+                    "unhealthyRule": {
+                      "operator": "LowerThan",
+                      "threshold": 1
+                    }
+                  }
+                },
+                {
+                  "name": "uniqueSignalName2",
+                  "signalDefinitionName": "sigdef1",
+                  "signalKind": "AzureResourceMetric"
+                }
+              ]
+            },
+            "azureLogAnalytics": {
+              "authenticationSetting": "auth123",
+              "logAnalyticsWorkspaceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.OperationalInsights/workspaces/myworkspace",
+              "signals": [
+                {
+                  "name": "uniqueSignalName3",
+                  "signalDefinitionName": null,
+                  "signalKind": "LogAnalyticsQuery",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 30,
+                    "reportedAt": "2025-11-26T10:00:00Z",
+                    "error": null
+                  },
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 1
+                    },
+                    "unhealthyRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 5
+                    }
+                  },
+                  "refreshInterval": "PT1M",
+                  "queryText": "print 1",
+                  "timeGrain": "PT30M",
+                  "valueColumnName": "result",
+                  "displayName": "Test LA signal",
+                  "dataUnit": "my unit"
+                }
+              ]
+            },
+            "azureMonitorWorkspace": {
+              "authenticationSetting": "auth123",
+              "azureMonitorWorkspaceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.OperationalInsights/workspaces/myworkspace",
+              "signals": [
+                {
+                  "name": "pod-cpu-usage",
+                  "signalDefinitionName": "PodCpuUsageDefinition",
+                  "signalKind": "PrometheusMetricsQuery",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 45.3,
+                    "reportedAt": "2025-12-11T10:30:00Z"
+                  },
+                  "displayName": "Pod CPU Usage",
+                  "refreshInterval": "PT1M",
+                  "dataUnit": "Percent",
+                  "queryText": "rate(container_cpu_usage_seconds_total{pod=~\"my-app-.*\"}[5m]) * 100",
+                  "timeGrain": "PT5M",
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 70
+                    },
+                    "unhealthyRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 90
+                    }
+                  }
+                }
+              ]
+            },
+            "dependencies": {
+              "aggregationType": "MinHealthy",
+              "unit": "Percentage",
+              "degradedThreshold": 80,
+              "unhealthyThreshold": 50
+            },
+            "external": {
+              "signals": [
+                {
+                  "name": "external-signal-1",
+                  "signalKind": "External",
+                  "status": {
+                    "healthState": "Degraded",
+                    "value": 75.5,
+                    "reportedAt": "2025-12-15T12:00:00Z"
+                  },
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 70
+                    },
+                    "unhealthyRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 90
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "discoveredBy": "discoveryRule1",
+          "alerts": {
+            "unhealthy": {
+              "severity": "Sev1",
+              "description": "Alert description",
+              "actionGroupIds": [
+                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Insights/actionGroups/myactiongroup"
+              ]
+            },
+            "degraded": {
+              "severity": "Sev4",
+              "description": "Alert description",
+              "actionGroupIds": [
+                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Insights/actionGroups/myactiongroup"
+              ]
+            }
+          }
+        },
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/myResourceGroup/providers/Microsoft.CloudHealth/healthmodels/myHealthModel/entities/entity1",
+        "name": "entity1",
+        "type": "Microsoft.CloudHealth/healthmodels/entities",
+        "systemData": {
+          "createdBy": "cbhzxxlvkmufetjjjwtk",
+          "createdByType": "User",
+          "createdAt": "2023-09-18T14:04:09.327Z",
+          "lastModifiedBy": "arz",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/Entities_GetHistory.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/Entities_GetHistory.json
@@ -1,0 +1,45 @@
+{
+  "title": "Entities_GetHistory",
+  "operationId": "Entities_GetHistory",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi",
+    "healthModelName": "myHealthModel",
+    "entityName": "entity1",
+    "body": {
+      "startAt": "2025-12-11T10:00:00Z",
+      "endAt": "2025-12-12T10:00:00Z"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "entityName": "entity1",
+        "history": [
+          {
+            "previousState": "Healthy",
+            "newState": "Degraded",
+            "occurredAt": "2025-12-11T14:30:00Z",
+            "reason": "SignalTransition"
+          },
+          {
+            "previousState": "Degraded",
+            "newState": "Unhealthy",
+            "occurredAt": "2025-12-11T18:45:00Z"
+          },
+          {
+            "previousState": "Unhealthy",
+            "newState": "Degraded",
+            "occurredAt": "2025-12-11T22:15:00Z"
+          },
+          {
+            "previousState": "Degraded",
+            "newState": "Healthy",
+            "occurredAt": "2025-12-12T02:30:00Z"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/Entities_GetSignalHistory.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/Entities_GetSignalHistory.json
@@ -1,0 +1,62 @@
+{
+  "title": "Entities_GetSignalHistory",
+  "operationId": "Entities_GetSignalHistory",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi",
+    "healthModelName": "myHealthModel",
+    "entityName": "entity1",
+    "body": {
+      "signalName": "uniqueSignalName1",
+      "startAt": "2025-12-11T10:00:00Z",
+      "endAt": "2025-12-12T10:00:00Z"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "entityName": "entity1",
+        "signalName": "uniqueSignalName1",
+        "history": [
+          {
+            "occurredAt": "2025-12-11T10:00:00Z",
+            "value": 15.2,
+            "healthState": "Healthy"
+          },
+          {
+            "occurredAt": "2025-12-11T14:00:00Z",
+            "value": 42.8,
+            "healthState": "Healthy",
+            "additionalContext": "Manual submission"
+          },
+          {
+            "occurredAt": "2025-12-11T18:00:00Z",
+            "value": 78.5,
+            "healthState": "Degraded"
+          },
+          {
+            "occurredAt": "2025-12-11T22:00:00Z",
+            "value": 95.3,
+            "healthState": "Unhealthy"
+          },
+          {
+            "occurredAt": "2025-12-12T02:00:00Z",
+            "value": 65.1,
+            "healthState": "Degraded"
+          },
+          {
+            "occurredAt": "2025-12-12T06:00:00Z",
+            "value": 28.4,
+            "healthState": "Healthy"
+          },
+          {
+            "occurredAt": "2025-12-12T10:00:00Z",
+            "value": 12.7,
+            "healthState": "Healthy"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/Entities_IngestHealthReport.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/Entities_IngestHealthReport.json
@@ -1,0 +1,31 @@
+{
+  "title": "Entities_IngestHealthReport",
+  "operationId": "Entities_IngestHealthReport",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi",
+    "healthModelName": "myHealthModel",
+    "entityName": "entity1",
+    "body": {
+      "signalName": "uniqueSignalName1",
+      "value": 85.5,
+      "healthState": "Degraded",
+      "evaluationRules": {
+        "degradedRule": {
+          "operator": "GreaterThan",
+          "threshold": 70
+        },
+        "unhealthyRule": {
+          "operator": "GreaterThan",
+          "threshold": 90
+        }
+      },
+      "expiresInMinutes": 60,
+      "additionalContext": "CPU usage elevated due to batch processing job"
+    }
+  },
+  "responses": {
+    "204": {}
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/Entities_ListByHealthModel.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/Entities_ListByHealthModel.json
@@ -1,0 +1,198 @@
+{
+  "title": "Entities_ListByHealthModel",
+  "operationId": "Entities_ListByHealthModel",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi",
+    "healthModelName": "gPWT6GP85xRV248L7LhNRTD--2Yc73wu-5Qk-0tS"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "provisioningState": "Succeeded",
+              "displayName": "entity 1",
+              "canvasPosition": {
+                "x": 14,
+                "y": 13
+              },
+              "icon": {
+                "iconName": "SystemComponent"
+              },
+              "healthObjective": 62,
+              "impact": "Standard",
+              "tags": {
+                "key1376": "sample tag"
+              },
+              "healthState": "Degraded",
+              "signalGroups": {
+                "azureResource": {
+                  "authenticationSetting": "auth123",
+                  "azureResourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
+                  "azureResourceKind": "functionapp",
+                  "signals": [
+                    {
+                      "name": "uniqueSignalName1",
+                      "signalDefinitionName": "sigdef1",
+                      "signalKind": "AzureResourceMetric",
+                      "status": {
+                        "healthState": "Healthy",
+                        "value": 15,
+                        "reportedAt": "2025-11-26T10:00:00Z",
+                        "error": null
+                      },
+                      "metricNamespace": "microsoft.compute/virtualMachines",
+                      "metricName": "cpuusage",
+                      "aggregationType": "None",
+                      "dimension": "nodename",
+                      "dimensionFilter": "node1",
+                      "displayName": "CPU usage",
+                      "refreshInterval": "PT1M",
+                      "timeGrain": "PT1M",
+                      "dataUnit": "Count",
+                      "evaluationRules": {
+                        "degradedRule": {
+                          "operator": "LowerThan",
+                          "threshold": 10
+                        },
+                        "unhealthyRule": {
+                          "operator": "LowerThan",
+                          "threshold": 1
+                        }
+                      }
+                    }
+                  ]
+                },
+                "azureLogAnalytics": {
+                  "authenticationSetting": "auth123",
+                  "logAnalyticsWorkspaceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.OperationalInsights/workspaces/myworkspace",
+                  "signals": [
+                    {
+                      "name": "uniqueSignalName2",
+                      "signalDefinitionName": null,
+                      "signalKind": "LogAnalyticsQuery",
+                      "status": {
+                        "healthState": "Healthy",
+                        "value": 30,
+                        "reportedAt": "2025-11-26T10:00:00Z",
+                        "error": null
+                      },
+                      "evaluationRules": {
+                        "degradedRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 1
+                        },
+                        "unhealthyRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 5
+                        }
+                      },
+                      "refreshInterval": "PT1M",
+                      "queryText": "print 1",
+                      "timeGrain": "PT30M",
+                      "valueColumnName": "result",
+                      "displayName": "Test LA signal",
+                      "dataUnit": "my unit"
+                    }
+                  ]
+                },
+                "azureMonitorWorkspace": {
+                  "authenticationSetting": "auth123",
+                  "azureMonitorWorkspaceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.OperationalInsights/workspaces/myworkspace",
+                  "signals": [
+                    {
+                      "name": "pod-cpu-usage",
+                      "signalDefinitionName": "PodCpuUsageDefinition",
+                      "signalKind": "PrometheusMetricsQuery",
+                      "status": {
+                        "healthState": "Healthy",
+                        "value": 45.3,
+                        "reportedAt": "2025-12-11T10:30:00Z"
+                      },
+                      "displayName": "Pod CPU Usage",
+                      "refreshInterval": "PT1M",
+                      "dataUnit": "Percent",
+                      "queryText": "rate(container_cpu_usage_seconds_total{pod=~\"my-app-.*\"}[5m]) * 100",
+                      "timeGrain": "PT5M",
+                      "evaluationRules": {
+                        "degradedRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 70
+                        },
+                        "unhealthyRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 90
+                        }
+                      }
+                    }
+                  ]
+                },
+                "dependencies": {
+                  "aggregationType": "MinHealthy",
+                  "unit": "Percentage",
+                  "degradedThreshold": 80,
+                  "unhealthyThreshold": 50
+                },
+                "external": {
+                  "signals": [
+                    {
+                      "name": "external-signal-1",
+                      "signalKind": "External",
+                      "status": {
+                        "healthState": "Degraded",
+                        "value": 75.5,
+                        "reportedAt": "2025-12-15T12:00:00Z"
+                      },
+                      "evaluationRules": {
+                        "degradedRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 70
+                        },
+                        "unhealthyRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 90
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              "discoveredBy": "discoveryRule1",
+              "alerts": {
+                "unhealthy": {
+                  "severity": "Sev1",
+                  "description": "Alert description",
+                  "actionGroupIds": [
+                    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Insights/actionGroups/myactiongroup"
+                  ]
+                },
+                "degraded": {
+                  "severity": "Sev4",
+                  "description": "Alert description",
+                  "actionGroupIds": [
+                    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Insights/actionGroups/myactiongroup"
+                  ]
+                }
+              }
+            },
+            "id": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/myResourceGroup/providers/Microsoft.CloudHealth/healthmodels/5D334Xv2hy4-Kj48w7b3JO0--51G625B6-m/entities/entity1",
+            "name": "entity1",
+            "type": "Microsoft.CloudHealth/healthmodels/entities",
+            "systemData": {
+              "createdBy": "cbhzxxlvkmufetjjjwtk",
+              "createdByType": "User",
+              "createdAt": "2023-09-18T14:04:09.327Z",
+              "lastModifiedBy": "arz",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/ai"
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/HealthModels_Create.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/HealthModels_Create.json
@@ -1,0 +1,94 @@
+{
+  "title": "HealthModels_Create",
+  "operationId": "HealthModels_Create",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi",
+    "healthModelName": "model1",
+    "resource": {
+      "properties": {},
+      "identity": {
+        "type": "SystemAssigned, UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ua1": {}
+        }
+      },
+      "tags": {
+        "key2961": "hbljozzkqrpcthsjtfkyozpwyx"
+      },
+      "location": "eastus2"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded"
+        },
+        "identity": {
+          "principalId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a1",
+          "tenantId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a0",
+          "type": "SystemAssigned, UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ua1": {
+              "principalId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a0",
+              "clientId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a0"
+            }
+          }
+        },
+        "tags": {
+          "key2961": "hbljozzkqrpcthsjtfkyozpwyx"
+        },
+        "location": "eastus2",
+        "id": "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.CloudHealth/healthmodels/model1",
+        "name": "model1",
+        "type": "Microsoft.CloudHealth/healthmodels",
+        "systemData": {
+          "createdBy": "cbhzxxlvkmufetjjjwtk",
+          "createdByType": "User",
+          "createdAt": "2023-09-18T14:04:09.327Z",
+          "lastModifiedBy": "arz",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+      },
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded"
+        },
+        "identity": {
+          "principalId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a1",
+          "tenantId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a0",
+          "type": "SystemAssigned, UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ua1": {
+              "principalId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a0",
+              "clientId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a0"
+            }
+          }
+        },
+        "tags": {
+          "key2961": "hbljozzkqrpcthsjtfkyozpwyx"
+        },
+        "location": "eastus2",
+        "id": "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.CloudHealth/healthmodels/model1",
+        "name": "model1",
+        "type": "Microsoft.CloudHealth/healthmodels",
+        "systemData": {
+          "createdBy": "cbhzxxlvkmufetjjjwtk",
+          "createdByType": "User",
+          "createdAt": "2023-09-18T14:04:09.327Z",
+          "lastModifiedBy": "arz",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/HealthModels_Delete.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/HealthModels_Delete.json
@@ -1,0 +1,18 @@
+{
+  "title": "HealthModels_Delete",
+  "operationId": "HealthModels_Delete",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi",
+    "healthModelName": "model1"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/HealthModels_Get.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/HealthModels_Get.json
@@ -1,0 +1,45 @@
+{
+  "title": "HealthModels_Get",
+  "operationId": "HealthModels_Get",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi",
+    "healthModelName": "myHealthModel"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded"
+        },
+        "identity": {
+          "principalId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a1",
+          "tenantId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a0",
+          "type": "SystemAssigned, UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ua1": {
+              "principalId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a0",
+              "clientId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a0"
+            }
+          }
+        },
+        "tags": {
+          "key2961": "hbljozzkqrpcthsjtfkyozpwyx"
+        },
+        "location": "eastus2",
+        "id": "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.CloudHealth/healthmodels/myHealthModel",
+        "name": "myHealthModel",
+        "type": "Microsoft.CloudHealth/healthmodels",
+        "systemData": {
+          "createdBy": "cbhzxxlvkmufetjjjwtk",
+          "createdByType": "User",
+          "createdAt": "2023-09-18T14:04:09.327Z",
+          "lastModifiedBy": "arz",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/HealthModels_ListByResourceGroup.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/HealthModels_ListByResourceGroup.json
@@ -1,0 +1,49 @@
+{
+  "title": "HealthModels_ListByResourceGroup",
+  "operationId": "HealthModels_ListByResourceGroup",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "provisioningState": "Succeeded"
+            },
+            "identity": {
+              "principalId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a1",
+              "tenantId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a0",
+              "type": "SystemAssigned, UserAssigned",
+              "userAssignedIdentities": {
+                "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ua1": {
+                  "principalId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a0",
+                  "clientId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a0"
+                }
+              }
+            },
+            "tags": {
+              "key2961": "hbljozzkqrpcthsjtfkyozpwyx"
+            },
+            "location": "eastus2",
+            "id": "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.CloudHealth/healthmodels/mproankhtrzzlpeqhwwsiibjcv",
+            "name": "ledqwyacixdfszgsxnsxggonrwk",
+            "type": "Microsoft.CloudHealth/healthmodels",
+            "systemData": {
+              "createdBy": "cbhzxxlvkmufetjjjwtk",
+              "createdByType": "User",
+              "createdAt": "2023-09-18T14:04:09.327Z",
+              "lastModifiedBy": "arz",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/HealthModels_ListBySubscription.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/HealthModels_ListBySubscription.json
@@ -1,0 +1,48 @@
+{
+  "title": "HealthModels_ListBySubscription",
+  "operationId": "HealthModels_ListBySubscription",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "provisioningState": "Succeeded"
+            },
+            "identity": {
+              "principalId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a0",
+              "tenantId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a0",
+              "type": "SystemAssigned, UserAssigned",
+              "userAssignedIdentities": {
+                "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ua1": {
+                  "principalId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a1",
+                  "clientId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a0"
+                }
+              }
+            },
+            "tags": {
+              "key2961": "hbljozzkqrpcthsjtfkyozpwyx"
+            },
+            "location": "eastus2",
+            "id": "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/MyResourceGroup/providers/Microsoft.CloudHealth/healthmodels/mproankhtrzzlpeqhwwsiibjcv",
+            "name": "mproankhtrzzlpeqhwwsiibjcv",
+            "type": "Microsoft.CloudHealth/healthmodels",
+            "systemData": {
+              "createdBy": "cbhzxxlvkmufetjjjwtk",
+              "createdByType": "User",
+              "createdAt": "2023-09-18T14:04:09.327Z",
+              "lastModifiedBy": "arz",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/HealthModels_Update.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/HealthModels_Update.json
@@ -1,0 +1,61 @@
+{
+  "title": "HealthModels_Update",
+  "operationId": "HealthModels_Update",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi",
+    "healthModelName": "model1",
+    "properties": {
+      "identity": {
+        "type": "SystemAssigned, UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ua1": {}
+        }
+      },
+      "tags": {
+        "key21": "menfkmseplchh"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded"
+        },
+        "identity": {
+          "principalId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a0",
+          "tenantId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a0",
+          "type": "SystemAssigned, UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ua1": {
+              "principalId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a1",
+              "clientId": "b3f9c5a0-7c5b-4a5a-8b7a-3b5fddc1b0a0"
+            }
+          }
+        },
+        "tags": {
+          "key2961": "hbljozzkqrpcthsjtfkyozpwyx"
+        },
+        "location": "eastus2",
+        "id": "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.CloudHealth/healthmodels/model1",
+        "name": "model1",
+        "type": "Microsoft.CloudHealth/healthmodels",
+        "systemData": {
+          "createdBy": "cbhzxxlvkmufetjjjwtk",
+          "createdByType": "User",
+          "createdAt": "2023-09-18T14:04:09.327Z",
+          "lastModifiedBy": "arz",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/Operations_List.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/Operations_List.json
@@ -1,0 +1,28 @@
+{
+  "title": "Operations_List",
+  "operationId": "Operations_List",
+  "parameters": {
+    "api-version": "2026-05-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "xnmopnrytj",
+            "isDataAction": true,
+            "display": {
+              "provider": "hzfhjoyiwiwree",
+              "resource": "oldzgb",
+              "operation": "lykzqcnt",
+              "description": "gec"
+            },
+            "origin": "user",
+            "actionType": "Internal"
+          }
+        ],
+        "nextLink": "https://foo.bar/pagednextlink"
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/Relationships_CreateOrUpdate.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/Relationships_CreateOrUpdate.json
@@ -1,0 +1,71 @@
+{
+  "title": "Relationships_CreateOrUpdate",
+  "operationId": "Relationships_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi",
+    "healthModelName": "model1",
+    "relationshipName": "rel1",
+    "resource": {
+      "properties": {
+        "displayName": "My relationship",
+        "parentEntityName": "Entity1",
+        "childEntityName": "Entity2",
+        "tags": {
+          "key9681": "ixfvzsfnpvkkbrce"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "displayName": "My relationship",
+          "parentEntityName": "Entity1",
+          "childEntityName": "Entity2",
+          "tags": {
+            "key9681": "ixfvzsfnpvkkbrce"
+          }
+        },
+        "id": "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.CloudHealth/healthmodels/J1-j5J-E4N1r4I7i226K7-6V-B27V1RiF6S5M6-pl7JgD3-lx4CF/relationships/rel1",
+        "name": "rel1",
+        "type": "Microsoft.CloudHealth/healthmodels/relationships",
+        "systemData": {
+          "createdBy": "cbhzxxlvkmufetjjjwtk",
+          "createdByType": "User",
+          "createdAt": "2023-09-18T14:04:09.327Z",
+          "lastModifiedBy": "arz",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "displayName": "My relationship",
+          "parentEntityName": "Entity1",
+          "childEntityName": "Entity2",
+          "tags": {
+            "key9681": "ixfvzsfnpvkkbrce"
+          }
+        },
+        "id": "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.CloudHealth/healthmodels/J1-j5J-E4N1r4I7i226K7-6V-B27V1RiF6S5M6-pl7JgD3-lx4CF/relationships/rel1",
+        "name": "rel1",
+        "type": "Microsoft.CloudHealth/healthmodels/relationships",
+        "systemData": {
+          "createdBy": "cbhzxxlvkmufetjjjwtk",
+          "createdByType": "User",
+          "createdAt": "2023-09-18T14:04:09.327Z",
+          "lastModifiedBy": "arz",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/Relationships_Delete.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/Relationships_Delete.json
@@ -1,0 +1,19 @@
+{
+  "title": "Relationships_Delete",
+  "operationId": "Relationships_Delete",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi",
+    "healthModelName": "model1",
+    "relationshipName": "rel1"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/Relationships_Get.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/Relationships_Get.json
@@ -1,0 +1,38 @@
+{
+  "title": "Relationships_Get",
+  "operationId": "Relationships_Get",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi",
+    "healthModelName": "myHealthModel",
+    "relationshipName": "Ue-21-F3M12V3w-13x18F8H-7HOk--kq6tP-HB"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "displayName": "My relationship",
+          "parentEntityName": "Entity1",
+          "childEntityName": "Entity2",
+          "tags": {
+            "key9681": "foo"
+          },
+          "discoveredBy": "discoveryRule1"
+        },
+        "id": "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.CloudHealth/healthmodels/myHealthModel/relationships/Ue-21-F3M12V3w-13x18F8H-7HOk--kq6tP-HB",
+        "name": "Ue-21-F3M12V3w-13x18F8H-7HOk--kq6tP-HB",
+        "type": "Microsoft.CloudHealth/healthmodels/relationships",
+        "systemData": {
+          "createdBy": "cbhzxxlvkmufetjjjwtk",
+          "createdByType": "User",
+          "createdAt": "2023-09-18T14:04:09.327Z",
+          "lastModifiedBy": "arz",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/Relationships_ListByHealthModel.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/Relationships_ListByHealthModel.json
@@ -1,0 +1,42 @@
+{
+  "title": "Relationships_ListByHealthModel",
+  "operationId": "Relationships_ListByHealthModel",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi",
+    "healthModelName": "model1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "provisioningState": "Succeeded",
+              "displayName": "My relationship",
+              "parentEntityName": "B3P1X3e-FZtZ-4Ak-2VLHGQ-4m4-05DE-XNW5zW3P-46XY-DC3SSX",
+              "childEntityName": "B3P1X3e-FZtZ-4Ak-2VLHGQ-4m4-05DE-XNW5zW3P-46XY-DC3SSX",
+              "tags": {
+                "key9681": "sdfsdfsdfsdfsd"
+              },
+              "discoveredBy": "discoveryRule1"
+            },
+            "id": "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.CloudHealth/healthmodels/model1/relationships/cnsofbwhgcen",
+            "name": "cnsofbwhgcen",
+            "type": "Microsoft.CloudHealth/healthmodels/relationships",
+            "systemData": {
+              "createdBy": "cbhzxxlvkmufetjjjwtk",
+              "createdByType": "User",
+              "createdAt": "2023-09-18T14:04:09.327Z",
+              "lastModifiedBy": "arz",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/SignalDefinitions_CreateOrUpdate.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/SignalDefinitions_CreateOrUpdate.json
@@ -1,0 +1,123 @@
+{
+  "title": "SignalDefinitions_CreateOrUpdate",
+  "operationId": "SignalDefinitions_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi",
+    "healthModelName": "myHealthModel",
+    "signalDefinitionName": "sig1",
+    "resource": {
+      "properties": {
+        "metricNamespace": "microsoft.compute/virtualMachines",
+        "metricName": "cpuusage",
+        "aggregationType": "None",
+        "dimension": "nodename",
+        "dimensionFilter": "node1",
+        "displayName": "cpu usage",
+        "signalKind": "AzureResourceMetric",
+        "refreshInterval": "PT1M",
+        "tags": {
+          "key4788": "ixfvzsfnpvkkbrce"
+        },
+        "timeGrain": "PT1M",
+        "dataUnit": "byte",
+        "evaluationRules": {
+          "degradedRule": {
+            "operator": "GreaterThan",
+            "threshold": 70
+          },
+          "unhealthyRule": {
+            "operator": "Dynamic",
+            "sensitivity": "Medium",
+            "lookBackWindow": "PT7D"
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "metricNamespace": "microsoft.compute/virtualMachines",
+          "metricName": "cpuusage",
+          "aggregationType": "None",
+          "dimension": "nodename",
+          "dimensionFilter": "node1",
+          "provisioningState": "Succeeded",
+          "displayName": "cpu usage",
+          "signalKind": "AzureResourceMetric",
+          "refreshInterval": "PT1M",
+          "tags": {
+            "key4788": "ixfvzsfnpvkkbrce"
+          },
+          "timeGrain": "PT1M",
+          "dataUnit": "byte",
+          "evaluationRules": {
+            "degradedRule": {
+              "operator": "LowerThan",
+              "threshold": 65
+            },
+            "unhealthyRule": {
+              "operator": "LowerThan",
+              "threshold": 60
+            }
+          }
+        },
+        "id": "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.CloudHealth/healthmodels/myHealthModel/signalDefinitions/sig1",
+        "name": "sig1",
+        "type": "Microsoft.CloudHealth/healthmodels/signalDefinitions",
+        "systemData": {
+          "createdBy": "cbhzxxlvkmufetjjjwtk",
+          "createdByType": "User",
+          "createdAt": "2023-09-18T14:04:09.327Z",
+          "lastModifiedBy": "arz",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "properties": {
+          "metricNamespace": "kujaurtzrdlyexshjcraswhnjrmcjlegmtbzduetqznxieewurnnezcwznjpvufjoypioxtfgrfziqhkfthbdvwbzmcvxmdzxgbzxviwmugayrhdyurhdcmvwhuzmhavbvliskxavzov",
+          "metricName": "xlsswqywkvtiulmxongbafoqksbsltadbggpeubkyiy",
+          "aggregationType": "None",
+          "dimension": "sxxlqypljsttlvuvsogtycoiydgzhjjtmbxu",
+          "dimensionFilter": "yhbqekkrnnippcgbeeimcdcuvuohaajzpqcviyqunqhsorduzecwmeawrpffpljlqeauvnhronbycqyurpqgdcrmeikppwezhvrwtqshomrcptiyvnanlticrlihpzjgttdxkawdujtlnwgg",
+          "provisioningState": "Succeeded",
+          "displayName": "mgrilplginubbvafosnnwwxkwflvsznaplxnlqnfhkcnuttrhskkforavbytgptctphwniskif",
+          "signalKind": "AzureResourceMetric",
+          "refreshInterval": "PT1M",
+          "tags": {
+            "key4788": "ixfvzsfnpvkkbrce"
+          },
+          "timeGrain": "PT1M",
+          "dataUnit": "byte",
+          "evaluationRules": {
+            "degradedRule": {
+              "operator": "LowerThan",
+              "threshold": 65
+            },
+            "unhealthyRule": {
+              "operator": "LowerThan",
+              "threshold": 60
+            }
+          }
+        },
+        "id": "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.CloudHealth/healthmodels/myHealthModel/signalDefinitions/sig1",
+        "name": "sig1",
+        "type": "Microsoft.CloudHealth/healthmodels/signalDefinitions",
+        "systemData": {
+          "createdBy": "cbhzxxlvkmufetjjjwtk",
+          "createdByType": "User",
+          "createdAt": "2023-09-18T14:04:09.327Z",
+          "lastModifiedBy": "arz",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/SignalDefinitions_Delete.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/SignalDefinitions_Delete.json
@@ -1,0 +1,19 @@
+{
+  "title": "SignalDefinitions_Delete",
+  "operationId": "SignalDefinitions_Delete",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi",
+    "healthModelName": "model1",
+    "signalDefinitionName": "sig"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/SignalDefinitions_Get.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/SignalDefinitions_Get.json
@@ -1,0 +1,55 @@
+{
+  "title": "SignalDefinitions_Get",
+  "operationId": "SignalDefinitions_Get",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi",
+    "healthModelName": "myHealthModel",
+    "signalDefinitionName": "sig1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "metricNamespace": "microsoft.compute/virtualMachines",
+          "metricName": "cpuusage",
+          "aggregationType": "None",
+          "dimension": "nodename",
+          "dimensionFilter": "node1",
+          "provisioningState": "Succeeded",
+          "displayName": "cpu upsage",
+          "signalKind": "AzureResourceMetric",
+          "refreshInterval": "PT1M",
+          "tags": {
+            "key4788": "foo"
+          },
+          "timeGrain": "PT1M",
+          "dataUnit": "Count",
+          "evaluationRules": {
+            "degradedRule": {
+              "operator": "GreaterThan",
+              "threshold": 70
+            },
+            "unhealthyRule": {
+              "operator": "Dynamic",
+              "sensitivity": "Medium",
+              "lookBackWindow": "PT7D"
+            }
+          }
+        },
+        "id": "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.CloudHealth/healthmodels/myHealthModel/signalDefinitions/sig1",
+        "name": "sig1",
+        "type": "Microsoft.CloudHealth/healthmodels/signalDefinitions",
+        "systemData": {
+          "createdBy": "cbhzxxlvkmufetjjjwtk",
+          "createdByType": "User",
+          "createdAt": "2023-09-18T14:04:09.327Z",
+          "lastModifiedBy": "arz",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/SignalDefinitions_ListByHealthModel.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/preview/2026-05-01-preview/examples/SignalDefinitions_ListByHealthModel.json
@@ -1,0 +1,96 @@
+{
+  "title": "SignalDefinitions_ListByHealthModel",
+  "operationId": "SignalDefinitions_ListByHealthModel",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "4980D7D5-4E07-47AD-AD34-E76C6BC9F061",
+    "resourceGroupName": "rgopenapi",
+    "healthModelName": "myHealthModel"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "metricNamespace": "microsoft.compute/virtualMachines",
+              "metricName": "cpuusage",
+              "aggregationType": "None",
+              "dimension": "node",
+              "dimensionFilter": "node1",
+              "provisioningState": "Succeeded",
+              "displayName": "cpu usage",
+              "signalKind": "AzureResourceMetric",
+              "refreshInterval": "PT1M",
+              "tags": {
+                "key4788": "bar"
+              },
+              "timeGrain": "PT10M",
+              "dataUnit": "Count",
+              "evaluationRules": {
+                "degradedRule": {
+                  "operator": "GreaterThan",
+                  "threshold": 70
+                },
+                "unhealthyRule": {
+                  "operator": "Dynamic",
+                  "sensitivity": "Medium",
+                  "lookBackWindow": "PT7D"
+                }
+              }
+            },
+            "id": "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.CloudHealth/healthmodels/myHealthModel/signalDefinitions/sig1",
+            "name": "sig1",
+            "type": "Microsoft.CloudHealth/healthmodels/signalDefinitions",
+            "systemData": {
+              "createdBy": "cbhzxxlvkmufetjjjwtk",
+              "createdByType": "User",
+              "createdAt": "2023-09-18T14:04:09.327Z",
+              "lastModifiedBy": "arz",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+            }
+          },
+          {
+            "properties": {
+              "metricNamespace": "microsoft.compute/virtualMachines",
+              "metricName": "memoryusage",
+              "aggregationType": "Average",
+              "provisioningState": "Succeeded",
+              "displayName": "memorey usage",
+              "signalKind": "AzureResourceMetric",
+              "refreshInterval": "PT1M",
+              "tags": {
+                "key4788": "bar"
+              },
+              "timeGrain": "PT10M",
+              "dataUnit": "Count",
+              "evaluationRules": {
+                "degradedRule": {
+                  "operator": "LowerThan",
+                  "threshold": 10
+                },
+                "unhealthyRule": {
+                  "operator": "LowerThan",
+                  "threshold": 1
+                }
+              }
+            },
+            "id": "/subscriptions/4980D7D5-4E07-47AD-AD34-E76C6BC9F061/resourceGroups/rgopenapi/providers/Microsoft.CloudHealth/healthmodels/myHealthModel/signalDefinitions/sig2",
+            "name": "sig2",
+            "type": "Microsoft.CloudHealth/healthmodels/signalDefinitions",
+            "systemData": {
+              "createdBy": "cbhzxxlvkmufetjjjwtk",
+              "createdByType": "User",
+              "createdAt": "2023-09-18T14:04:09.327Z",
+              "lastModifiedBy": "arz",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2023-09-18T14:04:09.328Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/aqvdhgvi"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Extends the CloudHealth API spec with a new version that introduces dynamic threshold evaluation for signal definitions. Changes include:
- Dynamic operator added to SignalOperator enum
- ThresholdRuleV2 threshold made optional for dynamic operators
- New DynamicThresholdSensitivity enum (Low/Medium/High)
- New lookBackWindow property for historical analysis window
- v2026-05-01-preview examples and generated swagger

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
