### PR TITLE
Add inspect_ai grader type and BenchmarkName enum

### DIFF
--- a/specification/ai-foundry/cspell.yaml
+++ b/specification/ai-foundry/cspell.yaml
@@ -35,6 +35,12 @@ overrides:
     - '**/specification/ai-foundry/data-plane/Foundry/preview'
     words:
     - gleu # Evaluation metric
+    - gpqa # Graduate-level Google-Proof Q&A benchmark
+    - bbeh # BIG-Bench Extra Hard benchmark
+    - musr # Multi-step reasoning benchmark
+    - chembench # Chemistry reasoning benchmark
+    - aime # American Invitational Mathematics Examination
+    - inspectai # inspect_ai evaluation framework
   # Audio/realtime related terms
   - filename:
     - '**/specification/ai-foundry/data-plane/Foundry/openapi3'

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -9107,7 +9107,11 @@
             "description": "Data schema scenario, always `benchmark` for benchmark evaluations."
           },
           "benchmark_name": {
-            "type": "string",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BenchmarkName"
+              }
+            ],
             "description": "The name of the benchmark specification."
           },
           "benchmark_version": {
@@ -9780,6 +9784,29 @@
           }
         },
         "description": "A base class for connection credentials"
+      },
+      "BenchmarkName": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "builtin.gpqa_diamond",
+              "builtin.bbeh",
+              "builtin.bigbenchhard",
+              "builtin.frontierscience",
+              "builtin.musr",
+              "builtin.truthful_qa",
+              "builtin.inspect_ai.gpqa_diamond",
+              "builtin.inspect_ai.chembench",
+              "builtin.inspect_ai.aime_2025",
+              "builtin.inspect_ai.musr"
+            ]
+          }
+        ],
+        "description": "The set of available benchmark specifications."
       },
       "BingCustomSearchConfiguration": {
         "type": "object",
@@ -10925,6 +10952,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/EvalGraderAzureAIEvaluator"
+                },
+                {
+                  "$ref": "#/components/schemas/EvalGraderInspectAI"
                 }
               ]
             },
@@ -11571,6 +11601,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/EvalGraderAzureAIEvaluator"
+                },
+                {
+                  "$ref": "#/components/schemas/EvalGraderInspectAI"
                 }
               ]
             },
@@ -11710,6 +11743,32 @@
           }
         },
         "title": "AzureAIEvaluatorGrader"
+      },
+      "EvalGraderInspectAI": {
+        "type": "object",
+        "required": [
+          "type",
+          "name",
+          "task_name"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "inspect_ai"
+            ],
+            "description": "The object type, which is always `inspect_ai`."
+          },
+          "name": {
+            "type": "string",
+            "description": "The display name of the benchmark."
+          },
+          "task_name": {
+            "type": "string",
+            "description": "The inspect_ai task module path (e.g., `inspect_evals/gpqa_diamond`)."
+          }
+        },
+        "title": "InspectAIGrader"
       },
       "EvalResult": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -11768,7 +11768,7 @@
             "description": "The inspect_ai task module path (e.g., `inspect_evals/gpqa_diamond`)."
           }
         },
-        "title": "InspectAIGrader"
+        "description": "Grader inspect_ai definition for inspect_ai benchmark evaluators."
       },
       "EvalResult": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -15377,7 +15377,7 @@
             "description": "The inspect_ai task module path (e.g., `inspect_evals/gpqa_diamond`)."
           }
         },
-        "title": "InspectAIGrader"
+        "description": "Grader inspect_ai definition for inspect_ai benchmark evaluators."
       },
       "EvalResult": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -12362,7 +12362,11 @@
             "description": "Data schema scenario, always `benchmark` for benchmark evaluations."
           },
           "benchmark_name": {
-            "type": "string",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BenchmarkName"
+              }
+            ],
             "description": "The name of the benchmark specification."
           },
           "benchmark_version": {
@@ -13035,6 +13039,29 @@
           }
         },
         "description": "A base class for connection credentials"
+      },
+      "BenchmarkName": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "builtin.gpqa_diamond",
+              "builtin.bbeh",
+              "builtin.bigbenchhard",
+              "builtin.frontierscience",
+              "builtin.musr",
+              "builtin.truthful_qa",
+              "builtin.inspect_ai.gpqa_diamond",
+              "builtin.inspect_ai.chembench",
+              "builtin.inspect_ai.aime_2025",
+              "builtin.inspect_ai.musr"
+            ]
+          }
+        ],
+        "description": "The set of available benchmark specifications."
       },
       "BingCustomSearchConfiguration": {
         "type": "object",
@@ -14421,6 +14448,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/EvalGraderAzureAIEvaluator"
+                },
+                {
+                  "$ref": "#/components/schemas/EvalGraderInspectAI"
                 }
               ]
             },
@@ -15180,6 +15210,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/EvalGraderAzureAIEvaluator"
+                },
+                {
+                  "$ref": "#/components/schemas/EvalGraderInspectAI"
                 }
               ]
             },
@@ -15319,6 +15352,32 @@
           }
         },
         "title": "AzureAIEvaluatorGrader"
