### PR TITLE
fix(foundry): address session CRUD review feedback

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/AgentSessions_CreateSession_MaximumSet_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/AgentSessions_CreateSession_MaximumSet_Gen.json
@@ -15,7 +15,7 @@
     }
   },
   "responses": {
-    "200": {
+    "201": {
       "body": {
         "agent_session_id": "my-session",
         "version_indicator": {

--- a/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/AgentSessions_ListSessions_MaximumSet_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/AgentSessions_ListSessions_MaximumSet_Gen.json
@@ -34,7 +34,9 @@
             "expires_at": 1712826567
           }
         ],
-        "pagination_token": null
+        "first_id": "my-session",
+        "last_id": "session-2",
+        "has_more": false
       }
     }
   }

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -547,21 +547,3 @@ model CreateAgentSessionRequest {
   version_indicator: VersionIndicator;
 }
 
-// ── Session List Result ─────────────────────────────────
-
-/** Paged result for session list operations using continuation token pagination. */
-@doc("Paged result for session list operations.")
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
-@removed(Versions.v1)
-model SessionListResult {
-  /** The list of sessions. */
-  @pageItems
-  data: AgentSessionResource[];
-
-  /** Opaque token to retrieve the next page. Null when there are no more results. */
-  @continuationToken
-  pagination_token?: string;
-}

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
@@ -225,7 +225,7 @@ interface Agents {
 
       ...CreateAgentSessionRequest;
     },
-    OkResponse<AgentSessionResource>
+    ResourceCreatedResponse<AgentSessionResource>
   >;
 
   /**
@@ -300,11 +300,8 @@ interface Agents {
       /** The name of the agent. */
       @path agent_name: string;
 
-      ...PageLimitQueryParameter;
-
-      /** Opaque continuation token from a previous list response. */
-      @query pagination_token?: string;
+      ...CommonPageQueryParameters;
     },
-    SessionListResult
+    AgentsPagedResult<AgentSessionResource>
   >;
 }


### PR DESCRIPTION
Addresses the two open review comments from #42080

### Changes

1. **createSession → 201 Created**
   - Switched from \OkResponse<AgentSessionResource>\ to \ResourceCreatedResponse<AgentSessionResource>\
   - Aligns with all other create operations in the Foundry spec

2. **listSessions → AgentsPagedResult archetype**
   - Removed custom \SessionListResult\ model
   - Now uses \AgentsPagedResult<AgentSessionResource>\ (shared archetype from \common/models.tsp\)
   - Replaced \PageLimitQueryParameter\ + manual \pagination_token\ with \CommonPageQueryParameters\ (\limit\, \order\, \fter\, \efore\)
   - Consistent with all other agent list operations

3. **Example files updated** to reflect new status code and pagination fields

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>