### PR TITLE
feat(agents): add session lifecycle CRUD API surface

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/AgentSessions_CreateSession_MaximumSet_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/AgentSessions_CreateSession_MaximumSet_Gen.json
@@ -15,7 +15,7 @@
     }
   },
   "responses": {
-    "200": {
+    "201": {
       "body": {
         "agent_session_id": "my-session",
         "version_indicator": {

--- a/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/AgentSessions_CreateSession_MaximumSet_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/AgentSessions_CreateSession_MaximumSet_Gen.json
@@ -1,0 +1,32 @@
+{
+  "title": "AgentSessions_CreateSession_MaximumSet",
+  "operationId": "Agents_CreateSession",
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "agent_name": "my-agent",
+    "x-session-isolation-key": "sk-abc123",
+    "Foundry-Features": "AgentEndpoints=V1Preview",
+    "body": {
+      "agent_session_id": "my-session",
+      "version_indicator": {
+        "type": "version_ref",
+        "agent_version": "3"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "agent_session_id": "my-session",
+        "version_indicator": {
+          "type": "version_ref",
+          "agent_version": "3"
+        },
+        "status": "Active",
+        "created_at": 1710234567,
+        "last_accessed_at": 1710234567,
+        "expires_at": 1712826567
+      }
+    }
+  }
+}

--- a/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/AgentSessions_DeleteSession_MaximumSet_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/AgentSessions_DeleteSession_MaximumSet_Gen.json
@@ -1,0 +1,14 @@
+{
+  "title": "AgentSessions_DeleteSession_MaximumSet",
+  "operationId": "Agents_DeleteSession",
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "agent_name": "my-agent",
+    "session_id": "my-session",
+    "x-session-isolation-key": "sk-abc123",
+    "Foundry-Features": "AgentEndpoints=V1Preview"
+  },
+  "responses": {
+    "204": {}
+  }
+}

--- a/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/AgentSessions_GetSession_MaximumSet_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/AgentSessions_GetSession_MaximumSet_Gen.json
@@ -1,0 +1,25 @@
+{
+  "title": "AgentSessions_GetSession_MaximumSet",
+  "operationId": "Agents_GetSession",
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "agent_name": "my-agent",
+    "session_id": "my-session",
+    "Foundry-Features": "AgentEndpoints=V1Preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "agent_session_id": "my-session",
+        "version_indicator": {
+          "type": "version_ref",
+          "agent_version": "3"
+        },
+        "status": "Active",
+        "created_at": 1710234567,
+        "last_accessed_at": 1710320967,
+        "expires_at": 1712826567
+      }
+    }
+  }
+}

--- a/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/AgentSessions_ListSessions_MaximumSet_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/AgentSessions_ListSessions_MaximumSet_Gen.json
@@ -1,0 +1,41 @@
+{
+  "title": "AgentSessions_ListSessions_MaximumSet",
+  "operationId": "Agents_ListSessions",
+  "parameters": {
+    "api-version": "2025-11-15-preview",
+    "agent_name": "my-agent",
+    "Foundry-Features": "AgentEndpoints=V1Preview",
+    "limit": 20
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "data": [
+          {
+            "agent_session_id": "my-session",
+            "version_indicator": {
+              "type": "version_ref",
+              "agent_version": "3"
+            },
+            "status": "Active",
+            "created_at": 1710234567,
+            "last_accessed_at": 1710320967,
+            "expires_at": 1712826567
+          },
+          {
+            "agent_session_id": "session-2",
+            "version_indicator": {
+              "type": "version_ref",
+              "agent_version": "2"
+            },
+            "status": "Idle",
+            "created_at": 1710148167,
+            "last_accessed_at": 1710234567,
+            "expires_at": 1712826567
+          }
+        ],
+        "pagination_token": null
+      }
+    }
+  }
+}

--- a/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/AgentSessions_ListSessions_MaximumSet_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/AgentSessions_ListSessions_MaximumSet_Gen.json
@@ -34,7 +34,9 @@
             "expires_at": 1712826567
           }
         ],
-        "pagination_token": null
+        "first_id": "my-session",
+        "last_id": "session-2",
+        "has_more": false
       }
     }
   }

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -572,7 +572,7 @@
             "name": "agent_session_id",
             "in": "query",
             "required": false,
-            "description": "Optional session ID to group related invocations. If not provided, a new session ID will be auto-generated.",
+            "description": "Optional session ID returned by the session CRUD APIs to reuse an existing sandbox. If not provided, a new session ID will be auto-generated.",
             "schema": {
               "type": "string"
             },
