### PR TITLE
Add threshold field to EvaluatorMetric model

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -15924,7 +15924,7 @@
           "threshold": {
             "type": "number",
             "format": "float",
-            "description": "Default pass/fail threshold for this metric. When set, this value is used as the evaluator-authored default instead of computing from min/max midpoint."
+            "description": "Default pass/fail threshold for this metric."
           },
           "is_primary": {
             "type": "boolean",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -15921,6 +15921,11 @@
             "format": "float",
             "description": "Maximum value for the metric. If not specified, it is assumed to be unbounded."
           },
+          "threshold": {
+            "type": "number",
+            "format": "float",
+            "description": "Default pass/fail threshold for this metric. When set, this value is used as the evaluator-authored default instead of computing from min/max midpoint."
+          },
           "is_primary": {
             "type": "boolean",
             "description": "Indicates if this metric is primary when there are multiple metrics."

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -17978,6 +17978,11 @@
             "format": "float",
             "description": "Maximum value for the metric. If not specified, it is assumed to be unbounded."
           },
+          "threshold": {
+            "type": "number",
+            "format": "float",
+            "description": "Default pass/fail threshold for this metric. When set, this value is used as the evaluator-authored default instead of computing from min/max midpoint."
+          },
           "is_primary": {
             "type": "boolean",
             "description": "Indicates if this metric is primary when there are multiple metrics."

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -17981,7 +17981,7 @@
           "threshold": {
             "type": "number",
             "format": "float",
-            "description": "Default pass/fail threshold for this metric. When set, this value is used as the evaluator-authored default instead of computing from min/max midpoint."
+            "description": "Default pass/fail threshold for this metric."
           },
           "is_primary": {
             "type": "boolean",

--- a/specification/ai-foundry/data-plane/Foundry/src/evaluators/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/evaluators/models.tsp
@@ -165,6 +165,9 @@ model EvaluatorMetric {
   @doc("Maximum value for the metric. If not specified, it is assumed to be unbounded.")
   max_value?: float32;
 
+  @doc("Default pass/fail threshold for this metric. When set, this value is used as the evaluator-authored default instead of computing from min/max midpoint.")
+  threshold?: float32;
+
   @doc("Indicates if this metric is primary when there are multiple metrics.")
   is_primary?: boolean;
 }

--- a/specification/ai-foundry/data-plane/Foundry/src/evaluators/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/evaluators/models.tsp
@@ -165,7 +165,7 @@ model EvaluatorMetric {
   @doc("Maximum value for the metric. If not specified, it is assumed to be unbounded.")
   max_value?: float32;
 
-  @doc("Default pass/fail threshold for this metric. When set, this value is used as the evaluator-authored default instead of computing from min/max midpoint.")
+  @doc("Default pass/fail threshold for this metric.")
   threshold?: float32;
 
   @doc("Indicates if this metric is primary when there are multiple metrics.")


### PR DESCRIPTION
Cherry-pick of PR #41870 to `feature/foundry-release`.

## Summary
Add optional `threshold` (float32) property to the EvaluatorMetric TypeSpec model.

## Motivation
Evaluator authors need to specify a default pass/fail threshold per metric, rather than relying on a generic midpoint computation algorithm. This enables more precise default thresholds for custom evaluators.

## Changes
- **specification/ai-foundry/data-plane/Foundry/src/evaluators/models.tsp** — Added `threshold?: float32` to EvaluatorMetric model, positioned between max_value and is_primary.
- Regenerated OpenAPI specs for v1 and virtual-public-preview.