### PR TITLE
Add Python-specific client name for Compute service

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/client.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/client.tsp
@@ -13,11 +13,22 @@ using ComputeSku;
 /**
  * Compute Client
  */
-@client({
-  name: "ComputeClient",
-  service: [Compute, ComputeDisk, ComputeGallery, ComputeSku],
-  autoMergeService: true,
-})
+@client(
+  {
+    name: "ComputeClient",
+    service: [Compute, ComputeDisk, ComputeGallery, ComputeSku],
+    autoMergeService: true,
+  },
+  "!python"
+)
+@client(
+  {
+    name: "ComputeManagementClient",
+    service: [Compute, ComputeDisk, ComputeGallery, ComputeSku],
+    autoMergeService: true,
+  },
+  "python"
+)
 namespace ComputeCombine;
 
 // VirtualMachineInstanceView needs input usage for premium layer constructor and setters


### PR DESCRIPTION
This PR adds a Python-specific `@client` decorator in `client.tsp` for the Compute service, setting the client name to `ComputeManagementClient` for Python while keeping `ComputeClient` for all other languages.

### Changes
- Split the single `@client` decorator into two:
  - `ComputeClient` for non-Python languages (`"!python"`)
  - `ComputeManagementClient` for Python (`"python"`)