@@ -883,6 +883,385 @@
         "x-ms-foundry-meta": {
           "required_previews": [
             "HostedAgents=V1Preview"
+          ]
+        }
+      }
+    },
+    "/agents/{agent_name}/endpoint/sessions": {
+      "post": {
+        "operationId": "Agents_createSession",
+        "description": "Creates a new session for an agent endpoint.\nThe endpoint resolves the backing agent version from `version_indicator` and\nenforces session ownership using the provided isolation key for session-mutating operations.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "AgentEndpoints=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "agent_name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the agent to create a session for.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-session-isolation-key",
+            "in": "header",
+            "required": true,
+            "description": "Isolation key used by the agent endpoint to enforce session ownership for session-mutating operations.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "The request has succeeded and a new resource has been created as a result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentSessionResource"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Agents"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAgentSessionRequest"
+              }
+            }
+          }
+        },
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentEndpoints=V1Preview"
+          ]
+        }
+      },
+      "get": {
+        "operationId": "Agents_listSessions",
+        "description": "Returns a list of sessions for the specified agent.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "AgentEndpoints=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "agent_name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the agent.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the\ndefault is 20.",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 20
+            },
+            "explode": false
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "required": false,
+            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`\nfor descending order.",
+            "schema": {
+              "$ref": "#/components/schemas/PageOrder"
+            },
+            "explode": false
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "required": false,
+            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include after=obj_foo in order to fetch the next page of the list.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "before",
+            "in": "query",
+            "required": false,
+            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include before=obj_foo in order to fetch the previous page of the list.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "has_more"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/AgentSessionResource"
+                      },
+                      "description": "The requested list of items."
+                    },
+                    "first_id": {
+                      "type": "string",
+                      "description": "The first ID represented in this list."
+                    },
+                    "last_id": {
+                      "type": "string",
+                      "description": "The last ID represented in this list."
+                    },
+                    "has_more": {
+                      "type": "boolean",
+                      "description": "A value indicating whether there are additional values available not captured in this list."
+                    }
+                  },
+                  "description": "The response data for a requested list of items."
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Agents"
+        ],
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentEndpoints=V1Preview"
+          ]
+        }
+      }
+    },
+    "/agents/{agent_name}/endpoint/sessions/{session_id}": {
+      "get": {
+        "operationId": "Agents_getSession",
+        "description": "Retrieves a session by ID.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "AgentEndpoints=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "agent_name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the agent.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "description": "The session identifier.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentSessionResource"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Agents"
+        ],
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentEndpoints=V1Preview"
+          ]
+        }
+      },
+      "delete": {
+        "operationId": "Agents_deleteSession",
+        "description": "Deletes a session synchronously.\nReturns 204 No Content when the session is deleted or does not exist.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "AgentEndpoints=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "agent_name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the agent.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "description": "The session identifier.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-session-isolation-key",
+            "in": "header",
+            "required": true,
+            "description": "Isolation key used by the agent endpoint to enforce session ownership for session-mutating operations.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Agents"
+        ],
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentEndpoints=V1Preview"
           ]
         }
       }
@@ -11020,6 +11399,89 @@
           }
         }
       },
+      "AgentSessionResource": {
+        "type": "object",
+        "required": [
+          "agent_session_id",
+          "version_indicator",
+          "status",
+          "created_at",
+          "last_accessed_at",
+          "expires_at"
+        ],
+        "properties": {
+          "agent_session_id": {
+            "type": "string",
+            "description": "The session identifier."
+          },
+          "version_indicator": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VersionIndicator"
+              }
+            ],
+            "description": "The version indicator determining which agent version backs this session."
+          },
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentSessionStatus"
+              }
+            ],
+            "description": "The current status of the session."
+          },
+          "created_at": {
+            "type": "integer",
+            "format": "unixtime",
+            "description": "The Unix timestamp (in seconds) when the session was created.",
+            "readOnly": true
+          },
+          "last_accessed_at": {
+            "type": "integer",
+            "format": "unixtime",
+            "description": "The Unix timestamp (in seconds) when the session was last accessed.",
+            "readOnly": true
+          },
+          "expires_at": {
+            "type": "integer",
+            "format": "unixtime",
+            "description": "The Unix timestamp (in seconds) when the session expires (rolling, 30 days from last activity).",
+            "readOnly": true
+          }
+        },
+        "description": "An agent session providing a long-lived compute sandbox for hosted agent invocations.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentEndpoints=V1Preview"
+          ]
+        }
+      },
+      "AgentSessionStatus": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "creating",
+              "active",
+              "idle",
+              "updating",
+              "failed",
+              "deleting",
+              "deleted",
+              "expired"
+            ]
+          }
+        ],
+        "description": "The status of an agent session.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentEndpoints=V1Preview"
+          ]
+        }
+      },
       "AgentTaxonomyInput": {
         "type": "object",
         "required": [
@@ -13274,6 +13736,32 @@
             "ContainerAgents=V1Preview",
             "WorkflowAgents=V1Preview",
             "CodeAgents=V1Preview"
+          ]
+        }
+      },
+      "CreateAgentSessionRequest": {
+        "type": "object",
+        "required": [
+          "version_indicator"
+        ],
+        "properties": {
+          "agent_session_id": {
+            "type": "string",
+            "description": "Optional caller-provided session ID. If specified, it must be unique within the agent endpoint. Auto-generated if omitted."
+          },
+          "version_indicator": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VersionIndicator"
+              }
+            ],
+            "description": "Determines which agent version backs the session."
+          }
+        },
+        "description": "Request to create a new agent session.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentEndpoints=V1Preview"
           ]
         }
       },
@@ -39565,6 +40053,84 @@
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "MemoryStores=V1Preview"
+          ]
+        }
+      },
+      "VersionIndicator": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VersionIndicatorType"
+              }
+            ],
+            "description": "The type of version indicator."
+          }
+        },
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "version_ref": "#/components/schemas/VersionRefIndicator"
+          }
+        },
+        "description": "Version indicator determining which agent version backs the session.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentEndpoints=V1Preview"
+          ]
+        }
+      },
+      "VersionIndicatorType": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "version_ref"
+            ]
+          }
+        ],
+        "description": "The type of version indicator used to determine the agent version backing a session.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentEndpoints=V1Preview"
+          ]
+        }
+      },
+      "VersionRefIndicator": {
+        "type": "object",
+        "required": [
+          "type",
+          "agent_version"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "version_ref"
+            ],
+            "description": "Discriminator value for version_ref."
+          },
+          "agent_version": {
+            "type": "string",
+            "description": "The agent version identifier returned by the agent version APIs."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/VersionIndicator"
+          }
+        ],
+        "description": "Version indicator that references a specific agent version by name.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentEndpoints=V1Preview"
           ]
         }
       },

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -374,7 +374,7 @@ paths:
         - name: agent_session_id
           in: query
           required: false
-          description: Optional session ID to group related invocations. If not provided, a new session ID will be auto-generated.
+          description: Optional session ID returned by the session CRUD APIs to reuse an existing sandbox. If not provided, a new session ID will be auto-generated.
           schema:
             type: string
           explode: false
@@ -582,6 +582,270 @@ paths:
       x-ms-foundry-meta:
         required_previews:
           - HostedAgents=V1Preview
+  /agents/{agent_name}/endpoint/sessions:
+    post:
+      operationId: Agents_createSession
+      description: |-
+        Creates a new session for an agent endpoint.
+        The endpoint resolves the backing agent version from `version_indicator` and
+        enforces session ownership using the provided isolation key for session-mutating operations.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - AgentEndpoints=V1Preview
+        - name: agent_name
+          in: path
+          required: true
+          description: The name of the agent to create a session for.
+          schema:
+            type: string
+        - name: x-session-isolation-key
+          in: header
+          required: true
+          description: Isolation key used by the agent endpoint to enforce session ownership for session-mutating operations.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '201':
+          description: The request has succeeded and a new resource has been created as a result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentSessionResource'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Agents
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateAgentSessionRequest'
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentEndpoints=V1Preview
+    get:
+      operationId: Agents_listSessions
+      description: Returns a list of sessions for the specified agent.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - AgentEndpoints=V1Preview
+        - name: agent_name
+          in: path
+          required: true
+          description: The name of the agent.
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          description: |-
+            A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+            default is 20.
+          schema:
+            type: integer
+            format: int32
+            default: 20
+          explode: false
+        - name: order
+          in: query
+          required: false
+          description: |-
+            Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`
+            for descending order.
+          schema:
+            $ref: '#/components/schemas/PageOrder'
+          explode: false
+        - name: after
+          in: query
+          required: false
+          description: |-
+            A cursor for use in pagination. `after` is an object ID that defines your place in the list.
+            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
+            subsequent call can include after=obj_foo in order to fetch the next page of the list.
+          schema:
+            type: string
+          explode: false
+        - name: before
+          in: query
+          required: false
+          description: |-
+            A cursor for use in pagination. `before` is an object ID that defines your place in the list.
+            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
+            subsequent call can include before=obj_foo in order to fetch the previous page of the list.
+          schema:
+            type: string
+          explode: false
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                  - has_more
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/AgentSessionResource'
+                    description: The requested list of items.
+                  first_id:
+                    type: string
+                    description: The first ID represented in this list.
+                  last_id:
+                    type: string
+                    description: The last ID represented in this list.
+                  has_more:
+                    type: boolean
+                    description: A value indicating whether there are additional values available not captured in this list.
+                description: The response data for a requested list of items.
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Agents
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentEndpoints=V1Preview
+  /agents/{agent_name}/endpoint/sessions/{session_id}:
+    get:
+      operationId: Agents_getSession
+      description: Retrieves a session by ID.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - AgentEndpoints=V1Preview
+        - name: agent_name
+          in: path
+          required: true
+          description: The name of the agent.
+          schema:
+            type: string
+        - name: session_id
+          in: path
+          required: true
+          description: The session identifier.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentSessionResource'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Agents
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentEndpoints=V1Preview
+    delete:
+      operationId: Agents_deleteSession
+      description: |-
+        Deletes a session synchronously.
+        Returns 204 No Content when the session is deleted or does not exist.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - AgentEndpoints=V1Preview
+        - name: agent_name
+          in: path
+          required: true
+          description: The name of the agent.
+          schema:
+            type: string
+        - name: session_id
+          in: path
+          required: true
+          description: The session identifier.
+          schema:
+            type: string
+        - name: x-session-isolation-key
+          in: header
+          required: true
+          description: Isolation key used by the agent endpoint to enforce session ownership for session-mutating operations.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '204':
+          description: There is no content to send for this request, but the headers may be useful.
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Agents
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentEndpoints=V1Preview
   /agents/{agent_name}/endpoint/sessions/{session_id}/files:
     get:
       operationId: AgentSessionFiles_listSessionFiles
