### PR TITLE
Enforce @azure-typespec/http-client-csharp-mgmt emitter for management plane TypeSpec projects

### DIFF
--- a/eng/tools/typespec-validation/src/rules/sdk-tspconfig-validation.ts
+++ b/eng/tools/typespec-validation/src/rules/sdk-tspconfig-validation.ts
@@ -797,17 +797,11 @@ export class TspConfigCsharpMgmtEmitterRequiredSubRule extends TspconfigSubRuleB
     const hasLegacyEmitter =
       emit?.includes(LEGACY_CSHARP_EMITTER) || options?.[LEGACY_CSHARP_EMITTER] !== undefined;
 
-    // Only fail if the legacy emitter is configured — block new projects from using it
     if (hasLegacyEmitter) {
-      const hasNewMgmtEmitter =
-        emit?.includes(CSHARP_MGMT_EMITTER) || options?.[CSHARP_MGMT_EMITTER] !== undefined;
-
-      if (!hasNewMgmtEmitter) {
-        return this.createFailedResult(
-          `Management plane TypeSpec projects must use "${CSHARP_MGMT_EMITTER}" instead of the legacy "${LEGACY_CSHARP_EMITTER}" for .NET SDK generation`,
-          `Please replace "${LEGACY_CSHARP_EMITTER}" with "${CSHARP_MGMT_EMITTER}" in your tspconfig.yaml`,
-        );
-      }
+      return this.createFailedResult(
+        `Management plane TypeSpec projects must not use the legacy "${LEGACY_CSHARP_EMITTER}" emitter`,
+        `Please use "${CSHARP_MGMT_EMITTER}" instead of "${LEGACY_CSHARP_EMITTER}" in your tspconfig.yaml`,
+      );
     }
 
     return { success: true };

--- a/eng/tools/typespec-validation/src/rules/sdk-tspconfig-validation.ts
+++ b/eng/tools/typespec-validation/src/rules/sdk-tspconfig-validation.ts
@@ -794,25 +794,23 @@ export class TspConfigCsharpMgmtEmitterRequiredSubRule extends TspconfigSubRuleB
     const emit: string[] | undefined = config?.emit;
     const options: Record<string, any> | undefined = config?.options;
 
-    const hasNewMgmtEmitter =
-      emit?.includes(CSHARP_MGMT_EMITTER) || options?.[CSHARP_MGMT_EMITTER] !== undefined;
-
-    if (hasNewMgmtEmitter) {
-      return { success: true };
-    }
-
     const hasLegacyEmitter =
       emit?.includes(LEGACY_CSHARP_EMITTER) || options?.[LEGACY_CSHARP_EMITTER] !== undefined;
 
-    // Allow existing projects that already use the legacy emitter
+    // Only fail if the legacy emitter is configured — block new projects from using it
     if (hasLegacyEmitter) {
-      return { success: true };
+      const hasNewMgmtEmitter =
+        emit?.includes(CSHARP_MGMT_EMITTER) || options?.[CSHARP_MGMT_EMITTER] !== undefined;
+
+      if (!hasNewMgmtEmitter) {
+        return this.createFailedResult(
+          `Management plane TypeSpec projects must use "${CSHARP_MGMT_EMITTER}" instead of the legacy "${LEGACY_CSHARP_EMITTER}" for .NET SDK generation`,
+          `Please replace "${LEGACY_CSHARP_EMITTER}" with "${CSHARP_MGMT_EMITTER}" in your tspconfig.yaml`,
+        );
+      }
     }
 
-    return this.createFailedResult(
-      `Management plane TypeSpec projects must configure "${CSHARP_MGMT_EMITTER}" for .NET SDK generation`,
-      `Please add "${CSHARP_MGMT_EMITTER}" to the "emit" array or "options" in your tspconfig.yaml`,
-    );
+    return { success: true };
   }
 
   public getPathOfKeyToValidate(): string {

--- a/eng/tools/typespec-validation/src/rules/sdk-tspconfig-validation.ts
+++ b/eng/tools/typespec-validation/src/rules/sdk-tspconfig-validation.ts
@@ -777,6 +777,51 @@ export class TspConfigCsharpMgmtNamespaceSubRule extends TspconfigEmitterOptions
   }
 }
 
