### PR TITLE
Connection policy updates

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/ConnectionPolicy.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/ConnectionPolicy.tsp
@@ -1,0 +1,97 @@
+import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-azure-resource-manager";
+import "@typespec/openapi";
+import "@typespec/rest";
+import "@typespec/versioning";
+import "./models.tsp";
+import "./VirtualHub.tsp";
+
+using TypeSpec.Rest;
+using Azure.ResourceManager;
+using TypeSpec.Http;
+using TypeSpec.OpenAPI;
+using TypeSpec.Versioning;
+
+namespace Microsoft.Network;
+/**
+ * ConnectionPolicy resource defined for VirtualHub.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-azure-core/no-private-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-custom-resource-usage-discourage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+@added(Versions.v2025_07_01)
+@Azure.ResourceManager.Legacy.feature(Features.virtualWAN)
+@parentResource(VirtualHub)
+@Http.Private.includeInapplicableMetadataInPayload(false)
+model ConnectionPolicy extends ReadOnlySubResourceModel {
+  properties?: ConnectionPolicyProperties;
+
+  /**
+   * The name of the resource that is unique within a resource group. This name can be used to access the resource.
+   */
+  @visibility(Lifecycle.Read)
+  @path
+  @key("connectionPolicyName")
+  @segment("connectionPolicies")
+  @pattern("^[a-zA-Z0-9]([a-zA-Z0-9_.-]{0,62}[a-zA-Z0-9])?$")
+  name: string;
+
+  /**
+   * A unique read-only string that changes whenever the resource is updated.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+  @visibility(Lifecycle.Read)
+  etag?: string;
+
+  /**
+   * The system metadata related to this resource.
+   */
+  @visibility(Lifecycle.Read)
+  systemData?: Azure.ResourceManager.Foundations.SystemData;
+}
+
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+@added(Versions.v2025_07_01)
+@Azure.ResourceManager.Legacy.feature(Features.virtualWAN)
+@armResourceOperations(#{ omitTags: true })
+interface ConnectionPolicies {
+  /**
+   * Retrieves the details of a ConnectionPolicy.
+   */
+  get is ArmResourceRead<ConnectionPolicy, Error = CloudError>;
+
+  /**
+   * Creates a ConnectionPolicy if it doesn't exist else updates the existing one.
+   */
+  createOrUpdate is ArmResourceCreateOrReplaceAsync<
+    ConnectionPolicy,
+    Error = CloudError
+  >;
+
+  /**
+   * Deletes a ConnectionPolicy.
+   */
+  delete is ArmResourceDeleteWithoutOkAsync<
+    ConnectionPolicy,
+    Response = ArmDeleteAcceptedLroResponse | ArmDeletedNoContentResponse,
+    Error = CloudError
+  >;
+
+  /**
+   * Retrieves the details of all ConnectionPolicies of the hub.
+   */
+  list is ArmResourceListByParent<
+    ConnectionPolicy,
+    Response = ArmResponse<ListConnectionPoliciesResult>,
+    Error = CloudError
+  >;
+}
+
+@@doc(ConnectionPolicy.name,
+  "The name of the resource that is unique within a resource group. This name can be used to access the resource."
+);
+@@doc(ConnectionPolicy.properties, "Properties of the ConnectionPolicy.");
+@@doc(ConnectionPolicies.createOrUpdate::parameters.resource,
+  "Parameters supplied to create or update a ConnectionPolicy."
+);

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/VirtualHub.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/VirtualHub.tsp
@@ -28,6 +28,7 @@ model VirtualHub extends TrackedResourceWithSettableIdOptionalLocation {
   @path
   @key("virtualHubName")
   @segment("virtualHubs")
+  @pattern("^[a-zA-Z0-9]([a-zA-Z0-9_.-]{0,62}[a-zA-Z0-9])?$")
   name: string;
 
   /**

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/ConnectionPolicyDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/ConnectionPolicyDelete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "virtualHubName": "virtualHub1",
+    "connectionPolicyName": "testpolicy",
+    "api-version": "2025-07-01"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/operationResults/{operationId}?api-version={api-version}"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ConnectionPolicies_Delete",
+  "title": "ConnectionPolicyDelete"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/ConnectionPolicyGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/ConnectionPolicyGet.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "virtualHubName": "TestHub",
+    "connectionPolicyName": "testpolicy",
+    "api-version": "2025-07-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testpolicy",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/connectionPolicies/testpolicy",
+        "etag": "W/\"2b03e4fa-c9ed-403c-815f-d8bd6d40a37b\"",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "enableInternetSecurity": true,
+          "associatedConnections": [],
+          "routingConfiguration": {
+            "associatedRouteTable": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/hubRouteTables/defaultRouteTable"
+            },
+            "propagatedRouteTables": {
+              "labels": [
+                "default"
+              ],
+              "ids": []
+            }
+          }
+        },
+        "type": "Microsoft.Network/virtualHubs/connectionPolicies"
+      }
+    }
+  },
+  "operationId": "ConnectionPolicies_Get",
+  "title": "ConnectionPolicyGet"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/ConnectionPolicyList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/ConnectionPolicyList.json
@@ -1,0 +1,68 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "virtualHubName": "TestHub",
+    "api-version": "2025-07-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testpolicy",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/connectionPolicies/testpolicy",
+            "etag": "W/\"2b03e4fa-c9ed-403c-815f-d8bd6d40a37b\"",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "enableInternetSecurity": true,
+              "associatedConnections": [],
+              "routingConfiguration": {
+                "associatedRouteTable": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/hubRouteTables/defaultRouteTable"
+                },
+                "propagatedRouteTables": {
+                  "labels": [
+                    "default"
+                  ],
+                  "ids": []
+                }
+              }
+            },
+            "type": "Microsoft.Network/virtualHubs/connectionPolicies"
+          },
+          {
+            "name": "testpolicy2",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/connectionPolicies/testpolicy2",
+            "etag": "W/\"2b03e4fa-c9ed-403c-815f-d8bd6d40a37b\"",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "enableInternetSecurity": true,
+              "associatedConnections": [],
+              "routingConfiguration": {
+                "associatedRouteTable": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/hubRouteTables/defaultRouteTable"
+                },
+                "propagatedRouteTables": {
+                  "labels": [
+                    "default"
+                  ],
+                  "ids": []
+                },
+                "inboundRouteMap": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/routeMaps/TestRouteMap"
+                },
+                "outboundRouteMap": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/routeMaps/TestRouteMap"
+                }
+              }
+            },
+            "type": "Microsoft.Network/virtualHubs/connectionPolicies"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ConnectionPolicies_List",
+  "title": "ConnectionPolicyList"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/ConnectionPolicyPut.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/ConnectionPolicyPut.json
@@ -1,0 +1,94 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "virtualHubName": "TestHub",
+    "connectionPolicyName": "testpolicy2",
+    "api-version": "2025-07-01",
+    "resource": {
+      "properties": {
+        "routingConfiguration": {
+          "associatedRouteTable": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/hubRouteTables/defaultRouteTable"
+          },
+          "inboundRouteMap": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/routeMaps/TestRouteMap"
+          },
+          "outboundRouteMap": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/routeMaps/TestRouteMap"
+          },
+          "propagatedRouteTables": {
+            "labels": [
+              "default"
+            ]
+          }
+        },
+        "enableInternetSecurity": true
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testpolicy2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/connectionPolicies/testpolicy2",
+        "etag": "W/\"2b03e4fa-c9ed-403c-815f-d8bd6d40a37b\"",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "enableInternetSecurity": true,
+          "associatedConnections": [],
+          "routingConfiguration": {
+            "associatedRouteTable": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/hubRouteTables/defaultRouteTable"
+            },
+            "propagatedRouteTables": {
+              "labels": [
+                "default"
+              ],
+              "ids": []
+            },
+            "inboundRouteMap": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/routeMaps/TestRouteMap"
+            },
+            "outboundRouteMap": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/routeMaps/TestRouteMap"
+            }
+          }
+        },
+        "type": "Microsoft.Network/virtualHubs/connectionPolicies"
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testpolicy2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/connectionPolicies/testpolicy2",
+        "etag": "W/\"2b03e4fa-c9ed-403c-815f-d8bd6d40a37b\"",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "enableInternetSecurity": true,
+          "associatedConnections": [],
+          "routingConfiguration": {
+            "associatedRouteTable": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/hubRouteTables/defaultRouteTable"
+            },
+            "propagatedRouteTables": {
+              "labels": [
+                "default"
+              ],
+              "ids": []
+            },
+            "inboundRouteMap": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/routeMaps/TestRouteMap"
+            },
+            "outboundRouteMap": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/routeMaps/TestRouteMap"
+            }
+          }
+        },
+        "type": "Microsoft.Network/virtualHubs/connectionPolicies"
+      }
+    }
+  },
+  "operationId": "ConnectionPolicies_CreateOrUpdate",
+  "title": "ConnectionPolicyPut"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/main.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/main.tsp
@@ -120,6 +120,7 @@ import "./VpnServerConfiguration.tsp";
 import "./VpnServerConfigurationPolicyGroup.tsp";
 import "./VirtualHub.tsp";
 import "./RouteMap.tsp";
+import "./ConnectionPolicy.tsp";
 import "./VpnGateway.tsp";
 import "./ConnectionSharedKeyResult.tsp";
 import "./VpnSiteLinkConnection.tsp";

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
@@ -3,6 +3,7 @@ import "@typespec/http";
 import "@typespec/versioning";
 import "@azure-tools/typespec-azure-core";
 import "@azure-tools/typespec-azure-resource-manager";
+import "@typespec/versioning";
 import "../Common/main.tsp";
 
 using TypeSpec.Rest;
@@ -22914,6 +22915,12 @@ model HubVirtualNetworkConnectionProperties {
   allowRemoteVnetToUseHubVnetGateways?: boolean;
 
   /**
+   * The resource id of the ConnectionPolicy associated with this HubVirtualNetworkConnection.
+   */
+  @added(Versions.v2025_07_01)
+  connectionPolicy?: SubResource;
+
+  /**
    * Enable internet security.
    */
   enableInternetSecurity?: boolean;
@@ -26000,3 +26007,39 @@ model VirtualNetworkApplianceIpConfigurationProperties {
   #["addressLocation"]
 );
 @@identifiers(GetServiceGatewayServicesResult.value, #["name"]);
+
+/**
+ * Parameters for ConnectionPolicy.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+@Azure.ResourceManager.Legacy.feature(Features.virtualWAN)
+model ConnectionPolicyProperties {
+  /**
+   * Enable internet security.
+   */
+  enableInternetSecurity?: boolean;
+
+  /**
+   * The Routing Configuration indicating the associated and propagated route tables on this connection.
+   */
+  routingConfiguration?: RoutingConfiguration;
+
+  /**
+   * The provisioning state of the ConnectionPolicy resource.
+   */
+  @visibility(Lifecycle.Read)
+  provisioningState?: ProvisioningState;
+
+  /**
+   * List of all connections associated with this ConnectionPolicy.
+   */
+  @visibility(Lifecycle.Read)
+  associatedConnections?: string[];
+}
+
+/**
+ * List of ConnectionPolicies and a URL nextLink to get the next set of results.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+@Azure.ResourceManager.Legacy.feature(Features.virtualWAN)
+model ListConnectionPoliciesResult is Azure.Core.Page<ConnectionPolicy>;

--- a/specification/network/resource-manager/Microsoft.Network/Network/readme.md
+++ b/specification/network/resource-manager/Microsoft.Network/Network/readme.md
@@ -95,6 +95,13 @@ suppressions:
     reason: Not a standard azure resource.
     where:
       - $.definitions.GetServiceGatewayServicesResult
+  - code: ProvisioningStateMustBeReadOnly
+    from: virtualWan.json
+    reason: ConnectionPolicy uses a legacy ReadOnlySubResourceModel pattern. The TypeSpec autorest emitter generates readOnly as a $ref sibling, which spectral's resolver drops during resolution. This is consistent with other VirtualHub child resources (e.g., BgpConnection, RoutingIntent) which use the same pattern.
+    where:
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/connectionPolicies/{connectionPolicyName}"].get.responses.200.schema
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/connectionPolicies/{connectionPolicyName}"].put.responses.200.schema
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/connectionPolicies/{connectionPolicyName}"].put.responses.201.schema
 directive:
   - from: specification/common-types/resource-management/v6/types.json
     where: "$.definitions.ProxyResource"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/ConnectionPolicyDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/ConnectionPolicyDelete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "virtualHubName": "virtualHub1",
+    "connectionPolicyName": "testpolicy",
+    "api-version": "2025-07-01"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/operationResults/{operationId}?api-version={api-version}"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ConnectionPolicies_Delete",
+  "title": "ConnectionPolicyDelete"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/ConnectionPolicyGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/ConnectionPolicyGet.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "virtualHubName": "TestHub",
+    "connectionPolicyName": "testpolicy",
+    "api-version": "2025-07-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testpolicy",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/connectionPolicies/testpolicy",
+        "etag": "W/\"2b03e4fa-c9ed-403c-815f-d8bd6d40a37b\"",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "enableInternetSecurity": true,
+          "associatedConnections": [],
+          "routingConfiguration": {
+            "associatedRouteTable": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/hubRouteTables/defaultRouteTable"
+            },
+            "propagatedRouteTables": {
+              "labels": [
+                "default"
+              ],
+              "ids": []
+            }
+          }
+        },
+        "type": "Microsoft.Network/virtualHubs/connectionPolicies"
+      }
+    }
+  },
+  "operationId": "ConnectionPolicies_Get",
+  "title": "ConnectionPolicyGet"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/ConnectionPolicyList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/ConnectionPolicyList.json
@@ -1,0 +1,68 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "virtualHubName": "TestHub",
+    "api-version": "2025-07-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testpolicy",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/connectionPolicies/testpolicy",
+            "etag": "W/\"2b03e4fa-c9ed-403c-815f-d8bd6d40a37b\"",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "enableInternetSecurity": true,
+              "associatedConnections": [],
+              "routingConfiguration": {
+                "associatedRouteTable": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/hubRouteTables/defaultRouteTable"
+                },
+                "propagatedRouteTables": {
+                  "labels": [
+                    "default"
+                  ],
+                  "ids": []
+                }
+              }
+            },
+            "type": "Microsoft.Network/virtualHubs/connectionPolicies"
+          },
+          {
+            "name": "testpolicy2",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/connectionPolicies/testpolicy2",
+            "etag": "W/\"2b03e4fa-c9ed-403c-815f-d8bd6d40a37b\"",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "enableInternetSecurity": true,
+              "associatedConnections": [],
+              "routingConfiguration": {
+                "associatedRouteTable": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/hubRouteTables/defaultRouteTable"
+                },
+                "propagatedRouteTables": {
+                  "labels": [
+                    "default"
+                  ],
+                  "ids": []
+                },
+                "inboundRouteMap": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/routeMaps/TestRouteMap"
+                },
+                "outboundRouteMap": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/routeMaps/TestRouteMap"
+                }
+              }
+            },
+            "type": "Microsoft.Network/virtualHubs/connectionPolicies"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ConnectionPolicies_List",
+  "title": "ConnectionPolicyList"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/ConnectionPolicyPut.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/ConnectionPolicyPut.json
@@ -1,0 +1,94 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "virtualHubName": "TestHub",
+    "connectionPolicyName": "testpolicy2",
+    "api-version": "2025-07-01",
+    "resource": {
+      "properties": {
+        "routingConfiguration": {
+          "associatedRouteTable": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/hubRouteTables/defaultRouteTable"
+          },
+          "inboundRouteMap": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/routeMaps/TestRouteMap"
+          },
+          "outboundRouteMap": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/routeMaps/TestRouteMap"
+          },
+          "propagatedRouteTables": {
+            "labels": [
+              "default"
+            ]
+          }
+        },
+        "enableInternetSecurity": true
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testpolicy2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/connectionPolicies/testpolicy2",
+        "etag": "W/\"2b03e4fa-c9ed-403c-815f-d8bd6d40a37b\"",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "enableInternetSecurity": true,
+          "associatedConnections": [],
+          "routingConfiguration": {
+            "associatedRouteTable": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/hubRouteTables/defaultRouteTable"
+            },
+            "propagatedRouteTables": {
+              "labels": [
+                "default"
+              ],
+              "ids": []
+            },
+            "inboundRouteMap": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/routeMaps/TestRouteMap"
+            },
+            "outboundRouteMap": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/routeMaps/TestRouteMap"
+            }
+          }
+        },
+        "type": "Microsoft.Network/virtualHubs/connectionPolicies"
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testpolicy2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/connectionPolicies/testpolicy2",
+        "etag": "W/\"2b03e4fa-c9ed-403c-815f-d8bd6d40a37b\"",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "enableInternetSecurity": true,
+          "associatedConnections": [],
+          "routingConfiguration": {
+            "associatedRouteTable": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/hubRouteTables/defaultRouteTable"
+            },
+            "propagatedRouteTables": {
+              "labels": [
+                "default"
+              ],
+              "ids": []
+            },
+            "inboundRouteMap": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/routeMaps/TestRouteMap"
+            },
+            "outboundRouteMap": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/routeMaps/TestRouteMap"
+            }
+          }
+        },
+        "type": "Microsoft.Network/virtualHubs/connectionPolicies"
+      }
+    }
+  },
+  "operationId": "ConnectionPolicies_CreateOrUpdate",
+  "title": "ConnectionPolicyPut"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/virtualWan.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/virtualWan.json
@@ -2384,6 +2384,251 @@
         "x-ms-long-running-operation": true
       }
     },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/connectionPolicies": {
+      "get": {
+        "operationId": "ConnectionPolicies_List",
+        "description": "Retrieves the details of all ConnectionPolicies of the hub.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9_.-]{0,62}[a-zA-Z0-9])?$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListConnectionPoliciesResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ConnectionPolicyList": {
+            "$ref": "./examples/ConnectionPolicyList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/connectionPolicies/{connectionPolicyName}": {
+      "get": {
+        "operationId": "ConnectionPolicies_Get",
+        "description": "Retrieves the details of a ConnectionPolicy.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9_.-]{0,62}[a-zA-Z0-9])?$"
+          },
+          {
+            "name": "connectionPolicyName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9_.-]{0,62}[a-zA-Z0-9])?$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectionPolicy"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ConnectionPolicyGet": {
+            "$ref": "./examples/ConnectionPolicyGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "ConnectionPolicies_CreateOrUpdate",
+        "description": "Creates a ConnectionPolicy if it doesn't exist else updates the existing one.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9_.-]{0,62}[a-zA-Z0-9])?$"
+          },
+          {
+            "name": "connectionPolicyName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9_.-]{0,62}[a-zA-Z0-9])?$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Parameters supplied to create or update a ConnectionPolicy.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ConnectionPolicy"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ConnectionPolicy' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ConnectionPolicy"
+            }
+          },
+          "201": {
+            "description": "Resource 'ConnectionPolicy' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ConnectionPolicy"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ConnectionPolicyPut": {
+            "$ref": "./examples/ConnectionPolicyPut.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ConnectionPolicy"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "ConnectionPolicies_Delete",
+        "description": "Deletes a ConnectionPolicy.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9_.-]{0,62}[a-zA-Z0-9])?$"
+          },
+          {
+            "name": "connectionPolicyName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9_.-]{0,62}[a-zA-Z0-9])?$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ConnectionPolicyDelete": {
+            "$ref": "./examples/ConnectionPolicyDelete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/effectiveRoutes": {
       "post": {
         "operationId": "VirtualHubs_GetEffectiveVirtualHubRoutes",
@@ -7227,6 +7472,58 @@
         }
       }
     },
+    "ConnectionPolicy": {
+      "type": "object",
+      "description": "ConnectionPolicy resource defined for VirtualHub.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ConnectionPolicyProperties",
+          "description": "Properties of the ConnectionPolicy."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "systemData": {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/systemData",
+          "description": "The system metadata related to this resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/ReadOnlySubResourceModel"
+        }
+      ]
+    },
+    "ConnectionPolicyProperties": {
+      "type": "object",
+      "description": "Parameters for ConnectionPolicy.",
+      "properties": {
+        "enableInternetSecurity": {
+          "type": "boolean",
+          "description": "Enable internet security."
+        },
+        "routingConfiguration": {
+          "$ref": "#/definitions/RoutingConfiguration",
+          "description": "The Routing Configuration indicating the associated and propagated route tables on this connection."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the ConnectionPolicy resource.",
+          "readOnly": true
+        },
+        "associatedConnections": {
+          "type": "array",
+          "description": "List of all connections associated with this ConnectionPolicy.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        }
+      }
+    },
     "ConnectionSharedKeyResult": {
       "type": "object",
       "description": "SharedKey Resource .",
@@ -7787,6 +8084,10 @@
           "type": "boolean",
           "description": "Deprecated: Allow RemoteVnet to use Virtual Hub's gateways."
         },
+        "connectionPolicy": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The resource id of the ConnectionPolicy associated with this HubVirtualNetworkConnection."
+        },
         "enableInternetSecurity": {
           "type": "boolean",
           "description": "Enable internet security."
@@ -7801,6 +8102,27 @@
           "readOnly": true
         }
       }
+    },
+    "ListConnectionPoliciesResult": {
+      "type": "object",
+      "description": "List of ConnectionPolicies and a URL nextLink to get the next set of results.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ConnectionPolicy items on this page",
+          "items": {
+            "$ref": "#/definitions/ConnectionPolicy"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
     },
     "ListHubRouteTablesResult": {
       "type": "object",


### PR DESCRIPTION
## Description
- Added **Connection policy** CRUD operations (*Get, Put, Delete, List*).

### New example files
- `ConnectionPolicyGet.json`
- `ConnectionPolicyPut.json`
- `ConnectionPolicyDelete.json`
- `ConnectionPolicyList.json`

## Validation

Prettier and TypeSpec

## Note
1. 26 pre-existing errors, no new errors introduced.
2. Previous PR with approvals: https://github.com/Azure/azure-rest-api-specs/pull/40806