### PR TITLE
[Python] Mitigate breaking changes for azure-mgmt-managementgroups

### DIFF
--- a/specification/management/resource-manager/Microsoft.Management/ManagementGroups/client.tsp
+++ b/specification/management/resource-manager/Microsoft.Management/ManagementGroups/client.tsp
@@ -6,7 +6,7 @@ using Microsoft.Management;
 
 namespace ClientCustomizations;
 
-@@clientName(Microsoft.Management, "ManagementGroupsMgmtClient", "python");
+@@clientName(Microsoft.Management, "ManagementGroupsAPI", "python");
 
 @@clientLocation(checkNameAvailability, "API", "go");
 @@clientLocation(startTenantBackfill, "API", "go");
@@ -37,4 +37,31 @@ namespace ClientCustomizations;
 @@Azure.ClientGenerator.Core.Legacy.clientDefaultValue(ManagementGroupsParameters.`Cache-Control`,
   "no-cache",
   "javascript"
+);
+
+// Python: Restore "no-cache" default for cache_control parameters
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy decorator required for SDK compatibility"
+@@Azure.ClientGenerator.Core.Legacy.clientDefaultValue(SubscriptionUnderManagementGroupsParameters.`Cache-Control`,
+  "no-cache",
+  "python"
+);
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy decorator required for SDK compatibility"
+@@Azure.ClientGenerator.Core.Legacy.clientDefaultValue(ManagementGroupsListParameters.`Cache-Control`,
+  "no-cache",
+  "python"
+);
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy decorator required for SDK compatibility"
+@@Azure.ClientGenerator.Core.Legacy.clientDefaultValue(EntitiesListParameters.`Cache-Control`,
+  "no-cache",
+  "python"
+);
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy decorator required for SDK compatibility"
+@@Azure.ClientGenerator.Core.Legacy.clientDefaultValue(ManagementGroupsGetParameters.`Cache-Control`,
+  "no-cache",
+  "python"
+);
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy decorator required for SDK compatibility"
+@@Azure.ClientGenerator.Core.Legacy.clientDefaultValue(ManagementGroupsParameters.`Cache-Control`,
+  "no-cache",
+  "python"
 );

--- a/specification/management/resource-manager/Microsoft.Management/ManagementGroups/client.tsp
+++ b/specification/management/resource-manager/Microsoft.Management/ManagementGroups/client.tsp
@@ -6,7 +6,7 @@ using Microsoft.Management;
 
 namespace ClientCustomizations;
 
-@@clientName(Microsoft.Management, "ManagementGroupsAPI", "python");
+@@clientName(Microsoft.Management, "ManagementGroupsMgmtClient", "python");
 
 @@clientLocation(checkNameAvailability, "API", "go");
 @@clientLocation(startTenantBackfill, "API", "go");


### PR DESCRIPTION
## Python SDK Breaking Change Mitigations for azure-mgmt-managementgroups

### Mitigations Applied

| Breaking Change | Classification | Mitigation |
|---|---|---|
| Client renamed from `ManagementGroupsAPI` to `ManagementGroupsMgmtClient` | MITIGATE | `@@clientName(Microsoft.Management, "ManagementGroupsAPI", "python")` |
| `cache_control` default changed from `"no-cache"` to `None` (9 occurrences) | MITIGATE | `@@Legacy.clientDefaultValue(..., "no-cache", "python")` for all 5 parameter types |

### Accepted Breaking Changes (no mitigation needed)

| Breaking Change | Category | Reason |
|---|---|---|
| Flattened properties on `CreateManagementGroupRequest` (`tenant_id`, `display_name`, `details`, `children`) | Removal of Flattened Properties | Already mitigated by `@@Legacy.flattenProperty` in `back-compatible.tsp` |
| Flattened properties on `CreateOrUpdateSettingsRequest` and `HierarchySettingsInfo` | Removal of Flattened Properties | Already mitigated in `back-compatible.tsp` |
| Deleted models: `AzureAsyncOperationResults`, `EntityHierarchyItem`, `OperationDisplayProperties`, `OperationResults` | Unreferenced Models | Not referenced by operations or LRO result types |
| Deleted model `ErrorDetails` | Common Types Upgrade | Replaced by ARM common error type |
| Deleted model `ListSubscriptionUnderManagementGroup` | Pageable Models | Python doesn't expose pageable wrappers |
| All `positional_or_keyword` to `keyword_only` param changes (20 entries) | Keyword-only Params | Standard TypeSpec behavior |