@@ -7253,6 +7517,63 @@ components:
         version:
           type: string
           description: The version identifier of the agent.
+    AgentSessionResource:
+      type: object
+      required:
+        - agent_session_id
+        - version_indicator
+        - status
+        - created_at
+        - last_accessed_at
+        - expires_at
+      properties:
+        agent_session_id:
+          type: string
+          description: The session identifier.
+        version_indicator:
+          allOf:
+            - $ref: '#/components/schemas/VersionIndicator'
+          description: The version indicator determining which agent version backs this session.
+        status:
+          allOf:
+            - $ref: '#/components/schemas/AgentSessionStatus'
+          description: The current status of the session.
+        created_at:
+          type: integer
+          format: unixtime
+          description: The Unix timestamp (in seconds) when the session was created.
+          readOnly: true
+        last_accessed_at:
+          type: integer
+          format: unixtime
+          description: The Unix timestamp (in seconds) when the session was last accessed.
+          readOnly: true
+        expires_at:
+          type: integer
+          format: unixtime
+          description: The Unix timestamp (in seconds) when the session expires (rolling, 30 days from last activity).
+          readOnly: true
+      description: An agent session providing a long-lived compute sandbox for hosted agent invocations.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentEndpoints=V1Preview
+    AgentSessionStatus:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - creating
+            - active
+            - idle
+            - updating
+            - failed
+            - deleting
+            - deleted
+            - expired
+      description: The status of an agent session.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentEndpoints=V1Preview
     AgentTaxonomyInput:
       type: object
       required:
@@ -8779,6 +9100,22 @@ components:
           - ContainerAgents=V1Preview
           - WorkflowAgents=V1Preview
           - CodeAgents=V1Preview
+    CreateAgentSessionRequest:
+      type: object
+      required:
+        - version_indicator
+      properties:
+        agent_session_id:
+          type: string
+          description: Optional caller-provided session ID. If specified, it must be unique within the agent endpoint. Auto-generated if omitted.
+        version_indicator:
+          allOf:
+            - $ref: '#/components/schemas/VersionIndicator'
+          description: Determines which agent version backs the session.
+      description: Request to create a new agent session.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentEndpoints=V1Preview
     CreateAgentVersionFromCodeContent:
       type: object
       properties:
@@ -28248,6 +28585,53 @@ components:
       x-ms-foundry-meta:
         conditional_previews:
           - MemoryStores=V1Preview
