### PR TITLE
[KeyVault Secrets] Bump Java api-version to 2025-07-01 and add PEM co…

### DIFF
--- a/specification/keyvault/Security.KeyVault.Secrets/examples/2025-06-01-preview/GetSecretWithPEMConversion-example.json
+++ b/specification/keyvault/Security.KeyVault.Secrets/examples/2025-06-01-preview/GetSecretWithPEMConversion-example.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "vaultBaseUrl": "https://myvault.vault.azure.net/",
+    "secret-name": "mycertname",
+    "secret-version": "4387e9f3d6e14c459867679a90fd0f79",
+    "api-version": "2025-06-01-preview",
+    "outContentType": "application/x-pem-file"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": "-----BEGIN CERTIFICATE-----\nMIICODCCAeagAwIBAgIQqHmpBAv+CY9IJFoUhlbziTAJBgUrDgMCHQUAMBYxFDAS\nBgNVBAMTC1Jvb3QgQWdlbmN5MB4XDTE1MDQyOTIxNTM0MVoXDTM5MTIzMTIzNTk1\nOVowFzEVMBMGA1UEAxMMa2V5VmF1bHRUZXN0MIIBIjANBgkqhkiG9w0BAQEFAAOC\nAQ8AMIIBCgKCAQEA5bVAT73zr4+N4WVv2+SvTunAw08ksS4BrJW/nNliz3S9XuzM\nBMXvmYzU5HJ8TtEgluBiZZYd5qsMJD+oa2CJKk2Gs3E5gNGdUMGgqDGqQCGQTIF9\njHi23gJE5F0Vj5k4HyL5VYeFpEH2BNEsBoMuRkA45F1c0TjOJC9klX7SLZB3FBIX\n-----END CERTIFICATE-----\n-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDltUBPvfOvj43h\nZW/b5K9O6cDDTySxLgGslb+c2WLPdL1e7MwExe+ZjNTkcnxO0SCW4GJllh3mqwwk\nP6hrYIkqTYazcTmA0Z1QwaCoMapAIZBMgX2MeLbeAkTkXRWPmTgfIvlVh4WkQfYE\n0SwGgy5GQDjkXVzROM4kL2SVftItkHcUEhcF\n-----END PRIVATE KEY-----\n",
+        "id": "https://myvault.vault.azure.net/secrets/mycertname/4387e9f3d6e14c459867679a90fd0f79",
+        "contentType": "application/x-pem-file",
+        "attributes": {
+          "enabled": true,
+          "created": 1493938410,
+          "updated": 1493938410,
+          "recoveryLevel": "Recoverable+Purgeable"
+        }
+      }
+    }
+  },
+  "operationId": "GetSecret",
+  "title": "GetSecretWithPEMConversion"
+}

--- a/specification/keyvault/Security.KeyVault.Secrets/examples/2025-07-01/GetSecretWithPEMConversion-example.json
+++ b/specification/keyvault/Security.KeyVault.Secrets/examples/2025-07-01/GetSecretWithPEMConversion-example.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "vaultBaseUrl": "https://myvault.vault.azure.net/",
+    "secret-name": "mycertname",
+    "secret-version": "4387e9f3d6e14c459867679a90fd0f79",
+    "api-version": "2025-07-01",
+    "outContentType": "application/x-pem-file"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": "-----BEGIN CERTIFICATE-----\nMIICODCCAeagAwIBAgIQqHmpBAv+CY9IJFoUhlbziTAJBgUrDgMCHQUAMBYxFDAS\nBgNVBAMTC1Jvb3QgQWdlbmN5MB4XDTE1MDQyOTIxNTM0MVoXDTM5MTIzMTIzNTk1\nOVowFzEVMBMGA1UEAxMMa2V5VmF1bHRUZXN0MIIBIjANBgkqhkiG9w0BAQEFAAOC\nAQ8AMIIBCgKCAQEA5bVAT73zr4+N4WVv2+SvTunAw08ksS4BrJW/nNliz3S9XuzM\nBMXvmYzU5HJ8TtEgluBiZZYd5qsMJD+oa2CJKk2Gs3E5gNGdUMGgqDGqQCGQTIF9\njHi23gJE5F0Vj5k4HyL5VYeFpEH2BNEsBoMuRkA45F1c0TjOJC9klX7SLZB3FBIX\n-----END CERTIFICATE-----\n-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDltUBPvfOvj43h\nZW/b5K9O6cDDTySxLgGslb+c2WLPdL1e7MwExe+ZjNTkcnxO0SCW4GJllh3mqwwk\nP6hrYIkqTYazcTmA0Z1QwaCoMapAIZBMgX2MeLbeAkTkXRWPmTgfIvlVh4WkQfYE\n0SwGgy5GQDjkXVzROM4kL2SVftItkHcUEhcF\n-----END PRIVATE KEY-----\n",
+        "id": "https://myvault.vault.azure.net/secrets/mycertname/4387e9f3d6e14c459867679a90fd0f79",
+        "contentType": "application/x-pem-file",
+        "attributes": {
+          "enabled": true,
+          "created": 1493938410,
+          "updated": 1493938410,
+          "recoveryLevel": "Recoverable+Purgeable"
+        }
+      }
+    }
+  },
+  "operationId": "GetSecret",
+  "title": "GetSecretWithPEMConversion"
+}

--- a/specification/keyvault/Security.KeyVault.Secrets/tspconfig.yaml
+++ b/specification/keyvault/Security.KeyVault.Secrets/tspconfig.yaml
@@ -26,7 +26,7 @@ options:
     "namespace": "azure.keyvault.secrets._generated"
     emitter-output-dir: "{output-dir}/{service-dir}/azure-keyvault-secrets"
   "@azure-tools/typespec-java":
-    api-version: "7.6"
+    api-version: "2025-07-01"
     flavor: azure
     emitter-output-dir: "{output-dir}/{service-dir}/azure-security-keyvault-secrets"
     namespace: "com.azure.security.keyvault.secrets"


### PR DESCRIPTION
…nversion examples

The outContentType query parameter was introduced in the 2025-06-01-preview API version (PR #35604). The Java emitter was still configured to target api-version 7.6, causing the parameter to be silently excluded from generated code.

Changes:
- tspconfig.yaml: api-version 7.6 -> 2025-07-01 for @azure-tools/typespec-java
- Add GetSecretWithPEMConversion-example.json for 2025-06-01-preview
- Add GetSecretWithPEMConversion-example.json for 2025-07-01 (stable)

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
