### PR TITLE
Change skills package format from gzip to zip

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/main.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/main.tsp
@@ -18,4 +18,5 @@ import "./src/openai-finetuning/routes.tsp";
 import "./src/openai-responses/routes.tsp";
 import "./src/red-teams/routes.tsp";
 import "./src/schedules/routes.tsp";
+import "./src/skills/routes.tsp";
 import "./src/toolboxes/routes.tsp";

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -37209,6 +37209,14 @@
             ],
             "description": "The object type, which is always 'work_iq_preview'."
           },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "work_iq_preview": {
             "allOf": [
               {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -7701,7 +7701,8 @@
                     "additionalProperties": {
                       "type": "string"
                     },
-                    "description": "Set of key-value pairs associated with the skill."
+                    "description": "Set of 16 key-value pairs that can be attached to an object. This can be\nuseful for storing additional information about the object in a structured\nformat, and querying for objects via API or the dashboard.\n\nKeys are strings with a maximum length of 64 characters. Values are strings\nwith a maximum length of 512 characters.",
+                    "x-oaiTypeLabel": "map"
                   }
                 },
                 "required": [
@@ -7995,7 +7996,8 @@
                     "additionalProperties": {
                       "type": "string"
                     },
-                    "description": "Set of key-value pairs associated with the skill."
+                    "description": "Set of 16 key-value pairs that can be attached to an object. This can be\nuseful for storing additional information about the object in a structured\nformat, and querying for objects via API or the dashboard.\n\nKeys are strings with a maximum length of 64 characters. Values are strings\nwith a maximum length of 512 characters.",
+                    "x-oaiTypeLabel": "map"
                   }
                 }
               }
@@ -8149,7 +8151,7 @@
     "/skills:import": {
       "post": {
         "operationId": "Skills_createSkillFromPackage",
-        "description": "Creates a skill from a GZip package.",
+        "description": "Creates a skill from a gzip package.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -8209,7 +8211,7 @@
               }
             }
           },
