### PR TITLE
Remove unused src-folder and generate-metadata from KeyVault JS emitter config

### DIFF
--- a/specification/keyvault/data-plane/Administration/tspconfig.yaml
+++ b/specification/keyvault/data-plane/Administration/tspconfig.yaml
@@ -51,8 +51,6 @@ options:
     clear-output-folder: true
   "@azure-tools/typespec-ts":
     emitter-output-dir: "{output-dir}/{service-dir}/keyvault-admin"
-    generate-metadata: true
-    src-folder: "src/generated"
     experimental-extensible-enums: true
     package-details:
       name: "@azure/keyvault-admin"

--- a/specification/keyvault/data-plane/Certificates/tspconfig.yaml
+++ b/specification/keyvault/data-plane/Certificates/tspconfig.yaml
@@ -42,8 +42,6 @@ options:
   # "@azure-tools/typespec-csharp": true
   "@azure-tools/typespec-ts":
     emitter-output-dir: "{output-dir}/{service-dir}/keyvault-certificates"
-    generate-metadata: true
-    src-folder: "src/generated"
     experimental-extensible-enums: true
     package-details:
       name: "@azure/keyvault-certificates"

--- a/specification/keyvault/data-plane/Keys/tspconfig.yaml
+++ b/specification/keyvault/data-plane/Keys/tspconfig.yaml
@@ -41,8 +41,6 @@ options:
   # "@azure-tools/typespec-csharp": true
   "@azure-tools/typespec-ts":
     emitter-output-dir: "{output-dir}/{service-dir}/keyvault-keys"
-    generate-metadata: true
-    src-folder: "src/generated"
     experimental-extensible-enums: true
     package-details:
       name: "@azure/keyvault-keys"

--- a/specification/keyvault/data-plane/Secrets/tspconfig.yaml
+++ b/specification/keyvault/data-plane/Secrets/tspconfig.yaml
@@ -40,8 +40,6 @@ options:
   # "@azure-tools/typespec-csharp": true
   "@azure-tools/typespec-ts":
     emitter-output-dir: "{output-dir}/{service-dir}/keyvault-secrets"
-    generate-metadata: true
-    src-folder: "src/generated"
     experimental-extensible-enums: true
     package-details:
       name: "@azure/keyvault-secrets"


### PR DESCRIPTION
## Description

Removes two unused options from the `@azure-tools/typespec-ts` emitter configuration across all KeyVault data-plane tspconfig.yaml files:

- **`src-folder`**: Support was never implemented for this option, so it has no effect.
- **`generate-metadata`**: Removed so we get the default behavior, which detects `package.json` automatically.

### Changed files
- `specification/keyvault/data-plane/Administration/tspconfig.yaml`
- `specification/keyvault/data-plane/Certificates/tspconfig.yaml`
- `specification/keyvault/data-plane/Keys/tspconfig.yaml`
- `specification/keyvault/data-plane/Secrets/tspconfig.yaml`