### PR TITLE
Change skills package format from gzip to zip

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -9796,7 +9796,7 @@
           "200": {
             "description": "The response body for downloading a skill package.",
             "content": {
-              "application/gzip": {
+              "application/zip": {
                 "schema": {
                   "type": "string",
                   "format": "binary"
@@ -9828,7 +9828,7 @@
     "/skills:import": {
       "post": {
         "operationId": "Skills_createSkillFromPackage",
-        "description": "Creates a skill from a gzip package.",
+        "description": "Creates a skill from a zip package.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -9881,14 +9881,14 @@
         "requestBody": {
           "required": true,
           "content": {
-            "application/gzip": {
+            "application/zip": {
               "schema": {
                 "type": "string",
                 "format": "binary"
               }
             }
           },
-          "description": "The gzip package used to create the skill."
+          "description": "The zip package used to create the skill."
         },
         "x-ms-foundry-meta": {
           "conditional_previews": [
@@ -39181,7 +39181,7 @@
           },
           "has_blob": {
             "type": "boolean",
-            "description": "Whether the skill was created from a gzip blob package."
+            "description": "Whether the skill was created from a zip blob package."
           },
           "name": {
             "type": "string",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -11091,7 +11091,7 @@
           "200": {
             "description": "The response body for downloading a skill package.",
             "content": {
-              "application/gzip": {
+              "application/zip": {
                 "schema": {
                   "type": "string",
                   "format": "binary"
@@ -11123,7 +11123,7 @@
     "/skills:import": {
       "post": {
         "operationId": "Skills_createSkillFromPackage",
-        "description": "Creates a skill from a gzip package.",
+        "description": "Creates a skill from a zip package.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -11176,14 +11176,14 @@
         "requestBody": {
           "required": true,
           "content": {
-            "application/gzip": {
+            "application/zip": {
               "schema": {
                 "type": "string",
                 "format": "binary"
               }
             }
           },
-          "description": "The gzip package used to create the skill."
+          "description": "The zip package used to create the skill."
         },
         "x-ms-foundry-meta": {
           "conditional_previews": [
@@ -41437,7 +41437,7 @@
           },
           "has_blob": {
             "type": "boolean",
-            "description": "Whether the skill was created from a gzip blob package."
+            "description": "Whether the skill was created from a zip blob package."
           },
           "name": {
             "type": "string",

--- a/specification/ai-foundry/data-plane/Foundry/src/skills/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/skills/models.tsp
@@ -25,9 +25,9 @@ alias CreateSkillRequest = {
 alias CreateSkillFromPackageRequest = {
   @doc("The content type of the incoming skill package payload.")
   @header("Content-Type")
-  content_type: "application/gzip";
+  content_type: "application/zip";
 
-  @doc("The gzip package used to create the skill.")
+  @doc("The zip package used to create the skill.")
   @body
   body: bytes;
 };
@@ -75,7 +75,7 @@ model SkillObject {
   @doc("The unique identifier of the skill.")
   skill_id: string;
 
-  @doc("Whether the skill was created from a gzip blob package.")
+  @doc("Whether the skill was created from a zip blob package.")
   has_blob: boolean;
 
   @doc("The unique name of the skill.")
@@ -102,9 +102,9 @@ model DeleteSkillResponse {
 model DownloadSkillResponse {
   @doc("The media type of the returned package content.")
   @header("Content-Type")
-  content_type: "application/gzip";
+  content_type: "application/zip";
 
-  @doc("The gzip skill package content.")
+  @doc("The zip skill package content.")
   @body
   body: bytes;
 }

--- a/specification/ai-foundry/data-plane/Foundry/src/skills/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/skills/routes.tsp
@@ -23,7 +23,7 @@ interface Skills {
   >;
 
   /**
-   * Creates a skill from a gzip package.
+   * Creates a skill from a zip package.
    */
   @post
   @route("/skills:import")


### PR DESCRIPTION
## Summary

This PR updates the skills TypeSpec to change the package format from gzip to zip.

## Changes

- Updated `CreateSkillFromPackageRequest` content type from `application/gzip` to `application/zip`
- Updated `DownloadSkillResponse` content type from `application/gzip` to `application/zip`
- Updated all related documentation to reflect the zip format instead of gzip
- Regenerated OpenAPI specifications

## Files Modified

- `specification/ai-foundry/data-plane/Foundry/src/skills/models.tsp`
- `specification/ai-foundry/data-plane/Foundry/src/skills/routes.tsp`
- Generated OpenAPI files updated automatically