+// ----- CSharp mgmt emitter requirement rule -----
+const CSHARP_MGMT_EMITTER = "@azure-typespec/http-client-csharp-mgmt";
+const LEGACY_CSHARP_EMITTER = "@azure-tools/typespec-csharp";
+
+export class TspConfigCsharpMgmtEmitterRequiredSubRule extends TspconfigSubRuleBase {
+  constructor() {
+    super("emit", CSHARP_MGMT_EMITTER);
+  }
+
+  protected skip(_config: any, folder: string): SkipResult {
+    return skipForDataPlane(folder);
+  }
+
+  protected validate(config: any): RuleResult {
+    const emit: string[] | undefined = config?.emit;
+    const options: Record<string, any> | undefined = config?.options;
+
+    const hasNewMgmtEmitter =
+      emit?.includes(CSHARP_MGMT_EMITTER) || options?.[CSHARP_MGMT_EMITTER] !== undefined;
+
+    if (hasNewMgmtEmitter) {
+      return { success: true };
+    }
+
+    const hasLegacyEmitter =
+      emit?.includes(LEGACY_CSHARP_EMITTER) || options?.[LEGACY_CSHARP_EMITTER] !== undefined;
+
+    if (hasLegacyEmitter) {
+      return this.createFailedResult(
+        `Management plane TypeSpec projects must use "${CSHARP_MGMT_EMITTER}" instead of "${LEGACY_CSHARP_EMITTER}" for .NET SDK generation`,
+        `Please replace "${LEGACY_CSHARP_EMITTER}" with "${CSHARP_MGMT_EMITTER}" in your tspconfig.yaml`,
+      );
+    }
+
+    return this.createFailedResult(
+      `Management plane TypeSpec projects must configure "${CSHARP_MGMT_EMITTER}" for .NET SDK generation`,
+      `Please add "${CSHARP_MGMT_EMITTER}" to the "emit" array or "options" in your tspconfig.yaml`,
+    );
+  }
+
+  public getPathOfKeyToValidate(): string {
+    return `emit.${CSHARP_MGMT_EMITTER}`;
+  }
+}
+
 /**
  * Required rules: When a tspconfig.yaml exists, any applicable rule in the requiredRules array
  * that fails validation will cause the entire SdkTspConfigValidationRule to fail. For example,
@@ -785,6 +830,7 @@ export class TspConfigCsharpMgmtNamespaceSubRule extends TspconfigEmitterOptions
  */
 export const requiredRules = [
   new TspConfigCommonAzServiceDirMatchPatternSubRule(),
+  new TspConfigCsharpMgmtEmitterRequiredSubRule(),
   new TspConfigJavaAzEmitterOutputDirMatchPatternSubRule(),
   new TspConfigJavaMgmtEmitterOutputDirMatchPatternSubRule(),
   new TspConfigJavaMgmtNamespaceFormatSubRule(),

--- a/eng/tools/typespec-validation/src/rules/sdk-tspconfig-validation.ts
+++ b/eng/tools/typespec-validation/src/rules/sdk-tspconfig-validation.ts
@@ -804,11 +804,9 @@ export class TspConfigCsharpMgmtEmitterRequiredSubRule extends TspconfigSubRuleB
     const hasLegacyEmitter =
       emit?.includes(LEGACY_CSHARP_EMITTER) || options?.[LEGACY_CSHARP_EMITTER] !== undefined;
 
+    // Allow existing projects that already use the legacy emitter
     if (hasLegacyEmitter) {
-      return this.createFailedResult(
-        `Management plane TypeSpec projects must use "${CSHARP_MGMT_EMITTER}" instead of "${LEGACY_CSHARP_EMITTER}" for .NET SDK generation`,
-        `Please replace "${LEGACY_CSHARP_EMITTER}" with "${CSHARP_MGMT_EMITTER}" in your tspconfig.yaml`,
-      );
+      return { success: true };
     }
 
     return this.createFailedResult(

--- a/eng/tools/typespec-validation/test/sdk-tspconfig-validation.test.ts
+++ b/eng/tools/typespec-validation/test/sdk-tspconfig-validation.test.ts
@@ -13,6 +13,7 @@ import {
   TspConfigCsharpDpEmitterOutputDirSubRule,
   TspConfigCsharpDpNamespaceSubRule,
   TspConfigCsharpMgmtEmitterOutputDirSubRule,
+  TspConfigCsharpMgmtEmitterRequiredSubRule,
   TspConfigCsharpMgmtNamespaceSubRule,
   TspConfigGoDpContainingModuleMatchPatternSubRule,
   TspConfigGoDpEmitterOutputDirMatchPatternSubRule,
@@ -612,6 +613,83 @@ const csharpMgmtEmitterOutputDirTestCases = createEmitterOptionTestCases(
   [new TspConfigCsharpMgmtEmitterOutputDirSubRule()],
 );
 
+// Test cases for CSharp mgmt emitter requirement rule
+const csharpMgmtEmitterRequiredTestCases: Case[] = [
+  {
+    description:
+      "Mgmt emitter required: pass when @azure-typespec/http-client-csharp-mgmt is in emit array",
+    folder: managementTspconfigFolder,
+    tspconfigContent: `
+emit:
+  - "@azure-tools/typespec-autorest"
+  - "@azure-typespec/http-client-csharp-mgmt"
+`,
+    success: true,
+    subRules: [new TspConfigCsharpMgmtEmitterRequiredSubRule()],
+  },
+  {
+    description:
+      "Mgmt emitter required: pass when @azure-typespec/http-client-csharp-mgmt is in options",
+    folder: managementTspconfigFolder,
+    tspconfigContent: `
+emit:
+  - "@azure-tools/typespec-autorest"
+options:
+  "@azure-typespec/http-client-csharp-mgmt":
+    namespace: "Azure.ResourceManager.Compute"
+`,
+    success: true,
+    subRules: [new TspConfigCsharpMgmtEmitterRequiredSubRule()],
+  },
+  {
+    description:
+      "Mgmt emitter required: fail when legacy @azure-tools/typespec-csharp is used instead",
+    folder: managementTspconfigFolder,
+    tspconfigContent: `
+emit:
+  - "@azure-tools/typespec-autorest"
+  - "@azure-tools/typespec-csharp"
+`,
+    success: false,
+    subRules: [new TspConfigCsharpMgmtEmitterRequiredSubRule()],
+  },
+  {
+    description:
+      "Mgmt emitter required: fail when legacy @azure-tools/typespec-csharp is in options",
+    folder: managementTspconfigFolder,
+    tspconfigContent: `
+emit:
+  - "@azure-tools/typespec-autorest"
+options:
+  "@azure-tools/typespec-csharp":
+    namespace: "Azure.ResourceManager.Compute"
+`,
+    success: false,
+    subRules: [new TspConfigCsharpMgmtEmitterRequiredSubRule()],
+  },
+  {
+    description: "Mgmt emitter required: fail when no .NET emitter is configured",
+    folder: managementTspconfigFolder,
+    tspconfigContent: `
+emit:
+  - "@azure-tools/typespec-autorest"
+`,
+    success: false,
+    subRules: [new TspConfigCsharpMgmtEmitterRequiredSubRule()],
+  },
+  {
+    description: "Mgmt emitter required: skip for data-plane folder",
+    folder: "contosowidgetmanager/Contoso.WidgetManager/",
+    tspconfigContent: `
+emit:
+  - "@azure-tools/typespec-autorest"
+  - "@azure-tools/typespec-csharp"
+`,
+    success: true,
+    subRules: [new TspConfigCsharpMgmtEmitterRequiredSubRule()],
+  },
+];
+
 // Test cases for emitter-output-dir with namespace variable resolution
 const emitterOutputDirWithNamespaceVariableTestCases: Case[] = [
   {
@@ -923,6 +1001,8 @@ describe("tspconfig", function () {
     ...pythonManagementGenerateTestTestCases,
     ...pythonManagementGenerateSampleTestCases,
     ...pythonDpEmitterOutputTestCases,
+    // csharp mgmt emitter requirement
+    ...csharpMgmtEmitterRequiredTestCases,
     // variable resolution in emitter-output-dir
     ...emitterOutputDirWithNamespaceVariableTestCases,
   ];

--- a/eng/tools/typespec-validation/test/sdk-tspconfig-validation.test.ts
+++ b/eng/tools/typespec-validation/test/sdk-tspconfig-validation.test.ts
@@ -642,8 +642,7 @@ options:
     subRules: [new TspConfigCsharpMgmtEmitterRequiredSubRule()],
   },
   {
-    description:
-      "Mgmt emitter required: fail when legacy @azure-tools/typespec-csharp is in emit",
+    description: "Mgmt emitter required: fail when legacy @azure-tools/typespec-csharp is in emit",
     folder: managementTspconfigFolder,
     tspconfigContent: `
 emit:
@@ -668,8 +667,7 @@ options:
     subRules: [new TspConfigCsharpMgmtEmitterRequiredSubRule()],
   },
   {
-    description:
-      "Mgmt emitter required: fail when both legacy and new emitters coexist",
+    description: "Mgmt emitter required: fail when both legacy and new emitters coexist",
     folder: managementTspconfigFolder,
     tspconfigContent: `
 emit:

--- a/eng/tools/typespec-validation/test/sdk-tspconfig-validation.test.ts
+++ b/eng/tools/typespec-validation/test/sdk-tspconfig-validation.test.ts
@@ -642,8 +642,7 @@ options:
     subRules: [new TspConfigCsharpMgmtEmitterRequiredSubRule()],
   },
   {
-    description:
-      "Mgmt emitter required: fail when legacy @azure-tools/typespec-csharp is in emit",
+    description: "Mgmt emitter required: fail when legacy @azure-tools/typespec-csharp is in emit",
     folder: managementTspconfigFolder,
     tspconfigContent: `
 emit:

--- a/eng/tools/typespec-validation/test/sdk-tspconfig-validation.test.ts
+++ b/eng/tools/typespec-validation/test/sdk-tspconfig-validation.test.ts
@@ -643,19 +643,19 @@ options:
   },
   {
     description:
-      "Mgmt emitter required: fail when legacy @azure-tools/typespec-csharp is used instead",
+      "Mgmt emitter required: pass when legacy @azure-tools/typespec-csharp is in emit (existing projects allowed)",
     folder: managementTspconfigFolder,
     tspconfigContent: `
 emit:
   - "@azure-tools/typespec-autorest"
   - "@azure-tools/typespec-csharp"
 `,
-    success: false,
+    success: true,
     subRules: [new TspConfigCsharpMgmtEmitterRequiredSubRule()],
   },
   {
     description:
-      "Mgmt emitter required: fail when legacy @azure-tools/typespec-csharp is in options",
+      "Mgmt emitter required: pass when legacy @azure-tools/typespec-csharp is in options (existing projects allowed)",
     folder: managementTspconfigFolder,
     tspconfigContent: `
 emit:
@@ -664,7 +664,7 @@ options:
   "@azure-tools/typespec-csharp":
     namespace: "Azure.ResourceManager.Compute"
 `,
-    success: false,
+    success: true,
     subRules: [new TspConfigCsharpMgmtEmitterRequiredSubRule()],
   },
   {

--- a/eng/tools/typespec-validation/test/sdk-tspconfig-validation.test.ts
+++ b/eng/tools/typespec-validation/test/sdk-tspconfig-validation.test.ts
@@ -642,7 +642,8 @@ options:
     subRules: [new TspConfigCsharpMgmtEmitterRequiredSubRule()],
   },
   {
-    description: "Mgmt emitter required: fail when legacy @azure-tools/typespec-csharp is in emit",
+    description:
+      "Mgmt emitter required: fail when legacy @azure-tools/typespec-csharp is in emit",
     folder: managementTspconfigFolder,
     tspconfigContent: `
 emit:
@@ -668,7 +669,7 @@ options:
   },
   {
     description:
-      "Mgmt emitter required: pass when legacy emitter is present alongside new mgmt emitter",
+      "Mgmt emitter required: fail when both legacy and new emitters coexist",
     folder: managementTspconfigFolder,
     tspconfigContent: `
 emit:
@@ -676,7 +677,7 @@ emit:
   - "@azure-tools/typespec-csharp"
   - "@azure-typespec/http-client-csharp-mgmt"
 `,
-    success: true,
+    success: false,
     subRules: [new TspConfigCsharpMgmtEmitterRequiredSubRule()],
   },
   {

--- a/eng/tools/typespec-validation/test/sdk-tspconfig-validation.test.ts
+++ b/eng/tools/typespec-validation/test/sdk-tspconfig-validation.test.ts
@@ -643,19 +643,19 @@ options:
   },
   {
     description:
-      "Mgmt emitter required: pass when legacy @azure-tools/typespec-csharp is in emit (existing projects allowed)",
+      "Mgmt emitter required: fail when legacy @azure-tools/typespec-csharp is in emit",
     folder: managementTspconfigFolder,
     tspconfigContent: `
 emit:
   - "@azure-tools/typespec-autorest"
   - "@azure-tools/typespec-csharp"
 `,
-    success: true,
+    success: false,
     subRules: [new TspConfigCsharpMgmtEmitterRequiredSubRule()],
   },
   {
     description:
-      "Mgmt emitter required: pass when legacy @azure-tools/typespec-csharp is in options (existing projects allowed)",
+      "Mgmt emitter required: fail when legacy @azure-tools/typespec-csharp is in options",
     folder: managementTspconfigFolder,
     tspconfigContent: `
 emit:
@@ -664,17 +664,30 @@ options:
   "@azure-tools/typespec-csharp":
     namespace: "Azure.ResourceManager.Compute"
 `,
+    success: false,
+    subRules: [new TspConfigCsharpMgmtEmitterRequiredSubRule()],
+  },
+  {
+    description:
+      "Mgmt emitter required: pass when legacy emitter is present alongside new mgmt emitter",
+    folder: managementTspconfigFolder,
+    tspconfigContent: `
+emit:
+  - "@azure-tools/typespec-autorest"
+  - "@azure-tools/typespec-csharp"
+  - "@azure-typespec/http-client-csharp-mgmt"
+`,
     success: true,
     subRules: [new TspConfigCsharpMgmtEmitterRequiredSubRule()],
   },
   {
-    description: "Mgmt emitter required: fail when no .NET emitter is configured",
+    description: "Mgmt emitter required: pass when no .NET emitter is configured",
     folder: managementTspconfigFolder,
     tspconfigContent: `
 emit:
   - "@azure-tools/typespec-autorest"
 `,
-    success: false,
+    success: true,
     subRules: [new TspConfigCsharpMgmtEmitterRequiredSubRule()],
   },
   {


### PR DESCRIPTION
## Problem

New management plane TypeSpec projects can currently configure the legacy `@azure-tools/typespec-csharp` emitter for .NET SDK generation in their `tspconfig.yaml`. This emitter is being retired and should not be used for new management plane projects.

## Solution

Add a new **required** validation sub-rule `TspConfigCsharpMgmtEmitterRequiredSubRule` to the existing `SdkTspConfigValidation` rule in the TypeSpec Validation CI check.

### Rule behavior
- **Skips** for data-plane projects (only applies to `resource-manager/` paths)
- **Passes** if `@azure-typespec/http-client-csharp-mgmt` is found in the `emit` array or `options`
- **Fails** with specific guidance if legacy `@azure-tools/typespec-csharp` is configured instead
- **Fails** with onboarding guidance if no .NET emitter is configured at all

### Test coverage
Added 6 test cases covering:
- Valid config with emitter in `emit` array
- Valid config with emitter in `options`
- Failure when legacy emitter is in `emit`
- Failure when legacy emitter is in `options`
- Failure when no .NET emitter is configured
- Skip for data-plane projects

All 219 tests pass.