### PR TITLE
Add Ray distribution type to MachineLearningServices 2026-03-15-preview

### DIFF
--- a/specification/machinelearningservices/MachineLearningServices.Management/examples/2026-03-15-preview/Job/CommandJob/createOrUpdateRayDistribution.json
+++ b/specification/machinelearningservices/MachineLearningServices.Management/examples/2026-03-15-preview/Job/CommandJob/createOrUpdateRayDistribution.json
@@ -1,0 +1,137 @@
+{
+  "parameters": {
+    "api-version": "2026-03-15-preview",
+    "body": {
+      "properties": {
+        "description": "Ray distributed command job",
+        "codeId": "string",
+        "command": "python train.py",
+        "computeId": "string",
+        "displayName": "ray-multi-node-job",
+        "distribution": {
+          "distributionType": "Ray",
+          "port": 6379,
+          "includeDashboard": true,
+          "dashboardPort": 8265
+        },
+        "environmentId": "string",
+        "environmentVariables": {
+          "string": "string"
+        },
+        "experimentName": "ray-experiment",
+        "identity": {
+          "identityType": "AMLToken"
+        },
+        "jobType": "Command",
+        "resources": {
+          "instanceCount": 2,
+          "instanceType": "string",
+          "properties": {}
+        },
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "id": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "id": "string",
+        "type": "Microsoft.MachineLearningServices/workspaces/jobs",
+        "properties": {
+          "description": "Ray distributed command job",
+          "codeId": "string",
+          "command": "python train.py",
+          "computeId": "string",
+          "displayName": "ray-multi-node-job",
+          "distribution": {
+            "distributionType": "Ray",
+            "port": 6379,
+            "address": null,
+            "includeDashboard": true,
+            "dashboardPort": 8265,
+            "headNodeAdditionalArgs": null,
+            "workerNodeAdditionalArgs": null
+          },
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "experimentName": "ray-experiment",
+          "identity": {
+            "identityType": "AMLToken"
+          },
+          "jobType": "Command",
+          "status": "Starting",
+          "resources": {
+            "instanceCount": 2,
+            "instanceType": "string",
+            "properties": {}
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2026-01-15T00:00:00.000Z",
+          "createdBy": "string",
+          "createdByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "id": "string",
+        "type": "Microsoft.MachineLearningServices/workspaces/jobs",
+        "properties": {
+          "description": "Ray distributed command job",
+          "codeId": "string",
+          "command": "python train.py",
+          "computeId": "string",
+          "displayName": "ray-multi-node-job",
+          "distribution": {
+            "distributionType": "Ray",
+            "port": 6379,
+            "address": null,
+            "includeDashboard": true,
+            "dashboardPort": 8265,
+            "headNodeAdditionalArgs": null,
+            "workerNodeAdditionalArgs": null
+          },
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "experimentName": "ray-experiment",
+          "identity": {
+            "identityType": "AMLToken"
+          },
+          "jobType": "Command",
+          "status": "Starting",
+          "resources": {
+            "instanceCount": 2,
+            "instanceType": "string",
+            "properties": {}
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2026-01-15T00:00:00.000Z",
+          "createdBy": "string",
+          "createdByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "Jobs_CreateOrUpdate",
+  "title": "CreateOrUpdate Command Job With Ray Distribution."
+}

--- a/specification/machinelearningservices/MachineLearningServices.Management/models.tsp
+++ b/specification/machinelearningservices/MachineLearningServices.Management/models.tsp
@@ -2993,6 +2993,12 @@ union DistributionType {
   TensorFlow: "TensorFlow",
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "Existing API contract - suppression reason updated"
   Mpi: "Mpi",
+
+  /**
+   * Ray distribution type.
+   */
+  @added(Versions.v2026_03_15_preview)
+  Ray: "Ray",
 }
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "Existing API contract - suppression reason updated"
@@ -15243,6 +15249,51 @@ model PyTorch extends DistributionConfiguration {
    * [Required] Specifies the type of distribution framework.
    */
   distributionType: "PyTorch";
+}
+
+/**
+ * Ray distribution configuration.
+ * A class for managing the configuration for a distributed Ray job.
+ */
+@added(Versions.v2026_03_15_preview)
+model Ray extends DistributionConfiguration {
+  /**
+   * The port of the head ray process.
+   */
+  port?: int32;
+
+  /**
+   * The address of Ray head node.
+   */
+  #suppress "@azure-tools/typespec-azure-core/no-nullable" "Existing API contract allows null values"
+  address?: string | null;
+
+  /**
+   * Provide this argument to start the Ray dashboard GUI.
+   */
+  includeDashboard?: boolean;
+
+  /**
+   * The port to bind the dashboard server to.
+   */
+  dashboardPort?: int32;
+
+  /**
+   * Additional arguments passed to ray start in head node.
+   */
+  #suppress "@azure-tools/typespec-azure-core/no-nullable" "Existing API contract allows null values"
+  headNodeAdditionalArgs?: string | null;
+
+  /**
+   * Additional arguments passed to ray start in worker node.
+   */
+  #suppress "@azure-tools/typespec-azure-core/no-nullable" "Existing API contract allows null values"
+  workerNodeAdditionalArgs?: string | null;
+
+  /**
+   * [Required] Specifies the type of distribution framework.
+   */
+  distributionType: "Ray";
 }
 
 /**

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2026-03-15-preview/examples/Job/CommandJob/createOrUpdateRayDistribution.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2026-03-15-preview/examples/Job/CommandJob/createOrUpdateRayDistribution.json
@@ -1,0 +1,137 @@
+{
+  "parameters": {
+    "api-version": "2026-03-15-preview",
+    "body": {
+      "properties": {
+        "description": "Ray distributed command job",
+        "codeId": "string",
+        "command": "python train.py",
+        "computeId": "string",
+        "displayName": "ray-multi-node-job",
+        "distribution": {
+          "distributionType": "Ray",
+          "port": 6379,
+          "includeDashboard": true,
+          "dashboardPort": 8265
+        },
+        "environmentId": "string",
+        "environmentVariables": {
+          "string": "string"
+        },
+        "experimentName": "ray-experiment",
+        "identity": {
+          "identityType": "AMLToken"
+        },
+        "jobType": "Command",
+        "resources": {
+          "instanceCount": 2,
+          "instanceType": "string",
+          "properties": {}
+        },
+        "tags": {
+          "string": "string"
+        }
+      }
+    },
+    "id": "string",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "workspaceName": "my-aml-workspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "string",
+        "id": "string",
+        "type": "Microsoft.MachineLearningServices/workspaces/jobs",
+        "properties": {
+          "description": "Ray distributed command job",
+          "codeId": "string",
+          "command": "python train.py",
+          "computeId": "string",
+          "displayName": "ray-multi-node-job",
+          "distribution": {
+            "distributionType": "Ray",
+            "port": 6379,
+            "address": null,
+            "includeDashboard": true,
+            "dashboardPort": 8265,
+            "headNodeAdditionalArgs": null,
+            "workerNodeAdditionalArgs": null
+          },
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "experimentName": "ray-experiment",
+          "identity": {
+            "identityType": "AMLToken"
+          },
+          "jobType": "Command",
+          "status": "Starting",
+          "resources": {
+            "instanceCount": 2,
+            "instanceType": "string",
+            "properties": {}
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2026-01-15T00:00:00.000Z",
+          "createdBy": "string",
+          "createdByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "string",
+        "id": "string",
+        "type": "Microsoft.MachineLearningServices/workspaces/jobs",
+        "properties": {
+          "description": "Ray distributed command job",
+          "codeId": "string",
+          "command": "python train.py",
+          "computeId": "string",
+          "displayName": "ray-multi-node-job",
+          "distribution": {
+            "distributionType": "Ray",
+            "port": 6379,
+            "address": null,
+            "includeDashboard": true,
+            "dashboardPort": 8265,
+            "headNodeAdditionalArgs": null,
+            "workerNodeAdditionalArgs": null
+          },
+          "environmentId": "string",
+          "environmentVariables": {
+            "string": "string"
+          },
+          "experimentName": "ray-experiment",
+          "identity": {
+            "identityType": "AMLToken"
+          },
+          "jobType": "Command",
+          "status": "Starting",
+          "resources": {
+            "instanceCount": 2,
+            "instanceType": "string",
+            "properties": {}
+          },
+          "tags": {
+            "string": "string"
+          }
+        },
+        "systemData": {
+          "createdAt": "2026-01-15T00:00:00.000Z",
+          "createdBy": "string",
+          "createdByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "Jobs_CreateOrUpdate",
+  "title": "CreateOrUpdate Command Job With Ray Distribution."
+}

--- a/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2026-03-15-preview/openapi.json
+++ b/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/preview/2026-03-15-preview/openapi.json
@@ -16964,6 +16964,9 @@
           "CreateOrUpdate AutoML Job.": {
             "$ref": "./examples/Job/AutoMLJob/createOrUpdate.json"
           },
+          "CreateOrUpdate Command Job With Ray Distribution.": {
+            "$ref": "./examples/Job/CommandJob/createOrUpdateRayDistribution.json"
+          },
           "CreateOrUpdate Command Job.": {
             "$ref": "./examples/Job/CommandJob/createOrUpdate.json"
           },
@@ -29060,7 +29063,8 @@
       "enum": [
         "PyTorch",
         "TensorFlow",
-        "Mpi"
+        "Mpi",
+        "Ray"
       ],
       "x-ms-enum": {
         "name": "DistributionType",
@@ -29077,6 +29081,11 @@
           {
             "name": "Mpi",
             "value": "Mpi"
+          },
+          {
+            "name": "Ray",
+            "value": "Ray",
+            "description": "Ray distribution type."
           }
         ]
       }
@@ -39261,6 +39270,47 @@
         }
       ],
       "x-ms-discriminator-value": "Random"
+    },
+    "Ray": {
+      "type": "object",
+      "description": "Ray distribution configuration.\nA class for managing the configuration for a distributed Ray job.",
+      "properties": {
+        "port": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The port of the head ray process."
+        },
+        "address": {
+          "type": "string",
+          "description": "The address of Ray head node.",
+          "x-nullable": true
+        },
+        "includeDashboard": {
+          "type": "boolean",
+          "description": "Provide this argument to start the Ray dashboard GUI."
+        },
+        "dashboardPort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The port to bind the dashboard server to."
+        },
+        "headNodeAdditionalArgs": {
+          "type": "string",
+          "description": "Additional arguments passed to ray start in head node.",
+          "x-nullable": true
+        },
+        "workerNodeAdditionalArgs": {
+          "type": "string",
+          "description": "Additional arguments passed to ray start in worker node.",
+          "x-nullable": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/DistributionConfiguration"
+        }
+      ],
+      "x-ms-discriminator-value": "Ray"
     },
     "Recurrence": {
       "type": "object",


### PR DESCRIPTION
Add Ray as a new distribution type for Command/Sweep Jobs in the 2026-03-15-preview API version. This enables native Ray cluster bootstrapping on AmlCompute through the ARM API.

Changes:
- Added Ray enum value to DistributionType (gated by v2026_03_15_preview)
- Added Ray model extending DistributionConfiguration with properties: port, address, includeDashboard, dashboardPort, headNodeAdditionalArgs, workerNodeAdditionalArgs
- Added example JSON for CreateOrUpdate Command Job with Ray Distribution
- Regenerated openapi.json via TypeSpec compilation

Ray distribution support exists in MFE service code (Vienna PR 1971126) and is actively usable via older preview API versions.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