+    VersionIndicator:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          allOf:
+            - $ref: '#/components/schemas/VersionIndicatorType'
+          description: The type of version indicator.
+      discriminator:
+        propertyName: type
+        mapping:
+          version_ref: '#/components/schemas/VersionRefIndicator'
+      description: Version indicator determining which agent version backs the session.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentEndpoints=V1Preview
+    VersionIndicatorType:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - version_ref
+      description: The type of version indicator used to determine the agent version backing a session.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentEndpoints=V1Preview
+    VersionRefIndicator:
+      type: object
+      required:
+        - type
+        - agent_version
+      properties:
+        type:
+          type: string
+          enum:
+            - version_ref
+          description: Discriminator value for version_ref.
+        agent_version:
+          type: string
+          description: The agent version identifier returned by the agent version APIs.
+      allOf:
+        - $ref: '#/components/schemas/VersionIndicator'
+      description: Version indicator that references a specific agent version by name.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentEndpoints=V1Preview
     VersionSelectionRule:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -575,7 +575,7 @@
             "name": "agent_session_id",
             "in": "query",
             "required": false,
-            "description": "Optional session ID to group related invocations. If not provided, a new session ID will be auto-generated.",
+            "description": "Optional session ID returned by the session CRUD APIs to reuse an existing sandbox. If not provided, a new session ID will be auto-generated.",
             "schema": {
               "type": "string"
             },
