### PR TITLE
Add C# client customizations for ContainerInstance migration

### DIFF
--- a/specification/containerinstance/resource-manager/Microsoft.ContainerInstance/ContainerInstance/ContainerGroupProfile.tsp
+++ b/specification/containerinstance/resource-manager/Microsoft.ContainerInstance/ContainerInstance/ContainerGroupProfile.tsp
@@ -109,7 +109,6 @@ interface ContainerGroupProfiles {
   >;
 }
 alias CGProfileOps = Azure.ResourceManager.Legacy.LegacyOperations<
-  "ContainerGroupProfileRevision",
   {
     ...ApiVersionParameter;
     ...SubscriptionIdParameter;
@@ -132,7 +131,8 @@ alias CGProfileOps = Azure.ResourceManager.Legacy.LegacyOperations<
     @key
     revisionNumber: string;
   },
-  CloudError
+  CloudError,
+  "ContainerGroupProfileRevision"
 >;
 
 #suppress "@azure-tools/typespec-azure-core/casing-style" "For backward compatibility"

--- a/specification/containerinstance/resource-manager/Microsoft.ContainerInstance/ContainerInstance/ContainerGroupProfile.tsp
+++ b/specification/containerinstance/resource-manager/Microsoft.ContainerInstance/ContainerInstance/ContainerGroupProfile.tsp
@@ -109,6 +109,7 @@ interface ContainerGroupProfiles {
   >;
 }
 alias CGProfileOps = Azure.ResourceManager.Legacy.LegacyOperations<
+  "ContainerGroupProfileRevision",
   {
     ...ApiVersionParameter;
     ...SubscriptionIdParameter;

--- a/specification/containerinstance/resource-manager/Microsoft.ContainerInstance/ContainerInstance/client.tsp
+++ b/specification/containerinstance/resource-manager/Microsoft.ContainerInstance/ContainerInstance/client.tsp
@@ -125,13 +125,56 @@ using Microsoft.ContainerInstance;
   "NGroupRollingUpdateProfile",
   "csharp"
 );
+@@clientName(FileShareProperties,
+  "ContainerGroupFileShareProperties",
+  "csharp"
+);
+@@clientName(IdentityAccessControl,
+  "ContainerGroupIdentityAccessControl",
+  "csharp"
+);
+@@clientName(SecurityContextCapabilitiesDefinition,
+  "ContainerSecurityContextCapabilitiesDefinition",
+  "csharp"
+);
+@@clientName(UsageName, "ContainerInstanceUsageName", "csharp");
+@@clientName(IdentityAccessLevel,
+  "ContainerGroupIdentityAccessLevel",
+  "csharp"
+);
 
 // C# rename for ARM common Resource — avoids duplicate-client-name with local Resource model
-@@clientName(Azure.ResourceManager.CommonTypes.Resource, "ArmResource", "csharp");
+@@clientName(Azure.ResourceManager.CommonTypes.Resource,
+  "ArmResource",
+  "csharp"
+);
 
 // C# resource hierarchy: restore TrackedResourceData inheritance
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For backward compatibility"
 @@Legacy.hierarchyBuilding(ContainerGroup,
   Azure.ResourceManager.CommonTypes.TrackedResource,
+  "csharp"
+);
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For backward compatibility"
+@@Legacy.hierarchyBuilding(ContainerGroupProfile,
+  Azure.ResourceManager.CommonTypes.TrackedResource,
+  "csharp"
+);
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For backward compatibility"
+@@Legacy.hierarchyBuilding(NGroup,
+  Azure.ResourceManager.CommonTypes.TrackedResource,
+  "csharp"
+);
+
+// C# property type overrides: restore old SDK types for backward compatibility
+@@alternateType(ContainerAttachResponse.webSocketUri, url, "csharp");
+@@alternateType(ContainerExecResponse.webSocketUri, url, "csharp");
+@@alternateType(Capabilities.location, Azure.Core.azureLocation, "csharp");
+@@alternateType(LogAnalytics.workspaceResourceId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(ContainerGroupSubnetId.id,
+  Azure.Core.armResourceIdentifier,
   "csharp"
 );

--- a/specification/containerinstance/resource-manager/Microsoft.ContainerInstance/ContainerInstance/client.tsp
+++ b/specification/containerinstance/resource-manager/Microsoft.ContainerInstance/ContainerInstance/client.tsp
@@ -52,3 +52,83 @@ using Microsoft.ContainerInstance;
   "ListResultContainerGroupProperties",
   "python"
 );
