### PR TITLE
Remove "string" option from MemoryStoreUpdateStatus

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -17835,20 +17835,13 @@
         }
       },
       "MemoryStoreUpdateStatus": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "queued",
-              "in_progress",
-              "completed",
-              "failed",
-              "superseded"
-            ]
-          }
+        "type": "string",
+        "enum": [
+          "queued",
+          "in_progress",
+          "completed",
+          "failed",
+          "superseded"
         ],
         "description": "Status of a memory store update operation.",
         "x-ms-foundry-meta": {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -20010,20 +20010,13 @@
         }
       },
       "MemoryStoreUpdateStatus": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "queued",
-              "in_progress",
-              "completed",
-              "failed",
-              "superseded"
-            ]
-          }
+        "type": "string",
+        "enum": [
+          "queued",
+          "in_progress",
+          "completed",
+          "failed",
+          "superseded"
         ],
         "description": "Status of a memory store update operation.",
         "x-ms-foundry-meta": {

--- a/specification/ai-foundry/data-plane/Foundry/src/memory-stores/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/memory-stores/models.tsp
@@ -121,7 +121,6 @@ model MemoryStoreOperationUsage {
 @doc("Status of a memory store update operation.")
 @extension("x-ms-foundry-meta", MemoryStoreRequiredPreviews)
 union MemoryStoreUpdateStatus {
-  string,
   queued: "queued",
   in_progress: "in_progress",
 


### PR DESCRIPTION
This change was present in `feature/foundry-staging`, but was left out of `feature/foundry-release`. Since this is an input enum, we don't need to have it extensible. If/when new values will be added, we will expose them in the next release of SDKs.