@@ -886,6 +886,385 @@
         "x-ms-foundry-meta": {
           "required_previews": [
             "HostedAgents=V1Preview"
+          ]
+        }
+      }
+    },
+    "/agents/{agent_name}/endpoint/sessions": {
+      "post": {
+        "operationId": "Agents_createSession",
+        "description": "Creates a new session for an agent endpoint.\nThe endpoint resolves the backing agent version from `version_indicator` and\nenforces session ownership using the provided isolation key for session-mutating operations.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "AgentEndpoints=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "agent_name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the agent to create a session for.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-session-isolation-key",
+            "in": "header",
+            "required": true,
+            "description": "Isolation key used by the agent endpoint to enforce session ownership for session-mutating operations.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "The request has succeeded and a new resource has been created as a result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentSessionResource"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Agents"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAgentSessionRequest"
+              }
+            }
+          }
+        },
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentEndpoints=V1Preview"
+          ]
+        }
+      },
+      "get": {
+        "operationId": "Agents_listSessions",
+        "description": "Returns a list of sessions for the specified agent.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "AgentEndpoints=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "agent_name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the agent.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the\ndefault is 20.",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 20
+            },
+            "explode": false
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "required": false,
+            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`\nfor descending order.",
+            "schema": {
+              "$ref": "#/components/schemas/PageOrder"
+            },
+            "explode": false
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "required": false,
+            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include after=obj_foo in order to fetch the next page of the list.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "before",
+            "in": "query",
+            "required": false,
+            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include before=obj_foo in order to fetch the previous page of the list.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "has_more"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/AgentSessionResource"
+                      },
+                      "description": "The requested list of items."
+                    },
+                    "first_id": {
+                      "type": "string",
+                      "description": "The first ID represented in this list."
+                    },
+                    "last_id": {
+                      "type": "string",
+                      "description": "The last ID represented in this list."
+                    },
+                    "has_more": {
+                      "type": "boolean",
+                      "description": "A value indicating whether there are additional values available not captured in this list."
+                    }
+                  },
+                  "description": "The response data for a requested list of items."
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Agents"
+        ],
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentEndpoints=V1Preview"
+          ]
+        }
+      }
+    },
+    "/agents/{agent_name}/endpoint/sessions/{session_id}": {
+      "get": {
+        "operationId": "Agents_getSession",
+        "description": "Retrieves a session by ID.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "AgentEndpoints=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "agent_name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the agent.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "description": "The session identifier.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentSessionResource"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Agents"
+        ],
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentEndpoints=V1Preview"
+          ]
+        }
+      },
+      "delete": {
+        "operationId": "Agents_deleteSession",
+        "description": "Deletes a session synchronously.\nReturns 204 No Content when the session is deleted or does not exist.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "AgentEndpoints=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "agent_name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the agent.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "description": "The session identifier.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-session-isolation-key",
+            "in": "header",
+            "required": true,
+            "description": "Isolation key used by the agent endpoint to enforce session ownership for session-mutating operations.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Agents"
+        ],
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentEndpoints=V1Preview"
           ]
         }
       }
@@ -12708,6 +13087,89 @@
           }
         }
       },
+      "AgentSessionResource": {
+        "type": "object",
+        "required": [
+          "agent_session_id",
+          "version_indicator",
+          "status",
+          "created_at",
+          "last_accessed_at",
+          "expires_at"
+        ],
+        "properties": {
+          "agent_session_id": {
+            "type": "string",
+            "description": "The session identifier."
+          },
+          "version_indicator": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VersionIndicator"
+              }
+            ],
+            "description": "The version indicator determining which agent version backs this session."
+          },
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentSessionStatus"
+              }
+            ],
+            "description": "The current status of the session."
+          },
+          "created_at": {
+            "type": "integer",
+            "format": "unixtime",
+            "description": "The Unix timestamp (in seconds) when the session was created.",
+            "readOnly": true
+          },
+          "last_accessed_at": {
+            "type": "integer",
+            "format": "unixtime",
+            "description": "The Unix timestamp (in seconds) when the session was last accessed.",
+            "readOnly": true
+          },
+          "expires_at": {
+            "type": "integer",
+            "format": "unixtime",
+            "description": "The Unix timestamp (in seconds) when the session expires (rolling, 30 days from last activity).",
+            "readOnly": true
+          }
+        },
+        "description": "An agent session providing a long-lived compute sandbox for hosted agent invocations.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentEndpoints=V1Preview"
+          ]
+        }
+      },
+      "AgentSessionStatus": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "creating",
+              "active",
+              "idle",
+              "updating",
+              "failed",
+              "deleting",
+              "deleted",
+              "expired"
+            ]
+          }
+        ],
+        "description": "The status of an agent session.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentEndpoints=V1Preview"
+          ]
+        }
+      },
       "AgentTaxonomyInput": {
         "type": "object",
         "required": [
@@ -15158,6 +15620,32 @@
             "ContainerAgents=V1Preview",
             "WorkflowAgents=V1Preview",
             "CodeAgents=V1Preview"
+          ]
+        }
+      },
+      "CreateAgentSessionRequest": {
+        "type": "object",
+        "required": [
+          "version_indicator"
+        ],
+        "properties": {
+          "agent_session_id": {
+            "type": "string",
+            "description": "Optional caller-provided session ID. If specified, it must be unique within the agent endpoint. Auto-generated if omitted."
+          },
+          "version_indicator": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VersionIndicator"
+              }
+            ],
+            "description": "Determines which agent version backs the session."
+          }
+        },
+        "description": "Request to create a new agent session.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentEndpoints=V1Preview"
           ]
         }
       },
@@ -41873,6 +42361,84 @@
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "MemoryStores=V1Preview"
+          ]
+        }
+      },
+      "VersionIndicator": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VersionIndicatorType"
+              }
+            ],
+            "description": "The type of version indicator."
+          }
+        },
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "version_ref": "#/components/schemas/VersionRefIndicator"
+          }
+        },
+        "description": "Version indicator determining which agent version backs the session.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentEndpoints=V1Preview"
+          ]
+        }
+      },
+      "VersionIndicatorType": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "version_ref"
+            ]
+          }
+        ],
+        "description": "The type of version indicator used to determine the agent version backing a session.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentEndpoints=V1Preview"
+          ]
+        }
+      },
+      "VersionRefIndicator": {
+        "type": "object",
+        "required": [
+          "type",
+          "agent_version"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "version_ref"
+            ],
+            "description": "Discriminator value for version_ref."
+          },
+          "agent_version": {
+            "type": "string",
+            "description": "The agent version identifier returned by the agent version APIs."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/VersionIndicator"
+          }
+        ],
+        "description": "Version indicator that references a specific agent version by name.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentEndpoints=V1Preview"
           ]
         }
       },

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -375,7 +375,7 @@ paths:
         - name: agent_session_id
           in: query
           required: false
-          description: Optional session ID to group related invocations. If not provided, a new session ID will be auto-generated.
+          description: Optional session ID returned by the session CRUD APIs to reuse an existing sandbox. If not provided, a new session ID will be auto-generated.
           schema:
             type: string
           explode: false
@@ -583,6 +583,270 @@ paths:
       x-ms-foundry-meta:
         required_previews:
           - HostedAgents=V1Preview
+  /agents/{agent_name}/endpoint/sessions:
+    post:
+      operationId: Agents_createSession
+      description: |-
+        Creates a new session for an agent endpoint.
+        The endpoint resolves the backing agent version from `version_indicator` and
+        enforces session ownership using the provided isolation key for session-mutating operations.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - AgentEndpoints=V1Preview
+        - name: agent_name
+          in: path
+          required: true
+          description: The name of the agent to create a session for.
+          schema:
+            type: string
+        - name: x-session-isolation-key
+          in: header
+          required: true
+          description: Isolation key used by the agent endpoint to enforce session ownership for session-mutating operations.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '201':
+          description: The request has succeeded and a new resource has been created as a result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentSessionResource'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Agents
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateAgentSessionRequest'
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentEndpoints=V1Preview
+    get:
+      operationId: Agents_listSessions
+      description: Returns a list of sessions for the specified agent.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - AgentEndpoints=V1Preview
+        - name: agent_name
+          in: path
+          required: true
+          description: The name of the agent.
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          description: |-
+            A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+            default is 20.
+          schema:
+            type: integer
+            format: int32
+            default: 20
+          explode: false
+        - name: order
+          in: query
+          required: false
+          description: |-
+            Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`
+            for descending order.
+          schema:
+            $ref: '#/components/schemas/PageOrder'
+          explode: false
+        - name: after
+          in: query
+          required: false
+          description: |-
+            A cursor for use in pagination. `after` is an object ID that defines your place in the list.
+            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
+            subsequent call can include after=obj_foo in order to fetch the next page of the list.
+          schema:
+            type: string
+          explode: false
+        - name: before
+          in: query
+          required: false
+          description: |-
+            A cursor for use in pagination. `before` is an object ID that defines your place in the list.
+            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
+            subsequent call can include before=obj_foo in order to fetch the previous page of the list.
+          schema:
+            type: string
+          explode: false
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                  - has_more
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/AgentSessionResource'
+                    description: The requested list of items.
+                  first_id:
+                    type: string
+                    description: The first ID represented in this list.
+                  last_id:
+                    type: string
+                    description: The last ID represented in this list.
+                  has_more:
+                    type: boolean
+                    description: A value indicating whether there are additional values available not captured in this list.
+                description: The response data for a requested list of items.
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Agents
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentEndpoints=V1Preview
+  /agents/{agent_name}/endpoint/sessions/{session_id}:
+    get:
+      operationId: Agents_getSession
+      description: Retrieves a session by ID.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - AgentEndpoints=V1Preview
+        - name: agent_name
+          in: path
+          required: true
+          description: The name of the agent.
+          schema:
+            type: string
+        - name: session_id
+          in: path
+          required: true
+          description: The session identifier.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentSessionResource'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Agents
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentEndpoints=V1Preview
+    delete:
+      operationId: Agents_deleteSession
+      description: |-
+        Deletes a session synchronously.
+        Returns 204 No Content when the session is deleted or does not exist.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - AgentEndpoints=V1Preview
+        - name: agent_name
+          in: path
+          required: true
+          description: The name of the agent.
+          schema:
+            type: string
+        - name: session_id
+          in: path
+          required: true
+          description: The session identifier.
+          schema:
+            type: string
+        - name: x-session-isolation-key
+          in: header
+          required: true
+          description: Isolation key used by the agent endpoint to enforce session ownership for session-mutating operations.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '204':
+          description: There is no content to send for this request, but the headers may be useful.
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - Agents
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentEndpoints=V1Preview
   /agents/{agent_name}/endpoint/sessions/{session_id}/files:
     get:
       operationId: AgentSessionFiles_listSessionFiles