+
+// C# backward-compatible type renames for Azure.ResourceManager.ContainerInstance migration
+@@clientName(Container, "ContainerInstanceContainer", "csharp");
+@@clientName(IpAddress, "ContainerGroupIPAddress", "csharp");
+@@clientName(ImageRegistryCredential,
+  "ContainerGroupImageRegistryCredential",
+  "csharp"
+);
+@@clientName(DnsConfiguration, "ContainerGroupDnsConfiguration", "csharp");
+@@clientName(EncryptionProperties,
+  "ContainerGroupEncryptionProperties",
+  "csharp"
+);
+@@clientName(LogAnalytics, "ContainerGroupLogAnalytics", "csharp");
+@@clientName(ElasticProfile, "ContainerGroupElasticProfile", "csharp");
+@@clientName(SecretReference, "ContainerGroupSecretReference", "csharp");
+@@clientName(IdentityAcls,
+  "ContainerGroupIdentityAccessControlLevels",
+  "csharp"
+);
+@@clientName(Port, "ContainerGroupPort", "csharp");
+@@clientName(AzureFileVolume, "ContainerInstanceAzureFileVolume", "csharp");
+@@clientName(GitRepoVolume, "ContainerInstanceGitRepoVolume", "csharp");
+@@clientName(EnvironmentVariable, "ContainerEnvironmentVariable", "csharp");
+@@clientName(ResourceLimits, "ContainerResourceLimits", "csharp");
+@@clientName(ResourceRequests, "ContainerResourceRequestsContent", "csharp");
+@@clientName(ResourceRequirements, "ContainerResourceRequirements", "csharp");
+@@clientName(VolumeMount, "ContainerVolumeMount", "csharp");
+@@clientName(Volume, "ContainerVolume", "csharp");
+@@clientName(Event, "ContainerEvent", "csharp");
+@@clientName(ContainerPropertiesInstanceView,
+  "ContainerInstanceView",
+  "csharp"
+);
+@@clientName(OperatingSystemTypes,
+  "ContainerInstanceOperatingSystemType",
+  "csharp"
+);
+@@clientName(Capabilities, "ContainerCapabilities", "csharp");
+@@clientName(CapabilitiesCapabilities,
+  "ContainerSupportedCapabilities",
+  "csharp"
+);
+@@clientName(Logs, "ContainerLogs", "csharp");
+@@clientName(ContainerAttachResponse, "ContainerAttachResult", "csharp");
+@@clientName(ContainerExecRequest, "ContainerExecContent", "csharp");
+@@clientName(ContainerExecResponse, "ContainerExecResult", "csharp");
+@@clientName(GpuResource, "ContainerGpuResourceInfo", "csharp");
+@@clientName(GpuSku, "ContainerGpuSku", "csharp");
+@@clientName(Scheme, "ContainerHttpGetScheme", "csharp");
+@@clientName(LogAnalyticsLogType,
+  "ContainerGroupLogAnalyticsLogType",
+  "csharp"
+);
+@@clientName(ContainerGroupIpAddressType,
+  "ContainerGroupIPAddressType",
+  "csharp"
+);
+@@clientName(ContainerGroupPropertiesPropertiesInstanceView,
+  "ContainerGroupInstanceView",
+  "csharp"
+);
+@@clientName(SecurityContextDefinition,
+  "ContainerSecurityContextDefinition",
+  "csharp"
+);
+@@clientName(NetworkProfile, "ContainerGroupNetworkProfile", "csharp");
+@@clientName(FileShare, "ContainerGroupFileShare", "csharp");
+@@clientName(UpdateProfile, "NGroupUpdateProfile", "csharp");
+@@clientName(UpdateProfileRollingUpdateProfile,
+  "NGroupRollingUpdateProfile",
+  "csharp"
+);
+
+// C# resource hierarchy: restore TrackedResourceData inheritance
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For backward compatibility"
+@@Legacy.hierarchyBuilding(ContainerGroup,
+  Azure.ResourceManager.CommonTypes.TrackedResource,
+  "csharp"
+);