+      },
+      "EvalGraderInspectAI": {
+        "type": "object",
+        "required": [
+          "type",
+          "name",
+          "task_name"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "inspect_ai"
+            ],
+            "description": "The object type, which is always `inspect_ai`."
+          },
+          "name": {
+            "type": "string",
+            "description": "The display name of the benchmark."
+          },
+          "task_name": {
+            "type": "string",
+            "description": "The inspect_ai task module path (e.g., `inspect_evals/gpqa_diamond`)."
+          }
+        },
+        "title": "InspectAIGrader"
       },
       "EvalResult": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/src/openai-evaluations/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai-evaluations/models.tsp
@@ -106,10 +106,10 @@ union BenchmarkName {
   string,
 
   /** GPQA Diamond — graduate-level science reasoning. */
-  builtinGpqaDiamond: "builtin.gpqa_diamond",
+  builtinGPQADiamond: "builtin.gpqa_diamond",
 
   /** BBEH — BIG-Bench Extra Hard. */
-  builtinBbeh: "builtin.bbeh",
+  builtinBBEH: "builtin.bbeh",
 
   /** BIG-Bench Hard — challenging BIG-Bench tasks. */
   builtinBigBenchHard: "builtin.bigbenchhard",
@@ -118,22 +118,22 @@ union BenchmarkName {
   builtinFrontierScience: "builtin.frontierscience",
 
   /** MuSR — multi-step reasoning. */
-  builtinMusr: "builtin.musr",
+  builtinMuSR: "builtin.musr",
 
   /** TruthfulQA — truthfulness evaluation. */
-  builtinTruthfulQa: "builtin.truthful_qa",
+  builtinTruthfulQA: "builtin.truthful_qa",
 
   /** GPQA Diamond via inspect_ai framework. */
-  builtinInspectAIGpqaDiamond: "builtin.inspect_ai.gpqa_diamond",
+  builtinInspectAIGPQADiamond: "builtin.inspect_ai.gpqa_diamond",
 
   /** ChemBench via inspect_ai framework. */
-  builtinInspectAIChembench: "builtin.inspect_ai.chembench",
+  builtinInspectAIChemBench: "builtin.inspect_ai.chembench",
 
   /** AIME 2025 via inspect_ai framework. */
-  builtinInspectAIAime2025: "builtin.inspect_ai.aime_2025",
+  builtinInspectAIAIME2025: "builtin.inspect_ai.aime_2025",
 
   /** MuSR via inspect_ai framework. */
-  builtinInspectAIMusr: "builtin.inspect_ai.musr",
+  builtinInspectAIMuSR: "builtin.inspect_ai.musr",
 }
 
 /** Data source configuration for benchmark evaluations. */

--- a/specification/ai-foundry/data-plane/Foundry/src/openai-evaluations/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai-evaluations/models.tsp
@@ -60,7 +60,7 @@ model EvalGraderAzureAIEvaluator {
 }
 
 /** Grader inspect_ai definition for inspect_ai benchmark evaluators. */
-model GraderInspectAI {
+model EvalGraderInspectAI {
   /** The object type, which is always `inspect_ai`. */
   type: "inspect_ai";
 
@@ -69,11 +69,6 @@ model GraderInspectAI {
 
   /** The inspect_ai task module path (e.g., `inspect_evals/gpqa_diamond`). */
   task_name: string;
-}
-
-@summary("InspectAIGrader")
-model EvalGraderInspectAI {
-  ...GraderInspectAI;
 }
 
 /** Base class for run data sources with discriminator support. */

--- a/specification/ai-foundry/data-plane/Foundry/src/openai-evaluations/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai-evaluations/models.tsp
@@ -59,6 +59,23 @@ model EvalGraderAzureAIEvaluator {
   ...GraderAzureAIEvaluator;
 }
 
+/** Grader inspect_ai definition for inspect_ai benchmark evaluators. */
+model GraderInspectAI {
+  /** The object type, which is always `inspect_ai`. */
+  type: "inspect_ai";
+
+  /** The display name of the benchmark. */
+  name: string;
+
+  /** The inspect_ai task module path (e.g., `inspect_evals/gpqa_diamond`). */
+  task_name: string;
+}
+
+@summary("InspectAIGrader")
+model EvalGraderInspectAI {
+  ...GraderInspectAI;
+}
+
 /** Base class for run data sources with discriminator support. */
 @discriminator("type")
 model DataSourceConfig {
@@ -84,13 +101,48 @@ model AzureAIDataSourceConfig extends DataSourceConfig {
     | "benchmark_preview";
 }
 
+/** The set of available benchmark specifications. */
+union BenchmarkName {
+  string,
+
+  /** GPQA Diamond — graduate-level science reasoning. */
+  builtinGpqaDiamond: "builtin.gpqa_diamond",
+
+  /** BBEH — BIG-Bench Extra Hard. */
+  builtinBbeh: "builtin.bbeh",
+
+  /** BIG-Bench Hard — challenging BIG-Bench tasks. */
+  builtinBigBenchHard: "builtin.bigbenchhard",
+
+  /** FrontierScience — frontier scientific reasoning. */
+  builtinFrontierScience: "builtin.frontierscience",
+
+  /** MuSR — multi-step reasoning. */
+  builtinMusr: "builtin.musr",
+
+  /** TruthfulQA — truthfulness evaluation. */
+  builtinTruthfulQa: "builtin.truthful_qa",
+
+  /** GPQA Diamond via inspect_ai framework. */
+  builtinInspectAIGpqaDiamond: "builtin.inspect_ai.gpqa_diamond",
+
+  /** ChemBench via inspect_ai framework. */
+  builtinInspectAIChembench: "builtin.inspect_ai.chembench",
+
+  /** AIME 2025 via inspect_ai framework. */
+  builtinInspectAIAime2025: "builtin.inspect_ai.aime_2025",
+
+  /** MuSR via inspect_ai framework. */
+  builtinInspectAIMusr: "builtin.inspect_ai.musr",
+}
+
 /** Data source configuration for benchmark evaluations. */
 model AzureAIBenchmarkDataSourceConfig extends AzureAIDataSourceConfig {
   /** Data schema scenario, always `benchmark` for benchmark evaluations. */
   scenario: "benchmark_preview";
 
   /** The name of the benchmark specification. */
-  benchmark_name: string;
+  benchmark_name: BenchmarkName;
 
   /** The version of the benchmark specification (e.g., '0.1'). Latest version if not specified. */
   benchmark_version?: string;
@@ -113,7 +165,7 @@ model AzureAIBenchmarkDataSourceConfig extends AzureAIDataSourceConfig {
     | AzureAIBenchmarkDataSourceConfig
 );
 
-/** Adding Azure AI Evaluator type to testing criteria for foundry extension. */
+/** Adding Azure AI Evaluator and inspect_ai types to testing criteria for foundry extension. */
 #suppress "@azure-tools/typespec-autorest/union-unsupported" "This union is defined according to the Azure OpenAI API."
 #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
 #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
@@ -124,7 +176,8 @@ model AzureAIBenchmarkDataSourceConfig extends AzureAIDataSourceConfig {
     | OpenAI.EvalGraderTextSimilarity
     | OpenAI.EvalGraderPython
     | OpenAI.EvalGraderScoreModel
-    | EvalGraderAzureAIEvaluator)[]
+    | EvalGraderAzureAIEvaluator
+    | EvalGraderInspectAI)[]
 );
 
 model Eval is OpenAI.Eval {
@@ -159,7 +212,7 @@ model Eval is OpenAI.Eval {
     | AzureAIBenchmarkDataSourceConfig
 );
 
-/** Adding Azure AI Evaluator type to testing criteria for foundry extension. */
+/** Adding Azure AI Evaluator and inspect_ai types to testing criteria for foundry extension. */
 #suppress "@azure-tools/typespec-autorest/union-unsupported" "This union is defined according to the Azure OpenAI API."
 #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
 #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
@@ -170,7 +223,8 @@ model Eval is OpenAI.Eval {
     | OpenAI.EvalGraderTextSimilarity
     | OpenAI.EvalGraderPython
     | OpenAI.EvalGraderScoreModel
-    | EvalGraderAzureAIEvaluator)[]
+    | EvalGraderAzureAIEvaluator
+    | EvalGraderInspectAI)[]
 );
 model CreateEvalRequest is OpenAI.CreateEvalRequest {
   /**


### PR DESCRIPTION
## Summary

Add `inspect_ai` as a new grader type for benchmark evaluations and introduce `BenchmarkName` enum to replace the free-form `benchmark_name` string.

### Changes

1. **`GraderInspectAI` model** — new grader type (`type: "inspect_ai"`) with `name` and `task_name` fields. The inspect_ai grader is auto-populated server-side from the BenchmarkSpec; it appears in API responses when reading back eval group `testing_criteria`.

2. **`EvalGraderInspectAI`** — added to both `Eval.testing_criteria` and `CreateEvalRequest.testing_criteria` unions (mirrors `EvalGraderAzureAIEvaluator` pattern).

3. **`BenchmarkName` union** — replaces `benchmark_name: string` with a typed enum. Includes `string` as base type for forward compatibility. Lists all 6 released benchmarks + 4 new inspect_ai benchmarks:
   - Released: `builtin.gpqa_diamond`, `builtin.bbeh`, `builtin.bigbenchhard`, `builtin.frontierscience`, `builtin.musr`, `builtin.truthful_qa`
   - New inspect_ai: `builtin.inspect_ai.gpqa_diamond`, `builtin.inspect_ai.chembench`, `builtin.inspect_ai.aime_2025`, `builtin.inspect_ai.musr`

### Context
- Spec PR: https://github.com/coreai-microsoft/foundrysdk_specs/pull/37
- Original benchmark TypeSpec PR: https://github.com/Azure/azure-rest-api-specs/pull/40012
- Supersedes #41980 (was targeting feature/foundry-release, retargeted to feature/foundry-staging per process guidance)
- API review feedback requested these changes (enum for benchmark names, inspect_ai grader type)