@@ -8420,6 +8684,63 @@ components:
         version:
           type: string
           description: The version identifier of the agent.
+    AgentSessionResource:
+      type: object
+      required:
+        - agent_session_id
+        - version_indicator
+        - status
+        - created_at
+        - last_accessed_at
+        - expires_at
+      properties:
+        agent_session_id:
+          type: string
+          description: The session identifier.
+        version_indicator:
+          allOf:
+            - $ref: '#/components/schemas/VersionIndicator'
+          description: The version indicator determining which agent version backs this session.
+        status:
+          allOf:
+            - $ref: '#/components/schemas/AgentSessionStatus'
+          description: The current status of the session.
+        created_at:
+          type: integer
+          format: unixtime
+          description: The Unix timestamp (in seconds) when the session was created.
+          readOnly: true
+        last_accessed_at:
+          type: integer
+          format: unixtime
+          description: The Unix timestamp (in seconds) when the session was last accessed.
+          readOnly: true
+        expires_at:
+          type: integer
+          format: unixtime
+          description: The Unix timestamp (in seconds) when the session expires (rolling, 30 days from last activity).
+          readOnly: true
+      description: An agent session providing a long-lived compute sandbox for hosted agent invocations.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentEndpoints=V1Preview
+    AgentSessionStatus:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - creating
+            - active
+            - idle
+            - updating
+            - failed
+            - deleting
+            - deleted
+            - expired
+      description: The status of an agent session.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentEndpoints=V1Preview
     AgentTaxonomyInput:
       type: object
       required:
@@ -10080,6 +10401,22 @@ components:
           - ContainerAgents=V1Preview
           - WorkflowAgents=V1Preview
           - CodeAgents=V1Preview
+    CreateAgentSessionRequest:
+      type: object
+      required:
+        - version_indicator
+      properties:
+        agent_session_id:
+          type: string
+          description: Optional caller-provided session ID. If specified, it must be unique within the agent endpoint. Auto-generated if omitted.
+        version_indicator:
+          allOf:
+            - $ref: '#/components/schemas/VersionIndicator'
+          description: Determines which agent version backs the session.
+      description: Request to create a new agent session.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentEndpoints=V1Preview
     CreateAgentVersionFromCodeContent:
       type: object
       properties:
@@ -29833,6 +30170,53 @@ components:
       x-ms-foundry-meta:
         conditional_previews:
           - MemoryStores=V1Preview
+    VersionIndicator:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          allOf:
+            - $ref: '#/components/schemas/VersionIndicatorType'
+          description: The type of version indicator.
+      discriminator:
+        propertyName: type
+        mapping:
+          version_ref: '#/components/schemas/VersionRefIndicator'
+      description: Version indicator determining which agent version backs the session.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentEndpoints=V1Preview
+    VersionIndicatorType:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - version_ref
+      description: The type of version indicator used to determine the agent version backing a session.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentEndpoints=V1Preview
+    VersionRefIndicator:
+      type: object
+      required:
+        - type
+        - agent_version
+      properties:
+        type:
+          type: string
+          enum:
+            - version_ref
+          description: Discriminator value for version_ref.
+        agent_version:
+          type: string
+          description: The agent version identifier returned by the agent version APIs.
+      allOf:
+        - $ref: '#/components/schemas/VersionIndicator'
+      description: Version indicator that references a specific agent version by name.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentEndpoints=V1Preview
     VersionSelectionRule:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-invocations/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-invocations/routes.tsp
