### PR TITLE
[Python] Mitigate breaking changes for azure-mgmt-map

### DIFF
--- a/specification/azuredependencymap/DependencyMap.Management/tspconfig.yaml
+++ b/specification/azuredependencymap/DependencyMap.Management/tspconfig.yaml
@@ -2,7 +2,7 @@ emit:
   - "@azure-tools/typespec-autorest"
 parameters:
   "service-dir":
-    default: "sdk/dependencymap"
+    default: "sdk/map"
 options:
   "@azure-tools/typespec-autorest":
     use-read-only-status-schema: true
@@ -16,8 +16,8 @@ options:
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     namespace: "Azure.ResourceManager.DependencyMap"
   "@azure-tools/typespec-python":
-    emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-dependencymap"
-    namespace: "azure.mgmt.dependencymap"
+    emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-map"
+    namespace: "azure.mgmt.map"
     generate-test: true
     generate-sample: true
     flavor: "azure"


### PR DESCRIPTION
# [Python] Mitigate breaking changes for azure-mgmt-map

## Changes

Updated `tspconfig.yaml` to use the correct Python SDK package name and namespace:

- `service-dir`: `sdk/dependencymap` → `sdk/map`
- `emitter-output-dir`: `azure-mgmt-dependencymap` → `azure-mgmt-map`
- `namespace`: `azure.mgmt.dependencymap` → `azure.mgmt.map`

## Breaking Changes Analysis

| # | Breaking Change | Classification | Reason |
|---|----------------|----------------|--------|
| 1 | Client class renamed: `MicrosoftDependencyMapManagementService` → `DependencyMapMgmtClient` | ACCEPT | Guide #4: Client naming change; package never published to PyPI |
| 2 | Removed paging models: `DiscoverySourceResourceListResult`, `MapsResourceListResult`, `OperationListResult` | ACCEPT | Guide #8: Pageable models removed in TypeSpec |
| 3 | `MapsResource` added `properties`, removed `provisioning_state` | ACCEPT | Guide #11: Multi-level flattened properties |
| 4 | `additional_properties` removed from all models | ACCEPT | Standard TypeSpec behavior |

### Summary

- **MITIGATE (tspconfig):** Package name/namespace change (`dependencymap` → `map`)
- **ACCEPT:** 4 remaining breaking changes (all follow accepted patterns)
