### PR TITLE
[Conversations Authoring] Add C#-specific clientName customizations

### DIFF
--- a/specification/cognitiveservices/data-plane/LanguageAnalyzeConversationsAuthoring/client.tsp
+++ b/specification/cognitiveservices/data-plane/LanguageAnalyzeConversationsAuthoring/client.tsp
@@ -9,6 +9,16 @@ using Versioning;
 @useDependency(Language.Conversations.Authoring.Versions.v2025_11_15_preview)
 namespace Language.ConversationsAuthoringClientCustomizations;
 
+// C#-specific client name customizations
+@@clientName(Language.Conversations.Authoring,
+  "ConversationAnalysisAuthoring",
+  "csharp"
+);
+@@clientName(AnalyzeConversationAuthoringUtteranceEntityEvaluationResult,
+  "UtteranceEntityEvaluationResult",
+  "csharp"
+);
+
 @@clientName(conversationAuthoringListDeployments, "listDeployments");
 @@clientName(conversationAuthoringListProjects, "listProjects");
 @@clientName(conversationAuthoringListSupportedLanguages,


### PR DESCRIPTION

This pull request introduces C#-specific client name customizations to the `Language.ConversationsAuthoringClientCustomizations` namespace. These changes ensure that the generated C# SDK uses more appropriate and consistent class and method names.

**C# Client Name Customizations:**

* Set the C# client name for `Language.Conversations.Authoring` to `ConversationAnalysisAuthoring` to improve clarity and consistency in the SDK.
* Set the C# client name for `AnalyzeConversationAuthoringUtteranceEntityEvaluationResult` to `UtteranceEntityEvaluationResult` for better alignment with C# naming conventions.