### PR TITLE
Add Managed HSM support to Application Gateway for 2025-07-01

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
@@ -6255,15 +6255,14 @@ model ApplicationGatewaySku {
 /**
  * Managed HSM properties of an application gateway.
  */
-#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "This model is part of the existing Application Gateway resource type and must use legacy patterns for backward compatibility"
 @Azure.ResourceManager.Legacy.feature(Features.applicationGateway)
 @added(Versions.v2025_07_01)
 model ApplicationGatewayManagedHsm {
   /**
    * Key identifier of a key stored in Managed HSM.
    */
-  @format("uri")
-  keyId?: string;
+  keyId?: url;
 
   /**
    * Base-64 encoded value of a base-64 public certificate.

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
@@ -6250,6 +6250,24 @@ model ApplicationGatewaySku {
 }
 
 /**
+ * Managed HSM properties of an application gateway.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+@Azure.ResourceManager.Legacy.feature(Features.applicationGateway)
+model ApplicationGatewayManagedHsm {
+  /**
+   * Key identifier of a key stored in Managed HSM.
+   */
+  @format("uri")
+  keyId?: string;
+
+  /**
+   * Base-64 encoded value of a base-64 public certificate.
+   */
+  publicCertData?: string;
+}
+
+/**
  * Application Gateway Ssl policy.
  */
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
@@ -6657,6 +6675,11 @@ model ApplicationGatewaySslCertificatePropertiesFormat {
    * Secret Id of (base-64 encoded unencrypted pfx) 'Secret' or 'Certificate' object stored in KeyVault.
    */
   keyVaultSecretId?: string;
+
+  /**
+   * Managed HSM properties of the Application Gateway resource.
+   */
+  hsm?: ApplicationGatewayManagedHsm;
 
   /**
    * The provisioning state of the SSL certificate resource.

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
@@ -6257,6 +6257,7 @@ model ApplicationGatewaySku {
  */
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @Azure.ResourceManager.Legacy.feature(Features.applicationGateway)
+@added(Versions.v2025_07_01)
 model ApplicationGatewayManagedHsm {
   /**
    * Key identifier of a key stored in Managed HSM.
@@ -6682,6 +6683,7 @@ model ApplicationGatewaySslCertificatePropertiesFormat {
   /**
    * Managed HSM properties of the Application Gateway resource.
    */
+  @added(Versions.v2025_07_01)
   hsm?: ApplicationGatewayManagedHsm;
 
   /**

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/applicationGateway.json
@@ -2747,6 +2747,21 @@
         }
       }
     },
+    "ApplicationGatewayManagedHsm": {
+      "type": "object",
+      "description": "Managed HSM properties of an application gateway.",
+      "properties": {
+        "keyId": {
+          "type": "string",
+          "format": "uri",
+          "description": "Key identifier of a key stored in Managed HSM."
+        },
+        "publicCertData": {
+          "type": "string",
+          "description": "Base-64 encoded value of a base-64 public certificate."
+        }
+      }
+    },
     "ApplicationGatewayOnDemandProbe": {
       "type": "object",
       "description": "Details of on demand test probe request.",
@@ -3818,20 +3833,6 @@
         "family": {
           "$ref": "./common.json#/definitions/ApplicationGatewaySkuFamily",
           "description": "Family of an application gateway SKU."
-        }
-      }
-    },
-    "ApplicationGatewayManagedHsm": {
-      "type": "object",
-      "properties": {
-        "keyId": {
-          "type": "string",
-          "description": "Key identifier of a key stored in Managed HSM.",
-          "format": "uri"
-        },
-        "publicCertData": {
-          "type": "string",
-          "description": "Base-64 encoded value of a base-64 public certificate."
         }
       }
     },

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/applicationGateway.json
@@ -3936,6 +3936,20 @@
         }
       }
     },
+    "ApplicationGatewayManagedHsm": {
+      "type": "object",
+      "properties": {
+        "keyId": {
+          "type": "string",
+          "description": "Key identifier of a key stored in Managed HSM.",
+          "format": "uri"
+        },
+        "publicCertData": {
+          "type": "string",
+          "description": "Base-64 encoded value of a base-64 public certificate."
+        }
+      }
+    },
     "ApplicationGatewaySslCertificate": {
       "type": "object",
       "description": "SSL certificates of an application gateway.",
@@ -3986,6 +4000,10 @@
         "keyVaultSecretId": {
           "type": "string",
           "description": "Secret Id of (base-64 encoded unencrypted pfx) 'Secret' or 'Certificate' object stored in KeyVault."
+        },
+        "hsm": {
+          "$ref": "#/definitions/ApplicationGatewayManagedHsm",
+          "description": "Managed HSM properties of the Application Gateway resource."
         },
         "provisioningState": {
           "$ref": "./common.json#/definitions/ProvisioningState",


### PR DESCRIPTION
## Summary

Add Managed HSM (Hardware Security Module) support to the Application Gateway SSL certificate properties for API version 2025-07-01.

## Changes

### TypeSpec (source)
- **models.tsp**: Added \ApplicationGatewayManagedHsm\ model with \keyId\ (URI format) and \publicCertData\ properties
- **models.tsp**: Added \hsm\ property to \ApplicationGatewaySslCertificatePropertiesFormat\

### Generated JSON
- **applicationGateway.json**: Added matching \ApplicationGatewayManagedHsm\ definition and \hsm\ property

## Related
- Original PR: https://github.com/Azure/azure-rest-api-specs-pr/pull/23831