@@ -44,7 +44,7 @@ interface AgentInvocations {
       /** The name of the agent. */
       @path agent_name: string;
 
-      /** Optional session ID to group related invocations. If not provided, a new session ID will be auto-generated. */
+      /** Optional session ID returned by the session CRUD APIs to reuse an existing sandbox. If not provided, a new session ID will be auto-generated. */
       @query agent_session_id?: string;
 
       /** The content type of the request body. */

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-session-files/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-session-files/routes.tsp
@@ -14,8 +14,8 @@ namespace Azure.AI.Projects;
  * files within a live ADC sandbox session. All file content is streamed
  * end-to-end (no buffering in Agents service memory).
  *
- * Sessions are scoped to agents (not versions), giving optionality to
- * mutate the associated agent version independently of the session lifecycle.
+ * Sessions are scoped to agent endpoints (not individual versions), allowing
+ * the endpoint to evolve the backing agent version independently of the session lifecycle.
  */
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" ""
 @tag("Agent Session Files")

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -412,3 +412,156 @@ union ContainerLogKind {
   /** System logs from the container. */
   system: "system",
 }
+
+// ══════════════════════════════════════════════════════════
+// Session Lifecycle Management
+// ══════════════════════════════════════════════════════════
+
+// ── Session Status ──────────────────────────────────────
+
+/** The status of an agent session. */
+@extension(
+  "x-ms-foundry-meta",
+  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
+)
+@removed(Versions.v1)
+union AgentSessionStatus {
+  string,
+
+  /** Session initialization is in progress. */
+  Creating: "creating",
+
+  /** Session is running and operational. */
+  Active: "active",
+
+  /** Session sandbox is auto-suspended; resumes on next invocation. */
+  Idle: "idle",
+
+  /** Reserved for future session re-parenting flows. */
+  Updating: "updating",
+
+  /** Session initialization or lifecycle handling failed and requires delete to recover. */
+  Failed: "failed",
+
+  /** Session is being deleted (cleanup in progress). */
+  Deleting: "deleting",
+
+  /** Session has been explicitly deleted. */
+  Deleted: "deleted",
+
+  /** Session TTL exceeded (30 days from last activity). */
+  Expired: "expired",
+}
+
+// ── Version Indicator ───────────────────────────────────
+
+/** The type of version indicator used to determine the agent version backing a session. */
+@extension(
+  "x-ms-foundry-meta",
+  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
+)
+@removed(Versions.v1)
+union VersionIndicatorType {
+  string,
+
+  /** Direct reference to a specific agent version. */
+  VersionRef: "version_ref",
+}
+
+/** Base class for version indicators. Uses type discriminator for polymorphism. */
+@doc("Version indicator determining which agent version backs the session.")
+@extension(
+  "x-ms-foundry-meta",
+  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
+)
+@removed(Versions.v1)
+@discriminator("type")
+model VersionIndicator {
+  /** The type of version indicator. */
+  type: VersionIndicatorType;
+}
+
+/** Version indicator that references a specific agent version by name. */
+@extension(
+  "x-ms-foundry-meta",
+  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
+)
+@removed(Versions.v1)
+model VersionRefIndicator extends VersionIndicator {
+  /** Discriminator value for version_ref. */
+  type: VersionIndicatorType.VersionRef;
+
+  /** The agent version identifier returned by the agent version APIs. */
+  agent_version: string;
+}
+
+// ── Session Resource ────────────────────────────────────
+
+/** Represents an agent session resource. */
+@doc("An agent session providing a long-lived compute sandbox for hosted agent invocations.")
+@extension(
+  "x-ms-foundry-meta",
+  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
+)
+@removed(Versions.v1)
+model AgentSessionResource {
+  /** The session identifier. */
+  agent_session_id: string;
+
+  /** The version indicator determining which agent version backs this session. */
+  version_indicator: VersionIndicator;
+
+  /** The current status of the session. */
+  status: AgentSessionStatus;
+
+  /** The Unix timestamp (in seconds) when the session was created. */
+  @encode("unixTimestamp", int64)
+  @visibility(Lifecycle.Read)
+  created_at: utcDateTime;
+
+  /** The Unix timestamp (in seconds) when the session was last accessed. */
+  @encode("unixTimestamp", int64)
+  @visibility(Lifecycle.Read)
+  last_accessed_at: utcDateTime;
+
+  /** The Unix timestamp (in seconds) when the session expires (rolling, 30 days from last activity). */
+  @encode("unixTimestamp", int64)
+  @visibility(Lifecycle.Read)
+  expires_at: utcDateTime;
+}
+
+// ── Session Request Models ──────────────────────────────
+
+/** Request body for creating a new agent session. */
+@doc("Request to create a new agent session.")
+@extension(
+  "x-ms-foundry-meta",
+  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
+)
+@removed(Versions.v1)
+model CreateAgentSessionRequest {
+  /** Optional caller-provided session ID. If specified, it must be unique within the agent endpoint. Auto-generated if omitted. */
+  agent_session_id?: string;
+
+  /** Determines which agent version backs the session. */
+  version_indicator: VersionIndicator;
+}
+
+// ── Session List Result ─────────────────────────────────
+
+/** Paged result for session list operations using continuation token pagination. */
+@doc("Paged result for session list operations.")
+@extension(
+  "x-ms-foundry-meta",
+  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
+)
+@removed(Versions.v1)
+model SessionListResult {
+  /** The list of sessions. */
+  @pageItems
+  data: AgentSessionResource[];
+
+  /** Opaque token to retrieve the next page. Null when there are no more results. */
+  @continuationToken
+  pagination_token?: string;
+}

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -547,21 +547,3 @@ model CreateAgentSessionRequest {
   version_indicator: VersionIndicator;
 }
 
-// ── Session List Result ─────────────────────────────────
-
-/** Paged result for session list operations using continuation token pagination. */
-@doc("Paged result for session list operations.")
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
-@removed(Versions.v1)
-model SessionListResult {
-  /** The list of sessions. */
-  @pageItems
-  data: AgentSessionResource[];
-
-  /** Opaque token to retrieve the next page. Null when there are no more results. */
-  @continuationToken
-  pagination_token?: string;
-}

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -898,7 +898,6 @@ model CreateAgentFromCodeContent {
   "x-ms-foundry-meta",
   #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
 )
-@removed(Versions.v1)
 union AgentSessionStatus {
   string,
 
@@ -934,7 +933,6 @@ union AgentSessionStatus {
   "x-ms-foundry-meta",
   #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
 )
-@removed(Versions.v1)
 union VersionIndicatorType {
   string,
 
@@ -948,7 +946,6 @@ union VersionIndicatorType {
   "x-ms-foundry-meta",
   #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
 )
-@removed(Versions.v1)
 @discriminator("type")
 model VersionIndicator {
   /** The type of version indicator. */
@@ -960,7 +957,6 @@ model VersionIndicator {
   "x-ms-foundry-meta",
   #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
 )
-@removed(Versions.v1)
 model VersionRefIndicator extends VersionIndicator {
   /** Discriminator value for version_ref. */
   type: VersionIndicatorType.VersionRef;
@@ -977,7 +973,6 @@ model VersionRefIndicator extends VersionIndicator {
   "x-ms-foundry-meta",
   #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
 )
-@removed(Versions.v1)
 model AgentSessionResource {
   /** The session identifier. */
   agent_session_id: string;
@@ -1012,7 +1007,6 @@ model AgentSessionResource {
   "x-ms-foundry-meta",
   #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
 )
-@removed(Versions.v1)
 model CreateAgentSessionRequest {
   /** Optional caller-provided session ID. If specified, it must be unique within the agent endpoint. Auto-generated if omitted. */
   agent_session_id?: string;

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
@@ -3,6 +3,7 @@ import "./models.tsp";
 
 using TypeSpec.Http;
 using TypeSpec.OpenAPI;
+using Versioning;
 
 namespace Azure.AI.Projects;
 
@@ -194,5 +195,116 @@ interface Agents {
       ...CommonPageQueryParameters;
     },
     AgentsPagedResult<AgentVersionObject>
+  >;
+
+  // ── Session Lifecycle Operations ────────────────────────
+
+  /**
+   * Creates a new session for an agent endpoint.
+   * The endpoint resolves the backing agent version from `version_indicator` and
+   * enforces session ownership using the provided isolation key for session-mutating operations.
+   */
+  @post
+  @route("/agents/{agent_name}/endpoint/sessions")
+  @extension(
+    "x-ms-foundry-meta",
+    #{
+      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
+    }
+  )
+  @removed(Versions.v1)
+  createSession is FoundryDataPlanePreviewOperation<
+    AgentDefinitionOptInKeys.agent_endpoint_v1_preview,
+    {
+      /** The name of the agent to create a session for. */
+      @path agent_name: string;
+
+      /** Isolation key used by the agent endpoint to enforce session ownership for session-mutating operations. */
+      @header("x-session-isolation-key")
+      isolation_key: string;
+
+      ...CreateAgentSessionRequest;
+    },
+    OkResponse<AgentSessionResource>
+  >;
+
+  /**
+   * Retrieves a session by ID.
+   */
+  @get
+  @route("/agents/{agent_name}/endpoint/sessions/{session_id}")
+  @extension(
+    "x-ms-foundry-meta",
+    #{
+      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
+    }
+  )
+  @removed(Versions.v1)
+  getSession is FoundryDataPlanePreviewOperation<
+    AgentDefinitionOptInKeys.agent_endpoint_v1_preview,
+    {
+      /** The name of the agent. */
+      @path agent_name: string;
+
+      /** The session identifier. */
+      @path session_id: string;
+    },
+    AgentSessionResource
+  >;
+
+  /**
+   * Deletes a session synchronously.
+   * Returns 204 No Content when the session is deleted or does not exist.
+   */
+  @delete
+  @route("/agents/{agent_name}/endpoint/sessions/{session_id}")
+  @extension(
+    "x-ms-foundry-meta",
+    #{
+      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
+    }
+  )
+  @removed(Versions.v1)
+  deleteSession is FoundryDataPlanePreviewOperation<
+    AgentDefinitionOptInKeys.agent_endpoint_v1_preview,
+    {
+      /** The name of the agent. */
+      @path agent_name: string;
+
+      /** The session identifier. */
+      @path session_id: string;
+
+      /** Isolation key used by the agent endpoint to enforce session ownership for session-mutating operations. */
+      @header("x-session-isolation-key")
+      isolation_key: string;
+    },
+    NoContentResponse
+  >;
+
+  /**
+   * Returns a list of sessions for the specified agent.
+   */
+  @get
+  @route("/agents/{agent_name}/endpoint/sessions")
+  @list
+  @extension(
+    "x-ms-foundry-meta",
+    #{
+      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
+    }
+  )
+  @removed(Versions.v1)
+  listSessions is FoundryDataPlanePreviewOperation<
+    AgentDefinitionOptInKeys.agent_endpoint_v1_preview,
+    {
+      /** The name of the agent. */
+      @path agent_name: string;
+
+      ...PageLimitQueryParameter;
+
+      /** Opaque continuation token from a previous list response. */
+      @query pagination_token?: string;
+    },
+    SessionListResult
   >;
 }

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
@@ -3,7 +3,6 @@ import "./models.tsp";
 
 using TypeSpec.Http;
 using TypeSpec.OpenAPI;
-using TypeSpec.Versioning;
 
 namespace Azure.AI.Projects;
 
@@ -350,7 +349,6 @@ interface Agents {
       required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
     }
   )
-  @removed(Versions.v1)
   createSession is FoundryDataPlanePreviewOperation<
     AgentDefinitionOptInKeys.agent_endpoint_v1_preview,
     {
@@ -377,7 +375,6 @@ interface Agents {
       required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
     }
   )
-  @removed(Versions.v1)
   getSession is FoundryDataPlanePreviewOperation<
     AgentDefinitionOptInKeys.agent_endpoint_v1_preview,
     {
@@ -402,7 +399,6 @@ interface Agents {
       required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
     }
   )
-  @removed(Versions.v1)
   deleteSession is FoundryDataPlanePreviewOperation<
     AgentDefinitionOptInKeys.agent_endpoint_v1_preview,
     {
@@ -431,7 +427,6 @@ interface Agents {
       required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
     }
   )
-  @removed(Versions.v1)
   listSessions is FoundryDataPlanePreviewOperation<
     AgentDefinitionOptInKeys.agent_endpoint_v1_preview,
     {

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
@@ -225,7 +225,7 @@ interface Agents {
 
       ...CreateAgentSessionRequest;
     },
-    OkResponse<AgentSessionResource>
+    ResourceCreatedResponse<AgentSessionResource>
   >;
 
   /**
@@ -300,11 +300,8 @@ interface Agents {
       /** The name of the agent. */
       @path agent_name: string;
 
-      ...PageLimitQueryParameter;
-
-      /** Opaque continuation token from a previous list response. */
-      @query pagination_token?: string;
+      ...CommonPageQueryParameters;
     },
-    SessionListResult
+    AgentsPagedResult<AgentSessionResource>
   >;
 }

--- a/specification/ai-foundry/data-plane/Foundry/src/common/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/common/models.tsp
@@ -54,6 +54,8 @@ union AgentDefinitionOptInKeys {
   hosted_agents_v1_preview: "HostedAgents=V1Preview",
   workflow_agents_v1_preview: "WorkflowAgents=V1Preview",
   container_agents_v1_preview: "ContainerAgents=V1Preview",
+
+  agent_endpoint_v1_preview: "AgentEndpoint=V1Preview",
 }
 
 union FoundryFeaturesOptInKeys {


### PR DESCRIPTION
Original staging PR #41691

* feat(agents): add session lifecycle CRUD API surface

Add TypeSpec models and routes for session lifecycle management:
- Create, Get, Delete (LRO), List, GetOperation endpoints
- SessionResource, VersionIndicator (discriminated), SessionOperationObject
- PascalCase enums aligned with C# contracts (PR 2011590)
- Continuation-token pagination (SessionListResult)
- x-session-isolation-key header on mutating operations
- 5 example JSON files

AB#5122803

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

* fix

* fix(foundry): align session CRUD with sync lifecycle review

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

* fix(foundry): normalize session status casing

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

---------

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com> Co-authored-by: Ali Soylemezoglu <alisoy@microsoft.com>

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