-          "description": "The GZip package used to create the skill."
+          "description": "The gzip package used to create the skill."
         },
         "x-ms-foundry-meta": {
           "conditional_previews": [
@@ -8994,14 +8996,6 @@
             ],
             "description": "The type of the tool. Always `\"a2a_preview`."
           },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "base_url": {
             "type": "string",
             "format": "uri",
@@ -9124,14 +9118,6 @@
           "index_name": {
             "type": "string",
             "description": "The name of an index in an IndexResource attached to this agent."
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
           },
           "query_type": {
             "allOf": [
@@ -10056,14 +10042,6 @@
             ],
             "description": "The object type, which is always 'azure_ai_search'."
           },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "azure_ai_search": {
             "allOf": [
               {
@@ -10167,14 +10145,6 @@
           "indexes"
         ],
         "properties": {
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "indexes": {
             "type": "array",
             "items": {
@@ -10461,14 +10431,6 @@
           "instance_name"
         ],
         "properties": {
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "project_connection_id": {
             "type": "string",
             "description": "Project connection id for grounding with bing search"
@@ -10510,14 +10472,6 @@
               "bing_custom_search_preview"
             ],
             "description": "The object type, which is always 'bing_custom_search_preview'."
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
           },
           "bing_custom_search_preview": {
             "allOf": [
@@ -10622,14 +10576,6 @@
           "search_configurations"
         ],
         "properties": {
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "search_configurations": {
             "type": "array",
             "items": {
@@ -10647,14 +10593,6 @@
           "project_connection_id"
         ],
         "properties": {
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "project_connection_id": {
             "type": "string",
             "description": "Project connection id for grounding with bing search"
@@ -10685,14 +10623,6 @@
           "search_configurations"
         ],
         "properties": {
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "search_configurations": {
             "type": "array",
             "items": {
@@ -10717,14 +10647,6 @@
               "bing_grounding"
             ],
             "description": "The object type, which is always 'bing_grounding'."
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
           },
           "bing_grounding": {
             "allOf": [
@@ -10865,14 +10787,6 @@
             ],
             "description": "The object type, which is always 'browser_automation_preview'."
           },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "browser_automation_preview": {
             "allOf": [
               {
@@ -10976,14 +10890,6 @@
           "project_connection_id"
         ],
         "properties": {
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "project_connection_id": {
             "type": "string",
             "description": "The ID of the project connection to your Azure Playwright resource."
@@ -10997,14 +10903,6 @@
           "connection"
         ],
         "properties": {
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "connection": {
             "allOf": [
               {
@@ -13797,14 +13695,6 @@
       "FabricDataAgentToolParameters": {
         "type": "object",
         "properties": {
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "project_connections": {
             "type": "array",
             "items": {
@@ -14716,14 +14606,6 @@
             ],
             "description": "The type of the tool. Always `memory_search_preview`."
           },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "memory_store_name": {
             "type": "string",
             "description": "The name of the memory store to use."
@@ -15253,14 +15135,6 @@
               "fabric_dataagent_preview"
             ],
             "description": "The object type, which is always 'fabric_dataagent_preview'."
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
           },
           "fabric_dataagent_preview": {
             "allOf": [
@@ -36399,14 +36273,6 @@
       "SharepointGroundingToolParameters": {
         "type": "object",
         "properties": {
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "project_connections": {
             "type": "array",
             "items": {
@@ -36431,14 +36297,6 @@
               "sharepoint_grounding_preview"
             ],
             "description": "The object type, which is always 'sharepoint_grounding_preview'."
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
           },
           "sharepoint_grounding_preview": {
             "allOf": [
@@ -36470,7 +36328,7 @@
           },
           "has_blob": {
             "type": "boolean",
-            "description": "Whether the skill was created from a GZip blob package."
+            "description": "Whether the skill was created from a gzip blob package."
           },
           "name": {
             "type": "string",
@@ -36487,7 +36345,8 @@
             "additionalProperties": {
               "type": "string"
             },
-            "description": "Set of key-value pairs associated with the skill."
+            "description": "Set of 16 key-value pairs that can be attached to an object. This can be\nuseful for storing additional information about the object in a structured\nformat, and querying for objects via API or the dashboard.\n\nKeys are strings with a maximum length of 64 characters. Values are strings\nwith a maximum length of 512 characters.",
+            "x-oaiTypeLabel": "map"
           }
         },
         "description": "A skill object."
@@ -36936,14 +36795,6 @@
           "project_connection_id"
         ],
         "properties": {
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "project_connection_id": {
             "type": "string",
             "description": "A project connection in a ToolProjectConnectionList attached to this tool."
@@ -37304,14 +37155,6 @@
           "instance_name"
         ],
         "properties": {
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "project_connection_id": {
             "type": "string",
             "description": "Project connection id for grounding with bing custom search"

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -54,6 +54,9 @@
       "name": "Schedules"
     },
     {
+      "name": "Skills"
+    },
+    {
       "name": "Toolboxes"
     }
   ],
@@ -7618,6 +7621,603 @@
         ]
       }
     },
+    "/skills": {
+      "post": {
+        "operationId": "Skills_createSkill",
+        "description": "Creates a skill.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Skills=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkillObject"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Skills"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "maxLength": 63,
+                    "description": "The unique name of the skill."
+                  },
+                  "description": {
+                    "type": "string",
+                    "maxLength": 1024,
+                    "description": "A human-readable description of the skill."
+                  },
+                  "instructions": {
+                    "type": "string",
+                    "maxLength": 102400,
+                    "description": "Instructions that define the behavior of the skill."
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Set of key-value pairs associated with the skill."
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              }
+            }
+          }
+        },
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Skills=V1Preview"
+          ]
+        }
+      },
+      "get": {
+        "operationId": "Skills_listSkills",
+        "description": "Returns the list of all skills.",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the\ndefault is 20.",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 20
+            },
+            "explode": false
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "required": false,
+            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`\nfor descending order.",
+            "schema": {
+              "$ref": "#/components/schemas/PageOrder"
+            },
+            "explode": false
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "required": false,
+            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include after=obj_foo in order to fetch the next page of the list.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "before",
+            "in": "query",
+            "required": false,
+            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include before=obj_foo in order to fetch the previous page of the list.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Skills=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "has_more"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/SkillObject"
+                      },
+                      "description": "The requested list of items."
+                    },
+                    "first_id": {
+                      "type": "string",
+                      "description": "The first ID represented in this list."
+                    },
+                    "last_id": {
+                      "type": "string",
+                      "description": "The last ID represented in this list."
+                    },
+                    "has_more": {
+                      "type": "boolean",
+                      "description": "A value indicating whether there are additional values available not captured in this list."
+                    }
+                  },
+                  "description": "The response data for a requested list of items."
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Skills"
+        ],
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Skills=V1Preview"
+          ]
+        }
+      }
+    },
+    "/skills/{skill_name}": {
+      "get": {
+        "operationId": "Skills_getSkill",
+        "description": "Retrieves a skill.",
+        "parameters": [
+          {
+            "name": "skill_name",
+            "in": "path",
+            "required": true,
+            "description": "The unique name of the skill.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Skills=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkillObject"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Skills"
+        ],
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Skills=V1Preview"
+          ]
+        }
+      },
+      "post": {
+        "operationId": "Skills_updateSkill",
+        "description": "Updates an existing skill.",
+        "parameters": [
+          {
+            "name": "skill_name",
+            "in": "path",
+            "required": true,
+            "description": "The unique name of the skill.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Skills=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkillObject"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Skills"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string",
+                    "maxLength": 1024,
+                    "description": "A human-readable description of the skill."
+                  },
+                  "instructions": {
+                    "type": "string",
+                    "maxLength": 102400,
+                    "description": "Instructions that define the behavior of the skill."
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Set of key-value pairs associated with the skill."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Skills=V1Preview"
+          ]
+        }
+      },
+      "delete": {
+        "operationId": "Skills_deleteSkill",
+        "description": "Deletes a skill.",
+        "parameters": [
+          {
+            "name": "skill_name",
+            "in": "path",
+            "required": true,
+            "description": "The unique name of the skill.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Skills=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteSkillResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Skills"
+        ],
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Skills=V1Preview"
+          ]
+        }
+      }
+    },
+    "/skills/{skill_name}:download": {
+      "get": {
+        "operationId": "Skills_downloadSkill",
+        "description": "Downloads a skill package.",
+        "parameters": [
+          {
+            "name": "skill_name",
+            "in": "path",
+            "required": true,
+            "description": "The unique name of the skill.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Skills=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The response body for downloading a skill package.",
+            "content": {
+              "application/gzip": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Skills"
+        ],
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Skills=V1Preview"
+          ]
+        }
+      }
+    },
+    "/skills:import": {
+      "post": {
+        "operationId": "Skills_createSkillFromPackage",
+        "description": "Creates a skill from a GZip package.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Skills=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkillObject"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Skills"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/gzip": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          },
+          "description": "The GZip package used to create the skill."
+        },
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Skills=V1Preview"
+          ]
+        }
+      }
+    },
     "/toolboxes": {
       "get": {
         "operationId": "listToolboxes",
@@ -8394,6 +8994,14 @@
             ],
             "description": "The type of the tool. Always `\"a2a_preview`."
           },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "base_url": {
             "type": "string",
             "format": "uri",
@@ -8516,6 +9124,14 @@
           "index_name": {
             "type": "string",
             "description": "The name of an index in an IndexResource attached to this agent."
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           },
           "query_type": {
             "allOf": [
@@ -9440,6 +10056,14 @@
             ],
             "description": "The object type, which is always 'azure_ai_search'."
           },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "azure_ai_search": {
             "allOf": [
               {
@@ -9543,6 +10167,14 @@
           "indexes"
         ],
         "properties": {
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "indexes": {
             "type": "array",
             "items": {
@@ -9829,6 +10461,14 @@
           "instance_name"
         ],
         "properties": {
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "project_connection_id": {
             "type": "string",
             "description": "Project connection id for grounding with bing search"
@@ -9870,6 +10510,14 @@
               "bing_custom_search_preview"
             ],
             "description": "The object type, which is always 'bing_custom_search_preview'."
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           },
           "bing_custom_search_preview": {
             "allOf": [
@@ -9974,6 +10622,14 @@
           "search_configurations"
         ],
         "properties": {
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "search_configurations": {
             "type": "array",
             "items": {
@@ -9991,6 +10647,14 @@
           "project_connection_id"
         ],
         "properties": {
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "project_connection_id": {
             "type": "string",
             "description": "Project connection id for grounding with bing search"
@@ -10021,6 +10685,14 @@
           "search_configurations"
         ],
         "properties": {
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "search_configurations": {
             "type": "array",
             "items": {
@@ -10045,6 +10717,14 @@
               "bing_grounding"
             ],
             "description": "The object type, which is always 'bing_grounding'."
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           },
           "bing_grounding": {
             "allOf": [
@@ -10185,6 +10865,14 @@
             ],
             "description": "The object type, which is always 'browser_automation_preview'."
           },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "browser_automation_preview": {
             "allOf": [
               {
@@ -10288,6 +10976,14 @@
           "project_connection_id"
         ],
         "properties": {
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "project_connection_id": {
             "type": "string",
             "description": "The ID of the project connection to your Azure Playwright resource."
@@ -10301,6 +10997,14 @@
           "connection"
         ],
         "properties": {
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "connection": {
             "allOf": [
               {
@@ -11368,6 +12072,24 @@
           }
         },
         "description": "The result of a delete response operation."
+      },
+      "DeleteSkillResponse": {
+        "type": "object",
+        "required": [
+          "name",
+          "deleted"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The unique name of the skill."
+          },
+          "deleted": {
+            "type": "boolean",
+            "description": "Whether the skill was successfully deleted."
+          }
+        },
+        "description": "A deleted skill Object"
       },
       "Deployment": {
         "type": "object",
@@ -13075,6 +13797,14 @@
       "FabricDataAgentToolParameters": {
         "type": "object",
         "properties": {
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "project_connections": {
             "type": "array",
             "items": {
@@ -13986,6 +14716,14 @@
             ],
             "description": "The type of the tool. Always `memory_search_preview`."
           },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "memory_store_name": {
             "type": "string",
             "description": "The name of the memory store to use."
@@ -14515,6 +15253,14 @@
               "fabric_dataagent_preview"
             ],
             "description": "The object type, which is always 'fabric_dataagent_preview'."
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           },
           "fabric_dataagent_preview": {
             "allOf": [
@@ -15426,6 +16172,14 @@
             ],
             "description": "The type of the code interpreter tool. Always `code_interpreter`.",
             "x-stainless-const": true
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           },
           "container": {
             "anyOf": [
@@ -19735,6 +20489,14 @@
               }
             ],
             "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [
@@ -21161,6 +21923,14 @@
               }
             ],
             "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [
@@ -21845,6 +22615,14 @@
               }
             ],
             "description": "Whether to generate a new image or edit an existing image. Default: `auto`."
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [
@@ -27586,6 +28364,14 @@
             "description": "The type of the local shell tool. Always `local_shell`.",
             "x-stainless-const": true,
             "default": "local_shell"
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [
@@ -33268,6 +34054,7 @@
             "azure_function": "#/components/schemas/AzureFunctionTool",
             "capture_structured_outputs": "#/components/schemas/CaptureStructuredOutputsTool",
             "a2a_preview": "#/components/schemas/A2APreviewTool",
+            "work_iq_preview": "#/components/schemas/WorkIQPreviewTool",
             "memory_search_preview": "#/components/schemas/MemorySearchPreviewTool",
             "code_interpreter": "#/components/schemas/OpenAI.CodeInterpreterTool",
             "function": "#/components/schemas/OpenAI.FunctionTool",
@@ -33623,6 +34410,7 @@
               "fabric_dataagent_preview",
               "sharepoint_grounding_preview",
               "memory_search_preview",
+              "work_iq_preview",
               "azure_ai_search",
               "azure_function",
               "bing_grounding",
@@ -34044,6 +34832,14 @@
             ],
             "description": "High level guidance for the amount of context window space to use for the search. One of `low`, `medium`, or `high`. `medium` is the default.",
             "default": "medium"
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           },
           "custom_search_configuration": {
             "allOf": [
@@ -35603,6 +36399,14 @@
       "SharepointGroundingToolParameters": {
         "type": "object",
         "properties": {
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "project_connections": {
             "type": "array",
             "items": {
@@ -35628,6 +36432,14 @@
             ],
             "description": "The object type, which is always 'sharepoint_grounding_preview'."
           },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "sharepoint_grounding_preview": {
             "allOf": [
               {
@@ -35643,6 +36455,42 @@
           }
         ],
         "description": "The input definition information for a sharepoint tool as used to configure an agent."
+      },
+      "SkillObject": {
+        "type": "object",
+        "required": [
+          "skill_id",
+          "has_blob",
+          "name"
+        ],
+        "properties": {
+          "skill_id": {
+            "type": "string",
+            "description": "The unique identifier of the skill."
+          },
+          "has_blob": {
+            "type": "boolean",
+            "description": "Whether the skill was created from a GZip blob package."
+          },
+          "name": {
+            "type": "string",
+            "maxLength": 63,
+            "description": "The unique name of the skill."
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 1024,
+            "description": "A human-readable description of the skill."
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Set of key-value pairs associated with the skill."
+          }
+        },
+        "description": "A skill object."
       },
       "Sku": {
         "type": "object",
@@ -36088,6 +36936,14 @@
           "project_connection_id"
         ],
         "properties": {
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "project_connection_id": {
             "type": "string",
             "description": "A project connection in a ToolProjectConnectionList attached to this tool."
@@ -36448,6 +37304,14 @@
           "instance_name"
         ],
         "properties": {
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "project_connection_id": {
             "type": "string",
             "description": "Project connection id for grounding with bing custom search"
@@ -36487,6 +37351,49 @@
           }
         ],
         "description": "Weekly recurrence schedule."
+      },
+      "WorkIQPreviewTool": {
+        "type": "object",
+        "required": [
+          "type",
+          "work_iq_preview"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "work_iq_preview"
+            ],
+            "description": "The object type, which is always 'work_iq_preview'."
+          },
+          "work_iq_preview": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WorkIQPreviewToolParameters"
+              }
+            ],
+            "description": "The WorkIQ tool parameters."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.Tool"
+          }
+        ],
+        "description": "A WorkIQ server-side tool."
+      },
+      "WorkIQPreviewToolParameters": {
+        "type": "object",
+        "required": [
+          "project_connection_id"
+        ],
+        "properties": {
+          "project_connection_id": {
+            "type": "string",
+            "description": "The ID of the WorkIQ project connection."
+          }
+        },
+        "description": "The WorkIQ tool parameters."
       },
       "WorkflowActionOutputItem": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -8017,8 +8017,8 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "The request has succeeded.",
+          "201": {
+            "description": "The request has succeeded and a new resource has been created as a result.",
             "content": {
               "application/json": {
                 "schema": {
@@ -8544,8 +8544,8 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "The request has succeeded.",
+          "201": {
+            "description": "The request has succeeded and a new resource has been created as a result.",
             "content": {
               "application/json": {
                 "schema": {
@@ -11296,6 +11296,14 @@
               "capture_structured_outputs"
             ],
             "description": "The type of the tool. Always `capture_structured_outputs`."
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           },
           "outputs": {
             "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -8486,7 +8486,7 @@
           "200": {
             "description": "The response body for downloading a skill package.",
             "content": {
-              "application/gzip": {
+              "application/zip": {
                 "schema": {
                   "type": "string",
                   "format": "binary"
@@ -8518,7 +8518,7 @@
     "/skills:import": {
       "post": {
         "operationId": "Skills_createSkillFromPackage",
-        "description": "Creates a skill from a gzip package.",
+        "description": "Creates a skill from a zip package.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -8571,14 +8571,14 @@
         "requestBody": {
           "required": true,
           "content": {
-            "application/gzip": {
+            "application/zip": {
               "schema": {
                 "type": "string",
                 "format": "binary"
               }
             }
           },
-          "description": "The gzip package used to create the skill."
+          "description": "The zip package used to create the skill."
         },
         "x-ms-foundry-meta": {
           "conditional_previews": [
@@ -36780,7 +36780,7 @@
           },
           "has_blob": {
             "type": "boolean",
-            "description": "Whether the skill was created from a gzip blob package."
+            "description": "Whether the skill was created from a zip blob package."
           },
           "name": {
             "type": "string",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -57,6 +57,9 @@
       "name": "Schedules"
     },
     {
+      "name": "Skills"
+    },
+    {
       "name": "Toolboxes"
     }
   ],
@@ -8913,6 +8916,603 @@
         ]
       }
     },
+    "/skills": {
+      "post": {
+        "operationId": "Skills_createSkill",
+        "description": "Creates a skill.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Skills=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkillObject"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Skills"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "maxLength": 63,
+                    "description": "The unique name of the skill."
+                  },
+                  "description": {
+                    "type": "string",
+                    "maxLength": 1024,
+                    "description": "A human-readable description of the skill."
+                  },
+                  "instructions": {
+                    "type": "string",
+                    "maxLength": 102400,
+                    "description": "Instructions that define the behavior of the skill."
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Set of key-value pairs associated with the skill."
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              }
+            }
+          }
+        },
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Skills=V1Preview"
+          ]
+        }
+      },
+      "get": {
+        "operationId": "Skills_listSkills",
+        "description": "Returns the list of all skills.",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the\ndefault is 20.",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 20
+            },
+            "explode": false
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "required": false,
+            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`\nfor descending order.",
+            "schema": {
+              "$ref": "#/components/schemas/PageOrder"
+            },
+            "explode": false
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "required": false,
+            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include after=obj_foo in order to fetch the next page of the list.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "before",
+            "in": "query",
+            "required": false,
+            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include before=obj_foo in order to fetch the previous page of the list.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Skills=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "has_more"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/SkillObject"
+                      },
+                      "description": "The requested list of items."
+                    },
+                    "first_id": {
+                      "type": "string",
+                      "description": "The first ID represented in this list."
+                    },
+                    "last_id": {
+                      "type": "string",
+                      "description": "The last ID represented in this list."
+                    },
+                    "has_more": {
+                      "type": "boolean",
+                      "description": "A value indicating whether there are additional values available not captured in this list."
+                    }
+                  },
+                  "description": "The response data for a requested list of items."
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Skills"
+        ],
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Skills=V1Preview"
+          ]
+        }
+      }
+    },
+    "/skills/{skill_name}": {
+      "get": {
+        "operationId": "Skills_getSkill",
+        "description": "Retrieves a skill.",
+        "parameters": [
+          {
+            "name": "skill_name",
+            "in": "path",
+            "required": true,
+            "description": "The unique name of the skill.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Skills=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkillObject"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Skills"
+        ],
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Skills=V1Preview"
+          ]
+        }
+      },
+      "post": {
+        "operationId": "Skills_updateSkill",
+        "description": "Updates an existing skill.",
+        "parameters": [
+          {
+            "name": "skill_name",
+            "in": "path",
+            "required": true,
+            "description": "The unique name of the skill.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Skills=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkillObject"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Skills"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string",
+                    "maxLength": 1024,
+                    "description": "A human-readable description of the skill."
+                  },
+                  "instructions": {
+                    "type": "string",
+                    "maxLength": 102400,
+                    "description": "Instructions that define the behavior of the skill."
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Set of key-value pairs associated with the skill."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Skills=V1Preview"
+          ]
+        }
+      },
+      "delete": {
+        "operationId": "Skills_deleteSkill",
+        "description": "Deletes a skill.",
+        "parameters": [
+          {
+            "name": "skill_name",
+            "in": "path",
+            "required": true,
+            "description": "The unique name of the skill.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Skills=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteSkillResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Skills"
+        ],
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Skills=V1Preview"
+          ]
+        }
+      }
+    },
+    "/skills/{skill_name}:download": {
+      "get": {
+        "operationId": "Skills_downloadSkill",
+        "description": "Downloads a skill package.",
+        "parameters": [
+          {
+            "name": "skill_name",
+            "in": "path",
+            "required": true,
+            "description": "The unique name of the skill.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Skills=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The response body for downloading a skill package.",
+            "content": {
+              "application/gzip": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Skills"
+        ],
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Skills=V1Preview"
+          ]
+        }
+      }
+    },
+    "/skills:import": {
+      "post": {
+        "operationId": "Skills_createSkillFromPackage",
+        "description": "Creates a skill from a GZip package.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Skills=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkillObject"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Skills"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/gzip": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          },
+          "description": "The GZip package used to create the skill."
+        },
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Skills=V1Preview"
+          ]
+        }
+      }
+    },
     "/toolboxes": {
       "get": {
         "operationId": "listToolboxes",
@@ -9689,6 +10289,14 @@
             ],
             "description": "The type of the tool. Always `\"a2a_preview`."
           },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "base_url": {
             "type": "string",
             "format": "uri",
@@ -9811,6 +10419,14 @@
           "index_name": {
             "type": "string",
             "description": "The name of an index in an IndexResource attached to this agent."
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           },
           "query_type": {
             "allOf": [
@@ -11185,6 +11801,14 @@
             ],
             "description": "The object type, which is always 'azure_ai_search'."
           },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "azure_ai_search": {
             "allOf": [
               {
@@ -11288,6 +11912,14 @@
           "indexes"
         ],
         "properties": {
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "indexes": {
             "type": "array",
             "items": {
@@ -11574,6 +12206,14 @@
           "instance_name"
         ],
         "properties": {
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "project_connection_id": {
             "type": "string",
             "description": "Project connection id for grounding with bing search"
@@ -11615,6 +12255,14 @@
               "bing_custom_search_preview"
             ],
             "description": "The object type, which is always 'bing_custom_search_preview'."
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           },
           "bing_custom_search_preview": {
             "allOf": [
@@ -11719,6 +12367,14 @@
           "search_configurations"
         ],
         "properties": {
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "search_configurations": {
             "type": "array",
             "items": {
@@ -11736,6 +12392,14 @@
           "project_connection_id"
         ],
         "properties": {
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "project_connection_id": {
             "type": "string",
             "description": "Project connection id for grounding with bing search"
@@ -11766,6 +12430,14 @@
           "search_configurations"
         ],
         "properties": {
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "search_configurations": {
             "type": "array",
             "items": {
@@ -11790,6 +12462,14 @@
               "bing_grounding"
             ],
             "description": "The object type, which is always 'bing_grounding'."
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           },
           "bing_grounding": {
             "allOf": [
@@ -11930,6 +12610,14 @@
             ],
             "description": "The object type, which is always 'browser_automation_preview'."
           },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "browser_automation_preview": {
             "allOf": [
               {
@@ -12033,6 +12721,14 @@
           "project_connection_id"
         ],
         "properties": {
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "project_connection_id": {
             "type": "string",
             "description": "The ID of the project connection to your Azure Playwright resource."
@@ -12046,6 +12742,14 @@
           "connection"
         ],
         "properties": {
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "connection": {
             "allOf": [
               {
@@ -13271,6 +13975,24 @@
           }
         },
         "description": "The result of a delete response operation."
+      },
+      "DeleteSkillResponse": {
+        "type": "object",
+        "required": [
+          "name",
+          "deleted"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The unique name of the skill."
+          },
+          "deleted": {
+            "type": "boolean",
+            "description": "Whether the skill was successfully deleted."
+          }
+        },
+        "description": "A deleted skill Object"
       },
       "Deployment": {
         "type": "object",
@@ -15134,6 +15856,14 @@
       "FabricDataAgentToolParameters": {
         "type": "object",
         "properties": {
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "project_connections": {
             "type": "array",
             "items": {
@@ -16118,6 +16848,14 @@
             ],
             "description": "The type of the tool. Always `memory_search_preview`."
           },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "memory_store_name": {
             "type": "string",
             "description": "The name of the memory store to use."
@@ -16162,6 +16900,14 @@
               "memory_search"
             ],
             "description": "The type of the tool. Always `memory_search_preview`."
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           },
           "memory_store_name": {
             "type": "string",
@@ -16727,6 +17473,14 @@
               "fabric_dataagent_preview"
             ],
             "description": "The object type, which is always 'fabric_dataagent_preview'."
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           },
           "fabric_dataagent_preview": {
             "allOf": [
@@ -17638,6 +18392,14 @@
             ],
             "description": "The type of the code interpreter tool. Always `code_interpreter`.",
             "x-stainless-const": true
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           },
           "container": {
             "anyOf": [
@@ -21947,6 +22709,14 @@
               }
             ],
             "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [
@@ -23373,6 +24143,14 @@
               }
             ],
             "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [
@@ -24057,6 +24835,14 @@
               }
             ],
             "description": "Whether to generate a new image or edit an existing image. Default: `auto`."
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [
@@ -29798,6 +30584,14 @@
             "description": "The type of the local shell tool. Always `local_shell`.",
             "x-stainless-const": true,
             "default": "local_shell"
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [
@@ -35503,6 +36297,7 @@
             "azure_function": "#/components/schemas/AzureFunctionTool",
             "capture_structured_outputs": "#/components/schemas/CaptureStructuredOutputsTool",
             "a2a_preview": "#/components/schemas/A2APreviewTool",
+            "work_iq_preview": "#/components/schemas/WorkIQPreviewTool",
             "memory_search_preview": "#/components/schemas/MemorySearchPreviewTool",
             "memory_search": "#/components/schemas/MemorySearchTool",
             "code_interpreter": "#/components/schemas/OpenAI.CodeInterpreterTool",
@@ -35859,6 +36654,7 @@
               "fabric_dataagent_preview",
               "sharepoint_grounding_preview",
               "memory_search_preview",
+              "work_iq_preview",
               "azure_ai_search",
               "azure_function",
               "bing_grounding",
@@ -36281,6 +37077,14 @@
             ],
             "description": "High level guidance for the amount of context window space to use for the search. One of `low`, `medium`, or `high`. `medium` is the default.",
             "default": "medium"
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           },
           "custom_search_configuration": {
             "allOf": [
@@ -37861,6 +38665,14 @@
       "SharepointGroundingToolParameters": {
         "type": "object",
         "properties": {
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "project_connections": {
             "type": "array",
             "items": {
@@ -37886,6 +38698,14 @@
             ],
             "description": "The object type, which is always 'sharepoint_grounding_preview'."
           },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "sharepoint_grounding_preview": {
             "allOf": [
               {
@@ -37901,6 +38721,42 @@
           }
         ],
         "description": "The input definition information for a sharepoint tool as used to configure an agent."
+      },
+      "SkillObject": {
+        "type": "object",
+        "required": [
+          "skill_id",
+          "has_blob",
+          "name"
+        ],
+        "properties": {
+          "skill_id": {
+            "type": "string",
+            "description": "The unique identifier of the skill."
+          },
+          "has_blob": {
+            "type": "boolean",
+            "description": "Whether the skill was created from a GZip blob package."
+          },
+          "name": {
+            "type": "string",
+            "maxLength": 63,
+            "description": "The unique name of the skill."
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 1024,
+            "description": "A human-readable description of the skill."
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Set of key-value pairs associated with the skill."
+          }
+        },
+        "description": "A skill object."
       },
       "Sku": {
         "type": "object",
@@ -38372,6 +39228,14 @@
           "project_connection_id"
         ],
         "properties": {
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "project_connection_id": {
             "type": "string",
             "description": "A project connection in a ToolProjectConnectionList attached to this tool."
@@ -38758,6 +39622,14 @@
           "instance_name"
         ],
         "properties": {
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "project_connection_id": {
             "type": "string",
             "description": "Project connection id for grounding with bing custom search"
@@ -38797,6 +39669,49 @@
           }
         ],
         "description": "Weekly recurrence schedule."
+      },
+      "WorkIQPreviewTool": {
+        "type": "object",
+        "required": [
+          "type",
+          "work_iq_preview"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "work_iq_preview"
+            ],
+            "description": "The object type, which is always 'work_iq_preview'."
+          },
+          "work_iq_preview": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WorkIQPreviewToolParameters"
+              }
+            ],
+            "description": "The WorkIQ tool parameters."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.Tool"
+          }
+        ],
+        "description": "A WorkIQ server-side tool."
+      },
+      "WorkIQPreviewToolParameters": {
+        "type": "object",
+        "required": [
+          "project_connection_id"
+        ],
+        "properties": {
+          "project_connection_id": {
+            "type": "string",
+            "description": "The ID of the WorkIQ project connection."
+          }
+        },
+        "description": "The WorkIQ tool parameters."
       },
       "WorkflowActionOutputItem": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -39519,6 +39519,14 @@
             ],
             "description": "The object type, which is always 'work_iq_preview'."
           },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "work_iq_preview": {
             "allOf": [
               {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -9684,8 +9684,8 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "The request has succeeded.",
+          "201": {
+            "description": "The request has succeeded and a new resource has been created as a result.",
             "content": {
               "application/json": {
                 "schema": {
@@ -10211,8 +10211,8 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "The request has succeeded.",
+          "201": {
+            "description": "The request has succeeded and a new resource has been created as a result.",
             "content": {
               "application/json": {
                 "schema": {
@@ -13411,6 +13411,14 @@
               "capture_structured_outputs"
             ],
             "description": "The type of the tool. Always `capture_structured_outputs`."
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           },
           "outputs": {
             "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -8996,7 +8996,8 @@
                     "additionalProperties": {
                       "type": "string"
                     },
-                    "description": "Set of key-value pairs associated with the skill."
+                    "description": "Set of 16 key-value pairs that can be attached to an object. This can be\nuseful for storing additional information about the object in a structured\nformat, and querying for objects via API or the dashboard.\n\nKeys are strings with a maximum length of 64 characters. Values are strings\nwith a maximum length of 512 characters.",
+                    "x-oaiTypeLabel": "map"
                   }
                 },
                 "required": [
@@ -9290,7 +9291,8 @@
                     "additionalProperties": {
                       "type": "string"
                     },
-                    "description": "Set of key-value pairs associated with the skill."
+                    "description": "Set of 16 key-value pairs that can be attached to an object. This can be\nuseful for storing additional information about the object in a structured\nformat, and querying for objects via API or the dashboard.\n\nKeys are strings with a maximum length of 64 characters. Values are strings\nwith a maximum length of 512 characters.",
+                    "x-oaiTypeLabel": "map"
                   }
                 }
               }
@@ -9444,7 +9446,7 @@
     "/skills:import": {
       "post": {
         "operationId": "Skills_createSkillFromPackage",
-        "description": "Creates a skill from a GZip package.",
+        "description": "Creates a skill from a gzip package.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -9504,7 +9506,7 @@
               }
             }
           },
-          "description": "The GZip package used to create the skill."
+          "description": "The gzip package used to create the skill."
         },
         "x-ms-foundry-meta": {
           "conditional_previews": [
@@ -10289,14 +10291,6 @@
             ],
             "description": "The type of the tool. Always `\"a2a_preview`."
           },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "base_url": {
             "type": "string",
             "format": "uri",
@@ -10419,14 +10413,6 @@
           "index_name": {
             "type": "string",
             "description": "The name of an index in an IndexResource attached to this agent."
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
           },
           "query_type": {
             "allOf": [
@@ -11801,14 +11787,6 @@
             ],
             "description": "The object type, which is always 'azure_ai_search'."
           },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "azure_ai_search": {
             "allOf": [
               {
@@ -11912,14 +11890,6 @@
           "indexes"
         ],
         "properties": {
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "indexes": {
             "type": "array",
             "items": {
@@ -12206,14 +12176,6 @@
           "instance_name"
         ],
         "properties": {
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "project_connection_id": {
             "type": "string",
             "description": "Project connection id for grounding with bing search"
@@ -12255,14 +12217,6 @@
               "bing_custom_search_preview"
             ],
             "description": "The object type, which is always 'bing_custom_search_preview'."
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
           },
           "bing_custom_search_preview": {
             "allOf": [
@@ -12367,14 +12321,6 @@
           "search_configurations"
         ],
         "properties": {
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "search_configurations": {
             "type": "array",
             "items": {
@@ -12392,14 +12338,6 @@
           "project_connection_id"
         ],
         "properties": {
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "project_connection_id": {
             "type": "string",
             "description": "Project connection id for grounding with bing search"
@@ -12430,14 +12368,6 @@
           "search_configurations"
         ],
         "properties": {
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "search_configurations": {
             "type": "array",
             "items": {
@@ -12462,14 +12392,6 @@
               "bing_grounding"
             ],
             "description": "The object type, which is always 'bing_grounding'."
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
           },
           "bing_grounding": {
             "allOf": [
@@ -12610,14 +12532,6 @@
             ],
             "description": "The object type, which is always 'browser_automation_preview'."
           },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "browser_automation_preview": {
             "allOf": [
               {
@@ -12721,14 +12635,6 @@
           "project_connection_id"
         ],
         "properties": {
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "project_connection_id": {
             "type": "string",
             "description": "The ID of the project connection to your Azure Playwright resource."
@@ -12742,14 +12648,6 @@
           "connection"
         ],
         "properties": {
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "connection": {
             "allOf": [
               {
@@ -15856,14 +15754,6 @@
       "FabricDataAgentToolParameters": {
         "type": "object",
         "properties": {
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "project_connections": {
             "type": "array",
             "items": {
@@ -16848,14 +16738,6 @@
             ],
             "description": "The type of the tool. Always `memory_search_preview`."
           },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "memory_store_name": {
             "type": "string",
             "description": "The name of the memory store to use."
@@ -16900,14 +16782,6 @@
               "memory_search"
             ],
             "description": "The type of the tool. Always `memory_search_preview`."
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
           },
           "memory_store_name": {
             "type": "string",
@@ -17473,14 +17347,6 @@
               "fabric_dataagent_preview"
             ],
             "description": "The object type, which is always 'fabric_dataagent_preview'."
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
           },
           "fabric_dataagent_preview": {
             "allOf": [
@@ -38665,14 +38531,6 @@
       "SharepointGroundingToolParameters": {
         "type": "object",
         "properties": {
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "project_connections": {
             "type": "array",
             "items": {
@@ -38697,14 +38555,6 @@
               "sharepoint_grounding_preview"
             ],
             "description": "The object type, which is always 'sharepoint_grounding_preview'."
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
           },
           "sharepoint_grounding_preview": {
             "allOf": [
@@ -38736,7 +38586,7 @@
           },
           "has_blob": {
             "type": "boolean",
-            "description": "Whether the skill was created from a GZip blob package."
+            "description": "Whether the skill was created from a gzip blob package."
           },
           "name": {
             "type": "string",
@@ -38753,7 +38603,8 @@
             "additionalProperties": {
               "type": "string"
             },
-            "description": "Set of key-value pairs associated with the skill."
+            "description": "Set of 16 key-value pairs that can be attached to an object. This can be\nuseful for storing additional information about the object in a structured\nformat, and querying for objects via API or the dashboard.\n\nKeys are strings with a maximum length of 64 characters. Values are strings\nwith a maximum length of 512 characters.",
+            "x-oaiTypeLabel": "map"
           }
         },
         "description": "A skill object."
@@ -39228,14 +39079,6 @@
           "project_connection_id"
         ],
         "properties": {
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "project_connection_id": {
             "type": "string",
             "description": "A project connection in a ToolProjectConnectionList attached to this tool."
@@ -39622,14 +39465,6 @@
           "instance_name"
         ],
         "properties": {
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "project_connection_id": {
             "type": "string",
             "description": "Project connection id for grounding with bing custom search"

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -10153,7 +10153,7 @@
           "200": {
             "description": "The response body for downloading a skill package.",
             "content": {
-              "application/gzip": {
+              "application/zip": {
                 "schema": {
                   "type": "string",
                   "format": "binary"
@@ -10185,7 +10185,7 @@
     "/skills:import": {
       "post": {
         "operationId": "Skills_createSkillFromPackage",
-        "description": "Creates a skill from a gzip package.",
+        "description": "Creates a skill from a zip package.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -10238,14 +10238,14 @@
         "requestBody": {
           "required": true,
           "content": {
-            "application/gzip": {
+            "application/zip": {
               "schema": {
                 "type": "string",
                 "format": "binary"
               }
             }
           },
-          "description": "The gzip package used to create the skill."
+          "description": "The zip package used to create the skill."
         },
         "x-ms-foundry-meta": {
           "conditional_previews": [
@@ -39408,7 +39408,7 @@
           },
           "has_blob": {
             "type": "boolean",
-            "description": "Whether the skill was created from a gzip blob package."
+            "description": "Whether the skill was created from a zip blob package."
           },
           "name": {
             "type": "string",

--- a/specification/ai-foundry/data-plane/Foundry/src/common/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/common/models.tsp
@@ -59,6 +59,7 @@ union AgentDefinitionOptInKeys {
 }
 
 union FoundryFeaturesOptInKeys {
+  skills_v1_preview: "Skills=V1Preview",
   evaluations_v1_preview: "Evaluations=V1Preview",
   schedules_v1_preview: "Schedules=V1Preview",
   red_teams_v1_preview: "RedTeams=V1Preview",

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-service-agents-contracts/main.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-service-agents-contracts/main.tsp
@@ -3,6 +3,7 @@ import "../agents-containers/routes.tsp";
 import "../common/models.tsp";
 import "../common/service.tsp";
 import "../memory-stores/routes.tsp";
+import "../skills/routes.tsp";
 import "../openai-conversations/routes.tsp";
 import "../openai-responses/routes.tsp";
 import "../toolboxes/routes.tsp";

--- a/specification/ai-foundry/data-plane/Foundry/src/skills/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/skills/models.tsp
@@ -89,7 +89,7 @@ model SkillObject {
   @doc("The unique identifier of the skill.")
   skill_id: string;
 
-  @doc("Whether the skill was created from a GZip blob package.")
+  @doc("Whether the skill was created from a gzip blob package.")
   has_blob: boolean;
 
   @doc("The unique name of the skill.")

--- a/specification/ai-foundry/data-plane/Foundry/src/skills/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/skills/models.tsp
@@ -6,15 +6,6 @@ const SkillsRequiredPreviews = #{
   conditional_previews: #[FoundryFeaturesOptInKeys.skills_v1_preview],
 };
 
-@doc("The object type of a skill resource.")
-enum SkillObjectType {
-  @doc("A skill object.")
-  skill: "skill",
-
-  @doc("A deleted skill object.")
-  skillDeleted: "skill.deleted",
-}
-
 alias CreateSkillRequest = {
   @doc("The unique name of the skill.")
   @maxLength(63)
@@ -81,9 +72,6 @@ alias DeleteSkillRequest = {
 
 @doc("A skill object.")
 model SkillObject {
-  @doc("The object type, which is always 'skill'.")
-  object: SkillObjectType = SkillObjectType.skill;
-
   @doc("The unique identifier of the skill.")
   skill_id: string;
 
@@ -103,9 +91,6 @@ model SkillObject {
 
 @doc("A deleted skill Object")
 model DeleteSkillResponse {
-  @doc("The object type. Always 'skill.deleted'.")
-  object: SkillObjectType = SkillObjectType.skillDeleted;
-
   @doc("The unique name of the skill.")
   name: string;
 

--- a/specification/ai-foundry/data-plane/Foundry/src/skills/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/skills/models.tsp
@@ -1,0 +1,128 @@
+using TypeSpec.Http;
+
+namespace Azure.AI.Projects;
+
+const SkillsRequiredPreviews = #{
+  conditional_previews: #[FoundryFeaturesOptInKeys.skills_v1_preview],
+};
+
+@doc("The object type of a skill resource.")
+enum SkillObjectType {
+  @doc("A skill object.")
+  skill: "skill",
+
+  @doc("A deleted skill object.")
+  skillDeleted: "skill.deleted",
+}
+
+alias CreateSkillRequest = {
+  @doc("The unique name of the skill.")
+  @maxLength(63)
+  name: string;
+
+  @doc("A human-readable description of the skill.")
+  @maxLength(1024)
+  description?: string;
+
+  @doc("Instructions that define the behavior of the skill.")
+  @maxLength(102400)
+  instructions?: string;
+
+  @doc("Set of key-value pairs associated with the skill.")
+  metadata?: Record<string>;
+};
+
+alias CreateSkillFromPackageRequest = {
+  @doc("The content type of the incoming skill package payload.")
+  @header("Content-Type")
+  content_type: "application/gzip";
+
+  @doc("The GZip package used to create the skill.")
+  @body
+  body: bytes;
+};
+
+alias UpdateSkillRequest = {
+  @doc("The unique name of the skill.")
+  @path
+  skill_name: string;
+
+  @doc("A human-readable description of the skill.")
+  @maxLength(1024)
+  description?: string;
+
+  @doc("Instructions that define the behavior of the skill.")
+  @maxLength(102400)
+  instructions?: string;
+
+  @doc("Set of key-value pairs associated with the skill.")
+  metadata?: Record<string>;
+};
+
+alias GetSkillRequest = {
+  @doc("The unique name of the skill.")
+  @path
+  skill_name: string;
+};
+
+alias DownloadSkillRequest = {
+  @doc("The unique name of the skill.")
+  @path
+  skill_name: string;
+};
+
+alias ListSkillsRequest = {
+  ...CommonPageQueryParameters;
+};
+
+alias DeleteSkillRequest = {
+  @doc("The unique name of the skill.")
+  @path
+  skill_name: string;
+};
+
+@doc("A skill object.")
+model SkillObject {
+  @doc("The object type, which is always 'skill'.")
+  object: SkillObjectType = SkillObjectType.skill;
+
+  @doc("The unique identifier of the skill.")
+  skill_id: string;
+
+  @doc("Whether the skill was created from a GZip blob package.")
+  has_blob: boolean;
+
+  @doc("The unique name of the skill.")
+  @maxLength(63)
+  name: string;
+
+  @doc("A human-readable description of the skill.")
+  @maxLength(1024)
+  description?: string;
+
+  @doc("Set of key-value pairs associated with the skill.")
+  metadata?: Record<string>;
+}
+
+@doc("A deleted skill Object")
+model DeleteSkillResponse {
+  @doc("The object type. Always 'skill.deleted'.")
+  object: SkillObjectType = SkillObjectType.skillDeleted;
+
+  @doc("The unique name of the skill.")
+  name: string;
+
+  @doc("Whether the skill was successfully deleted.")
+  deleted: boolean;
+}
+
+@doc("The response body for downloading a skill package.")
+model DownloadSkillResponse {
+  @doc("The media type of the returned package content.")
+  @header("Content-Type")
+  content_type: "application/gzip";
+
+  @doc("The GZip skill package content.")
+  @body
+  body: bytes;
+}

--- a/specification/ai-foundry/data-plane/Foundry/src/skills/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/skills/models.tsp
@@ -37,7 +37,7 @@ alias CreateSkillFromPackageRequest = {
   @header("Content-Type")
   content_type: "application/gzip";
 
-  @doc("The GZip package used to create the skill.")
+  @doc("The gzip package used to create the skill.")
   @body
   body: bytes;
 };

--- a/specification/ai-foundry/data-plane/Foundry/src/skills/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/skills/models.tsp
@@ -28,8 +28,7 @@ alias CreateSkillRequest = {
   @maxLength(102400)
   instructions?: string;
 
-  @doc("Set of key-value pairs associated with the skill.")
-  metadata?: Record<string>;
+...MetadataPropertyForRequest;
 };
 
 alias CreateSkillFromPackageRequest = {

--- a/specification/ai-foundry/data-plane/Foundry/src/skills/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/skills/models.tsp
@@ -99,8 +99,7 @@ model SkillObject {
   @maxLength(1024)
   description?: string;
 
-  @doc("Set of key-value pairs associated with the skill.")
-  metadata?: Record<string>;
+  ...MetadataPropertyForRequest;
 }
 
 @doc("A deleted skill Object")

--- a/specification/ai-foundry/data-plane/Foundry/src/skills/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/skills/models.tsp
@@ -54,8 +54,7 @@ alias UpdateSkillRequest = {
   @maxLength(102400)
   instructions?: string;
 
-  @doc("Set of key-value pairs associated with the skill.")
-  metadata?: Record<string>;
+  ...MetadataPropertyForRequest;
 };
 
 alias GetSkillRequest = {

--- a/specification/ai-foundry/data-plane/Foundry/src/skills/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/skills/models.tsp
@@ -25,9 +25,9 @@ alias CreateSkillRequest = {
 alias CreateSkillFromPackageRequest = {
   @doc("The content type of the incoming skill package payload.")
   @header("Content-Type")
-  content_type: "application/gzip";
+  content_type: "application/zip";
 
-  @doc("The gzip package used to create the skill.")
+  @doc("The zip package used to create the skill.")
   @body
   body: bytes;
 };
@@ -75,7 +75,7 @@ model SkillObject {
   @doc("The unique identifier of the skill.")
   skill_id: string;
 
-  @doc("Whether the skill was created from a gzip blob package.")
+  @doc("Whether the skill was created from a zip blob package.")
   has_blob: boolean;
 
   @doc("The unique name of the skill.")
@@ -102,9 +102,9 @@ model DeleteSkillResponse {
 model DownloadSkillResponse {
   @doc("The media type of the returned package content.")
   @header("Content-Type")
-  content_type: "application/gzip";
+  content_type: "application/zip";
 
-  @doc("The gzip skill package content.")
+  @doc("The zip skill package content.")
   @body
   body: bytes;
 }

--- a/specification/ai-foundry/data-plane/Foundry/src/skills/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/skills/models.tsp
@@ -120,7 +120,7 @@ model DownloadSkillResponse {
   @header("Content-Type")
   content_type: "application/gzip";
 
-  @doc("The GZip skill package content.")
+  @doc("The gzip skill package content.")
   @body
   body: bytes;
 }

--- a/specification/ai-foundry/data-plane/Foundry/src/skills/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/skills/routes.tsp
@@ -1,0 +1,91 @@
+import "../common/models.tsp";
+import "./models.tsp";
+
+using TypeSpec.Http;
+using TypeSpec.OpenAPI;
+
+namespace Azure.AI.Projects;
+
+alias SkillsPreviewHeader = WithRequiredFoundryPreviewHeader<FoundryFeaturesOptInKeys.skills_v1_preview>;
+
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" ""
+@tag("Skills")
+interface Skills {
+  /**
+   * Creates a skill.
+   */
+  @post
+  @route("/skills")
+  @extension("x-ms-foundry-meta", SkillsRequiredPreviews)
+  createSkill is FoundryDataPlaneOperation<
+    CreateSkillRequest & SkillsPreviewHeader,
+    SkillObject
+  >;
+
+  /**
+   * Creates a skill from a GZip package.
+   */
+  @post
+  @route("/skills:import")
+  @extension("x-ms-foundry-meta", SkillsRequiredPreviews)
+  createSkillFromPackage is FoundryDataPlaneOperation<
+    CreateSkillFromPackageRequest & SkillsPreviewHeader,
+    SkillObject
+  >;
+
+  /**
+   * Retrieves a skill.
+   */
+  @get
+  @route("/skills/{skill_name}")
+  @extension("x-ms-foundry-meta", SkillsRequiredPreviews)
+  getSkill is FoundryDataPlaneOperation<
+    GetSkillRequest & SkillsPreviewHeader,
+    SkillObject
+  >;
+
+  /**
+   * Downloads a skill package.
+   */
+  @get
+  @route("/skills/{skill_name}:download")
+  @extension("x-ms-foundry-meta", SkillsRequiredPreviews)
+  downloadSkill is FoundryDataPlaneOperation<
+    DownloadSkillRequest & SkillsPreviewHeader,
+    DownloadSkillResponse
+  >;
+
+  /**
+   * Returns the list of all skills.
+   */
+  @route("/skills")
+  @list
+  @extension("x-ms-foundry-meta", SkillsRequiredPreviews)
+  listSkills is FoundryDataPlaneOperation<
+    ListSkillsRequest & SkillsPreviewHeader,
+    AgentsPagedResult<SkillObject>
+  >;
+
+  /**
+   * Updates an existing skill.
+   */
+  @post
+  @route("/skills/{skill_name}")
+  @extension("x-ms-foundry-meta", SkillsRequiredPreviews)
+  updateSkill is FoundryDataPlaneOperation<
+    UpdateSkillRequest & SkillsPreviewHeader,
+    SkillObject
+  >;
+
+  /**
+   * Deletes a skill.
+   */
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" ""
+  @delete
+  @route("/skills/{skill_name}")
+  @extension("x-ms-foundry-meta", SkillsRequiredPreviews)
+  deleteSkill is FoundryDataPlaneOperation<
+    DeleteSkillRequest & SkillsPreviewHeader,
+    DeleteSkillResponse
+  >;
+}

--- a/specification/ai-foundry/data-plane/Foundry/src/skills/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/skills/routes.tsp
@@ -23,7 +23,7 @@ interface Skills {
   >;
 
   /**
-   * Creates a skill from a GZip package.
+   * Creates a skill from a gzip package.
    */
   @post
   @route("/skills:import")

--- a/specification/ai-foundry/data-plane/Foundry/src/skills/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/skills/routes.tsp
@@ -23,7 +23,7 @@ interface Skills {
   >;
 
   /**
-   * Creates a skill from a gzip package.
+   * Creates a skill from a zip package.
    */
   @post
   @route("/skills:import")

--- a/specification/ai-foundry/data-plane/Foundry/src/skills/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/skills/routes.tsp
@@ -19,7 +19,7 @@ interface Skills {
   @extension("x-ms-foundry-meta", SkillsRequiredPreviews)
   createSkill is FoundryDataPlaneOperation<
     CreateSkillRequest & SkillsPreviewHeader,
-    SkillObject
+    ResourceCreatedResponse<SkillObject>
   >;
 
   /**
@@ -30,7 +30,7 @@ interface Skills {
   @extension("x-ms-foundry-meta", SkillsRequiredPreviews)
   createSkillFromPackage is FoundryDataPlaneOperation<
     CreateSkillFromPackageRequest & SkillsPreviewHeader,
-    SkillObject
+    ResourceCreatedResponse<SkillObject>
   >;
 
   /**

--- a/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
@@ -104,7 +104,6 @@ namespace Azure.AI.Projects {
    * A web search configuration for bing custom search
    */
   model WebSearchConfiguration {
-    ...ToolNameAndDescriptionExtension;
 
     /**
      * Project connection id for grounding with bing custom search
@@ -141,8 +140,6 @@ namespace Azure.AI.Projects {
      */
     type: "bing_grounding";
 
-      ...ToolNameAndDescriptionExtension;
-
     /**
      * The bing grounding search tool parameters.
      */
@@ -153,7 +150,6 @@ namespace Azure.AI.Projects {
    * The fabric data agent tool parameters.
    */
   model FabricDataAgentToolParameters {
-    ...ToolNameAndDescriptionExtension;
 
     /**
      * The project connections attached to this tool. There can be a maximum of 1 connection
@@ -172,8 +168,6 @@ namespace Azure.AI.Projects {
      */
     type: "fabric_dataagent_preview";
 
-    ...ToolNameAndDescriptionExtension;
-
     /**
      * The fabric data agent tool parameters.
      */
@@ -184,7 +178,6 @@ namespace Azure.AI.Projects {
    * The sharepoint grounding tool parameters.
    */
   model SharepointGroundingToolParameters {
-    ...ToolNameAndDescriptionExtension;
 
     /**
      * The project connections attached to this tool. There can be a maximum of 1 connection
@@ -203,8 +196,6 @@ namespace Azure.AI.Projects {
      */
     type: "sharepoint_grounding_preview";
 
-    ...ToolNameAndDescriptionExtension;
-
     /**
      * The sharepoint grounding tool parameters.
      */
@@ -220,8 +211,6 @@ namespace Azure.AI.Projects {
      */
     type: "azure_ai_search";
 
-    ...ToolNameAndDescriptionExtension;
-
     /**
      * The azure ai search index resource.
      */
@@ -232,7 +221,6 @@ namespace Azure.AI.Projects {
    * A set of index resources used by the `azure_ai_search` tool.
    */
   model AzureAISearchToolResource {
-    ...ToolNameAndDescriptionExtension;
 
     /**
      * The indices attached to this agent. There can be a maximum of 1 index
@@ -262,7 +250,6 @@ namespace Azure.AI.Projects {
    */
   model AISearchIndexResource {
     ...IndexResource;
-    ...ToolNameAndDescriptionExtension;
 
     /**
      *  Type of query in an AIIndexResource attached to this agent.
@@ -329,8 +316,6 @@ namespace Azure.AI.Projects {
      */
     type: "bing_custom_search_preview";
 
-    ...ToolNameAndDescriptionExtension;
-
     /**
      * The bing custom search tool parameters.
      */
@@ -346,8 +331,6 @@ namespace Azure.AI.Projects {
      */
     type: "browser_automation_preview";
 
-    ...ToolNameAndDescriptionExtension;
-
     /**
      * The Browser Automation Tool parameters.
      */
@@ -358,7 +341,6 @@ namespace Azure.AI.Projects {
    * Definition of input parameters for the Browser Automation Tool.
    */
   model BrowserAutomationToolParameters {
-    ...ToolNameAndDescriptionExtension;
 
     /**
      * The project connection parameters associated with the Browser Automation Tool.
@@ -370,7 +352,6 @@ namespace Azure.AI.Projects {
    * Definition of input parameters for the connection used by the Browser Automation Tool.
    */
   model BrowserAutomationToolConnectionParameters {
-    ...ToolNameAndDescriptionExtension;
 
     /**
      * The ID of the project connection to your Azure Playwright resource.
@@ -569,7 +550,6 @@ namespace Azure.AI.Projects {
    * A project connection resource.
    */
   model ToolProjectConnection {
-    ...ToolNameAndDescriptionExtension;
 
     /**
      * A project connection in a ToolProjectConnectionList attached to this tool.
@@ -593,7 +573,6 @@ namespace Azure.AI.Projects {
    * Search configuration for Bing Grounding
    */
   model BingGroundingSearchConfiguration {
-    ...ToolNameAndDescriptionExtension;
 
     /**
      * Project connection id for grounding with bing search
@@ -625,7 +604,6 @@ namespace Azure.AI.Projects {
    * The bing grounding search tool parameters.
    */
   model BingGroundingSearchToolParameters {
-    ...ToolNameAndDescriptionExtension;
 
     /**
      * The search configurations attached to this tool. There can be a maximum of 1
@@ -639,7 +617,6 @@ namespace Azure.AI.Projects {
    * The bing custom search tool parameters.
    */
   model BingCustomSearchToolParameters {
-    ...ToolNameAndDescriptionExtension;
 
     /**
      * The project connections attached to this tool. There can be a maximum of 1 connection
@@ -653,7 +630,6 @@ namespace Azure.AI.Projects {
    * A bing custom search configuration.
    */
   model BingCustomSearchConfiguration {
-    ...ToolNameAndDescriptionExtension;
 
     /**
      * Project connection id for grounding with bing search
@@ -767,8 +743,6 @@ namespace Azure.AI.Projects {
      */
     type: "a2a_preview";
 
-    ...ToolNameAndDescriptionExtension;
-
     /**
      * Base URL of the agent.
      */
@@ -821,8 +795,6 @@ namespace Azure.AI.Projects {
      */
     type: "memory_search_preview";
 
-    ...ToolNameAndDescriptionExtension;
-
     /**
      * The name of the memory store to use.
      */
@@ -855,8 +827,6 @@ namespace Azure.AI.Projects {
      * The type of the tool. Always `memory_search_preview`.
      */
     type: "memory_search";
-
-    ...ToolNameAndDescriptionExtension;
 
     /**
      * The name of the memory store to use.
@@ -1239,3 +1209,4 @@ namespace Azure.AI.Projects {
     status: ToolCallStatus;
   }
 }
+

--- a/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
@@ -56,6 +56,16 @@ namespace Azure.AI.Projects {
   @@copyProperties(OpenAI.WebSearchTool,
     {
       /**
+       * Optional user-defined name for this tool.
+       */
+      name?: string,
+
+      /**
+       * Optional user-defined description for this tool.
+       */
+      description?: string,
+
+      /**
        * The project connections attached to this tool. There can be a maximum of 1 connection
        * resource attached to the tool.
        */
@@ -63,10 +73,87 @@ namespace Azure.AI.Projects {
     }
   );
 
+  #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
+  @@copyProperties(OpenAI.CodeInterpreterTool,
+    {
+      /**
+       * Optional user-defined name for this tool.
+       */
+      name?: string,
+
+      /**
+       * Optional user-defined description for this tool.
+       */
+      description?: string,
+    }
+  );
+
+  #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
+  @@copyProperties(OpenAI.ImageGenTool,
+    {
+      /**
+       * Optional user-defined name for this tool.
+       */
+      name?: string,
+
+      /**
+       * Optional user-defined description for this tool.
+       */
+      description?: string,
+    }
+  );
+
+  #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
+  @@copyProperties(OpenAI.LocalShellToolParam,
+    {
+      /**
+       * Optional user-defined name for this tool.
+       */
+      name?: string,
+
+      /**
+       * Optional user-defined description for this tool.
+       */
+      description?: string,
+    }
+  );
+
+  #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
+  @@copyProperties(OpenAI.FunctionShellToolParam,
+    {
+      /**
+       * Optional user-defined name for this tool.
+       */
+      name?: string,
+
+      /**
+       * Optional user-defined description for this tool.
+       */
+      description?: string,
+    }
+  );
+
+  #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
+  @@copyProperties(OpenAI.FileSearchTool,
+    {
+      /**
+       * Optional user-defined name for this tool.
+       */
+      name?: string,
+
+      /**
+       * Optional user-defined description for this tool.
+       */
+      description?: string,
+    }
+  );
+
   /**
    * A web search configuration for bing custom search
    */
   model WebSearchConfiguration {
+    ...FriendlyToolNameDescriptionExtension;
+
     /**
      * Project connection id for grounding with bing custom search
      */
@@ -79,6 +166,21 @@ namespace Azure.AI.Projects {
   }
 
   /**
+   * Optional name and description fields for tool definitions and nested tool configurations.
+   */
+  alias FriendlyToolNameDescriptionExtension = {
+    /**
+     * Optional user-defined name for this tool or configuration.
+     */
+      name?: string;
+
+    /**
+     * Optional user-defined description for this tool or configuration.
+     */
+    description?: string;
+  };
+
+  /**
    * The input definition information for a bing grounding search tool as used to configure an agent.
    */
   model BingGroundingTool extends OpenAI.Tool {
@@ -86,6 +188,8 @@ namespace Azure.AI.Projects {
      * The object type, which is always 'bing_grounding'.
      */
     type: "bing_grounding";
+
+      ...FriendlyToolNameDescriptionExtension;
 
     /**
      * The bing grounding search tool parameters.
@@ -97,6 +201,8 @@ namespace Azure.AI.Projects {
    * The fabric data agent tool parameters.
    */
   model FabricDataAgentToolParameters {
+    ...FriendlyToolNameDescriptionExtension;
+
     /**
      * The project connections attached to this tool. There can be a maximum of 1 connection
      * resource attached to the tool.
@@ -114,6 +220,8 @@ namespace Azure.AI.Projects {
      */
     type: "fabric_dataagent_preview";
 
+    ...FriendlyToolNameDescriptionExtension;
+
     /**
      * The fabric data agent tool parameters.
      */
@@ -124,6 +232,8 @@ namespace Azure.AI.Projects {
    * The sharepoint grounding tool parameters.
    */
   model SharepointGroundingToolParameters {
+    ...FriendlyToolNameDescriptionExtension;
+
     /**
      * The project connections attached to this tool. There can be a maximum of 1 connection
      * resource attached to the tool.
@@ -141,6 +251,8 @@ namespace Azure.AI.Projects {
      */
     type: "sharepoint_grounding_preview";
 
+    ...FriendlyToolNameDescriptionExtension;
+
     /**
      * The sharepoint grounding tool parameters.
      */
@@ -156,6 +268,8 @@ namespace Azure.AI.Projects {
      */
     type: "azure_ai_search";
 
+    ...FriendlyToolNameDescriptionExtension;
+
     /**
      * The azure ai search index resource.
      */
@@ -166,6 +280,8 @@ namespace Azure.AI.Projects {
    * A set of index resources used by the `azure_ai_search` tool.
    */
   model AzureAISearchToolResource {
+    ...FriendlyToolNameDescriptionExtension;
+
     /**
      * The indices attached to this agent. There can be a maximum of 1 index
      * resource attached to the agent.
@@ -194,6 +310,7 @@ namespace Azure.AI.Projects {
    */
   model AISearchIndexResource {
     ...IndexResource;
+    ...FriendlyToolNameDescriptionExtension;
 
     /**
      *  Type of query in an AIIndexResource attached to this agent.
@@ -260,6 +377,8 @@ namespace Azure.AI.Projects {
      */
     type: "bing_custom_search_preview";
 
+    ...FriendlyToolNameDescriptionExtension;
+
     /**
      * The bing custom search tool parameters.
      */
@@ -275,6 +394,8 @@ namespace Azure.AI.Projects {
      */
     type: "browser_automation_preview";
 
+    ...FriendlyToolNameDescriptionExtension;
+
     /**
      * The Browser Automation Tool parameters.
      */
@@ -285,6 +406,8 @@ namespace Azure.AI.Projects {
    * Definition of input parameters for the Browser Automation Tool.
    */
   model BrowserAutomationToolParameters {
+    ...FriendlyToolNameDescriptionExtension;
+
     /**
      * The project connection parameters associated with the Browser Automation Tool.
      */
@@ -295,6 +418,8 @@ namespace Azure.AI.Projects {
    * Definition of input parameters for the connection used by the Browser Automation Tool.
    */
   model BrowserAutomationToolConnectionParameters {
+    ...FriendlyToolNameDescriptionExtension;
+
     /**
      * The ID of the project connection to your Azure Playwright resource.
      */
@@ -492,6 +617,8 @@ namespace Azure.AI.Projects {
    * A project connection resource.
    */
   model ToolProjectConnection {
+    ...FriendlyToolNameDescriptionExtension;
+
     /**
      * A project connection in a ToolProjectConnectionList attached to this tool.
      */
@@ -514,6 +641,8 @@ namespace Azure.AI.Projects {
    * Search configuration for Bing Grounding
    */
   model BingGroundingSearchConfiguration {
+    ...FriendlyToolNameDescriptionExtension;
+
     /**
      * Project connection id for grounding with bing search
      */
@@ -544,6 +673,8 @@ namespace Azure.AI.Projects {
    * The bing grounding search tool parameters.
    */
   model BingGroundingSearchToolParameters {
+    ...FriendlyToolNameDescriptionExtension;
+
     /**
      * The search configurations attached to this tool. There can be a maximum of 1
      * search configuration resource attached to the tool.
@@ -556,6 +687,8 @@ namespace Azure.AI.Projects {
    * The bing custom search tool parameters.
    */
   model BingCustomSearchToolParameters {
+    ...FriendlyToolNameDescriptionExtension;
+
     /**
      * The project connections attached to this tool. There can be a maximum of 1 connection
      * resource attached to the tool.
@@ -568,6 +701,8 @@ namespace Azure.AI.Projects {
    * A bing custom search configuration.
    */
   model BingCustomSearchConfiguration {
+    ...FriendlyToolNameDescriptionExtension;
+
     /**
      * Project connection id for grounding with bing search
      */
@@ -663,6 +798,8 @@ namespace Azure.AI.Projects {
      */
     type: "capture_structured_outputs";
 
+    ...FriendlyToolNameDescriptionExtension;
+
     /**
      * The structured outputs to capture from the model.
      */
@@ -677,6 +814,8 @@ namespace Azure.AI.Projects {
      * The type of the tool. Always `"a2a_preview`.
      */
     type: "a2a_preview";
+
+    ...FriendlyToolNameDescriptionExtension;
 
     /**
      * Base URL of the agent.
@@ -730,6 +869,8 @@ namespace Azure.AI.Projects {
      */
     type: "memory_search_preview";
 
+    ...FriendlyToolNameDescriptionExtension;
+
     /**
      * The name of the memory store to use.
      */
@@ -762,6 +903,8 @@ namespace Azure.AI.Projects {
      * The type of the tool. Always `memory_search_preview`.
      */
     type: "memory_search";
+
+    ...FriendlyToolNameDescriptionExtension;
 
     /**
      * The name of the memory store to use.

--- a/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
@@ -780,6 +780,8 @@ namespace Azure.AI.Projects {
      */
     type: "work_iq_preview";
 
+    ...ToolNameAndDescriptionExtension;
+
     /**
      * The WorkIQ tool parameters.
      */

--- a/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
@@ -55,15 +55,7 @@ namespace Azure.AI.Projects {
   #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
   @@copyProperties(OpenAI.WebSearchTool,
     {
-      /**
-       * Optional user-defined name for this tool.
-       */
-      name?: string,
-
-      /**
-       * Optional user-defined description for this tool.
-       */
-      description?: string,
+      ...ToolNameAndDescriptionExtension,
 
       /**
        * The project connections attached to this tool. There can be a maximum of 1 connection
@@ -76,75 +68,35 @@ namespace Azure.AI.Projects {
   #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
   @@copyProperties(OpenAI.CodeInterpreterTool,
     {
-      /**
-       * Optional user-defined name for this tool.
-       */
-      name?: string,
-
-      /**
-       * Optional user-defined description for this tool.
-       */
-      description?: string,
+      ...ToolNameAndDescriptionExtension,
     }
   );
 
   #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
   @@copyProperties(OpenAI.ImageGenTool,
     {
-      /**
-       * Optional user-defined name for this tool.
-       */
-      name?: string,
-
-      /**
-       * Optional user-defined description for this tool.
-       */
-      description?: string,
+      ...ToolNameAndDescriptionExtension,
     }
   );
 
   #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
   @@copyProperties(OpenAI.LocalShellToolParam,
     {
-      /**
-       * Optional user-defined name for this tool.
-       */
-      name?: string,
-
-      /**
-       * Optional user-defined description for this tool.
-       */
-      description?: string,
+      ...ToolNameAndDescriptionExtension,
     }
   );
 
   #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
   @@copyProperties(OpenAI.FunctionShellToolParam,
     {
-      /**
-       * Optional user-defined name for this tool.
-       */
-      name?: string,
-
-      /**
-       * Optional user-defined description for this tool.
-       */
-      description?: string,
+      ...ToolNameAndDescriptionExtension,
     }
   );
 
   #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
   @@copyProperties(OpenAI.FileSearchTool,
     {
-      /**
-       * Optional user-defined name for this tool.
-       */
-      name?: string,
-
-      /**
-       * Optional user-defined description for this tool.
-       */
-      description?: string,
+      ...ToolNameAndDescriptionExtension,
     }
   );
 
@@ -152,7 +104,7 @@ namespace Azure.AI.Projects {
    * A web search configuration for bing custom search
    */
   model WebSearchConfiguration {
-    ...FriendlyToolNameDescriptionExtension;
+    ...ToolNameAndDescriptionExtension;
 
     /**
      * Project connection id for grounding with bing custom search
@@ -168,7 +120,7 @@ namespace Azure.AI.Projects {
   /**
    * Optional name and description fields for tool definitions and nested tool configurations.
    */
-  alias FriendlyToolNameDescriptionExtension = {
+  alias ToolNameAndDescriptionExtension = {
     /**
      * Optional user-defined name for this tool or configuration.
      */
@@ -189,7 +141,7 @@ namespace Azure.AI.Projects {
      */
     type: "bing_grounding";
 
-      ...FriendlyToolNameDescriptionExtension;
+      ...ToolNameAndDescriptionExtension;
 
     /**
      * The bing grounding search tool parameters.
@@ -201,7 +153,7 @@ namespace Azure.AI.Projects {
    * The fabric data agent tool parameters.
    */
   model FabricDataAgentToolParameters {
-    ...FriendlyToolNameDescriptionExtension;
+    ...ToolNameAndDescriptionExtension;
 
     /**
      * The project connections attached to this tool. There can be a maximum of 1 connection
@@ -220,7 +172,7 @@ namespace Azure.AI.Projects {
      */
     type: "fabric_dataagent_preview";
 
-    ...FriendlyToolNameDescriptionExtension;
+    ...ToolNameAndDescriptionExtension;
 
     /**
      * The fabric data agent tool parameters.
@@ -232,7 +184,7 @@ namespace Azure.AI.Projects {
    * The sharepoint grounding tool parameters.
    */
   model SharepointGroundingToolParameters {
-    ...FriendlyToolNameDescriptionExtension;
+    ...ToolNameAndDescriptionExtension;
 
     /**
      * The project connections attached to this tool. There can be a maximum of 1 connection
@@ -251,7 +203,7 @@ namespace Azure.AI.Projects {
      */
     type: "sharepoint_grounding_preview";
 
-    ...FriendlyToolNameDescriptionExtension;
+    ...ToolNameAndDescriptionExtension;
 
     /**
      * The sharepoint grounding tool parameters.
@@ -268,7 +220,7 @@ namespace Azure.AI.Projects {
      */
     type: "azure_ai_search";
 
-    ...FriendlyToolNameDescriptionExtension;
+    ...ToolNameAndDescriptionExtension;
 
     /**
      * The azure ai search index resource.
@@ -280,7 +232,7 @@ namespace Azure.AI.Projects {
    * A set of index resources used by the `azure_ai_search` tool.
    */
   model AzureAISearchToolResource {
-    ...FriendlyToolNameDescriptionExtension;
+    ...ToolNameAndDescriptionExtension;
 
     /**
      * The indices attached to this agent. There can be a maximum of 1 index
@@ -310,7 +262,7 @@ namespace Azure.AI.Projects {
    */
   model AISearchIndexResource {
     ...IndexResource;
-    ...FriendlyToolNameDescriptionExtension;
+    ...ToolNameAndDescriptionExtension;
 
     /**
      *  Type of query in an AIIndexResource attached to this agent.
@@ -377,7 +329,7 @@ namespace Azure.AI.Projects {
      */
     type: "bing_custom_search_preview";
 
-    ...FriendlyToolNameDescriptionExtension;
+    ...ToolNameAndDescriptionExtension;
 
     /**
      * The bing custom search tool parameters.
@@ -394,7 +346,7 @@ namespace Azure.AI.Projects {
      */
     type: "browser_automation_preview";
 
-    ...FriendlyToolNameDescriptionExtension;
+    ...ToolNameAndDescriptionExtension;
 
     /**
      * The Browser Automation Tool parameters.
@@ -406,7 +358,7 @@ namespace Azure.AI.Projects {
    * Definition of input parameters for the Browser Automation Tool.
    */
   model BrowserAutomationToolParameters {
-    ...FriendlyToolNameDescriptionExtension;
+    ...ToolNameAndDescriptionExtension;
 
     /**
      * The project connection parameters associated with the Browser Automation Tool.
@@ -418,7 +370,7 @@ namespace Azure.AI.Projects {
    * Definition of input parameters for the connection used by the Browser Automation Tool.
    */
   model BrowserAutomationToolConnectionParameters {
-    ...FriendlyToolNameDescriptionExtension;
+    ...ToolNameAndDescriptionExtension;
 
     /**
      * The ID of the project connection to your Azure Playwright resource.
@@ -617,7 +569,7 @@ namespace Azure.AI.Projects {
    * A project connection resource.
    */
   model ToolProjectConnection {
-    ...FriendlyToolNameDescriptionExtension;
+    ...ToolNameAndDescriptionExtension;
 
     /**
      * A project connection in a ToolProjectConnectionList attached to this tool.
@@ -641,7 +593,7 @@ namespace Azure.AI.Projects {
    * Search configuration for Bing Grounding
    */
   model BingGroundingSearchConfiguration {
-    ...FriendlyToolNameDescriptionExtension;
+    ...ToolNameAndDescriptionExtension;
 
     /**
      * Project connection id for grounding with bing search
@@ -673,7 +625,7 @@ namespace Azure.AI.Projects {
    * The bing grounding search tool parameters.
    */
   model BingGroundingSearchToolParameters {
-    ...FriendlyToolNameDescriptionExtension;
+    ...ToolNameAndDescriptionExtension;
 
     /**
      * The search configurations attached to this tool. There can be a maximum of 1
@@ -687,7 +639,7 @@ namespace Azure.AI.Projects {
    * The bing custom search tool parameters.
    */
   model BingCustomSearchToolParameters {
-    ...FriendlyToolNameDescriptionExtension;
+    ...ToolNameAndDescriptionExtension;
 
     /**
      * The project connections attached to this tool. There can be a maximum of 1 connection
@@ -701,7 +653,7 @@ namespace Azure.AI.Projects {
    * A bing custom search configuration.
    */
   model BingCustomSearchConfiguration {
-    ...FriendlyToolNameDescriptionExtension;
+    ...ToolNameAndDescriptionExtension;
 
     /**
      * Project connection id for grounding with bing search
@@ -798,7 +750,7 @@ namespace Azure.AI.Projects {
      */
     type: "capture_structured_outputs";
 
-    ...FriendlyToolNameDescriptionExtension;
+    ...ToolNameAndDescriptionExtension;
 
     /**
      * The structured outputs to capture from the model.
@@ -815,7 +767,7 @@ namespace Azure.AI.Projects {
      */
     type: "a2a_preview";
 
-    ...FriendlyToolNameDescriptionExtension;
+    ...ToolNameAndDescriptionExtension;
 
     /**
      * Base URL of the agent.
@@ -869,7 +821,7 @@ namespace Azure.AI.Projects {
      */
     type: "memory_search_preview";
 
-    ...FriendlyToolNameDescriptionExtension;
+    ...ToolNameAndDescriptionExtension;
 
     /**
      * The name of the memory store to use.
@@ -904,7 +856,7 @@ namespace Azure.AI.Projects {
      */
     type: "memory_search";
 
-    ...FriendlyToolNameDescriptionExtension;
+    ...ToolNameAndDescriptionExtension;
 
     /**
      * The name of the memory store to use.

--- a/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
@@ -17,6 +17,7 @@ namespace Azure.AI.Projects {
     fabric_dataagent_preview: "fabric_dataagent_preview",
     sharepoint_grounding_preview: "sharepoint_grounding_preview",
     memory_search_preview: "memory_search_preview",
+    work_iq_preview: "work_iq_preview",
   }
 
   // General availability tools:
@@ -693,6 +694,31 @@ namespace Azure.AI.Projects {
      * The connection stores authentication and other connection details needed to connect to the A2A server.
      */
     project_connection_id?: string;
+  }
+
+  /**
+   * The WorkIQ tool parameters.
+   */
+  model WorkIQPreviewToolParameters {
+    /**
+     * The ID of the WorkIQ project connection.
+     */
+    project_connection_id: string;
+  }
+
+  /**
+   * A WorkIQ server-side tool.
+   */
+  model WorkIQPreviewTool extends OpenAI.Tool {
+    /**
+     * The object type, which is always 'work_iq_preview'.
+     */
+    type: "work_iq_preview";
+
+    /**
+     * The WorkIQ tool parameters.
+     */
+    work_iq_preview: WorkIQPreviewToolParameters;
   }
 
   /**


### PR DESCRIPTION
## Summary

This PR updates the skills TypeSpec to change the package format from gzip to zip.

## Changes

- Updated `CreateSkillFromPackageRequest` content type from `application/gzip` to `application/zip`
- Updated `DownloadSkillResponse` content type from `application/gzip` to `application/zip`
- Updated all related documentation to reflect the zip format instead of gzip
- Regenerated OpenAPI specifications

## Files Modified

- `specification/ai-foundry/data-plane/Foundry/src/skills/models.tsp`
- `specification/ai-foundry/data-plane/Foundry/src/skills/routes.tsp`
- Generated OpenAPI files updated automatically