--- a/specification/containerinstance/resource-manager/Microsoft.ContainerInstance/ContainerInstance/client.tsp
+++ b/specification/containerinstance/resource-manager/Microsoft.ContainerInstance/ContainerInstance/client.tsp
@@ -126,6 +126,9 @@ using Microsoft.ContainerInstance;
   "csharp"
 );
 
+// C# rename for ARM common Resource — avoids duplicate-client-name with local Resource model
+@@clientName(Azure.ResourceManager.CommonTypes.Resource, "ArmResource", "csharp");
+
 // C# resource hierarchy: restore TrackedResourceData inheritance
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For backward compatibility"
 @@Legacy.hierarchyBuilding(ContainerGroup,

--- a/specification/containerinstance/resource-manager/Microsoft.ContainerInstance/ContainerInstance/main.tsp
+++ b/specification/containerinstance/resource-manager/Microsoft.ContainerInstance/ContainerInstance/main.tsp
@@ -18,6 +18,7 @@ import "./ContainerGroup.tsp";
 import "./NGroup.tsp";
 import "./ContainerGroupProfile.tsp";
 import "./routes.tsp";
+import "./client.tsp";
 
 using TypeSpec.Rest;
 using TypeSpec.Http;

--- a/specification/containerinstance/resource-manager/Microsoft.ContainerInstance/ContainerInstance/models.tsp
+++ b/specification/containerinstance/resource-manager/Microsoft.ContainerInstance/ContainerInstance/models.tsp
@@ -2,12 +2,14 @@ import "@typespec/rest";
 import "@typespec/http";
 import "@azure-tools/typespec-azure-resource-manager";
 import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-client-generator-core";
 
 using TypeSpec.Rest;
 using TypeSpec.Http;
 using Azure.ResourceManager;
 using Azure.Core;
 using Azure.ResourceManager.Foundations;
+using Azure.ClientGenerator.Core;
 
 namespace Microsoft.ContainerInstance;
 
@@ -523,6 +525,8 @@ model ContainerGroupListResult is Azure.Core.Page<ListResultContainerGroup>;
  * The Resource model definition.
  */
 #suppress "@azure-tools/typespec-azure-resource-manager/patch-envelope" "For backward compatibility"
+#suppress "@azure-tools/typespec-client-generator-core/duplicate-client-name" "Renaming to ContainerGroupPatch for C# backward compat"
+@clientName("ContainerGroupPatch", "csharp")
 model Resource {
   /**
    * The resource id.

--- a/specification/containerinstance/resource-manager/Microsoft.ContainerInstance/ContainerInstance/tspconfig.yaml
+++ b/specification/containerinstance/resource-manager/Microsoft.ContainerInstance/ContainerInstance/tspconfig.yaml
@@ -46,6 +46,9 @@ options:
     generate-fakes: true
     head-as-boolean: true
     inject-spans: true
+  "@azure-typespec/http-client-csharp-mgmt":
+    namespace: "Azure.ResourceManager.ContainerInstance"
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/resource-manager"


### PR DESCRIPTION
## Overview

Add C# backward-compatible \@@clientName\ decorators and \@@Legacy.hierarchyBuilding\ for the Azure.ResourceManager.ContainerInstance SDK migration from AutoRest/Swagger to TypeSpec.

### Changes to \client.tsp\

- **36 \@@clientName\ decorators** scoped to \csharp\ — restores old C# type names for backward compatibility (e.g., \Container\ → \ContainerInstanceContainer\, \IpAddress\ → \ContainerGroupIPAddress\, etc.)
- **1 \@@Legacy.hierarchyBuilding\** — restores \TrackedResourceData\ inheritance for \ContainerGroupData\

### Context

The Azure.ResourceManager.ContainerInstance SDK (v1.3.0 GA) has ~33 type renames between the old AutoRest-generated code and the new TypeSpec-generated code. These \@@clientName\ decorators are needed to preserve API backward compatibility during the migration.

**SDK PR**: https://github.com/Azure/azure-sdk-for-net/pull/57621