### PR TITLE
[SDK Generation Pipeline] Prefix PR title only when it enforces

### DIFF
--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -314,13 +314,14 @@ stages:
             WorkingDirectory: $(SdkRepoDirectory)
             ScriptDirectory: $(SdkRepoDirectory)/eng/common/scripts
 
-        - pwsh: |
-            $currentTitle = "$(PrTitle)"
-            $updatedTitle = "Failed-$currentTitle"
-            Write-Host "##vso[task.setvariable variable=PrTitle]$updatedTitle"
-            Write-Host "Updated PR Title to: '$updatedTitle'"
-          displayName: "Set PR title prefix on failures"
-          condition: or(eq(variables['Agent.JobStatus'], 'Failed'), eq(variables['Agent.JobStatus'], 'SucceededWithIssues'))
+        - ${{ if eq(parameters.ForceCreateEvenWithFailures, true) }}:
+          - pwsh: |
+              $currentTitle = "$(PrTitle)"
+              $updatedTitle = "Failed-$currentTitle"
+              Write-Host "##vso[task.setvariable variable=PrTitle]$updatedTitle"
+              Write-Host "Updated PR Title to: '$updatedTitle'"
+            displayName: "Set PR title prefix on failures"
+            condition: or(eq(variables['Agent.JobStatus'], 'Failed'), eq(variables['Agent.JobStatus'], 'SucceededWithIssues'))
 
         - task: PowerShell@2
           displayName: Create pull request


### PR DESCRIPTION
## Problem
Recent change in PR(https://github.com/Azure/azure-rest-api-specs/pull/41769) for the `spec-gen-sdk-runner` set the pipeline task result when the generation step has warnings. This change makes the subsequent step to prefix the PR title with `Failed` run when SDK generation step succeeds with warnings.

## Changes to pipeline conditional logic:

* Added a conditional PowerShell step to update the PR title when `ForceCreateEvenWithFailures` is `true` in `archetype-spec-gen-sdk.yml`.