### PR TITLE
Add Soft Delete TypeSpec for CosmosDB 2026-04-01-preview

### DIFF
--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/SoftDeletedResources.tsp
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/SoftDeletedResources.tsp
@@ -110,6 +110,7 @@ model SoftDeletedDatabaseAccountGetResult {
   /**
    * The properties of a soft-deleted database account.
    */
+  #suppress "@azure-tools/typespec-azure-core/no-openapi" "x-ms-client-flatten is required for swagger compatibility"
   @extension("x-ms-client-flatten", true)
   properties?: SoftDeletedDatabaseAccountProperties;
 
@@ -196,6 +197,7 @@ model SoftDeletedSqlDatabaseGetResult {
   /**
    * The properties of a soft-deleted SQL database.
    */
+  #suppress "@azure-tools/typespec-azure-core/no-openapi" "x-ms-client-flatten is required for swagger compatibility"
   @extension("x-ms-client-flatten", true)
   properties?: SoftDeletedSqlDatabaseProperties;
 
@@ -292,6 +294,7 @@ model SoftDeletedSqlContainerGetResult {
   /**
    * The properties of a soft-deleted SQL container.
    */
+  #suppress "@azure-tools/typespec-azure-core/no-openapi" "x-ms-client-flatten is required for swagger compatibility"
   @extension("x-ms-client-flatten", true)
   properties?: SoftDeletedSqlContainerProperties;
 
@@ -375,6 +378,7 @@ interface SoftDeletedDatabaseAccounts {
    */
   @route("/subscriptions/{subscriptionId}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts")
   @get
+  #suppress "@azure-tools/typespec-azure-core/no-openapi" "x-ms-pageable is required for ARM list operations"
   @extension("x-ms-pageable", #{nextLinkName: "nextLink"})
   listByLocation(
     ...Azure.ResourceManager.ApiVersionParameter,
@@ -392,6 +396,7 @@ interface SoftDeletedDatabaseAccounts {
    */
   @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts")
   @get
+  #suppress "@azure-tools/typespec-azure-core/no-openapi" "x-ms-pageable is required for ARM list operations"
   @extension("x-ms-pageable", #{nextLinkName: "nextLink"})
   listByResourceGroupAndLocation(
     ...Azure.ResourceManager.SubscriptionIdParameter,
@@ -488,6 +493,7 @@ interface SoftDeletedSqlDatabases {
    */
   @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases")
   @get
+  #suppress "@azure-tools/typespec-azure-core/no-openapi" "x-ms-pageable is required for ARM list operations"
   @extension("x-ms-pageable", #{nextLinkName: "nextLink"})
   list(
     ...Azure.ResourceManager.ApiVersionParameter,
@@ -610,6 +616,7 @@ interface SoftDeletedSqlContainers {
    */
   @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}/softDeletedSqlContainers")
   @get
+  #suppress "@azure-tools/typespec-azure-core/no-openapi" "x-ms-pageable is required for ARM list operations"
   @extension("x-ms-pageable", #{nextLinkName: "nextLink"})
   list(
     ...Azure.ResourceManager.ApiVersionParameter,

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/SoftDeletedResources.tsp
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/SoftDeletedResources.tsp
@@ -1,0 +1,675 @@
+import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-azure-resource-manager";
+import "@typespec/openapi";
+import "@typespec/rest";
+import "@typespec/versioning";
+import "./models.tsp";
+
+using TypeSpec.Rest;
+using Azure.ResourceManager;
+using TypeSpec.Http;
+using TypeSpec.OpenAPI;
+using TypeSpec.Versioning;
+
+namespace Microsoft.DocumentDB;
+
+// ──────────────────────────────────────────────
+//  Soft-Delete Models
+// ──────────────────────────────────────────────
+
+@added(Versions.v2026_04_01_preview)
+/**
+ * The kind of soft delete action to perform.
+ */
+union SoftDeleteActionKind {
+  string,
+
+  /** Restores the soft-deleted resource to active/online state. */
+  RestoreSoftDeletedResource: "RestoreSoftDeletedResource",
+
+  /** Permanently deletes the soft-deleted resource. */
+  PermanentDeleteResource: "PermanentDeleteResource",
+}
+
+@added(Versions.v2026_04_01_preview)
+/**
+ * Metadata about the soft deletion of a resource.
+ */
+model SoftDeletionMetadata {
+  /**
+   * Indicates whether the resource is soft deleted.
+   */
+  isSoftDeleted?: boolean;
+
+  /**
+   * The timestamp when the soft deletion started.
+   */
+  softDeletionStartTimestamp?: int64;
+
+  /**
+   * The timestamp when the soft-deleted resource will expire and be permanently deleted.
+   */
+  softDeletionResourceExpirationTimestamp?: int64;
+}
+
+@added(Versions.v2026_04_01_preview)
+/**
+ * The database account resource information for a soft-deleted account.
+ */
+model SoftDeletedDatabaseAccountResource {
+  /**
+   * An array that contains all of the locations enabled for the Cosmos DB account.
+   */
+  @identifiers(#[])
+  locations?: Location[];
+
+  /**
+   * An array that contains the write location(s) for the Cosmos DB account.
+   */
+  @identifiers(#[])
+  writeLocations?: Location[];
+
+  /**
+   * An array that contains the read locations enabled for the Cosmos DB account.
+   */
+  @identifiers(#[])
+  readLocations?: Location[];
+}
+
+@added(Versions.v2026_04_01_preview)
+/**
+ * The properties of a soft-deleted database account.
+ */
+model SoftDeletedDatabaseAccountProperties {
+  /**
+   * The name of the database account.
+   */
+  accountName?: string;
+
+  /**
+   * Metadata related to the soft deletion of the database account.
+   */
+  softDeletionMetadata?: SoftDeletionMetadata;
+
+  /**
+   * The soft delete configuration for the database account.
+   */
+  softDeleteConfiguration?: SoftDeleteConfiguration;
+
+  /**
+   * A subset of properties of the underlying database account resource.
+   */
+  resource?: SoftDeletedDatabaseAccountResource;
+}
+
+@added(Versions.v2026_04_01_preview)
+/**
+ * A Azure Cosmos DB soft-deleted database account.
+ */
+model SoftDeletedDatabaseAccountGetResult {
+  /**
+   * The properties of a soft-deleted database account.
+   */
+  @extension("x-ms-client-flatten", true)
+  properties?: SoftDeletedDatabaseAccountProperties;
+
+  /**
+   * The unique resource identifier of the ARM resource.
+   */
+  @visibility(Lifecycle.Read)
+  id?: string;
+
+  /**
+   * The name of the ARM resource.
+   */
+  @visibility(Lifecycle.Read)
+  name?: string;
+
+  /**
+   * The type of Azure resource.
+   */
+  @visibility(Lifecycle.Read)
+  type?: string;
+
+  /**
+   * The location of the resource group to which the resource belongs.
+   */
+  location?: string;
+}
+
+@added(Versions.v2026_04_01_preview)
+/**
+ * The List operation response, that contains the soft-deleted database accounts and their properties.
+ */
+model SoftDeletedDatabaseAccountsListResult {
+  /**
+   * List of soft-deleted database accounts and their properties.
+   */
+  @visibility(Lifecycle.Read)
+  value?: SoftDeletedDatabaseAccountGetResult[];
+}
+
+@added(Versions.v2026_04_01_preview)
+/**
+ * Cosmos DB SQL database resource object
+ */
+model SoftDeletedSqlDatabaseResource {
+  /**
+   * Name of the Cosmos DB SQL database
+   */
+  id: string;
+
+  /**
+   * A system generated property. A unique identifier.
+   */
+  @visibility(Lifecycle.Read)
+  @encodedName("application/json", "_rid")
+  rid?: string;
+}
+
+@added(Versions.v2026_04_01_preview)
+/**
+ * The properties of a soft-deleted SQL database.
+ */
+model SoftDeletedSqlDatabaseProperties {
+  /**
+   * Metadata related to the soft deletion of the SQL database.
+   */
+  softDeletionMetadata?: SoftDeletionMetadata;
+
+  /**
+   * The resource information for the soft-deleted SQL database.
+   */
+  resource?: SoftDeletedSqlDatabaseResource;
+}
+
+@added(Versions.v2026_04_01_preview)
+/**
+ * An Azure Cosmos DB soft-deleted SQL database.
+ */
+model SoftDeletedSqlDatabaseGetResult {
+  /**
+   * The properties of a soft-deleted SQL database.
+   */
+  @extension("x-ms-client-flatten", true)
+  properties?: SoftDeletedSqlDatabaseProperties;
+
+  /**
+   * The unique resource identifier of the ARM resource.
+   */
+  @visibility(Lifecycle.Read)
+  id?: string;
+
+  /**
+   * The name of the ARM resource.
+   */
+  @visibility(Lifecycle.Read)
+  name?: string;
+
+  /**
+   * The type of Azure resource.
+   */
+  @visibility(Lifecycle.Read)
+  type?: string;
+
+  /**
+   * The location of the resource group to which the resource belongs.
+   */
+  location?: string;
+}
+
+@added(Versions.v2026_04_01_preview)
+/**
+ * The List operation response, that contains the soft-deleted SQL databases and their properties.
+ */
+model SoftDeletedSqlDatabasesListResult {
+  /**
+   * List of soft-deleted SQL databases and their properties.
+   */
+  @visibility(Lifecycle.Read)
+  value?: SoftDeletedSqlDatabaseGetResult[];
+}
+
+@added(Versions.v2026_04_01_preview)
+/**
+ * Cosmos DB SQL container resource object
+ */
+model SoftDeletedSqlContainerResource {
+  /**
+   * Name of the Cosmos DB SQL container
+   */
+  id: string;
+
+  /**
+   * A system generated property. A unique identifier.
+   */
+  @visibility(Lifecycle.Read)
+  @encodedName("application/json", "_rid")
+  rid?: string;
+
+  /**
+   * The configuration of the partition key to be used for partitioning data into multiple partitions
+   */
+  partitionKey?: ContainerPartitionKey;
+
+  /**
+   * Default time to live
+   */
+  defaultTtl?: int32;
+}
+
+@added(Versions.v2026_04_01_preview)
+/**
+ * The properties of a soft-deleted SQL container.
+ */
+model SoftDeletedSqlContainerProperties {
+  /**
+   * Metadata related to the soft deletion of the SQL container.
+   */
+  softDeletionMetadata?: SoftDeletionMetadata;
+
+  /**
+   * The resource information for the soft-deleted SQL container.
+   */
+  resource?: SoftDeletedSqlContainerResource;
+}
+
+@added(Versions.v2026_04_01_preview)
+/**
+ * An Azure Cosmos DB soft-deleted SQL container.
+ */
+model SoftDeletedSqlContainerGetResult {
+  /**
+   * The properties of a soft-deleted SQL container.
+   */
+  @extension("x-ms-client-flatten", true)
+  properties?: SoftDeletedSqlContainerProperties;
+
+  /**
+   * The unique resource identifier of the ARM resource.
+   */
+  @visibility(Lifecycle.Read)
+  id?: string;
+
+  /**
+   * The name of the ARM resource.
+   */
+  @visibility(Lifecycle.Read)
+  name?: string;
+
+  /**
+   * The type of Azure resource.
+   */
+  @visibility(Lifecycle.Read)
+  type?: string;
+
+  /**
+   * The location of the resource group to which the resource belongs.
+   */
+  location?: string;
+}
+
+@added(Versions.v2026_04_01_preview)
+/**
+ * The List operation response, that contains the soft-deleted SQL containers and their properties.
+ */
+model SoftDeletedSqlContainersListResult {
+  /**
+   * List of soft-deleted SQL containers and their properties.
+   */
+  @visibility(Lifecycle.Read)
+  value?: SoftDeletedSqlContainerGetResult[];
+}
+
+// ──────────────────────────────────────────────
+//  Soft-Deleted Database Account Operations
+// ──────────────────────────────────────────────
+
+@added(Versions.v2026_04_01_preview)
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-interface-requires-decorator" "Custom routes for soft-deleted resources"
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Custom routes for soft-deleted resources"
+interface SoftDeletedDatabaseAccounts {
+  /**
+   * Retrieves the properties of a soft-deleted Azure Cosmos DB database account by location and accountName. This call requires 'Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/read' permission.
+   */
+  @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}")
+  @get
+  get(
+    @query("api-version") apiVersion: string,
+    @path subscriptionId: string,
+    @path resourceGroupName: string,
+
+    /**
+     * Cosmos DB region, with spaces between words and each word capitalized.
+     */
+    @path
+    location: string,
+
+    /**
+     * Cosmos DB database account name.
+     */
+    @maxLength(50)
+    @minLength(3)
+    @pattern("^[a-z0-9]+(-[a-z0-9]+)*")
+    @path
+    accountName: string,
+  ): ArmResponse<SoftDeletedDatabaseAccountGetResult> | Azure.ResourceManager.CommonTypes.ErrorResponse;
+
+  /**
+   * Lists all the soft-deleted Azure Cosmos DB database accounts available under the subscription and in a region. This call requires 'Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/read' permission.
+   */
+  @route("/subscriptions/{subscriptionId}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts")
+  @get
+  listByLocation(
+    @query("api-version") apiVersion: string,
+    @path subscriptionId: string,
+
+    /**
+     * Cosmos DB region, with spaces between words and each word capitalized.
+     */
+    @path
+    location: string,
+  ): ArmResponse<SoftDeletedDatabaseAccountsListResult> | Azure.ResourceManager.CommonTypes.ErrorResponse;
+
+  /**
+   * Lists all the soft-deleted Azure Cosmos DB database accounts available under the given resource group and in a region. This call requires 'Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/read' permission.
+   */
+  @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts")
+  @get
+  listByResourceGroupAndLocation(
+    @path subscriptionId: string,
+    @path resourceGroupName: string,
+
+    /**
+     * Cosmos DB region, with spaces between words and each word capitalized.
+     */
+    @path
+    location: string,
+
+    @query("api-version") apiVersion: string,
+  ): ArmResponse<SoftDeletedDatabaseAccountsListResult> | Azure.ResourceManager.CommonTypes.ErrorResponse;
+
+  /**
+   * Performs a soft delete action (restore or permanently delete) on a soft-deleted Azure Cosmos DB database account.
+   */
+  @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}")
+  @delete
+  delete(
+    @path subscriptionId: string,
+    @path resourceGroupName: string,
+
+    /**
+     * Cosmos DB region, with spaces between words and each word capitalized.
+     */
+    @path
+    location: string,
+
+    /**
+     * Cosmos DB database account name.
+     */
+    @maxLength(50)
+    @minLength(3)
+    @pattern("^[a-z0-9]+(-[a-z0-9]+)*")
+    @path
+    accountName: string,
+
+    @query("api-version") apiVersion: string,
+
+    /**
+     * The kind of soft delete action to perform.
+     */
+    @query("softDeleteActionKind")
+    softDeleteActionKind?: SoftDeleteActionKind,
+  ): ArmDeleteAcceptedLroResponse | ArmDeletedNoContentResponse | Azure.ResourceManager.CommonTypes.ErrorResponse;
+}
+
+// ──────────────────────────────────────────────
+//  Soft-Deleted SQL Database Operations
+// ──────────────────────────────────────────────
+
+@added(Versions.v2026_04_01_preview)
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-interface-requires-decorator" "Custom routes for soft-deleted resources"
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Custom routes for soft-deleted resources"
+interface SoftDeletedSqlDatabases {
+  /**
+   * Retrieves the properties of a soft-deleted Azure Cosmos DB SQL database. This call requires 'Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/softDeletedSqlDatabases/read' permission.
+   */
+  @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}")
+  @get
+  get(
+    @query("api-version") apiVersion: string,
+    @path subscriptionId: string,
+    @path resourceGroupName: string,
+
+    /**
+     * Cosmos DB region, with spaces between words and each word capitalized.
+     */
+    @path
+    location: string,
+
+    /**
+     * Cosmos DB database account name.
+     */
+    @maxLength(50)
+    @minLength(3)
+    @pattern("^[a-z0-9]+(-[a-z0-9]+)*")
+    @path
+    accountName: string,
+
+    /**
+     * Cosmos DB SQL database name.
+     */
+    @maxLength(255)
+    @minLength(1)
+    @pattern("^[^/\\\\#?]+$")
+    @path
+    databaseName: string,
+  ): ArmResponse<SoftDeletedSqlDatabaseGetResult> | Azure.ResourceManager.CommonTypes.ErrorResponse;
+
+  /**
+   * Lists all the soft-deleted Azure Cosmos DB SQL databases under a soft-deleted database account. This call requires 'Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/softDeletedSqlDatabases/read' permission.
+   */
+  @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases")
+  @get
+  list(
+    @query("api-version") apiVersion: string,
+    @path subscriptionId: string,
+    @path resourceGroupName: string,
+
+    /**
+     * Cosmos DB region, with spaces between words and each word capitalized.
+     */
+    @path
+    location: string,
+
+    /**
+     * Cosmos DB database account name.
+     */
+    @maxLength(50)
+    @minLength(3)
+    @pattern("^[a-z0-9]+(-[a-z0-9]+)*")
+    @path
+    accountName: string,
+  ): ArmResponse<SoftDeletedSqlDatabasesListResult> | Azure.ResourceManager.CommonTypes.ErrorResponse;
+
+  /**
+   * Performs a soft delete action (restore or permanently delete) on a soft-deleted Azure Cosmos DB SQL database.
+   */
+  @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}")
+  @delete
+  delete(
+    @path subscriptionId: string,
+    @path resourceGroupName: string,
+
+    /**
+     * Cosmos DB region, with spaces between words and each word capitalized.
+     */
+    @path
+    location: string,
+
+    /**
+     * Cosmos DB database account name.
+     */
+    @maxLength(50)
+    @minLength(3)
+    @pattern("^[a-z0-9]+(-[a-z0-9]+)*")
+    @path
+    accountName: string,
+
+    /**
+     * Cosmos DB SQL database name.
+     */
+    @maxLength(255)
+    @minLength(1)
+    @pattern("^[^/\\\\#?]+$")
+    @path
+    databaseName: string,
+
+    @query("api-version") apiVersion: string,
+
+    /**
+     * The kind of soft delete action to perform.
+     */
+    @query("softDeleteActionKind")
+    softDeleteActionKind?: SoftDeleteActionKind,
+  ): ArmDeleteAcceptedLroResponse | ArmDeletedNoContentResponse | Azure.ResourceManager.CommonTypes.ErrorResponse;
+}
+
+// ──────────────────────────────────────────────
+//  Soft-Deleted SQL Container Operations
+// ──────────────────────────────────────────────
+
+@added(Versions.v2026_04_01_preview)
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-interface-requires-decorator" "Custom routes for soft-deleted resources"
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Custom routes for soft-deleted resources"
+interface SoftDeletedSqlContainers {
+  /**
+   * Retrieves the properties of a soft-deleted Azure Cosmos DB SQL container. This call requires 'Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/softDeletedSqlDatabases/softDeletedSqlContainers/read' permission.
+   */
+  @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}/softDeletedSqlContainers/{containerName}")
+  @get
+  get(
+    @query("api-version") apiVersion: string,
+    @path subscriptionId: string,
+    @path resourceGroupName: string,
+
+    /**
+     * Cosmos DB region, with spaces between words and each word capitalized.
+     */
+    @path
+    location: string,
+
+    /**
+     * Cosmos DB database account name.
+     */
+    @maxLength(50)
+    @minLength(3)
+    @pattern("^[a-z0-9]+(-[a-z0-9]+)*")
+    @path
+    accountName: string,
+
+    /**
+     * Cosmos DB SQL database name.
+     */
+    @maxLength(255)
+    @minLength(1)
+    @pattern("^[^/\\\\#?]+$")
+    @path
+    databaseName: string,
+
+    /**
+     * Cosmos DB SQL container name.
+     */
+    @maxLength(255)
+    @minLength(1)
+    @pattern("^[^/\\\\#?]+$")
+    @path
+    containerName: string,
+  ): ArmResponse<SoftDeletedSqlContainerGetResult> | Azure.ResourceManager.CommonTypes.ErrorResponse;
+
+  /**
+   * Lists all the soft-deleted Azure Cosmos DB SQL containers under a soft-deleted SQL database. This call requires 'Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/softDeletedSqlDatabases/softDeletedSqlContainers/read' permission.
+   */
+  @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}/softDeletedSqlContainers")
+  @get
+  list(
+    @query("api-version") apiVersion: string,
+    @path subscriptionId: string,
+    @path resourceGroupName: string,
+
+    /**
+     * Cosmos DB region, with spaces between words and each word capitalized.
+     */
+    @path
+    location: string,
+
+    /**
+     * Cosmos DB database account name.
+     */
+    @maxLength(50)
+    @minLength(3)
+    @pattern("^[a-z0-9]+(-[a-z0-9]+)*")
+    @path
+    accountName: string,
+
+    /**
+     * Cosmos DB SQL database name.
+     */
+    @maxLength(255)
+    @minLength(1)
+    @pattern("^[^/\\\\#?]+$")
+    @path
+    databaseName: string,
+  ): ArmResponse<SoftDeletedSqlContainersListResult> | Azure.ResourceManager.CommonTypes.ErrorResponse;
+
+  /**
+   * Performs a soft delete action (restore or permanently delete) on a soft-deleted Azure Cosmos DB SQL container.
+   */
+  @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}/softDeletedSqlContainers/{containerName}")
+  @delete
+  delete(
+    @path subscriptionId: string,
+    @path resourceGroupName: string,
+
+    /**
+     * Cosmos DB region, with spaces between words and each word capitalized.
+     */
+    @path
+    location: string,
+
+    /**
+     * Cosmos DB database account name.
+     */
+    @maxLength(50)
+    @minLength(3)
+    @pattern("^[a-z0-9]+(-[a-z0-9]+)*")
+    @path
+    accountName: string,
+
+    /**
+     * Cosmos DB SQL database name.
+     */
+    @maxLength(255)
+    @minLength(1)
+    @pattern("^[^/\\\\#?]+$")
+    @path
+    databaseName: string,
+
+    /**
+     * Cosmos DB SQL container name.
+     */
+    @maxLength(255)
+    @minLength(1)
+    @pattern("^[^/\\\\#?]+$")
+    @path
+    containerName: string,
+
+    @query("api-version") apiVersion: string,
+
+    /**
+     * The kind of soft delete action to perform.
+     */
+    @query("softDeleteActionKind")
+    softDeleteActionKind?: SoftDeleteActionKind,
+  ): ArmDeleteAcceptedLroResponse | ArmDeletedNoContentResponse | Azure.ResourceManager.CommonTypes.ErrorResponse;
+}

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/SoftDeletedResources.tsp
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/SoftDeletedResources.tsp
@@ -362,7 +362,7 @@ interface SoftDeletedDatabaseAccounts {
     ...Azure.ResourceManager.ApiVersionParameter,
     ...Azure.ResourceManager.SubscriptionIdParameter,
     ...Azure.ResourceManager.ResourceGroupParameter,
-    ...Azure.ResourceManager.LocationParameter,
+    ...Azure.ResourceManager.LocationResourceParameter,
 
     /**
      * Cosmos DB database account name.
@@ -385,7 +385,7 @@ interface SoftDeletedDatabaseAccounts {
   listByLocation(
     ...Azure.ResourceManager.ApiVersionParameter,
     ...Azure.ResourceManager.SubscriptionIdParameter,
-    ...Azure.ResourceManager.LocationParameter,
+    ...Azure.ResourceManager.LocationResourceParameter,
   ): ArmResponse<SoftDeletedDatabaseAccountsListResult> | Azure.ResourceManager.CommonTypes.ErrorResponse;
 
   /**
@@ -398,21 +398,21 @@ interface SoftDeletedDatabaseAccounts {
   listByResourceGroupAndLocation(
     ...Azure.ResourceManager.SubscriptionIdParameter,
     ...Azure.ResourceManager.ResourceGroupParameter,
-    ...Azure.ResourceManager.LocationParameter,
+    ...Azure.ResourceManager.LocationResourceParameter,
     ...Azure.ResourceManager.ApiVersionParameter,
   ): ArmResponse<SoftDeletedDatabaseAccountsListResult> | Azure.ResourceManager.CommonTypes.ErrorResponse;
 
   /**
    * Restores a soft-deleted Azure Cosmos DB database account.
    */
+  #suppress "@azure-tools/typespec-azure-core/no-openapi" "Explicit operationId needed for separate Restore/Purge SDK methods"
   @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}?softDeleteActionKind=RestoreSoftDeletedResource")
   @delete
-  #suppress "@azure-tools/typespec-azure-core/no-openapi" "Explicit operationId needed for separate Restore/Purge SDK methods"
   @operationId("SoftDeletedDatabaseAccounts_Restore")
   restore(
     ...Azure.ResourceManager.SubscriptionIdParameter,
     ...Azure.ResourceManager.ResourceGroupParameter,
-    ...Azure.ResourceManager.LocationParameter,
+    ...Azure.ResourceManager.LocationResourceParameter,
 
     /**
      * Cosmos DB database account name.
@@ -435,14 +435,14 @@ interface SoftDeletedDatabaseAccounts {
   /**
    * Permanently deletes (purges) a soft-deleted Azure Cosmos DB database account.
    */
+  #suppress "@azure-tools/typespec-azure-core/no-openapi" "Explicit operationId needed for separate Restore/Purge SDK methods"
   @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}?softDeleteActionKind=PermanentDeleteResource")
   @delete
-  #suppress "@azure-tools/typespec-azure-core/no-openapi" "Explicit operationId needed for separate Restore/Purge SDK methods"
   @operationId("SoftDeletedDatabaseAccounts_Purge")
   purge(
     ...Azure.ResourceManager.SubscriptionIdParameter,
     ...Azure.ResourceManager.ResourceGroupParameter,
-    ...Azure.ResourceManager.LocationParameter,
+    ...Azure.ResourceManager.LocationResourceParameter,
 
     /**
      * Cosmos DB database account name.
@@ -480,7 +480,7 @@ interface SoftDeletedSqlDatabases {
     ...Azure.ResourceManager.ApiVersionParameter,
     ...Azure.ResourceManager.SubscriptionIdParameter,
     ...Azure.ResourceManager.ResourceGroupParameter,
-    ...Azure.ResourceManager.LocationParameter,
+    ...Azure.ResourceManager.LocationResourceParameter,
 
     /**
      * Cosmos DB database account name.
@@ -494,6 +494,7 @@ interface SoftDeletedSqlDatabases {
     /**
      * Cosmos DB SQL database name.
      */
+    @pattern("^[^/\\\\#?]+$")
     @path
     databaseName: string,
   ): ArmResponse<SoftDeletedSqlDatabaseGetResult> | Azure.ResourceManager.CommonTypes.ErrorResponse;
@@ -509,7 +510,7 @@ interface SoftDeletedSqlDatabases {
     ...Azure.ResourceManager.ApiVersionParameter,
     ...Azure.ResourceManager.SubscriptionIdParameter,
     ...Azure.ResourceManager.ResourceGroupParameter,
-    ...Azure.ResourceManager.LocationParameter,
+    ...Azure.ResourceManager.LocationResourceParameter,
 
     /**
      * Cosmos DB database account name.
@@ -524,14 +525,14 @@ interface SoftDeletedSqlDatabases {
   /**
    * Restores a soft-deleted Azure Cosmos DB SQL database.
    */
+  #suppress "@azure-tools/typespec-azure-core/no-openapi" "Explicit operationId needed for separate Restore/Purge SDK methods"
   @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}?softDeleteActionKind=RestoreSoftDeletedResource")
   @delete
-  #suppress "@azure-tools/typespec-azure-core/no-openapi" "Explicit operationId needed for separate Restore/Purge SDK methods"
   @operationId("SoftDeletedSqlDatabases_Restore")
   restore(
     ...Azure.ResourceManager.SubscriptionIdParameter,
     ...Azure.ResourceManager.ResourceGroupParameter,
-    ...Azure.ResourceManager.LocationParameter,
+    ...Azure.ResourceManager.LocationResourceParameter,
 
     /**
      * Cosmos DB database account name.
@@ -545,6 +546,7 @@ interface SoftDeletedSqlDatabases {
     /**
      * Cosmos DB SQL database name.
      */
+    @pattern("^[^/\\\\#?]+$")
     @path
     databaseName: string,
 
@@ -560,14 +562,14 @@ interface SoftDeletedSqlDatabases {
   /**
    * Permanently deletes a soft-deleted Azure Cosmos DB SQL database.
    */
+  #suppress "@azure-tools/typespec-azure-core/no-openapi" "Explicit operationId needed for separate Restore/Purge SDK methods"
   @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}?softDeleteActionKind=PermanentDeleteResource")
   @delete
-  #suppress "@azure-tools/typespec-azure-core/no-openapi" "Explicit operationId needed for separate Restore/Purge SDK methods"
   @operationId("SoftDeletedSqlDatabases_Purge")
   purge(
     ...Azure.ResourceManager.SubscriptionIdParameter,
     ...Azure.ResourceManager.ResourceGroupParameter,
-    ...Azure.ResourceManager.LocationParameter,
+    ...Azure.ResourceManager.LocationResourceParameter,
 
     /**
      * Cosmos DB database account name.
@@ -581,6 +583,7 @@ interface SoftDeletedSqlDatabases {
     /**
      * Cosmos DB SQL database name.
      */
+    @pattern("^[^/\\\\#?]+$")
     @path
     databaseName: string,
 
@@ -611,7 +614,7 @@ interface SoftDeletedSqlContainers {
     ...Azure.ResourceManager.ApiVersionParameter,
     ...Azure.ResourceManager.SubscriptionIdParameter,
     ...Azure.ResourceManager.ResourceGroupParameter,
-    ...Azure.ResourceManager.LocationParameter,
+    ...Azure.ResourceManager.LocationResourceParameter,
 
     /**
      * Cosmos DB database account name.
@@ -625,12 +628,14 @@ interface SoftDeletedSqlContainers {
     /**
      * Cosmos DB SQL database name.
      */
+    @pattern("^[^/\\\\#?]+$")
     @path
     databaseName: string,
 
     /**
      * Cosmos DB SQL container name.
      */
+    @pattern("^[^/\\\\#?]+$")
     @path
     containerName: string,
   ): ArmResponse<SoftDeletedSqlContainerGetResult> | Azure.ResourceManager.CommonTypes.ErrorResponse;
@@ -646,7 +651,7 @@ interface SoftDeletedSqlContainers {
     ...Azure.ResourceManager.ApiVersionParameter,
     ...Azure.ResourceManager.SubscriptionIdParameter,
     ...Azure.ResourceManager.ResourceGroupParameter,
-    ...Azure.ResourceManager.LocationParameter,
+    ...Azure.ResourceManager.LocationResourceParameter,
 
     /**
      * Cosmos DB database account name.
@@ -660,6 +665,7 @@ interface SoftDeletedSqlContainers {
     /**
      * Cosmos DB SQL database name.
      */
+    @pattern("^[^/\\\\#?]+$")
     @path
     databaseName: string,
   ): ArmResponse<SoftDeletedSqlContainersListResult> | Azure.ResourceManager.CommonTypes.ErrorResponse;
@@ -667,14 +673,14 @@ interface SoftDeletedSqlContainers {
   /**
    * Restores a soft-deleted Azure Cosmos DB SQL container to active state.
    */
+  #suppress "@azure-tools/typespec-azure-core/no-openapi" "Explicit operationId needed for separate Restore/Purge SDK methods"
   @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}/softDeletedSqlContainers/{containerName}?softDeleteActionKind=RestoreSoftDeletedResource")
   @delete
-  #suppress "@azure-tools/typespec-azure-core/no-openapi" "Explicit operationId needed for separate Restore/Purge SDK methods"
   @operationId("SoftDeletedSqlContainers_Restore")
   restore(
     ...Azure.ResourceManager.SubscriptionIdParameter,
     ...Azure.ResourceManager.ResourceGroupParameter,
-    ...Azure.ResourceManager.LocationParameter,
+    ...Azure.ResourceManager.LocationResourceParameter,
 
     /**
      * Cosmos DB database account name.
@@ -688,12 +694,14 @@ interface SoftDeletedSqlContainers {
     /**
      * Cosmos DB SQL database name.
      */
+    @pattern("^[^/\\\\#?]+$")
     @path
     databaseName: string,
 
     /**
      * Cosmos DB SQL container name.
      */
+    @pattern("^[^/\\\\#?]+$")
     @path
     containerName: string,
 
@@ -709,14 +717,14 @@ interface SoftDeletedSqlContainers {
   /**
    * Permanently deletes a soft-deleted Azure Cosmos DB SQL container.
    */
+  #suppress "@azure-tools/typespec-azure-core/no-openapi" "Explicit operationId needed for separate Restore/Purge SDK methods"
   @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}/softDeletedSqlContainers/{containerName}?softDeleteActionKind=PermanentDeleteResource")
   @delete
-  #suppress "@azure-tools/typespec-azure-core/no-openapi" "Explicit operationId needed for separate Restore/Purge SDK methods"
   @operationId("SoftDeletedSqlContainers_Purge")
   purge(
     ...Azure.ResourceManager.SubscriptionIdParameter,
     ...Azure.ResourceManager.ResourceGroupParameter,
-    ...Azure.ResourceManager.LocationParameter,
+    ...Azure.ResourceManager.LocationResourceParameter,
 
     /**
      * Cosmos DB database account name.
@@ -730,12 +738,14 @@ interface SoftDeletedSqlContainers {
     /**
      * Cosmos DB SQL database name.
      */
+    @pattern("^[^/\\\\#?]+$")
     @path
     databaseName: string,
 
     /**
      * Cosmos DB SQL container name.
      */
+    @pattern("^[^/\\\\#?]+$")
     @path
     containerName: string,
 

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/SoftDeletedResources.tsp
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/SoftDeletedResources.tsp
@@ -403,11 +403,45 @@ interface SoftDeletedDatabaseAccounts {
   ): ArmResponse<SoftDeletedDatabaseAccountsListResult> | Azure.ResourceManager.CommonTypes.ErrorResponse;
 
   /**
-   * Performs a soft delete action (restore or permanently delete) on a soft-deleted Azure Cosmos DB database account.
+   * Restores a soft-deleted Azure Cosmos DB database account.
    */
+  @sharedRoute
   @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}")
   @delete
-  delete(
+  #suppress "@azure-tools/typespec-azure-core/no-openapi" "Explicit operationId needed for separate Restore/Purge SDK methods"
+  @operationId("SoftDeletedDatabaseAccounts_Restore")
+  restore(
+    ...Azure.ResourceManager.SubscriptionIdParameter,
+    ...Azure.ResourceManager.ResourceGroupParameter,
+    ...Azure.ResourceManager.LocationParameter,
+
+    /**
+     * Cosmos DB database account name.
+     */
+    @maxLength(50)
+    @minLength(3)
+    @pattern("^[a-z0-9]+(-[a-z0-9]+)*")
+    @path
+    accountName: string,
+
+    ...Azure.ResourceManager.ApiVersionParameter,
+
+    /**
+     * The kind of soft delete action to perform.
+     */
+    @query("softDeleteActionKind")
+    softDeleteActionKind?: SoftDeleteActionKind,
+  ): ArmDeleteAcceptedLroResponse | ArmDeletedNoContentResponse | Azure.ResourceManager.CommonTypes.ErrorResponse;
+
+  /**
+   * Permanently deletes (purges) a soft-deleted Azure Cosmos DB database account.
+   */
+  @sharedRoute
+  @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}")
+  @delete
+  #suppress "@azure-tools/typespec-azure-core/no-openapi" "Explicit operationId needed for separate Restore/Purge SDK methods"
+  @operationId("SoftDeletedDatabaseAccounts_Purge")
+  purge(
     ...Azure.ResourceManager.SubscriptionIdParameter,
     ...Azure.ResourceManager.ResourceGroupParameter,
     ...Azure.ResourceManager.LocationParameter,
@@ -493,11 +527,54 @@ interface SoftDeletedSqlDatabases {
   ): ArmResponse<SoftDeletedSqlDatabasesListResult> | Azure.ResourceManager.CommonTypes.ErrorResponse;
 
   /**
-   * Performs a soft delete action (restore or permanently delete) on a soft-deleted Azure Cosmos DB SQL database.
+   * Restores a soft-deleted Azure Cosmos DB SQL database.
    */
+  @sharedRoute
   @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}")
   @delete
-  delete(
+  #suppress "@azure-tools/typespec-azure-core/no-openapi" "Explicit operationId needed for separate Restore/Purge SDK methods"
+  @operationId("SoftDeletedSqlDatabases_Restore")
+  restore(
+    ...Azure.ResourceManager.SubscriptionIdParameter,
+    ...Azure.ResourceManager.ResourceGroupParameter,
+    ...Azure.ResourceManager.LocationParameter,
+
+    /**
+     * Cosmos DB database account name.
+     */
+    @maxLength(50)
+    @minLength(3)
+    @pattern("^[a-z0-9]+(-[a-z0-9]+)*")
+    @path
+    accountName: string,
+
+    /**
+     * Cosmos DB SQL database name.
+     */
+    @maxLength(255)
+    @minLength(1)
+    @pattern("^[^/\\\\#?]+$")
+    @path
+    databaseName: string,
+
+    ...Azure.ResourceManager.ApiVersionParameter,
+
+    /**
+     * The kind of soft delete action to perform.
+     */
+    @query("softDeleteActionKind")
+    softDeleteActionKind?: SoftDeleteActionKind,
+  ): ArmDeleteAcceptedLroResponse | ArmDeletedNoContentResponse | Azure.ResourceManager.CommonTypes.ErrorResponse;
+
+  /**
+   * Permanently deletes a soft-deleted Azure Cosmos DB SQL database.
+   */
+  @sharedRoute
+  @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}")
+  @delete
+  #suppress "@azure-tools/typespec-azure-core/no-openapi" "Explicit operationId needed for separate Restore/Purge SDK methods"
+  @operationId("SoftDeletedSqlDatabases_Purge")
+  purge(
     ...Azure.ResourceManager.SubscriptionIdParameter,
     ...Azure.ResourceManager.ResourceGroupParameter,
     ...Azure.ResourceManager.LocationParameter,
@@ -610,11 +687,63 @@ interface SoftDeletedSqlContainers {
   ): ArmResponse<SoftDeletedSqlContainersListResult> | Azure.ResourceManager.CommonTypes.ErrorResponse;
 
   /**
-   * Performs a soft delete action (restore or permanently delete) on a soft-deleted Azure Cosmos DB SQL container.
+   * Restores a soft-deleted Azure Cosmos DB SQL container to active state.
    */
+  @sharedRoute
   @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}/softDeletedSqlContainers/{containerName}")
   @delete
-  delete(
+  #suppress "@azure-tools/typespec-azure-core/no-openapi" "Explicit operationId needed for separate Restore/Purge SDK methods"
+  @operationId("SoftDeletedSqlContainers_Restore")
+  restore(
+    ...Azure.ResourceManager.SubscriptionIdParameter,
+    ...Azure.ResourceManager.ResourceGroupParameter,
+    ...Azure.ResourceManager.LocationParameter,
+
+    /**
+     * Cosmos DB database account name.
+     */
+    @maxLength(50)
+    @minLength(3)
+    @pattern("^[a-z0-9]+(-[a-z0-9]+)*")
+    @path
+    accountName: string,
+
+    /**
+     * Cosmos DB SQL database name.
+     */
+    @maxLength(255)
+    @minLength(1)
+    @pattern("^[^/\\\\#?]+$")
+    @path
+    databaseName: string,
+
+    /**
+     * Cosmos DB SQL container name.
+     */
+    @maxLength(255)
+    @minLength(1)
+    @pattern("^[^/\\\\#?]+$")
+    @path
+    containerName: string,
+
+    ...Azure.ResourceManager.ApiVersionParameter,
+
+    /**
+     * The kind of soft delete action to perform.
+     */
+    @query("softDeleteActionKind")
+    softDeleteActionKind?: SoftDeleteActionKind,
+  ): ArmDeleteAcceptedLroResponse | ArmDeletedNoContentResponse | Azure.ResourceManager.CommonTypes.ErrorResponse;
+
+  /**
+   * Permanently deletes a soft-deleted Azure Cosmos DB SQL container.
+   */
+  @sharedRoute
+  @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}/softDeletedSqlContainers/{containerName}")
+  @delete
+  #suppress "@azure-tools/typespec-azure-core/no-openapi" "Explicit operationId needed for separate Restore/Purge SDK methods"
+  @operationId("SoftDeletedSqlContainers_Purge")
+  purge(
     ...Azure.ResourceManager.SubscriptionIdParameter,
     ...Azure.ResourceManager.ResourceGroupParameter,
     ...Azure.ResourceManager.LocationParameter,

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/SoftDeletedResources.tsp
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/SoftDeletedResources.tsp
@@ -405,8 +405,7 @@ interface SoftDeletedDatabaseAccounts {
   /**
    * Restores a soft-deleted Azure Cosmos DB database account.
    */
-  @sharedRoute
-  @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}")
+  @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}?softDeleteActionKind=RestoreSoftDeletedResource")
   @delete
   #suppress "@azure-tools/typespec-azure-core/no-openapi" "Explicit operationId needed for separate Restore/Purge SDK methods"
   @operationId("SoftDeletedDatabaseAccounts_Restore")
@@ -436,8 +435,7 @@ interface SoftDeletedDatabaseAccounts {
   /**
    * Permanently deletes (purges) a soft-deleted Azure Cosmos DB database account.
    */
-  @sharedRoute
-  @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}")
+  @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}?softDeleteActionKind=PermanentDeleteResource")
   @delete
   #suppress "@azure-tools/typespec-azure-core/no-openapi" "Explicit operationId needed for separate Restore/Purge SDK methods"
   @operationId("SoftDeletedDatabaseAccounts_Purge")
@@ -529,8 +527,7 @@ interface SoftDeletedSqlDatabases {
   /**
    * Restores a soft-deleted Azure Cosmos DB SQL database.
    */
-  @sharedRoute
-  @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}")
+  @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}?softDeleteActionKind=RestoreSoftDeletedResource")
   @delete
   #suppress "@azure-tools/typespec-azure-core/no-openapi" "Explicit operationId needed for separate Restore/Purge SDK methods"
   @operationId("SoftDeletedSqlDatabases_Restore")
@@ -569,8 +566,7 @@ interface SoftDeletedSqlDatabases {
   /**
    * Permanently deletes a soft-deleted Azure Cosmos DB SQL database.
    */
-  @sharedRoute
-  @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}")
+  @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}?softDeleteActionKind=PermanentDeleteResource")
   @delete
   #suppress "@azure-tools/typespec-azure-core/no-openapi" "Explicit operationId needed for separate Restore/Purge SDK methods"
   @operationId("SoftDeletedSqlDatabases_Purge")
@@ -689,8 +685,7 @@ interface SoftDeletedSqlContainers {
   /**
    * Restores a soft-deleted Azure Cosmos DB SQL container to active state.
    */
-  @sharedRoute
-  @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}/softDeletedSqlContainers/{containerName}")
+  @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}/softDeletedSqlContainers/{containerName}?softDeleteActionKind=RestoreSoftDeletedResource")
   @delete
   #suppress "@azure-tools/typespec-azure-core/no-openapi" "Explicit operationId needed for separate Restore/Purge SDK methods"
   @operationId("SoftDeletedSqlContainers_Restore")
@@ -738,8 +733,7 @@ interface SoftDeletedSqlContainers {
   /**
    * Permanently deletes a soft-deleted Azure Cosmos DB SQL container.
    */
-  @sharedRoute
-  @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}/softDeletedSqlContainers/{containerName}")
+  @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}/softDeletedSqlContainers/{containerName}?softDeleteActionKind=PermanentDeleteResource")
   @delete
   #suppress "@azure-tools/typespec-azure-core/no-openapi" "Explicit operationId needed for separate Restore/Purge SDK methods"
   @operationId("SoftDeletedSqlContainers_Purge")

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/SoftDeletedResources.tsp
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/SoftDeletedResources.tsp
@@ -494,9 +494,6 @@ interface SoftDeletedSqlDatabases {
     /**
      * Cosmos DB SQL database name.
      */
-    @maxLength(255)
-    @minLength(1)
-    @pattern("^[^/\\\\#?]+$")
     @path
     databaseName: string,
   ): ArmResponse<SoftDeletedSqlDatabaseGetResult> | Azure.ResourceManager.CommonTypes.ErrorResponse;
@@ -548,9 +545,6 @@ interface SoftDeletedSqlDatabases {
     /**
      * Cosmos DB SQL database name.
      */
-    @maxLength(255)
-    @minLength(1)
-    @pattern("^[^/\\\\#?]+$")
     @path
     databaseName: string,
 
@@ -587,9 +581,6 @@ interface SoftDeletedSqlDatabases {
     /**
      * Cosmos DB SQL database name.
      */
-    @maxLength(255)
-    @minLength(1)
-    @pattern("^[^/\\\\#?]+$")
     @path
     databaseName: string,
 
@@ -634,18 +625,12 @@ interface SoftDeletedSqlContainers {
     /**
      * Cosmos DB SQL database name.
      */
-    @maxLength(255)
-    @minLength(1)
-    @pattern("^[^/\\\\#?]+$")
     @path
     databaseName: string,
 
     /**
      * Cosmos DB SQL container name.
      */
-    @maxLength(255)
-    @minLength(1)
-    @pattern("^[^/\\\\#?]+$")
     @path
     containerName: string,
   ): ArmResponse<SoftDeletedSqlContainerGetResult> | Azure.ResourceManager.CommonTypes.ErrorResponse;
@@ -675,9 +660,6 @@ interface SoftDeletedSqlContainers {
     /**
      * Cosmos DB SQL database name.
      */
-    @maxLength(255)
-    @minLength(1)
-    @pattern("^[^/\\\\#?]+$")
     @path
     databaseName: string,
   ): ArmResponse<SoftDeletedSqlContainersListResult> | Azure.ResourceManager.CommonTypes.ErrorResponse;
@@ -706,18 +688,12 @@ interface SoftDeletedSqlContainers {
     /**
      * Cosmos DB SQL database name.
      */
-    @maxLength(255)
-    @minLength(1)
-    @pattern("^[^/\\\\#?]+$")
     @path
     databaseName: string,
 
     /**
      * Cosmos DB SQL container name.
      */
-    @maxLength(255)
-    @minLength(1)
-    @pattern("^[^/\\\\#?]+$")
     @path
     containerName: string,
 
@@ -754,18 +730,12 @@ interface SoftDeletedSqlContainers {
     /**
      * Cosmos DB SQL database name.
      */
-    @maxLength(255)
-    @minLength(1)
-    @pattern("^[^/\\\\#?]+$")
     @path
     databaseName: string,
 
     /**
      * Cosmos DB SQL container name.
      */
-    @maxLength(255)
-    @minLength(1)
-    @pattern("^[^/\\\\#?]+$")
     @path
     containerName: string,
 

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/SoftDeletedResources.tsp
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/SoftDeletedResources.tsp
@@ -135,6 +135,8 @@ model SoftDeletedDatabaseAccountGetResult {
   /**
    * The location of the resource group to which the resource belongs.
    */
+  #suppress "@azure-tools/typespec-azure-core/no-openapi" "x-ms-mutability is required for ARM location property"
+  @extension("x-ms-mutability", #["read", "create"])
   location?: string;
 }
 
@@ -222,6 +224,8 @@ model SoftDeletedSqlDatabaseGetResult {
   /**
    * The location of the resource group to which the resource belongs.
    */
+  #suppress "@azure-tools/typespec-azure-core/no-openapi" "x-ms-mutability is required for ARM location property"
+  @extension("x-ms-mutability", #["read", "create"])
   location?: string;
 }
 
@@ -319,6 +323,8 @@ model SoftDeletedSqlContainerGetResult {
   /**
    * The location of the resource group to which the resource belongs.
    */
+  #suppress "@azure-tools/typespec-azure-core/no-openapi" "x-ms-mutability is required for ARM location property"
+  @extension("x-ms-mutability", #["read", "create"])
   location?: string;
 }
 
@@ -357,11 +363,7 @@ interface SoftDeletedDatabaseAccounts {
     ...Azure.ResourceManager.SubscriptionIdParameter,
     ...Azure.ResourceManager.ResourceGroupParameter,
 
-    /**
-     * Cosmos DB region, with spaces between words and each word capitalized.
-     */
-    @path
-    location: string,
+    ...Azure.ResourceManager.LocationParameter,
 
     /**
      * Cosmos DB database account name.
@@ -378,17 +380,14 @@ interface SoftDeletedDatabaseAccounts {
    */
   @route("/subscriptions/{subscriptionId}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts")
   @get
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "Custom operation for soft-deleted resources"
   #suppress "@azure-tools/typespec-azure-core/no-openapi" "x-ms-pageable is required for ARM list operations"
   @extension("x-ms-pageable", #{nextLinkName: "nextLink"})
   listByLocation(
     ...Azure.ResourceManager.ApiVersionParameter,
     ...Azure.ResourceManager.SubscriptionIdParameter,
 
-    /**
-     * Cosmos DB region, with spaces between words and each word capitalized.
-     */
-    @path
-    location: string,
+    ...Azure.ResourceManager.LocationParameter,
   ): ArmResponse<SoftDeletedDatabaseAccountsListResult> | Azure.ResourceManager.CommonTypes.ErrorResponse;
 
   /**
@@ -402,11 +401,7 @@ interface SoftDeletedDatabaseAccounts {
     ...Azure.ResourceManager.SubscriptionIdParameter,
     ...Azure.ResourceManager.ResourceGroupParameter,
 
-    /**
-     * Cosmos DB region, with spaces between words and each word capitalized.
-     */
-    @path
-    location: string,
+    ...Azure.ResourceManager.LocationParameter,
 
     ...Azure.ResourceManager.ApiVersionParameter,
   ): ArmResponse<SoftDeletedDatabaseAccountsListResult> | Azure.ResourceManager.CommonTypes.ErrorResponse;
@@ -420,11 +415,7 @@ interface SoftDeletedDatabaseAccounts {
     ...Azure.ResourceManager.SubscriptionIdParameter,
     ...Azure.ResourceManager.ResourceGroupParameter,
 
-    /**
-     * Cosmos DB region, with spaces between words and each word capitalized.
-     */
-    @path
-    location: string,
+    ...Azure.ResourceManager.LocationParameter,
 
     /**
      * Cosmos DB database account name.
@@ -463,11 +454,7 @@ interface SoftDeletedSqlDatabases {
     ...Azure.ResourceManager.SubscriptionIdParameter,
     ...Azure.ResourceManager.ResourceGroupParameter,
 
-    /**
-     * Cosmos DB region, with spaces between words and each word capitalized.
-     */
-    @path
-    location: string,
+    ...Azure.ResourceManager.LocationParameter,
 
     /**
      * Cosmos DB database account name.
@@ -500,11 +487,7 @@ interface SoftDeletedSqlDatabases {
     ...Azure.ResourceManager.SubscriptionIdParameter,
     ...Azure.ResourceManager.ResourceGroupParameter,
 
-    /**
-     * Cosmos DB region, with spaces between words and each word capitalized.
-     */
-    @path
-    location: string,
+    ...Azure.ResourceManager.LocationParameter,
 
     /**
      * Cosmos DB database account name.
@@ -525,11 +508,7 @@ interface SoftDeletedSqlDatabases {
     ...Azure.ResourceManager.SubscriptionIdParameter,
     ...Azure.ResourceManager.ResourceGroupParameter,
 
-    /**
-     * Cosmos DB region, with spaces between words and each word capitalized.
-     */
-    @path
-    location: string,
+    ...Azure.ResourceManager.LocationParameter,
 
     /**
      * Cosmos DB database account name.
@@ -577,11 +556,7 @@ interface SoftDeletedSqlContainers {
     ...Azure.ResourceManager.SubscriptionIdParameter,
     ...Azure.ResourceManager.ResourceGroupParameter,
 
-    /**
-     * Cosmos DB region, with spaces between words and each word capitalized.
-     */
-    @path
-    location: string,
+    ...Azure.ResourceManager.LocationParameter,
 
     /**
      * Cosmos DB database account name.
@@ -623,11 +598,7 @@ interface SoftDeletedSqlContainers {
     ...Azure.ResourceManager.SubscriptionIdParameter,
     ...Azure.ResourceManager.ResourceGroupParameter,
 
-    /**
-     * Cosmos DB region, with spaces between words and each word capitalized.
-     */
-    @path
-    location: string,
+    ...Azure.ResourceManager.LocationParameter,
 
     /**
      * Cosmos DB database account name.
@@ -657,11 +628,7 @@ interface SoftDeletedSqlContainers {
     ...Azure.ResourceManager.SubscriptionIdParameter,
     ...Azure.ResourceManager.ResourceGroupParameter,
 
-    /**
-     * Cosmos DB region, with spaces between words and each word capitalized.
-     */
-    @path
-    location: string,
+    ...Azure.ResourceManager.LocationParameter,
 
     /**
      * Cosmos DB database account name.

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/SoftDeletedResources.tsp
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/SoftDeletedResources.tsp
@@ -147,6 +147,11 @@ model SoftDeletedDatabaseAccountsListResult {
    */
   @visibility(Lifecycle.Read)
   value?: SoftDeletedDatabaseAccountGetResult[];
+
+  /**
+   * The URL to get the next set of results.
+   */
+  nextLink?: string;
 }
 
 @added(Versions.v2026_04_01_preview)
@@ -163,8 +168,8 @@ model SoftDeletedSqlDatabaseResource {
    * A system generated property. A unique identifier.
    */
   @visibility(Lifecycle.Read)
-  @encodedName("application/json", "_rid")
-  rid?: string;
+  #suppress "@azure-tools/typespec-azure-core/casing-style" "_rid is a backend property"
+  _rid?: string;
 }
 
 @added(Versions.v2026_04_01_preview)
@@ -228,6 +233,11 @@ model SoftDeletedSqlDatabasesListResult {
    */
   @visibility(Lifecycle.Read)
   value?: SoftDeletedSqlDatabaseGetResult[];
+
+  /**
+   * The URL to get the next set of results.
+   */
+  nextLink?: string;
 }
 
 @added(Versions.v2026_04_01_preview)
@@ -244,8 +254,8 @@ model SoftDeletedSqlContainerResource {
    * A system generated property. A unique identifier.
    */
   @visibility(Lifecycle.Read)
-  @encodedName("application/json", "_rid")
-  rid?: string;
+  #suppress "@azure-tools/typespec-azure-core/casing-style" "_rid is a backend property"
+  _rid?: string;
 
   /**
    * The configuration of the partition key to be used for partitioning data into multiple partitions
@@ -319,6 +329,11 @@ model SoftDeletedSqlContainersListResult {
    */
   @visibility(Lifecycle.Read)
   value?: SoftDeletedSqlContainerGetResult[];
+
+  /**
+   * The URL to get the next set of results.
+   */
+  nextLink?: string;
 }
 
 // ──────────────────────────────────────────────
@@ -335,9 +350,9 @@ interface SoftDeletedDatabaseAccounts {
   @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}")
   @get
   get(
-    @query("api-version") apiVersion: string,
-    @path subscriptionId: string,
-    @path resourceGroupName: string,
+    ...Azure.ResourceManager.ApiVersionParameter,
+    ...Azure.ResourceManager.SubscriptionIdParameter,
+    ...Azure.ResourceManager.ResourceGroupParameter,
 
     /**
      * Cosmos DB region, with spaces between words and each word capitalized.
@@ -360,9 +375,10 @@ interface SoftDeletedDatabaseAccounts {
    */
   @route("/subscriptions/{subscriptionId}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts")
   @get
+  @extension("x-ms-pageable", #{nextLinkName: "nextLink"})
   listByLocation(
-    @query("api-version") apiVersion: string,
-    @path subscriptionId: string,
+    ...Azure.ResourceManager.ApiVersionParameter,
+    ...Azure.ResourceManager.SubscriptionIdParameter,
 
     /**
      * Cosmos DB region, with spaces between words and each word capitalized.
@@ -376,9 +392,10 @@ interface SoftDeletedDatabaseAccounts {
    */
   @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts")
   @get
+  @extension("x-ms-pageable", #{nextLinkName: "nextLink"})
   listByResourceGroupAndLocation(
-    @path subscriptionId: string,
-    @path resourceGroupName: string,
+    ...Azure.ResourceManager.SubscriptionIdParameter,
+    ...Azure.ResourceManager.ResourceGroupParameter,
 
     /**
      * Cosmos DB region, with spaces between words and each word capitalized.
@@ -386,7 +403,7 @@ interface SoftDeletedDatabaseAccounts {
     @path
     location: string,
 
-    @query("api-version") apiVersion: string,
+    ...Azure.ResourceManager.ApiVersionParameter,
   ): ArmResponse<SoftDeletedDatabaseAccountsListResult> | Azure.ResourceManager.CommonTypes.ErrorResponse;
 
   /**
@@ -395,8 +412,8 @@ interface SoftDeletedDatabaseAccounts {
   @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}")
   @delete
   delete(
-    @path subscriptionId: string,
-    @path resourceGroupName: string,
+    ...Azure.ResourceManager.SubscriptionIdParameter,
+    ...Azure.ResourceManager.ResourceGroupParameter,
 
     /**
      * Cosmos DB region, with spaces between words and each word capitalized.
@@ -413,7 +430,7 @@ interface SoftDeletedDatabaseAccounts {
     @path
     accountName: string,
 
-    @query("api-version") apiVersion: string,
+    ...Azure.ResourceManager.ApiVersionParameter,
 
     /**
      * The kind of soft delete action to perform.
@@ -437,9 +454,9 @@ interface SoftDeletedSqlDatabases {
   @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}")
   @get
   get(
-    @query("api-version") apiVersion: string,
-    @path subscriptionId: string,
-    @path resourceGroupName: string,
+    ...Azure.ResourceManager.ApiVersionParameter,
+    ...Azure.ResourceManager.SubscriptionIdParameter,
+    ...Azure.ResourceManager.ResourceGroupParameter,
 
     /**
      * Cosmos DB region, with spaces between words and each word capitalized.
@@ -471,10 +488,11 @@ interface SoftDeletedSqlDatabases {
    */
   @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases")
   @get
+  @extension("x-ms-pageable", #{nextLinkName: "nextLink"})
   list(
-    @query("api-version") apiVersion: string,
-    @path subscriptionId: string,
-    @path resourceGroupName: string,
+    ...Azure.ResourceManager.ApiVersionParameter,
+    ...Azure.ResourceManager.SubscriptionIdParameter,
+    ...Azure.ResourceManager.ResourceGroupParameter,
 
     /**
      * Cosmos DB region, with spaces between words and each word capitalized.
@@ -498,8 +516,8 @@ interface SoftDeletedSqlDatabases {
   @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}")
   @delete
   delete(
-    @path subscriptionId: string,
-    @path resourceGroupName: string,
+    ...Azure.ResourceManager.SubscriptionIdParameter,
+    ...Azure.ResourceManager.ResourceGroupParameter,
 
     /**
      * Cosmos DB region, with spaces between words and each word capitalized.
@@ -525,7 +543,7 @@ interface SoftDeletedSqlDatabases {
     @path
     databaseName: string,
 
-    @query("api-version") apiVersion: string,
+    ...Azure.ResourceManager.ApiVersionParameter,
 
     /**
      * The kind of soft delete action to perform.
@@ -549,9 +567,9 @@ interface SoftDeletedSqlContainers {
   @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}/softDeletedSqlContainers/{containerName}")
   @get
   get(
-    @query("api-version") apiVersion: string,
-    @path subscriptionId: string,
-    @path resourceGroupName: string,
+    ...Azure.ResourceManager.ApiVersionParameter,
+    ...Azure.ResourceManager.SubscriptionIdParameter,
+    ...Azure.ResourceManager.ResourceGroupParameter,
 
     /**
      * Cosmos DB region, with spaces between words and each word capitalized.
@@ -592,10 +610,11 @@ interface SoftDeletedSqlContainers {
    */
   @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}/softDeletedSqlContainers")
   @get
+  @extension("x-ms-pageable", #{nextLinkName: "nextLink"})
   list(
-    @query("api-version") apiVersion: string,
-    @path subscriptionId: string,
-    @path resourceGroupName: string,
+    ...Azure.ResourceManager.ApiVersionParameter,
+    ...Azure.ResourceManager.SubscriptionIdParameter,
+    ...Azure.ResourceManager.ResourceGroupParameter,
 
     /**
      * Cosmos DB region, with spaces between words and each word capitalized.
@@ -628,8 +647,8 @@ interface SoftDeletedSqlContainers {
   @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}/softDeletedSqlContainers/{containerName}")
   @delete
   delete(
-    @path subscriptionId: string,
-    @path resourceGroupName: string,
+    ...Azure.ResourceManager.SubscriptionIdParameter,
+    ...Azure.ResourceManager.ResourceGroupParameter,
 
     /**
      * Cosmos DB region, with spaces between words and each word capitalized.
@@ -664,7 +683,7 @@ interface SoftDeletedSqlContainers {
     @path
     containerName: string,
 
-    @query("api-version") apiVersion: string,
+    ...Azure.ResourceManager.ApiVersionParameter,
 
     /**
      * The kind of soft delete action to perform.

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/SoftDeletedResources.tsp
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/SoftDeletedResources.tsp
@@ -17,10 +17,10 @@ namespace Microsoft.DocumentDB;
 //  Soft-Delete Models
 // ──────────────────────────────────────────────
 
-@added(Versions.v2026_04_01_preview)
 /**
  * The kind of soft delete action to perform.
  */
+@added(Versions.v2026_04_01_preview)
 union SoftDeleteActionKind {
   string,
 
@@ -31,10 +31,10 @@ union SoftDeleteActionKind {
   PermanentDeleteResource: "PermanentDeleteResource",
 }
 
-@added(Versions.v2026_04_01_preview)
 /**
  * Metadata about the soft deletion of a resource.
  */
+@added(Versions.v2026_04_01_preview)
 model SoftDeletionMetadata {
   /**
    * Indicates whether the resource is soft deleted.
@@ -52,10 +52,10 @@ model SoftDeletionMetadata {
   softDeletionResourceExpirationTimestamp?: int64;
 }
 
-@added(Versions.v2026_04_01_preview)
 /**
  * The database account resource information for a soft-deleted account.
  */
+@added(Versions.v2026_04_01_preview)
 model SoftDeletedDatabaseAccountResource {
   /**
    * An array that contains all of the locations enabled for the Cosmos DB account.
@@ -76,10 +76,10 @@ model SoftDeletedDatabaseAccountResource {
   readLocations?: Location[];
 }
 
-@added(Versions.v2026_04_01_preview)
 /**
  * The properties of a soft-deleted database account.
  */
+@added(Versions.v2026_04_01_preview)
 model SoftDeletedDatabaseAccountProperties {
   /**
    * The name of the database account.
@@ -102,10 +102,10 @@ model SoftDeletedDatabaseAccountProperties {
   resource?: SoftDeletedDatabaseAccountResource;
 }
 
-@added(Versions.v2026_04_01_preview)
 /**
  * A Azure Cosmos DB soft-deleted database account.
  */
+@added(Versions.v2026_04_01_preview)
 model SoftDeletedDatabaseAccountGetResult {
   /**
    * The properties of a soft-deleted database account.
@@ -140,10 +140,10 @@ model SoftDeletedDatabaseAccountGetResult {
   location?: string;
 }
 
-@added(Versions.v2026_04_01_preview)
 /**
  * The List operation response, that contains the soft-deleted database accounts and their properties.
  */
+@added(Versions.v2026_04_01_preview)
 model SoftDeletedDatabaseAccountsListResult {
   /**
    * List of soft-deleted database accounts and their properties.
@@ -157,10 +157,10 @@ model SoftDeletedDatabaseAccountsListResult {
   nextLink?: string;
 }
 
-@added(Versions.v2026_04_01_preview)
 /**
  * Cosmos DB SQL database resource object
  */
+@added(Versions.v2026_04_01_preview)
 model SoftDeletedSqlDatabaseResource {
   /**
    * Name of the Cosmos DB SQL database
@@ -170,15 +170,15 @@ model SoftDeletedSqlDatabaseResource {
   /**
    * A system generated property. A unique identifier.
    */
-  @visibility(Lifecycle.Read)
   #suppress "@azure-tools/typespec-azure-core/casing-style" "_rid is a backend property"
+  @visibility(Lifecycle.Read)
   _rid?: string;
 }
 
-@added(Versions.v2026_04_01_preview)
 /**
  * The properties of a soft-deleted SQL database.
  */
+@added(Versions.v2026_04_01_preview)
 model SoftDeletedSqlDatabaseProperties {
   /**
    * Metadata related to the soft deletion of the SQL database.
@@ -191,10 +191,10 @@ model SoftDeletedSqlDatabaseProperties {
   resource?: SoftDeletedSqlDatabaseResource;
 }
 
-@added(Versions.v2026_04_01_preview)
 /**
  * An Azure Cosmos DB soft-deleted SQL database.
  */
+@added(Versions.v2026_04_01_preview)
 model SoftDeletedSqlDatabaseGetResult {
   /**
    * The properties of a soft-deleted SQL database.
@@ -229,10 +229,10 @@ model SoftDeletedSqlDatabaseGetResult {
   location?: string;
 }
 
-@added(Versions.v2026_04_01_preview)
 /**
  * The List operation response, that contains the soft-deleted SQL databases and their properties.
  */
+@added(Versions.v2026_04_01_preview)
 model SoftDeletedSqlDatabasesListResult {
   /**
    * List of soft-deleted SQL databases and their properties.
@@ -246,10 +246,10 @@ model SoftDeletedSqlDatabasesListResult {
   nextLink?: string;
 }
 
-@added(Versions.v2026_04_01_preview)
 /**
  * Cosmos DB SQL container resource object
  */
+@added(Versions.v2026_04_01_preview)
 model SoftDeletedSqlContainerResource {
   /**
    * Name of the Cosmos DB SQL container
@@ -259,8 +259,8 @@ model SoftDeletedSqlContainerResource {
   /**
    * A system generated property. A unique identifier.
    */
-  @visibility(Lifecycle.Read)
   #suppress "@azure-tools/typespec-azure-core/casing-style" "_rid is a backend property"
+  @visibility(Lifecycle.Read)
   _rid?: string;
 
   /**
@@ -274,10 +274,10 @@ model SoftDeletedSqlContainerResource {
   defaultTtl?: int32;
 }
 
-@added(Versions.v2026_04_01_preview)
 /**
  * The properties of a soft-deleted SQL container.
  */
+@added(Versions.v2026_04_01_preview)
 model SoftDeletedSqlContainerProperties {
   /**
    * Metadata related to the soft deletion of the SQL container.
@@ -290,10 +290,10 @@ model SoftDeletedSqlContainerProperties {
   resource?: SoftDeletedSqlContainerResource;
 }
 
-@added(Versions.v2026_04_01_preview)
 /**
  * An Azure Cosmos DB soft-deleted SQL container.
  */
+@added(Versions.v2026_04_01_preview)
 model SoftDeletedSqlContainerGetResult {
   /**
    * The properties of a soft-deleted SQL container.
@@ -328,10 +328,10 @@ model SoftDeletedSqlContainerGetResult {
   location?: string;
 }
 
-@added(Versions.v2026_04_01_preview)
 /**
  * The List operation response, that contains the soft-deleted SQL containers and their properties.
  */
+@added(Versions.v2026_04_01_preview)
 model SoftDeletedSqlContainersListResult {
   /**
    * List of soft-deleted SQL containers and their properties.
@@ -349,9 +349,9 @@ model SoftDeletedSqlContainersListResult {
 //  Soft-Deleted Database Account Operations
 // ──────────────────────────────────────────────
 
-@added(Versions.v2026_04_01_preview)
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-interface-requires-decorator" "Custom routes for soft-deleted resources"
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Custom routes for soft-deleted resources"
+@added(Versions.v2026_04_01_preview)
 interface SoftDeletedDatabaseAccounts {
   /**
    * Retrieves the properties of a soft-deleted Azure Cosmos DB database account by location and accountName. This call requires 'Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/read' permission.
@@ -362,7 +362,6 @@ interface SoftDeletedDatabaseAccounts {
     ...Azure.ResourceManager.ApiVersionParameter,
     ...Azure.ResourceManager.SubscriptionIdParameter,
     ...Azure.ResourceManager.ResourceGroupParameter,
-
     ...Azure.ResourceManager.LocationParameter,
 
     /**
@@ -378,31 +377,28 @@ interface SoftDeletedDatabaseAccounts {
   /**
    * Lists all the soft-deleted Azure Cosmos DB database accounts available under the subscription and in a region. This call requires 'Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/read' permission.
    */
-  @route("/subscriptions/{subscriptionId}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts")
-  @get
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "Custom operation for soft-deleted resources"
   #suppress "@azure-tools/typespec-azure-core/no-openapi" "x-ms-pageable is required for ARM list operations"
-  @extension("x-ms-pageable", #{nextLinkName: "nextLink"})
+  @route("/subscriptions/{subscriptionId}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts")
+  @get
+  @extension("x-ms-pageable", #{ nextLinkName: "nextLink" })
   listByLocation(
     ...Azure.ResourceManager.ApiVersionParameter,
     ...Azure.ResourceManager.SubscriptionIdParameter,
-
     ...Azure.ResourceManager.LocationParameter,
   ): ArmResponse<SoftDeletedDatabaseAccountsListResult> | Azure.ResourceManager.CommonTypes.ErrorResponse;
 
   /**
    * Lists all the soft-deleted Azure Cosmos DB database accounts available under the given resource group and in a region. This call requires 'Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/read' permission.
    */
+  #suppress "@azure-tools/typespec-azure-core/no-openapi" "x-ms-pageable is required for ARM list operations"
   @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts")
   @get
-  #suppress "@azure-tools/typespec-azure-core/no-openapi" "x-ms-pageable is required for ARM list operations"
-  @extension("x-ms-pageable", #{nextLinkName: "nextLink"})
+  @extension("x-ms-pageable", #{ nextLinkName: "nextLink" })
   listByResourceGroupAndLocation(
     ...Azure.ResourceManager.SubscriptionIdParameter,
     ...Azure.ResourceManager.ResourceGroupParameter,
-
     ...Azure.ResourceManager.LocationParameter,
-
     ...Azure.ResourceManager.ApiVersionParameter,
   ): ArmResponse<SoftDeletedDatabaseAccountsListResult> | Azure.ResourceManager.CommonTypes.ErrorResponse;
 
@@ -414,7 +410,6 @@ interface SoftDeletedDatabaseAccounts {
   delete(
     ...Azure.ResourceManager.SubscriptionIdParameter,
     ...Azure.ResourceManager.ResourceGroupParameter,
-
     ...Azure.ResourceManager.LocationParameter,
 
     /**
@@ -440,9 +435,9 @@ interface SoftDeletedDatabaseAccounts {
 //  Soft-Deleted SQL Database Operations
 // ──────────────────────────────────────────────
 
-@added(Versions.v2026_04_01_preview)
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-interface-requires-decorator" "Custom routes for soft-deleted resources"
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Custom routes for soft-deleted resources"
+@added(Versions.v2026_04_01_preview)
 interface SoftDeletedSqlDatabases {
   /**
    * Retrieves the properties of a soft-deleted Azure Cosmos DB SQL database. This call requires 'Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/softDeletedSqlDatabases/read' permission.
@@ -453,7 +448,6 @@ interface SoftDeletedSqlDatabases {
     ...Azure.ResourceManager.ApiVersionParameter,
     ...Azure.ResourceManager.SubscriptionIdParameter,
     ...Azure.ResourceManager.ResourceGroupParameter,
-
     ...Azure.ResourceManager.LocationParameter,
 
     /**
@@ -478,15 +472,14 @@ interface SoftDeletedSqlDatabases {
   /**
    * Lists all the soft-deleted Azure Cosmos DB SQL databases under a soft-deleted database account. This call requires 'Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/softDeletedSqlDatabases/read' permission.
    */
+  #suppress "@azure-tools/typespec-azure-core/no-openapi" "x-ms-pageable is required for ARM list operations"
   @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases")
   @get
-  #suppress "@azure-tools/typespec-azure-core/no-openapi" "x-ms-pageable is required for ARM list operations"
-  @extension("x-ms-pageable", #{nextLinkName: "nextLink"})
+  @extension("x-ms-pageable", #{ nextLinkName: "nextLink" })
   list(
     ...Azure.ResourceManager.ApiVersionParameter,
     ...Azure.ResourceManager.SubscriptionIdParameter,
     ...Azure.ResourceManager.ResourceGroupParameter,
-
     ...Azure.ResourceManager.LocationParameter,
 
     /**
@@ -507,7 +500,6 @@ interface SoftDeletedSqlDatabases {
   delete(
     ...Azure.ResourceManager.SubscriptionIdParameter,
     ...Azure.ResourceManager.ResourceGroupParameter,
-
     ...Azure.ResourceManager.LocationParameter,
 
     /**
@@ -542,9 +534,9 @@ interface SoftDeletedSqlDatabases {
 //  Soft-Deleted SQL Container Operations
 // ──────────────────────────────────────────────
 
-@added(Versions.v2026_04_01_preview)
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-interface-requires-decorator" "Custom routes for soft-deleted resources"
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Custom routes for soft-deleted resources"
+@added(Versions.v2026_04_01_preview)
 interface SoftDeletedSqlContainers {
   /**
    * Retrieves the properties of a soft-deleted Azure Cosmos DB SQL container. This call requires 'Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/softDeletedSqlDatabases/softDeletedSqlContainers/read' permission.
@@ -555,7 +547,6 @@ interface SoftDeletedSqlContainers {
     ...Azure.ResourceManager.ApiVersionParameter,
     ...Azure.ResourceManager.SubscriptionIdParameter,
     ...Azure.ResourceManager.ResourceGroupParameter,
-
     ...Azure.ResourceManager.LocationParameter,
 
     /**
@@ -589,15 +580,14 @@ interface SoftDeletedSqlContainers {
   /**
    * Lists all the soft-deleted Azure Cosmos DB SQL containers under a soft-deleted SQL database. This call requires 'Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/softDeletedSqlDatabases/softDeletedSqlContainers/read' permission.
    */
+  #suppress "@azure-tools/typespec-azure-core/no-openapi" "x-ms-pageable is required for ARM list operations"
   @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}/softDeletedSqlContainers")
   @get
-  #suppress "@azure-tools/typespec-azure-core/no-openapi" "x-ms-pageable is required for ARM list operations"
-  @extension("x-ms-pageable", #{nextLinkName: "nextLink"})
+  @extension("x-ms-pageable", #{ nextLinkName: "nextLink" })
   list(
     ...Azure.ResourceManager.ApiVersionParameter,
     ...Azure.ResourceManager.SubscriptionIdParameter,
     ...Azure.ResourceManager.ResourceGroupParameter,
-
     ...Azure.ResourceManager.LocationParameter,
 
     /**
@@ -627,7 +617,6 @@ interface SoftDeletedSqlContainers {
   delete(
     ...Azure.ResourceManager.SubscriptionIdParameter,
     ...Azure.ResourceManager.ResourceGroupParameter,
-
     ...Azure.ResourceManager.LocationParameter,
 
     /**

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedDatabaseAccountGet.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedDatabaseAccountGet.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2026-04-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "location": "West US",
+    "accountName": "softdeleted-cosmosdb-1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/softdeleted-cosmosdb-1",
+        "name": "softdeleted-cosmosdb-1",
+        "type": "Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts",
+        "properties": {
+          "accountName": "softdeleted-cosmosdb-1",
+          "softDeletionMetadata": {
+            "isSoftDeleted": true,
+            "softDeletionStartTimestamp": 1729000530,
+            "softDeletionResourceExpirationTimestamp": 1731592530
+          }
+        }
+      }
+    }
+  },
+  "operationId": "SoftDeletedDatabaseAccounts_Get",
+  "title": "CosmosDBSoftDeletedDatabaseAccountGet"
+}

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedDatabaseAccountListByLocation.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedDatabaseAccountListByLocation.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "api-version": "2026-04-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "location": "West US"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/a1b2c3d4-5678-90ab-cdef-1234567890ab",
+            "name": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+            "type": "Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts",
+            "properties": {
+              "accountName": "softdeleted-cosmosdb-1",
+              "softDeletionMetadata": {
+                "isSoftDeleted": true,
+                "softDeletionStartTimestamp": 1729000530,
+                "softDeletionResourceExpirationTimestamp": 1731592530
+              }
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/b2c3d4e5-6789-01bc-def2-234567890abc",
+            "name": "b2c3d4e5-6789-01bc-def2-234567890abc",
+            "type": "Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts",
+            "properties": {
+              "accountName": "softdeleted-cosmosdb-2",
+              "softDeletionMetadata": {
+                "isSoftDeleted": true,
+                "softDeletionStartTimestamp": 1728655215,
+                "softDeletionResourceExpirationTimestamp": 1731247215
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SoftDeletedDatabaseAccounts_ListByLocation",
+  "title": "CosmosDBSoftDeletedDatabaseAccountListByLocation"
+}

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedDatabaseAccountListByResourceGroupAndLocation.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedDatabaseAccountListByResourceGroupAndLocation.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "api-version": "2026-04-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "location": "West US"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/a1b2c3d4-5678-90ab-cdef-1234567890ab",
+            "name": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+            "type": "Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts",
+            "properties": {
+              "accountName": "softdeleted-cosmosdb-1",
+              "softDeletionMetadata": {
+                "isSoftDeleted": true,
+                "softDeletionStartTimestamp": 1729000530,
+                "softDeletionResourceExpirationTimestamp": 1731592530
+              }
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/b2c3d4e5-6789-01bc-def2-234567890abc",
+            "name": "b2c3d4e5-6789-01bc-def2-234567890abc",
+            "type": "Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts",
+            "properties": {
+              "accountName": "softdeleted-cosmosdb-2",
+              "softDeletionMetadata": {
+                "isSoftDeleted": true,
+                "softDeletionStartTimestamp": 1728655215,
+                "softDeletionResourceExpirationTimestamp": 1731247215
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SoftDeletedDatabaseAccounts_ListByResourceGroupAndLocation",
+  "title": "CosmosDBSoftDeletedDatabaseAccountListByResourceGroupAndLocation"
+}

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedDatabaseAccountPurge.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedDatabaseAccountPurge.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "accountName": "softdeleted-cosmosdb-1",
+    "resourceGroupName": "rg1",
+    "api-version": "2026-04-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/purge-operation-id?api-version=2026-04-01-preview",
+        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/purge-operation-id?api-version=2026-04-01-preview"
+      }
+    },
+    "204": {},
+    "default": {
+      "body": {
+        "error": {
+          "code": "BadRequest",
+          "message": "The soft-deleted database account cannot be purged yet. Minimum retention period has not elapsed."
+        }
+      }
+    }
+  },
+  "operationId": "SoftDeletedDatabaseAccounts_Delete",
+  "title": "CosmosDBSoftDeletedDatabaseAccountPurge"
+}

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedDatabaseAccountPurge.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedDatabaseAccountPurge.json
@@ -23,6 +23,6 @@
       }
     }
   },
-  "operationId": "SoftDeletedDatabaseAccounts_Delete",
+  "operationId": "SoftDeletedDatabaseAccounts_Purge",
   "title": "CosmosDBSoftDeletedDatabaseAccountPurge"
 }

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedDatabaseAccountPurge.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedDatabaseAccountPurge.json
@@ -2,6 +2,7 @@
   "parameters": {
     "accountName": "softdeleted-cosmosdb-1",
     "resourceGroupName": "rg1",
+    "location": "West US",
     "api-version": "2026-04-01-preview",
     "subscriptionId": "00000000-0000-0000-0000-000000000000"
   },

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedDatabaseAccountRestore.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedDatabaseAccountRestore.json
@@ -15,6 +15,6 @@
     },
     "204": {}
   },
-  "operationId": "SoftDeletedDatabaseAccounts_Delete",
+  "operationId": "SoftDeletedDatabaseAccounts_Restore",
   "title": "CosmosDBSoftDeletedDatabaseAccountRestore"
 }

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedDatabaseAccountRestore.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedDatabaseAccountRestore.json
@@ -2,6 +2,7 @@
   "parameters": {
     "accountName": "softdeleted-cosmosdb-2",
     "resourceGroupName": "rg2",
+    "location": "West US",
     "api-version": "2026-04-01-preview",
     "subscriptionId": "00000000-0000-0000-0000-000000000000"
   },

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedDatabaseAccountRestore.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedDatabaseAccountRestore.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "accountName": "softdeleted-cosmosdb-2",
+    "resourceGroupName": "rg2",
+    "api-version": "2026-04-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/restore-operation-id?api-version=2026-04-01-preview",
+        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/restore-operation-id?api-version=2026-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "SoftDeletedDatabaseAccounts_Delete",
+  "title": "CosmosDBSoftDeletedDatabaseAccountRestore"
+}

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedSqlContainerGet.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedSqlContainerGet.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2026-04-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "location": "West US",
+    "accountName": "softdeleted-cosmosdb-1",
+    "databaseName": "MyDatabase",
+    "containerName": "MyContainer"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/softdeleted-cosmosdb-1/softDeletedSqlDatabases/MyDatabase/softDeletedSqlContainers/MyContainer",
+        "name": "MyContainer",
+        "type": "Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/softDeletedSqlDatabases/softDeletedSqlContainers",
+        "properties": {
+          "softDeletionMetadata": {
+            "isSoftDeleted": true,
+            "softDeletionStartTimestamp": 1729000530,
+            "softDeletionResourceExpirationTimestamp": 1731592530
+          },
+          "resource": {
+            "id": "MyContainer",
+            "_rid": "PD5DALigDgwBAAAAAAAAAA==",
+            "partitionKey": {
+              "paths": [
+                "/accountNumber"
+              ],
+              "kind": "Hash"
+            },
+            "defaultTtl": 3600
+          }
+        }
+      }
+    }
+  },
+  "operationId": "SoftDeletedSqlContainers_Get",
+  "title": "CosmosDBSoftDeletedSqlContainerGet"
+}

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedSqlContainerList.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedSqlContainerList.json
@@ -1,0 +1,66 @@
+{
+  "parameters": {
+    "api-version": "2026-04-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "location": "West US",
+    "accountName": "softdeleted-cosmosdb-1",
+    "databaseName": "MyDatabase"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/softdeleted-cosmosdb-1/softDeletedSqlDatabases/MyDatabase/softDeletedSqlContainers/MyContainer",
+            "name": "MyContainer",
+            "type": "Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/softDeletedSqlDatabases/softDeletedSqlContainers",
+            "properties": {
+              "softDeletionMetadata": {
+                "isSoftDeleted": true,
+                "softDeletionStartTimestamp": 1729000530,
+                "softDeletionResourceExpirationTimestamp": 1731592530
+              },
+              "resource": {
+                "id": "MyContainer",
+                "_rid": "PD5DALigDgwBAAAAAAAAAA==",
+                "partitionKey": {
+                  "paths": [
+                    "/accountNumber"
+                  ],
+                  "kind": "Hash"
+                },
+                "defaultTtl": 3600
+              }
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/softdeleted-cosmosdb-1/softDeletedSqlDatabases/MyDatabase/softDeletedSqlContainers/TestContainer",
+            "name": "TestContainer",
+            "type": "Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/softDeletedSqlDatabases/softDeletedSqlContainers",
+            "properties": {
+              "softDeletionMetadata": {
+                "isSoftDeleted": true,
+                "softDeletionStartTimestamp": 1728668415,
+                "softDeletionResourceExpirationTimestamp": 1731260415
+              },
+              "resource": {
+                "id": "TestContainer",
+                "_rid": "PD5DALigDgwCAAAAAAAAAA==",
+                "partitionKey": {
+                  "paths": [
+                    "/id"
+                  ],
+                  "kind": "Hash"
+                },
+                "defaultTtl": 7200
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SoftDeletedSqlContainers_List",
+  "title": "CosmosDBSoftDeletedSqlContainerList"
+}

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedSqlContainerPurge.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedSqlContainerPurge.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-04-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "location": "West US",
+    "accountName": "softdeleted-cosmosdb-1",
+    "databaseName": "MyDatabase",
+    "containerName": "MyContainer"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/purge-container-operation-id?api-version=2026-04-01-preview",
+        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/purge-container-operation-id?api-version=2026-04-01-preview"
+      }
+    },
+    "204": {},
+    "default": {
+      "body": {
+        "error": {
+          "code": "BadRequest",
+          "message": "The soft-deleted SQL container cannot be purged yet. Minimum retention period has not elapsed."
+        }
+      }
+    }
+  },
+  "operationId": "SoftDeletedSqlContainers_Delete",
+  "title": "CosmosDBSoftDeletedSqlContainerPurge"
+}

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedSqlContainerPurge.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedSqlContainerPurge.json
@@ -25,6 +25,6 @@
       }
     }
   },
-  "operationId": "SoftDeletedSqlContainers_Delete",
+  "operationId": "SoftDeletedSqlContainers_Purge",
   "title": "CosmosDBSoftDeletedSqlContainerPurge"
 }

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedSqlContainerRestore.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedSqlContainerRestore.json
@@ -17,6 +17,6 @@
     },
     "204": {}
   },
-  "operationId": "SoftDeletedSqlContainers_Delete",
+  "operationId": "SoftDeletedSqlContainers_Restore",
   "title": "CosmosDBSoftDeletedSqlContainerRestore"
 }

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedSqlContainerRestore.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedSqlContainerRestore.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-04-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "location": "West US",
+    "accountName": "softdeleted-cosmosdb-1",
+    "databaseName": "MyDatabase",
+    "containerName": "MyContainer"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/restore-container-operation-id?api-version=2026-04-01-preview",
+        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/restore-container-operation-id?api-version=2026-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "SoftDeletedSqlContainers_Delete",
+  "title": "CosmosDBSoftDeletedSqlContainerRestore"
+}

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedSqlDatabaseGet.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedSqlDatabaseGet.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2026-04-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "location": "West US",
+    "accountName": "softdeleted-cosmosdb-1",
+    "databaseName": "MyDatabase"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/softdeleted-cosmosdb-1/softDeletedSqlDatabases/MyDatabase",
+        "name": "MyDatabase",
+        "type": "Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/softDeletedSqlDatabases",
+        "properties": {
+          "softDeletionMetadata": {
+            "isSoftDeleted": true,
+            "softDeletionStartTimestamp": 1729000530,
+            "softDeletionResourceExpirationTimestamp": 1731592530
+          },
+          "resource": {
+            "id": "MyDatabase",
+            "_rid": "PD5DALigDgw="
+          }
+        }
+      }
+    }
+  },
+  "operationId": "SoftDeletedSqlDatabases_Get",
+  "title": "CosmosDBSoftDeletedSqlDatabaseGet"
+}

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedSqlDatabaseList.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedSqlDatabaseList.json
@@ -1,0 +1,51 @@
+{
+  "parameters": {
+    "api-version": "2026-04-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "location": "West US",
+    "accountName": "softdeleted-cosmosdb-1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/softdeleted-cosmosdb-1/softDeletedSqlDatabases/MyDatabase",
+            "name": "MyDatabase",
+            "type": "Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/softDeletedSqlDatabases",
+            "properties": {
+              "softDeletionMetadata": {
+                "isSoftDeleted": true,
+                "softDeletionStartTimestamp": 1729000530,
+                "softDeletionResourceExpirationTimestamp": 1731592530
+              },
+              "resource": {
+                "id": "MyDatabase",
+                "_rid": "PD5DALigDgw="
+              }
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/softdeleted-cosmosdb-1/softDeletedSqlDatabases/TestDatabase",
+            "name": "TestDatabase",
+            "type": "Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/softDeletedSqlDatabases",
+            "properties": {
+              "softDeletionMetadata": {
+                "isSoftDeleted": true,
+                "softDeletionStartTimestamp": 1728668415,
+                "softDeletionResourceExpirationTimestamp": 1731260415
+              },
+              "resource": {
+                "id": "TestDatabase",
+                "_rid": "PD5DALigDgy="
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SoftDeletedSqlDatabases_List",
+  "title": "CosmosDBSoftDeletedSqlDatabaseList"
+}

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedSqlDatabasePurge.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedSqlDatabasePurge.json
@@ -24,6 +24,6 @@
       }
     }
   },
-  "operationId": "SoftDeletedSqlDatabases_Delete",
+  "operationId": "SoftDeletedSqlDatabases_Purge",
   "title": "CosmosDBSoftDeletedSqlDatabasePurge"
 }

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedSqlDatabasePurge.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedSqlDatabasePurge.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2026-04-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "location": "West US",
+    "accountName": "softdeleted-cosmosdb-1",
+    "databaseName": "MyDatabase"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/purge-database-operation-id?api-version=2026-04-01-preview",
+        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/purge-database-operation-id?api-version=2026-04-01-preview"
+      }
+    },
+    "204": {},
+    "default": {
+      "body": {
+        "error": {
+          "code": "BadRequest",
+          "message": "The soft-deleted SQL database cannot be purged yet. Minimum retention period has not elapsed."
+        }
+      }
+    }
+  },
+  "operationId": "SoftDeletedSqlDatabases_Delete",
+  "title": "CosmosDBSoftDeletedSqlDatabasePurge"
+}

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedSqlDatabaseRestore.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedSqlDatabaseRestore.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "location": "West US",
+    "accountName": "ddb1",
+    "databaseName": "softDeletedDatabase1",
+    "api-version": "2026-04-01-preview"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/restore-operation-id?api-version=2026-04-01-preview",
+        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/restore-operation-id?api-version=2026-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "SoftDeletedSqlDatabases_Delete",
+  "title": "CosmosDBSoftDeletedSqlDatabaseRestore"
+}

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedSqlDatabaseRestore.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedSqlDatabaseRestore.json
@@ -16,6 +16,6 @@
     },
     "204": {}
   },
-  "operationId": "SoftDeletedSqlDatabases_Delete",
+  "operationId": "SoftDeletedSqlDatabases_Restore",
   "title": "CosmosDBSoftDeletedSqlDatabaseRestore"
 }

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/main.tsp
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/main.tsp
@@ -61,6 +61,7 @@ import "./FleetResource.tsp";
 import "./FleetAnalyticsResource.tsp";
 import "./FleetspaceResource.tsp";
 import "./FleetspaceAccountResource.tsp";
+import "./SoftDeletedResources.tsp";
 import "./routes.tsp";
 
 using TypeSpec.Rest;

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/models.tsp
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/models.tsp
@@ -475,6 +475,27 @@ union AnalyticalStorageSchemaType {
 }
 
 /**
+ * Configuration for soft delete on the Cosmos DB account.
+ */
+@added(Versions.v2026_04_01_preview)
+model SoftDeleteConfiguration {
+  /**
+   * Flag to indicate whether soft delete is enabled on the account.
+   */
+  softDeletionEnabled?: boolean | null;
+
+  /**
+   * Minimum number of minutes before a soft deleted resource can be permanently deleted.
+   */
+  minMinutesBeforePermanentDeletionAllowed?: int32 | null;
+
+  /**
+   * Soft delete retention period in minutes for resources.
+   */
+  softDeleteRetentionPeriodInMinutes?: int32 | null;
+}
+
+/**
  * Enum to indicate the mode of account creation.
  */
 union CreateMode {
@@ -1752,6 +1773,12 @@ model DatabaseAccountGetProperties {
   enableAllVersionsAndDeletesChangeFeed?: boolean;
 
   /**
+   * The configuration for soft delete on the Cosmos DB account.
+   */
+  @added(Versions.v2026_04_01_preview)
+  softDeleteConfiguration?: SoftDeleteConfiguration;
+
+  /**
    * Total dedicated throughput (RU/s) for database account. Represents the sum of all manual provisioned throughput and all autoscale max RU/s across all shared throughput databases and dedicated throughput containers in the account for 1 region. READ ONLY.
    */
   #suppress "@azure-tools/typespec-azure-core/casing-style" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
@@ -2543,6 +2570,12 @@ model DatabaseAccountUpdateProperties {
   enableAllVersionsAndDeletesChangeFeed?: boolean;
 
   /**
+   * The configuration for soft delete on the Cosmos DB account.
+   */
+  @added(Versions.v2026_04_01_preview)
+  softDeleteConfiguration?: SoftDeleteConfiguration;
+
+  /**
    * Flag to indicate enabling/disabling of hierarchical partition key ID last level enforcement on the account.
    */
   enforceHierarchicalPartitionKeyIdLastLevel?: boolean;
@@ -2768,6 +2801,12 @@ model DatabaseAccountCreateUpdateProperties {
    * Flag to indicate if All Versions and Deletes Change feed feature is enabled on the account
    */
   enableAllVersionsAndDeletesChangeFeed?: boolean;
+
+  /**
+   * The configuration for soft delete on the Cosmos DB account.
+   */
+  @added(Versions.v2026_04_01_preview)
+  softDeleteConfiguration?: SoftDeleteConfiguration;
 
   /**
    * Flag to indicate enabling/disabling of hierarchical partition key ID last level enforcement on the account.

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/models.tsp
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/models.tsp
@@ -482,16 +482,19 @@ model SoftDeleteConfiguration {
   /**
    * Flag to indicate whether soft delete is enabled on the account.
    */
+  #suppress "@azure-tools/typespec-azure-core/no-nullable" "Matching original swagger x-nullable behavior"
   softDeletionEnabled?: boolean | null;
 
   /**
    * Minimum number of minutes before a soft deleted resource can be permanently deleted.
    */
+  #suppress "@azure-tools/typespec-azure-core/no-nullable" "Matching original swagger x-nullable behavior"
   minMinutesBeforePermanentDeletionAllowed?: int32 | null;
 
   /**
    * Soft delete retention period in minutes for resources.
    */
+  #suppress "@azure-tools/typespec-azure-core/no-nullable" "Matching original swagger x-nullable behavior"
   softDeleteRetentionPeriodInMinutes?: int32 | null;
 }
 

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/models.tsp
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/models.tsp
@@ -482,20 +482,17 @@ model SoftDeleteConfiguration {
   /**
    * Flag to indicate whether soft delete is enabled on the account.
    */
-  #suppress "@azure-tools/typespec-azure-core/no-nullable" "Matching original swagger x-nullable behavior"
-  softDeletionEnabled?: boolean | null;
+  softDeletionEnabled?: boolean;
 
   /**
    * Minimum number of minutes before a soft deleted resource can be permanently deleted.
    */
-  #suppress "@azure-tools/typespec-azure-core/no-nullable" "Matching original swagger x-nullable behavior"
-  minMinutesBeforePermanentDeletionAllowed?: int32 | null;
+  minMinutesBeforePermanentDeletionAllowed?: int32;
 
   /**
    * Soft delete retention period in minutes for resources.
    */
-  #suppress "@azure-tools/typespec-azure-core/no-nullable" "Matching original swagger x-nullable behavior"
-  softDeleteRetentionPeriodInMinutes?: int32 | null;
+  softDeleteRetentionPeriodInMinutes?: int32;
 }
 
 /**

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedDatabaseAccountGet.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedDatabaseAccountGet.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2026-04-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "location": "West US",
+    "accountName": "softdeleted-cosmosdb-1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/softdeleted-cosmosdb-1",
+        "name": "softdeleted-cosmosdb-1",
+        "type": "Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts",
+        "properties": {
+          "accountName": "softdeleted-cosmosdb-1",
+          "softDeletionMetadata": {
+            "isSoftDeleted": true,
+            "softDeletionStartTimestamp": 1729000530,
+            "softDeletionResourceExpirationTimestamp": 1731592530
+          }
+        }
+      }
+    }
+  },
+  "operationId": "SoftDeletedDatabaseAccounts_Get",
+  "title": "CosmosDBSoftDeletedDatabaseAccountGet"
+}

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedDatabaseAccountListByLocation.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedDatabaseAccountListByLocation.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "api-version": "2026-04-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "location": "West US"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/a1b2c3d4-5678-90ab-cdef-1234567890ab",
+            "name": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+            "type": "Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts",
+            "properties": {
+              "accountName": "softdeleted-cosmosdb-1",
+              "softDeletionMetadata": {
+                "isSoftDeleted": true,
+                "softDeletionStartTimestamp": 1729000530,
+                "softDeletionResourceExpirationTimestamp": 1731592530
+              }
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/b2c3d4e5-6789-01bc-def2-234567890abc",
+            "name": "b2c3d4e5-6789-01bc-def2-234567890abc",
+            "type": "Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts",
+            "properties": {
+              "accountName": "softdeleted-cosmosdb-2",
+              "softDeletionMetadata": {
+                "isSoftDeleted": true,
+                "softDeletionStartTimestamp": 1728655215,
+                "softDeletionResourceExpirationTimestamp": 1731247215
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SoftDeletedDatabaseAccounts_ListByLocation",
+  "title": "CosmosDBSoftDeletedDatabaseAccountListByLocation"
+}

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedDatabaseAccountListByResourceGroupAndLocation.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedDatabaseAccountListByResourceGroupAndLocation.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "api-version": "2026-04-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "location": "West US"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/a1b2c3d4-5678-90ab-cdef-1234567890ab",
+            "name": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+            "type": "Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts",
+            "properties": {
+              "accountName": "softdeleted-cosmosdb-1",
+              "softDeletionMetadata": {
+                "isSoftDeleted": true,
+                "softDeletionStartTimestamp": 1729000530,
+                "softDeletionResourceExpirationTimestamp": 1731592530
+              }
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/b2c3d4e5-6789-01bc-def2-234567890abc",
+            "name": "b2c3d4e5-6789-01bc-def2-234567890abc",
+            "type": "Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts",
+            "properties": {
+              "accountName": "softdeleted-cosmosdb-2",
+              "softDeletionMetadata": {
+                "isSoftDeleted": true,
+                "softDeletionStartTimestamp": 1728655215,
+                "softDeletionResourceExpirationTimestamp": 1731247215
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SoftDeletedDatabaseAccounts_ListByResourceGroupAndLocation",
+  "title": "CosmosDBSoftDeletedDatabaseAccountListByResourceGroupAndLocation"
+}

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedDatabaseAccountPurge.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedDatabaseAccountPurge.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "accountName": "softdeleted-cosmosdb-1",
+    "resourceGroupName": "rg1",
+    "api-version": "2026-04-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/purge-operation-id?api-version=2026-04-01-preview",
+        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/purge-operation-id?api-version=2026-04-01-preview"
+      }
+    },
+    "204": {},
+    "default": {
+      "body": {
+        "error": {
+          "code": "BadRequest",
+          "message": "The soft-deleted database account cannot be purged yet. Minimum retention period has not elapsed."
+        }
+      }
+    }
+  },
+  "operationId": "SoftDeletedDatabaseAccounts_Delete",
+  "title": "CosmosDBSoftDeletedDatabaseAccountPurge"
+}

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedDatabaseAccountPurge.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedDatabaseAccountPurge.json
@@ -23,6 +23,6 @@
       }
     }
   },
-  "operationId": "SoftDeletedDatabaseAccounts_Delete",
+  "operationId": "SoftDeletedDatabaseAccounts_Purge",
   "title": "CosmosDBSoftDeletedDatabaseAccountPurge"
 }

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedDatabaseAccountPurge.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedDatabaseAccountPurge.json
@@ -2,6 +2,7 @@
   "parameters": {
     "accountName": "softdeleted-cosmosdb-1",
     "resourceGroupName": "rg1",
+    "location": "West US",
     "api-version": "2026-04-01-preview",
     "subscriptionId": "00000000-0000-0000-0000-000000000000"
   },

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedDatabaseAccountRestore.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedDatabaseAccountRestore.json
@@ -15,6 +15,6 @@
     },
     "204": {}
   },
-  "operationId": "SoftDeletedDatabaseAccounts_Delete",
+  "operationId": "SoftDeletedDatabaseAccounts_Restore",
   "title": "CosmosDBSoftDeletedDatabaseAccountRestore"
 }

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedDatabaseAccountRestore.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedDatabaseAccountRestore.json
@@ -2,6 +2,7 @@
   "parameters": {
     "accountName": "softdeleted-cosmosdb-2",
     "resourceGroupName": "rg2",
+    "location": "West US",
     "api-version": "2026-04-01-preview",
     "subscriptionId": "00000000-0000-0000-0000-000000000000"
   },

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedDatabaseAccountRestore.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedDatabaseAccountRestore.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "accountName": "softdeleted-cosmosdb-2",
+    "resourceGroupName": "rg2",
+    "api-version": "2026-04-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/restore-operation-id?api-version=2026-04-01-preview",
+        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/restore-operation-id?api-version=2026-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "SoftDeletedDatabaseAccounts_Delete",
+  "title": "CosmosDBSoftDeletedDatabaseAccountRestore"
+}

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedSqlContainerGet.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedSqlContainerGet.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2026-04-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "location": "West US",
+    "accountName": "softdeleted-cosmosdb-1",
+    "databaseName": "MyDatabase",
+    "containerName": "MyContainer"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/softdeleted-cosmosdb-1/softDeletedSqlDatabases/MyDatabase/softDeletedSqlContainers/MyContainer",
+        "name": "MyContainer",
+        "type": "Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/softDeletedSqlDatabases/softDeletedSqlContainers",
+        "properties": {
+          "softDeletionMetadata": {
+            "isSoftDeleted": true,
+            "softDeletionStartTimestamp": 1729000530,
+            "softDeletionResourceExpirationTimestamp": 1731592530
+          },
+          "resource": {
+            "id": "MyContainer",
+            "_rid": "PD5DALigDgwBAAAAAAAAAA==",
+            "partitionKey": {
+              "paths": [
+                "/accountNumber"
+              ],
+              "kind": "Hash"
+            },
+            "defaultTtl": 3600
+          }
+        }
+      }
+    }
+  },
+  "operationId": "SoftDeletedSqlContainers_Get",
+  "title": "CosmosDBSoftDeletedSqlContainerGet"
+}

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedSqlContainerList.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedSqlContainerList.json
@@ -1,0 +1,66 @@
+{
+  "parameters": {
+    "api-version": "2026-04-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "location": "West US",
+    "accountName": "softdeleted-cosmosdb-1",
+    "databaseName": "MyDatabase"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/softdeleted-cosmosdb-1/softDeletedSqlDatabases/MyDatabase/softDeletedSqlContainers/MyContainer",
+            "name": "MyContainer",
+            "type": "Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/softDeletedSqlDatabases/softDeletedSqlContainers",
+            "properties": {
+              "softDeletionMetadata": {
+                "isSoftDeleted": true,
+                "softDeletionStartTimestamp": 1729000530,
+                "softDeletionResourceExpirationTimestamp": 1731592530
+              },
+              "resource": {
+                "id": "MyContainer",
+                "_rid": "PD5DALigDgwBAAAAAAAAAA==",
+                "partitionKey": {
+                  "paths": [
+                    "/accountNumber"
+                  ],
+                  "kind": "Hash"
+                },
+                "defaultTtl": 3600
+              }
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/softdeleted-cosmosdb-1/softDeletedSqlDatabases/MyDatabase/softDeletedSqlContainers/TestContainer",
+            "name": "TestContainer",
+            "type": "Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/softDeletedSqlDatabases/softDeletedSqlContainers",
+            "properties": {
+              "softDeletionMetadata": {
+                "isSoftDeleted": true,
+                "softDeletionStartTimestamp": 1728668415,
+                "softDeletionResourceExpirationTimestamp": 1731260415
+              },
+              "resource": {
+                "id": "TestContainer",
+                "_rid": "PD5DALigDgwCAAAAAAAAAA==",
+                "partitionKey": {
+                  "paths": [
+                    "/id"
+                  ],
+                  "kind": "Hash"
+                },
+                "defaultTtl": 7200
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SoftDeletedSqlContainers_List",
+  "title": "CosmosDBSoftDeletedSqlContainerList"
+}

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedSqlContainerPurge.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedSqlContainerPurge.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-04-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "location": "West US",
+    "accountName": "softdeleted-cosmosdb-1",
+    "databaseName": "MyDatabase",
+    "containerName": "MyContainer"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/purge-container-operation-id?api-version=2026-04-01-preview",
+        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/purge-container-operation-id?api-version=2026-04-01-preview"
+      }
+    },
+    "204": {},
+    "default": {
+      "body": {
+        "error": {
+          "code": "BadRequest",
+          "message": "The soft-deleted SQL container cannot be purged yet. Minimum retention period has not elapsed."
+        }
+      }
+    }
+  },
+  "operationId": "SoftDeletedSqlContainers_Delete",
+  "title": "CosmosDBSoftDeletedSqlContainerPurge"
+}

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedSqlContainerPurge.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedSqlContainerPurge.json
@@ -25,6 +25,6 @@
       }
     }
   },
-  "operationId": "SoftDeletedSqlContainers_Delete",
+  "operationId": "SoftDeletedSqlContainers_Purge",
   "title": "CosmosDBSoftDeletedSqlContainerPurge"
 }

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedSqlContainerRestore.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedSqlContainerRestore.json
@@ -17,6 +17,6 @@
     },
     "204": {}
   },
-  "operationId": "SoftDeletedSqlContainers_Delete",
+  "operationId": "SoftDeletedSqlContainers_Restore",
   "title": "CosmosDBSoftDeletedSqlContainerRestore"
 }

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedSqlContainerRestore.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedSqlContainerRestore.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-04-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "location": "West US",
+    "accountName": "softdeleted-cosmosdb-1",
+    "databaseName": "MyDatabase",
+    "containerName": "MyContainer"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/restore-container-operation-id?api-version=2026-04-01-preview",
+        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/restore-container-operation-id?api-version=2026-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "SoftDeletedSqlContainers_Delete",
+  "title": "CosmosDBSoftDeletedSqlContainerRestore"
+}

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedSqlDatabaseGet.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedSqlDatabaseGet.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2026-04-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "location": "West US",
+    "accountName": "softdeleted-cosmosdb-1",
+    "databaseName": "MyDatabase"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/softdeleted-cosmosdb-1/softDeletedSqlDatabases/MyDatabase",
+        "name": "MyDatabase",
+        "type": "Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/softDeletedSqlDatabases",
+        "properties": {
+          "softDeletionMetadata": {
+            "isSoftDeleted": true,
+            "softDeletionStartTimestamp": 1729000530,
+            "softDeletionResourceExpirationTimestamp": 1731592530
+          },
+          "resource": {
+            "id": "MyDatabase",
+            "_rid": "PD5DALigDgw="
+          }
+        }
+      }
+    }
+  },
+  "operationId": "SoftDeletedSqlDatabases_Get",
+  "title": "CosmosDBSoftDeletedSqlDatabaseGet"
+}

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedSqlDatabaseList.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedSqlDatabaseList.json
@@ -1,0 +1,51 @@
+{
+  "parameters": {
+    "api-version": "2026-04-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "location": "West US",
+    "accountName": "softdeleted-cosmosdb-1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/softdeleted-cosmosdb-1/softDeletedSqlDatabases/MyDatabase",
+            "name": "MyDatabase",
+            "type": "Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/softDeletedSqlDatabases",
+            "properties": {
+              "softDeletionMetadata": {
+                "isSoftDeleted": true,
+                "softDeletionStartTimestamp": 1729000530,
+                "softDeletionResourceExpirationTimestamp": 1731592530
+              },
+              "resource": {
+                "id": "MyDatabase",
+                "_rid": "PD5DALigDgw="
+              }
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/softdeleted-cosmosdb-1/softDeletedSqlDatabases/TestDatabase",
+            "name": "TestDatabase",
+            "type": "Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/softDeletedSqlDatabases",
+            "properties": {
+              "softDeletionMetadata": {
+                "isSoftDeleted": true,
+                "softDeletionStartTimestamp": 1728668415,
+                "softDeletionResourceExpirationTimestamp": 1731260415
+              },
+              "resource": {
+                "id": "TestDatabase",
+                "_rid": "PD5DALigDgy="
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SoftDeletedSqlDatabases_List",
+  "title": "CosmosDBSoftDeletedSqlDatabaseList"
+}

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedSqlDatabasePurge.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedSqlDatabasePurge.json
@@ -24,6 +24,6 @@
       }
     }
   },
-  "operationId": "SoftDeletedSqlDatabases_Delete",
+  "operationId": "SoftDeletedSqlDatabases_Purge",
   "title": "CosmosDBSoftDeletedSqlDatabasePurge"
 }

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedSqlDatabasePurge.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedSqlDatabasePurge.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2026-04-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "location": "West US",
+    "accountName": "softdeleted-cosmosdb-1",
+    "databaseName": "MyDatabase"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/purge-database-operation-id?api-version=2026-04-01-preview",
+        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/purge-database-operation-id?api-version=2026-04-01-preview"
+      }
+    },
+    "204": {},
+    "default": {
+      "body": {
+        "error": {
+          "code": "BadRequest",
+          "message": "The soft-deleted SQL database cannot be purged yet. Minimum retention period has not elapsed."
+        }
+      }
+    }
+  },
+  "operationId": "SoftDeletedSqlDatabases_Delete",
+  "title": "CosmosDBSoftDeletedSqlDatabasePurge"
+}

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedSqlDatabaseRestore.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedSqlDatabaseRestore.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "location": "West US",
+    "accountName": "ddb1",
+    "databaseName": "softDeletedDatabase1",
+    "api-version": "2026-04-01-preview"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/restore-operation-id?api-version=2026-04-01-preview",
+        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/restore-operation-id?api-version=2026-04-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "SoftDeletedSqlDatabases_Delete",
+  "title": "CosmosDBSoftDeletedSqlDatabaseRestore"
+}

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedSqlDatabaseRestore.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedSqlDatabaseRestore.json
@@ -16,6 +16,6 @@
     },
     "204": {}
   },
-  "operationId": "SoftDeletedSqlDatabases_Delete",
+  "operationId": "SoftDeletedSqlDatabases_Restore",
   "title": "CosmosDBSoftDeletedSqlDatabaseRestore"
 }

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/openapi.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/openapi.json
@@ -1155,7 +1155,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           }
         ],
         "responses": {
@@ -19788,7 +19788,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
@@ -19833,7 +19833,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "accountName",
@@ -19882,7 +19882,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "accountName",
@@ -19934,7 +19934,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "accountName",
@@ -19951,7 +19951,8 @@
             "in": "path",
             "description": "Cosmos DB SQL database name.",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "^[^/\\\\#?]+$"
           }
         ],
         "responses": {
@@ -19990,7 +19991,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "accountName",
@@ -20007,7 +20008,8 @@
             "in": "path",
             "description": "Cosmos DB SQL database name.",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "^[^/\\\\#?]+$"
           }
         ],
         "responses": {
@@ -20049,7 +20051,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "accountName",
@@ -20066,14 +20068,16 @@
             "in": "path",
             "description": "Cosmos DB SQL database name.",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "^[^/\\\\#?]+$"
           },
           {
             "name": "containerName",
             "in": "path",
             "description": "Cosmos DB SQL container name.",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "^[^/\\\\#?]+$"
           }
         ],
         "responses": {
@@ -20669,7 +20673,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "accountName",
@@ -20735,6 +20739,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBSoftDeletedDatabaseAccountRestore": {
+            "$ref": "./examples/CosmosDBSoftDeletedDatabaseAccountRestore.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -20755,7 +20764,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "accountName",
@@ -20821,6 +20830,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBSoftDeletedDatabaseAccountPurge": {
+            "$ref": "./examples/CosmosDBSoftDeletedDatabaseAccountPurge.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -20841,7 +20855,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "accountName",
@@ -20858,7 +20872,8 @@
             "in": "path",
             "description": "Cosmos DB SQL database name.",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "^[^/\\\\#?]+$"
           },
           {
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
@@ -20914,6 +20929,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBSoftDeletedSqlDatabaseRestore": {
+            "$ref": "./examples/CosmosDBSoftDeletedSqlDatabaseRestore.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -20934,7 +20954,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "accountName",
@@ -20951,7 +20971,8 @@
             "in": "path",
             "description": "Cosmos DB SQL database name.",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "^[^/\\\\#?]+$"
           },
           {
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
@@ -21007,6 +21028,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBSoftDeletedSqlDatabasePurge": {
+            "$ref": "./examples/CosmosDBSoftDeletedSqlDatabasePurge.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -21027,7 +21053,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "accountName",
@@ -21044,14 +21070,16 @@
             "in": "path",
             "description": "Cosmos DB SQL database name.",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "^[^/\\\\#?]+$"
           },
           {
             "name": "containerName",
             "in": "path",
             "description": "Cosmos DB SQL container name.",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "^[^/\\\\#?]+$"
           },
           {
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
@@ -21107,6 +21135,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBSoftDeletedSqlContainerRestore": {
+            "$ref": "./examples/CosmosDBSoftDeletedSqlContainerRestore.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -21127,7 +21160,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           },
           {
             "name": "accountName",
@@ -21144,14 +21177,16 @@
             "in": "path",
             "description": "Cosmos DB SQL database name.",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "^[^/\\\\#?]+$"
           },
           {
             "name": "containerName",
             "in": "path",
             "description": "Cosmos DB SQL container name.",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "^[^/\\\\#?]+$"
           },
           {
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
@@ -21207,6 +21242,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBSoftDeletedSqlContainerPurge": {
+            "$ref": "./examples/CosmosDBSoftDeletedSqlContainerPurge.json"
           }
         },
         "x-ms-long-running-operation-options": {

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/openapi.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/openapi.json
@@ -19951,10 +19951,7 @@
             "in": "path",
             "description": "Cosmos DB SQL database name.",
             "required": true,
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 255,
-            "pattern": "^[^/\\\\#?]+$"
+            "type": "string"
           }
         ],
         "responses": {
@@ -20010,10 +20007,7 @@
             "in": "path",
             "description": "Cosmos DB SQL database name.",
             "required": true,
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 255,
-            "pattern": "^[^/\\\\#?]+$"
+            "type": "string"
           }
         ],
         "responses": {
@@ -20072,20 +20066,14 @@
             "in": "path",
             "description": "Cosmos DB SQL database name.",
             "required": true,
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 255,
-            "pattern": "^[^/\\\\#?]+$"
+            "type": "string"
           },
           {
             "name": "containerName",
             "in": "path",
             "description": "Cosmos DB SQL container name.",
             "required": true,
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 255,
-            "pattern": "^[^/\\\\#?]+$"
+            "type": "string"
           }
         ],
         "responses": {
@@ -20870,10 +20858,7 @@
             "in": "path",
             "description": "Cosmos DB SQL database name.",
             "required": true,
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 255,
-            "pattern": "^[^/\\\\#?]+$"
+            "type": "string"
           },
           {
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
@@ -20966,10 +20951,7 @@
             "in": "path",
             "description": "Cosmos DB SQL database name.",
             "required": true,
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 255,
-            "pattern": "^[^/\\\\#?]+$"
+            "type": "string"
           },
           {
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
@@ -21062,20 +21044,14 @@
             "in": "path",
             "description": "Cosmos DB SQL database name.",
             "required": true,
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 255,
-            "pattern": "^[^/\\\\#?]+$"
+            "type": "string"
           },
           {
             "name": "containerName",
             "in": "path",
             "description": "Cosmos DB SQL container name.",
             "required": true,
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 255,
-            "pattern": "^[^/\\\\#?]+$"
+            "type": "string"
           },
           {
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
@@ -21168,20 +21144,14 @@
             "in": "path",
             "description": "Cosmos DB SQL database name.",
             "required": true,
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 255,
-            "pattern": "^[^/\\\\#?]+$"
+            "type": "string"
           },
           {
             "name": "containerName",
             "in": "path",
             "description": "Cosmos DB SQL container name.",
             "required": true,
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 255,
-            "pattern": "^[^/\\\\#?]+$"
+            "type": "string"
           },
           {
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/openapi.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/openapi.json
@@ -1149,17 +1149,10 @@
         "description": "Lists all the soft-deleted Azure Cosmos DB database accounts available under the subscription and in a region. This call requires 'Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/read' permission.",
         "parameters": [
           {
-            "name": "api-version",
-            "in": "query",
-            "required": true,
-            "type": "string",
-            "x-ms-client-name": "apiVersion"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "name": "subscriptionId",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
             "name": "location",
@@ -1187,6 +1180,9 @@
           "CosmosDBSoftDeletedDatabaseAccountListByLocation": {
             "$ref": "./examples/CosmosDBSoftDeletedDatabaseAccountListByLocation.json"
           }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
         }
       }
     },
@@ -19790,16 +19786,10 @@
         "description": "Lists all the soft-deleted Azure Cosmos DB database accounts available under the given resource group and in a region. This call requires 'Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/read' permission.",
         "parameters": [
           {
-            "name": "subscriptionId",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "name": "resourceGroupName",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "location",
@@ -19809,11 +19799,7 @@
             "type": "string"
           },
           {
-            "name": "api-version",
-            "in": "query",
-            "required": true,
-            "type": "string",
-            "x-ms-client-name": "apiVersion"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           }
         ],
         "responses": {
@@ -19834,6 +19820,9 @@
           "CosmosDBSoftDeletedDatabaseAccountListByResourceGroupAndLocation": {
             "$ref": "./examples/CosmosDBSoftDeletedDatabaseAccountListByResourceGroupAndLocation.json"
           }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
         }
       }
     },
@@ -19843,23 +19832,13 @@
         "description": "Retrieves the properties of a soft-deleted Azure Cosmos DB database account by location and accountName. This call requires 'Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/read' permission.",
         "parameters": [
           {
-            "name": "api-version",
-            "in": "query",
-            "required": true,
-            "type": "string",
-            "x-ms-client-name": "apiVersion"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "name": "subscriptionId",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "name": "resourceGroupName",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "location",
@@ -19904,16 +19883,10 @@
         "description": "Performs a soft delete action (restore or permanently delete) on a soft-deleted Azure Cosmos DB database account.",
         "parameters": [
           {
-            "name": "subscriptionId",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "name": "resourceGroupName",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "location",
@@ -19933,11 +19906,7 @@
             "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
           },
           {
-            "name": "api-version",
-            "in": "query",
-            "required": true,
-            "type": "string",
-            "x-ms-client-name": "apiVersion"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
             "name": "softDeleteActionKind",
@@ -20012,23 +19981,13 @@
         "description": "Lists all the soft-deleted Azure Cosmos DB SQL databases under a soft-deleted database account. This call requires 'Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/softDeletedSqlDatabases/read' permission.",
         "parameters": [
           {
-            "name": "api-version",
-            "in": "query",
-            "required": true,
-            "type": "string",
-            "x-ms-client-name": "apiVersion"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "name": "subscriptionId",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "name": "resourceGroupName",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "location",
@@ -20066,6 +20025,9 @@
           "CosmosDBSoftDeletedSqlDatabaseList": {
             "$ref": "./examples/CosmosDBSoftDeletedSqlDatabaseList.json"
           }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
         }
       }
     },
@@ -20075,23 +20037,13 @@
         "description": "Retrieves the properties of a soft-deleted Azure Cosmos DB SQL database. This call requires 'Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/softDeletedSqlDatabases/read' permission.",
         "parameters": [
           {
-            "name": "api-version",
-            "in": "query",
-            "required": true,
-            "type": "string",
-            "x-ms-client-name": "apiVersion"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "name": "subscriptionId",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "name": "resourceGroupName",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "location",
@@ -20146,16 +20098,10 @@
         "description": "Performs a soft delete action (restore or permanently delete) on a soft-deleted Azure Cosmos DB SQL database.",
         "parameters": [
           {
-            "name": "subscriptionId",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "name": "resourceGroupName",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "location",
@@ -20185,11 +20131,7 @@
             "pattern": "^[^/\\\\#?]+$"
           },
           {
-            "name": "api-version",
-            "in": "query",
-            "required": true,
-            "type": "string",
-            "x-ms-client-name": "apiVersion"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
             "name": "softDeleteActionKind",
@@ -20264,23 +20206,13 @@
         "description": "Lists all the soft-deleted Azure Cosmos DB SQL containers under a soft-deleted SQL database. This call requires 'Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/softDeletedSqlDatabases/softDeletedSqlContainers/read' permission.",
         "parameters": [
           {
-            "name": "api-version",
-            "in": "query",
-            "required": true,
-            "type": "string",
-            "x-ms-client-name": "apiVersion"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "name": "subscriptionId",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "name": "resourceGroupName",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "location",
@@ -20328,6 +20260,9 @@
           "CosmosDBSoftDeletedSqlContainerList": {
             "$ref": "./examples/CosmosDBSoftDeletedSqlContainerList.json"
           }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
         }
       }
     },
@@ -20337,23 +20272,13 @@
         "description": "Retrieves the properties of a soft-deleted Azure Cosmos DB SQL container. This call requires 'Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/softDeletedSqlDatabases/softDeletedSqlContainers/read' permission.",
         "parameters": [
           {
-            "name": "api-version",
-            "in": "query",
-            "required": true,
-            "type": "string",
-            "x-ms-client-name": "apiVersion"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "name": "subscriptionId",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "name": "resourceGroupName",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "location",
@@ -20418,16 +20343,10 @@
         "description": "Performs a soft delete action (restore or permanently delete) on a soft-deleted Azure Cosmos DB SQL container.",
         "parameters": [
           {
-            "name": "subscriptionId",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "name": "resourceGroupName",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "location",
@@ -20467,11 +20386,7 @@
             "pattern": "^[^/\\\\#?]+$"
           },
           {
-            "name": "api-version",
-            "in": "query",
-            "required": true,
-            "type": "string",
-            "x-ms-client-name": "apiVersion"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
             "name": "softDeleteActionKind",
@@ -31445,6 +31360,10 @@
             "$ref": "#/definitions/SoftDeletedDatabaseAccountGetResult"
           },
           "readOnly": true
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to get the next set of results."
         }
       }
     },
@@ -31503,8 +31422,7 @@
         "_rid": {
           "type": "string",
           "description": "A system generated property. A unique identifier.",
-          "readOnly": true,
-          "x-ms-client-name": "rid"
+          "readOnly": true
         },
         "partitionKey": {
           "$ref": "#/definitions/ContainerPartitionKey",
@@ -31531,6 +31449,10 @@
             "$ref": "#/definitions/SoftDeletedSqlContainerGetResult"
           },
           "readOnly": true
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to get the next set of results."
         }
       }
     },
@@ -31589,8 +31511,7 @@
         "_rid": {
           "type": "string",
           "description": "A system generated property. A unique identifier.",
-          "readOnly": true,
-          "x-ms-client-name": "rid"
+          "readOnly": true
         }
       },
       "required": [
@@ -31608,6 +31529,10 @@
             "$ref": "#/definitions/SoftDeletedSqlDatabaseGetResult"
           },
           "readOnly": true
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to get the next set of results."
         }
       }
     },

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/openapi.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/openapi.json
@@ -19865,90 +19865,6 @@
             "$ref": "./examples/CosmosDBSoftDeletedDatabaseAccountGet.json"
           }
         }
-      },
-      "delete": {
-        "operationId": "SoftDeletedDatabaseAccounts_Restore",
-        "description": "Restores a soft-deleted Azure Cosmos DB database account.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "name": "softDeleteActionKind",
-            "in": "query",
-            "description": "The kind of soft delete action to perform.",
-            "required": false,
-            "type": "string",
-            "enum": [
-              "RestoreSoftDeletedResource",
-              "PermanentDeleteResource"
-            ],
-            "x-ms-enum": {
-              "name": "SoftDeleteActionKind",
-              "modelAsString": true,
-              "values": [
-                {
-                  "name": "RestoreSoftDeletedResource",
-                  "value": "RestoreSoftDeletedResource",
-                  "description": "Restores the soft-deleted resource to active/online state."
-                },
-                {
-                  "name": "PermanentDeleteResource",
-                  "value": "PermanentDeleteResource",
-                  "description": "Permanently deletes the soft-deleted resource."
-                }
-              ]
-            }
-          }
-        ],
-        "responses": {
-          "202": {
-            "description": "Resource deletion accepted.",
-            "headers": {
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
-          },
-          "204": {
-            "description": "Resource does not exist."
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
-        },
-        "x-ms-long-running-operation": true
       }
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases": {
@@ -20060,100 +19976,6 @@
             "$ref": "./examples/CosmosDBSoftDeletedSqlDatabaseGet.json"
           }
         }
-      },
-      "delete": {
-        "operationId": "SoftDeletedSqlDatabases_Restore",
-        "description": "Restores a soft-deleted Azure Cosmos DB SQL database.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "databaseName",
-            "in": "path",
-            "description": "Cosmos DB SQL database name.",
-            "required": true,
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 255,
-            "pattern": "^[^/\\\\#?]+$"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "name": "softDeleteActionKind",
-            "in": "query",
-            "description": "The kind of soft delete action to perform.",
-            "required": false,
-            "type": "string",
-            "enum": [
-              "RestoreSoftDeletedResource",
-              "PermanentDeleteResource"
-            ],
-            "x-ms-enum": {
-              "name": "SoftDeleteActionKind",
-              "modelAsString": true,
-              "values": [
-                {
-                  "name": "RestoreSoftDeletedResource",
-                  "value": "RestoreSoftDeletedResource",
-                  "description": "Restores the soft-deleted resource to active/online state."
-                },
-                {
-                  "name": "PermanentDeleteResource",
-                  "value": "PermanentDeleteResource",
-                  "description": "Permanently deletes the soft-deleted resource."
-                }
-              ]
-            }
-          }
-        ],
-        "responses": {
-          "202": {
-            "description": "Resource deletion accepted.",
-            "headers": {
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
-          },
-          "204": {
-            "description": "Resource does not exist."
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
-        },
-        "x-ms-long-running-operation": true
       }
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}/softDeletedSqlContainers": {
@@ -20285,110 +20107,6 @@
             "$ref": "./examples/CosmosDBSoftDeletedSqlContainerGet.json"
           }
         }
-      },
-      "delete": {
-        "operationId": "SoftDeletedSqlContainers_Restore",
-        "description": "Restores a soft-deleted Azure Cosmos DB SQL container to active state.",
-        "parameters": [
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
-          },
-          {
-            "name": "accountName",
-            "in": "path",
-            "description": "Cosmos DB database account name.",
-            "required": true,
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 50,
-            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
-          },
-          {
-            "name": "databaseName",
-            "in": "path",
-            "description": "Cosmos DB SQL database name.",
-            "required": true,
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 255,
-            "pattern": "^[^/\\\\#?]+$"
-          },
-          {
-            "name": "containerName",
-            "in": "path",
-            "description": "Cosmos DB SQL container name.",
-            "required": true,
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 255,
-            "pattern": "^[^/\\\\#?]+$"
-          },
-          {
-            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "name": "softDeleteActionKind",
-            "in": "query",
-            "description": "The kind of soft delete action to perform.",
-            "required": false,
-            "type": "string",
-            "enum": [
-              "RestoreSoftDeletedResource",
-              "PermanentDeleteResource"
-            ],
-            "x-ms-enum": {
-              "name": "SoftDeleteActionKind",
-              "modelAsString": true,
-              "values": [
-                {
-                  "name": "RestoreSoftDeletedResource",
-                  "value": "RestoreSoftDeletedResource",
-                  "description": "Restores the soft-deleted resource to active/online state."
-                },
-                {
-                  "name": "PermanentDeleteResource",
-                  "value": "PermanentDeleteResource",
-                  "description": "Permanently deletes the soft-deleted resource."
-                }
-              ]
-            }
-          }
-        ],
-        "responses": {
-          "202": {
-            "description": "Resource deletion accepted.",
-            "headers": {
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
-          },
-          "204": {
-            "description": "Resource does not exist."
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
-        },
-        "x-ms-long-running-operation": true
       }
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/throughputPools": {
@@ -20951,7 +20669,93 @@
     }
   },
   "x-ms-paths": {
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}?_overload=purge": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}?softDeleteActionKind=RestoreSoftDeletedResource": {
+      "delete": {
+        "operationId": "SoftDeletedDatabaseAccounts_Restore",
+        "description": "Restores a soft-deleted Azure Cosmos DB database account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "softDeleteActionKind",
+            "in": "query",
+            "description": "The kind of soft delete action to perform.",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "RestoreSoftDeletedResource",
+              "PermanentDeleteResource"
+            ],
+            "x-ms-enum": {
+              "name": "SoftDeleteActionKind",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "RestoreSoftDeletedResource",
+                  "value": "RestoreSoftDeletedResource",
+                  "description": "Restores the soft-deleted resource to active/online state."
+                },
+                {
+                  "name": "PermanentDeleteResource",
+                  "value": "PermanentDeleteResource",
+                  "description": "Permanently deletes the soft-deleted resource."
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}?softDeleteActionKind=PermanentDeleteResource": {
       "delete": {
         "operationId": "SoftDeletedDatabaseAccounts_Purge",
         "description": "Permanently deletes (purges) a soft-deleted Azure Cosmos DB database account.",
@@ -21037,7 +20841,103 @@
         "x-ms-long-running-operation": true
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}?_overload=purge": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}?softDeleteActionKind=RestoreSoftDeletedResource": {
+      "delete": {
+        "operationId": "SoftDeletedSqlDatabases_Restore",
+        "description": "Restores a soft-deleted Azure Cosmos DB SQL database.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "Cosmos DB SQL database name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "pattern": "^[^/\\\\#?]+$"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "softDeleteActionKind",
+            "in": "query",
+            "description": "The kind of soft delete action to perform.",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "RestoreSoftDeletedResource",
+              "PermanentDeleteResource"
+            ],
+            "x-ms-enum": {
+              "name": "SoftDeleteActionKind",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "RestoreSoftDeletedResource",
+                  "value": "RestoreSoftDeletedResource",
+                  "description": "Restores the soft-deleted resource to active/online state."
+                },
+                {
+                  "name": "PermanentDeleteResource",
+                  "value": "PermanentDeleteResource",
+                  "description": "Permanently deletes the soft-deleted resource."
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}?softDeleteActionKind=PermanentDeleteResource": {
       "delete": {
         "operationId": "SoftDeletedSqlDatabases_Purge",
         "description": "Permanently deletes a soft-deleted Azure Cosmos DB SQL database.",
@@ -21133,7 +21033,113 @@
         "x-ms-long-running-operation": true
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}/softDeletedSqlContainers/{containerName}?_overload=purge": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}/softDeletedSqlContainers/{containerName}?softDeleteActionKind=RestoreSoftDeletedResource": {
+      "delete": {
+        "operationId": "SoftDeletedSqlContainers_Restore",
+        "description": "Restores a soft-deleted Azure Cosmos DB SQL container to active state.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "Cosmos DB SQL database name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "pattern": "^[^/\\\\#?]+$"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "Cosmos DB SQL container name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "pattern": "^[^/\\\\#?]+$"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "softDeleteActionKind",
+            "in": "query",
+            "description": "The kind of soft delete action to perform.",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "RestoreSoftDeletedResource",
+              "PermanentDeleteResource"
+            ],
+            "x-ms-enum": {
+              "name": "SoftDeleteActionKind",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "RestoreSoftDeletedResource",
+                  "value": "RestoreSoftDeletedResource",
+                  "description": "Restores the soft-deleted resource to active/online state."
+                },
+                {
+                  "name": "PermanentDeleteResource",
+                  "value": "PermanentDeleteResource",
+                  "description": "Permanently deletes the soft-deleted resource."
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}/softDeletedSqlContainers/{containerName}?softDeleteActionKind=PermanentDeleteResource": {
       "delete": {
         "operationId": "SoftDeletedSqlContainers_Purge",
         "description": "Permanently deletes a soft-deleted Azure Cosmos DB SQL container.",

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/openapi.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/openapi.json
@@ -31492,20 +31492,17 @@
       "properties": {
         "softDeletionEnabled": {
           "type": "boolean",
-          "description": "Flag to indicate whether soft delete is enabled on the account.",
-          "x-nullable": true
+          "description": "Flag to indicate whether soft delete is enabled on the account."
         },
         "minMinutesBeforePermanentDeletionAllowed": {
           "type": "integer",
           "format": "int32",
-          "description": "Minimum number of minutes before a soft deleted resource can be permanently deleted.",
-          "x-nullable": true
+          "description": "Minimum number of minutes before a soft deleted resource can be permanently deleted."
         },
         "softDeleteRetentionPeriodInMinutes": {
           "type": "integer",
           "format": "int32",
-          "description": "Soft delete retention period in minutes for resources.",
-          "x-nullable": true
+          "description": "Soft delete retention period in minutes for resources."
         }
       }
     },

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/openapi.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/openapi.json
@@ -19867,8 +19867,8 @@
         }
       },
       "delete": {
-        "operationId": "SoftDeletedDatabaseAccounts_Delete",
-        "description": "Performs a soft delete action (restore or permanently delete) on a soft-deleted Azure Cosmos DB database account.",
+        "operationId": "SoftDeletedDatabaseAccounts_Restore",
+        "description": "Restores a soft-deleted Azure Cosmos DB database account.",
         "parameters": [
           {
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
@@ -19943,14 +19943,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBSoftDeletedDatabaseAccountPurge": {
-            "$ref": "./examples/CosmosDBSoftDeletedDatabaseAccountPurge.json"
-          },
-          "CosmosDBSoftDeletedDatabaseAccountRestore": {
-            "$ref": "./examples/CosmosDBSoftDeletedDatabaseAccountRestore.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -20070,8 +20062,8 @@
         }
       },
       "delete": {
-        "operationId": "SoftDeletedSqlDatabases_Delete",
-        "description": "Performs a soft delete action (restore or permanently delete) on a soft-deleted Azure Cosmos DB SQL database.",
+        "operationId": "SoftDeletedSqlDatabases_Restore",
+        "description": "Restores a soft-deleted Azure Cosmos DB SQL database.",
         "parameters": [
           {
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
@@ -20156,14 +20148,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBSoftDeletedSqlDatabasePurge": {
-            "$ref": "./examples/CosmosDBSoftDeletedSqlDatabasePurge.json"
-          },
-          "CosmosDBSoftDeletedSqlDatabaseRestore": {
-            "$ref": "./examples/CosmosDBSoftDeletedSqlDatabaseRestore.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -20303,8 +20287,8 @@
         }
       },
       "delete": {
-        "operationId": "SoftDeletedSqlContainers_Delete",
-        "description": "Performs a soft delete action (restore or permanently delete) on a soft-deleted Azure Cosmos DB SQL container.",
+        "operationId": "SoftDeletedSqlContainers_Restore",
+        "description": "Restores a soft-deleted Azure Cosmos DB SQL container to active state.",
         "parameters": [
           {
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
@@ -20399,14 +20383,6 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
-          }
-        },
-        "x-ms-examples": {
-          "CosmosDBSoftDeletedSqlContainerPurge": {
-            "$ref": "./examples/CosmosDBSoftDeletedSqlContainerPurge.json"
-          },
-          "CosmosDBSoftDeletedSqlContainerRestore": {
-            "$ref": "./examples/CosmosDBSoftDeletedSqlContainerRestore.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -20965,6 +20941,296 @@
         "x-ms-examples": {
           "CosmosDB ThroughputPool Account Delete": {
             "$ref": "./examples/throughputPool/CosmosDBThroughputPoolAccountDelete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    }
+  },
+  "x-ms-paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}?_overload=purge": {
+      "delete": {
+        "operationId": "SoftDeletedDatabaseAccounts_Purge",
+        "description": "Permanently deletes (purges) a soft-deleted Azure Cosmos DB database account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "softDeleteActionKind",
+            "in": "query",
+            "description": "The kind of soft delete action to perform.",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "RestoreSoftDeletedResource",
+              "PermanentDeleteResource"
+            ],
+            "x-ms-enum": {
+              "name": "SoftDeleteActionKind",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "RestoreSoftDeletedResource",
+                  "value": "RestoreSoftDeletedResource",
+                  "description": "Restores the soft-deleted resource to active/online state."
+                },
+                {
+                  "name": "PermanentDeleteResource",
+                  "value": "PermanentDeleteResource",
+                  "description": "Permanently deletes the soft-deleted resource."
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}?_overload=purge": {
+      "delete": {
+        "operationId": "SoftDeletedSqlDatabases_Purge",
+        "description": "Permanently deletes a soft-deleted Azure Cosmos DB SQL database.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "Cosmos DB SQL database name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "pattern": "^[^/\\\\#?]+$"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "softDeleteActionKind",
+            "in": "query",
+            "description": "The kind of soft delete action to perform.",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "RestoreSoftDeletedResource",
+              "PermanentDeleteResource"
+            ],
+            "x-ms-enum": {
+              "name": "SoftDeleteActionKind",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "RestoreSoftDeletedResource",
+                  "value": "RestoreSoftDeletedResource",
+                  "description": "Restores the soft-deleted resource to active/online state."
+                },
+                {
+                  "name": "PermanentDeleteResource",
+                  "value": "PermanentDeleteResource",
+                  "description": "Permanently deletes the soft-deleted resource."
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}/softDeletedSqlContainers/{containerName}?_overload=purge": {
+      "delete": {
+        "operationId": "SoftDeletedSqlContainers_Purge",
+        "description": "Permanently deletes a soft-deleted Azure Cosmos DB SQL container.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "Cosmos DB SQL database name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "pattern": "^[^/\\\\#?]+$"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "Cosmos DB SQL container name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "pattern": "^[^/\\\\#?]+$"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "softDeleteActionKind",
+            "in": "query",
+            "description": "The kind of soft delete action to perform.",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "RestoreSoftDeletedResource",
+              "PermanentDeleteResource"
+            ],
+            "x-ms-enum": {
+              "name": "SoftDeleteActionKind",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "RestoreSoftDeletedResource",
+                  "value": "RestoreSoftDeletedResource",
+                  "description": "Restores the soft-deleted resource to active/online state."
+                },
+                {
+                  "name": "PermanentDeleteResource",
+                  "value": "PermanentDeleteResource",
+                  "description": "Permanently deletes the soft-deleted resource."
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
           }
         },
         "x-ms-long-running-operation-options": {

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/openapi.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/openapi.json
@@ -1143,6 +1143,53 @@
         }
       }
     },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts": {
+      "get": {
+        "operationId": "SoftDeletedDatabaseAccounts_ListByLocation",
+        "description": "Lists all the soft-deleted Azure Cosmos DB database accounts available under the subscription and in a region. This call requires 'Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/read' permission.",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "x-ms-client-name": "apiVersion"
+          },
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "location",
+            "in": "path",
+            "description": "Cosmos DB region, with spaces between words and each word capitalized.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SoftDeletedDatabaseAccountsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBSoftDeletedDatabaseAccountListByLocation": {
+            "$ref": "./examples/CosmosDBSoftDeletedDatabaseAccountListByLocation.json"
+          }
+        }
+      }
+    },
     "/subscriptions/{subscriptionId}/providers/Microsoft.DocumentDB/restorableDatabaseAccounts": {
       "get": {
         "operationId": "RestorableDatabaseAccounts_List",
@@ -19737,6 +19784,762 @@
         "x-ms-long-running-operation": true
       }
     },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts": {
+      "get": {
+        "operationId": "SoftDeletedDatabaseAccounts_ListByResourceGroupAndLocation",
+        "description": "Lists all the soft-deleted Azure Cosmos DB database accounts available under the given resource group and in a region. This call requires 'Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/read' permission.",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "location",
+            "in": "path",
+            "description": "Cosmos DB region, with spaces between words and each word capitalized.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "x-ms-client-name": "apiVersion"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SoftDeletedDatabaseAccountsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBSoftDeletedDatabaseAccountListByResourceGroupAndLocation": {
+            "$ref": "./examples/CosmosDBSoftDeletedDatabaseAccountListByResourceGroupAndLocation.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}": {
+      "get": {
+        "operationId": "SoftDeletedDatabaseAccounts_Get",
+        "description": "Retrieves the properties of a soft-deleted Azure Cosmos DB database account by location and accountName. This call requires 'Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/read' permission.",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "x-ms-client-name": "apiVersion"
+          },
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "location",
+            "in": "path",
+            "description": "Cosmos DB region, with spaces between words and each word capitalized.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SoftDeletedDatabaseAccountGetResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBSoftDeletedDatabaseAccountGet": {
+            "$ref": "./examples/CosmosDBSoftDeletedDatabaseAccountGet.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "SoftDeletedDatabaseAccounts_Delete",
+        "description": "Performs a soft delete action (restore or permanently delete) on a soft-deleted Azure Cosmos DB database account.",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "location",
+            "in": "path",
+            "description": "Cosmos DB region, with spaces between words and each word capitalized.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "x-ms-client-name": "apiVersion"
+          },
+          {
+            "name": "softDeleteActionKind",
+            "in": "query",
+            "description": "The kind of soft delete action to perform.",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "RestoreSoftDeletedResource",
+              "PermanentDeleteResource"
+            ],
+            "x-ms-enum": {
+              "name": "SoftDeleteActionKind",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "RestoreSoftDeletedResource",
+                  "value": "RestoreSoftDeletedResource",
+                  "description": "Restores the soft-deleted resource to active/online state."
+                },
+                {
+                  "name": "PermanentDeleteResource",
+                  "value": "PermanentDeleteResource",
+                  "description": "Permanently deletes the soft-deleted resource."
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBSoftDeletedDatabaseAccountPurge": {
+            "$ref": "./examples/CosmosDBSoftDeletedDatabaseAccountPurge.json"
+          },
+          "CosmosDBSoftDeletedDatabaseAccountRestore": {
+            "$ref": "./examples/CosmosDBSoftDeletedDatabaseAccountRestore.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases": {
+      "get": {
+        "operationId": "SoftDeletedSqlDatabases_List",
+        "description": "Lists all the soft-deleted Azure Cosmos DB SQL databases under a soft-deleted database account. This call requires 'Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/softDeletedSqlDatabases/read' permission.",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "x-ms-client-name": "apiVersion"
+          },
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "location",
+            "in": "path",
+            "description": "Cosmos DB region, with spaces between words and each word capitalized.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SoftDeletedSqlDatabasesListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBSoftDeletedSqlDatabaseList": {
+            "$ref": "./examples/CosmosDBSoftDeletedSqlDatabaseList.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}": {
+      "get": {
+        "operationId": "SoftDeletedSqlDatabases_Get",
+        "description": "Retrieves the properties of a soft-deleted Azure Cosmos DB SQL database. This call requires 'Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/softDeletedSqlDatabases/read' permission.",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "x-ms-client-name": "apiVersion"
+          },
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "location",
+            "in": "path",
+            "description": "Cosmos DB region, with spaces between words and each word capitalized.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "Cosmos DB SQL database name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "pattern": "^[^/\\\\#?]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SoftDeletedSqlDatabaseGetResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBSoftDeletedSqlDatabaseGet": {
+            "$ref": "./examples/CosmosDBSoftDeletedSqlDatabaseGet.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "SoftDeletedSqlDatabases_Delete",
+        "description": "Performs a soft delete action (restore or permanently delete) on a soft-deleted Azure Cosmos DB SQL database.",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "location",
+            "in": "path",
+            "description": "Cosmos DB region, with spaces between words and each word capitalized.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "Cosmos DB SQL database name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "pattern": "^[^/\\\\#?]+$"
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "x-ms-client-name": "apiVersion"
+          },
+          {
+            "name": "softDeleteActionKind",
+            "in": "query",
+            "description": "The kind of soft delete action to perform.",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "RestoreSoftDeletedResource",
+              "PermanentDeleteResource"
+            ],
+            "x-ms-enum": {
+              "name": "SoftDeleteActionKind",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "RestoreSoftDeletedResource",
+                  "value": "RestoreSoftDeletedResource",
+                  "description": "Restores the soft-deleted resource to active/online state."
+                },
+                {
+                  "name": "PermanentDeleteResource",
+                  "value": "PermanentDeleteResource",
+                  "description": "Permanently deletes the soft-deleted resource."
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBSoftDeletedSqlDatabasePurge": {
+            "$ref": "./examples/CosmosDBSoftDeletedSqlDatabasePurge.json"
+          },
+          "CosmosDBSoftDeletedSqlDatabaseRestore": {
+            "$ref": "./examples/CosmosDBSoftDeletedSqlDatabaseRestore.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}/softDeletedSqlContainers": {
+      "get": {
+        "operationId": "SoftDeletedSqlContainers_List",
+        "description": "Lists all the soft-deleted Azure Cosmos DB SQL containers under a soft-deleted SQL database. This call requires 'Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/softDeletedSqlDatabases/softDeletedSqlContainers/read' permission.",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "x-ms-client-name": "apiVersion"
+          },
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "location",
+            "in": "path",
+            "description": "Cosmos DB region, with spaces between words and each word capitalized.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "Cosmos DB SQL database name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "pattern": "^[^/\\\\#?]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SoftDeletedSqlContainersListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBSoftDeletedSqlContainerList": {
+            "$ref": "./examples/CosmosDBSoftDeletedSqlContainerList.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/locations/{location}/softDeletedDatabaseAccounts/{accountName}/softDeletedSqlDatabases/{databaseName}/softDeletedSqlContainers/{containerName}": {
+      "get": {
+        "operationId": "SoftDeletedSqlContainers_Get",
+        "description": "Retrieves the properties of a soft-deleted Azure Cosmos DB SQL container. This call requires 'Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/softDeletedSqlDatabases/softDeletedSqlContainers/read' permission.",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "x-ms-client-name": "apiVersion"
+          },
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "location",
+            "in": "path",
+            "description": "Cosmos DB region, with spaces between words and each word capitalized.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "Cosmos DB SQL database name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "pattern": "^[^/\\\\#?]+$"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "Cosmos DB SQL container name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "pattern": "^[^/\\\\#?]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SoftDeletedSqlContainerGetResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBSoftDeletedSqlContainerGet": {
+            "$ref": "./examples/CosmosDBSoftDeletedSqlContainerGet.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "SoftDeletedSqlContainers_Delete",
+        "description": "Performs a soft delete action (restore or permanently delete) on a soft-deleted Azure Cosmos DB SQL container.",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "location",
+            "in": "path",
+            "description": "Cosmos DB region, with spaces between words and each word capitalized.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "Cosmos DB database account name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 50,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "Cosmos DB SQL database name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "pattern": "^[^/\\\\#?]+$"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "Cosmos DB SQL container name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "pattern": "^[^/\\\\#?]+$"
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "x-ms-client-name": "apiVersion"
+          },
+          {
+            "name": "softDeleteActionKind",
+            "in": "query",
+            "description": "The kind of soft delete action to perform.",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "RestoreSoftDeletedResource",
+              "PermanentDeleteResource"
+            ],
+            "x-ms-enum": {
+              "name": "SoftDeleteActionKind",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "RestoreSoftDeletedResource",
+                  "value": "RestoreSoftDeletedResource",
+                  "description": "Restores the soft-deleted resource to active/online state."
+                },
+                {
+                  "name": "PermanentDeleteResource",
+                  "value": "PermanentDeleteResource",
+                  "description": "Permanently deletes the soft-deleted resource."
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "CosmosDBSoftDeletedSqlContainerPurge": {
+            "$ref": "./examples/CosmosDBSoftDeletedSqlContainerPurge.json"
+          },
+          "CosmosDBSoftDeletedSqlContainerRestore": {
+            "$ref": "./examples/CosmosDBSoftDeletedSqlContainerRestore.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/throughputPools": {
       "get": {
         "operationId": "ThroughputPools_ListByResourceGroup",
@@ -24059,6 +24862,10 @@
           "type": "boolean",
           "description": "Flag to indicate if All Versions and Deletes Change feed feature is enabled on the account"
         },
+        "softDeleteConfiguration": {
+          "$ref": "#/definitions/SoftDeleteConfiguration",
+          "description": "The configuration for soft delete on the Cosmos DB account."
+        },
         "enforceHierarchicalPartitionKeyIdLastLevel": {
           "type": "boolean",
           "description": "Flag to indicate enabling/disabling of hierarchical partition key ID last level enforcement on the account."
@@ -24334,6 +25141,10 @@
         "enableAllVersionsAndDeletesChangeFeed": {
           "type": "boolean",
           "description": "Flag to indicate if All Versions and Deletes Change feed feature is enabled on the account"
+        },
+        "softDeleteConfiguration": {
+          "$ref": "#/definitions/SoftDeleteConfiguration",
+          "description": "The configuration for soft delete on the Cosmos DB account."
         },
         "throughputPoolDedicatedRUs": {
           "type": "integer",
@@ -24703,6 +25514,10 @@
         "enableAllVersionsAndDeletesChangeFeed": {
           "type": "boolean",
           "description": "Flag to indicate if All Versions and Deletes Change feed feature is enabled on the account"
+        },
+        "softDeleteConfiguration": {
+          "$ref": "#/definitions/SoftDeleteConfiguration",
+          "description": "The configuration for soft delete on the Cosmos DB account."
         },
         "enforceHierarchicalPartitionKeyIdLastLevel": {
           "type": "boolean",
@@ -30512,6 +31327,308 @@
             "value": "MaterializedViewsBuilder"
           }
         ]
+      }
+    },
+    "SoftDeleteConfiguration": {
+      "type": "object",
+      "description": "Configuration for soft delete on the Cosmos DB account.",
+      "properties": {
+        "softDeletionEnabled": {
+          "type": "boolean",
+          "description": "Flag to indicate whether soft delete is enabled on the account.",
+          "x-nullable": true
+        },
+        "minMinutesBeforePermanentDeletionAllowed": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Minimum number of minutes before a soft deleted resource can be permanently deleted.",
+          "x-nullable": true
+        },
+        "softDeleteRetentionPeriodInMinutes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Soft delete retention period in minutes for resources.",
+          "x-nullable": true
+        }
+      }
+    },
+    "SoftDeletedDatabaseAccountGetResult": {
+      "type": "object",
+      "description": "A Azure Cosmos DB soft-deleted database account.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/SoftDeletedDatabaseAccountProperties",
+          "description": "The properties of a soft-deleted database account.",
+          "x-ms-client-flatten": true
+        },
+        "id": {
+          "type": "string",
+          "description": "The unique resource identifier of the ARM resource.",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the ARM resource.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of Azure resource.",
+          "readOnly": true
+        },
+        "location": {
+          "type": "string",
+          "description": "The location of the resource group to which the resource belongs."
+        }
+      }
+    },
+    "SoftDeletedDatabaseAccountProperties": {
+      "type": "object",
+      "description": "The properties of a soft-deleted database account.",
+      "properties": {
+        "accountName": {
+          "type": "string",
+          "description": "The name of the database account."
+        },
+        "softDeletionMetadata": {
+          "$ref": "#/definitions/SoftDeletionMetadata",
+          "description": "Metadata related to the soft deletion of the database account."
+        },
+        "softDeleteConfiguration": {
+          "$ref": "#/definitions/SoftDeleteConfiguration",
+          "description": "The soft delete configuration for the database account."
+        },
+        "resource": {
+          "$ref": "#/definitions/SoftDeletedDatabaseAccountResource",
+          "description": "A subset of properties of the underlying database account resource."
+        }
+      }
+    },
+    "SoftDeletedDatabaseAccountResource": {
+      "type": "object",
+      "description": "The database account resource information for a soft-deleted account.",
+      "properties": {
+        "locations": {
+          "type": "array",
+          "description": "An array that contains all of the locations enabled for the Cosmos DB account.",
+          "items": {
+            "$ref": "#/definitions/Location"
+          },
+          "x-ms-identifiers": []
+        },
+        "writeLocations": {
+          "type": "array",
+          "description": "An array that contains the write location(s) for the Cosmos DB account.",
+          "items": {
+            "$ref": "#/definitions/Location"
+          },
+          "x-ms-identifiers": []
+        },
+        "readLocations": {
+          "type": "array",
+          "description": "An array that contains the read locations enabled for the Cosmos DB account.",
+          "items": {
+            "$ref": "#/definitions/Location"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "SoftDeletedDatabaseAccountsListResult": {
+      "type": "object",
+      "description": "The List operation response, that contains the soft-deleted database accounts and their properties.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "List of soft-deleted database accounts and their properties.",
+          "items": {
+            "$ref": "#/definitions/SoftDeletedDatabaseAccountGetResult"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "SoftDeletedSqlContainerGetResult": {
+      "type": "object",
+      "description": "An Azure Cosmos DB soft-deleted SQL container.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/SoftDeletedSqlContainerProperties",
+          "description": "The properties of a soft-deleted SQL container.",
+          "x-ms-client-flatten": true
+        },
+        "id": {
+          "type": "string",
+          "description": "The unique resource identifier of the ARM resource.",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the ARM resource.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of Azure resource.",
+          "readOnly": true
+        },
+        "location": {
+          "type": "string",
+          "description": "The location of the resource group to which the resource belongs."
+        }
+      }
+    },
+    "SoftDeletedSqlContainerProperties": {
+      "type": "object",
+      "description": "The properties of a soft-deleted SQL container.",
+      "properties": {
+        "softDeletionMetadata": {
+          "$ref": "#/definitions/SoftDeletionMetadata",
+          "description": "Metadata related to the soft deletion of the SQL container."
+        },
+        "resource": {
+          "$ref": "#/definitions/SoftDeletedSqlContainerResource",
+          "description": "The resource information for the soft-deleted SQL container."
+        }
+      }
+    },
+    "SoftDeletedSqlContainerResource": {
+      "type": "object",
+      "description": "Cosmos DB SQL container resource object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Name of the Cosmos DB SQL container"
+        },
+        "_rid": {
+          "type": "string",
+          "description": "A system generated property. A unique identifier.",
+          "readOnly": true,
+          "x-ms-client-name": "rid"
+        },
+        "partitionKey": {
+          "$ref": "#/definitions/ContainerPartitionKey",
+          "description": "The configuration of the partition key to be used for partitioning data into multiple partitions"
+        },
+        "defaultTtl": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Default time to live"
+        }
+      },
+      "required": [
+        "id"
+      ]
+    },
+    "SoftDeletedSqlContainersListResult": {
+      "type": "object",
+      "description": "The List operation response, that contains the soft-deleted SQL containers and their properties.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "List of soft-deleted SQL containers and their properties.",
+          "items": {
+            "$ref": "#/definitions/SoftDeletedSqlContainerGetResult"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "SoftDeletedSqlDatabaseGetResult": {
+      "type": "object",
+      "description": "An Azure Cosmos DB soft-deleted SQL database.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/SoftDeletedSqlDatabaseProperties",
+          "description": "The properties of a soft-deleted SQL database.",
+          "x-ms-client-flatten": true
+        },
+        "id": {
+          "type": "string",
+          "description": "The unique resource identifier of the ARM resource.",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the ARM resource.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of Azure resource.",
+          "readOnly": true
+        },
+        "location": {
+          "type": "string",
+          "description": "The location of the resource group to which the resource belongs."
+        }
+      }
+    },
+    "SoftDeletedSqlDatabaseProperties": {
+      "type": "object",
+      "description": "The properties of a soft-deleted SQL database.",
+      "properties": {
+        "softDeletionMetadata": {
+          "$ref": "#/definitions/SoftDeletionMetadata",
+          "description": "Metadata related to the soft deletion of the SQL database."
+        },
+        "resource": {
+          "$ref": "#/definitions/SoftDeletedSqlDatabaseResource",
+          "description": "The resource information for the soft-deleted SQL database."
+        }
+      }
+    },
+    "SoftDeletedSqlDatabaseResource": {
+      "type": "object",
+      "description": "Cosmos DB SQL database resource object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Name of the Cosmos DB SQL database"
+        },
+        "_rid": {
+          "type": "string",
+          "description": "A system generated property. A unique identifier.",
+          "readOnly": true,
+          "x-ms-client-name": "rid"
+        }
+      },
+      "required": [
+        "id"
+      ]
+    },
+    "SoftDeletedSqlDatabasesListResult": {
+      "type": "object",
+      "description": "The List operation response, that contains the soft-deleted SQL databases and their properties.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "List of soft-deleted SQL databases and their properties.",
+          "items": {
+            "$ref": "#/definitions/SoftDeletedSqlDatabaseGetResult"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "SoftDeletionMetadata": {
+      "type": "object",
+      "description": "Metadata about the soft deletion of a resource.",
+      "properties": {
+        "isSoftDeleted": {
+          "type": "boolean",
+          "description": "Indicates whether the resource is soft deleted."
+        },
+        "softDeletionStartTimestamp": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The timestamp when the soft deletion started."
+        },
+        "softDeletionResourceExpirationTimestamp": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The timestamp when the soft-deleted resource will expire and be permanently deleted."
+        }
       }
     },
     "SpatialSpec": {

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/openapi.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/openapi.json
@@ -1155,11 +1155,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "name": "location",
-            "in": "path",
-            "description": "Cosmos DB region, with spaces between words and each word capitalized.",
-            "required": true,
-            "type": "string"
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
           }
         ],
         "responses": {
@@ -19792,11 +19788,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
-            "name": "location",
-            "in": "path",
-            "description": "Cosmos DB region, with spaces between words and each word capitalized.",
-            "required": true,
-            "type": "string"
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
           },
           {
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
@@ -19841,11 +19833,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
-            "name": "location",
-            "in": "path",
-            "description": "Cosmos DB region, with spaces between words and each word capitalized.",
-            "required": true,
-            "type": "string"
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
           },
           {
             "name": "accountName",
@@ -19889,11 +19877,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
-            "name": "location",
-            "in": "path",
-            "description": "Cosmos DB region, with spaces between words and each word capitalized.",
-            "required": true,
-            "type": "string"
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
           },
           {
             "name": "accountName",
@@ -19990,11 +19974,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
-            "name": "location",
-            "in": "path",
-            "description": "Cosmos DB region, with spaces between words and each word capitalized.",
-            "required": true,
-            "type": "string"
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
           },
           {
             "name": "accountName",
@@ -20046,11 +20026,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
-            "name": "location",
-            "in": "path",
-            "description": "Cosmos DB region, with spaces between words and each word capitalized.",
-            "required": true,
-            "type": "string"
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
           },
           {
             "name": "accountName",
@@ -20104,11 +20080,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
-            "name": "location",
-            "in": "path",
-            "description": "Cosmos DB region, with spaces between words and each word capitalized.",
-            "required": true,
-            "type": "string"
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
           },
           {
             "name": "accountName",
@@ -20215,11 +20187,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
-            "name": "location",
-            "in": "path",
-            "description": "Cosmos DB region, with spaces between words and each word capitalized.",
-            "required": true,
-            "type": "string"
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
           },
           {
             "name": "accountName",
@@ -20281,11 +20249,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
-            "name": "location",
-            "in": "path",
-            "description": "Cosmos DB region, with spaces between words and each word capitalized.",
-            "required": true,
-            "type": "string"
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
           },
           {
             "name": "accountName",
@@ -20349,11 +20313,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
-            "name": "location",
-            "in": "path",
-            "description": "Cosmos DB region, with spaces between words and each word capitalized.",
-            "required": true,
-            "type": "string"
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
           },
           {
             "name": "accountName",
@@ -31293,7 +31253,11 @@
         },
         "location": {
           "type": "string",
-          "description": "The location of the resource group to which the resource belongs."
+          "description": "The location of the resource group to which the resource belongs.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         }
       }
     },
@@ -31393,7 +31357,11 @@
         },
         "location": {
           "type": "string",
-          "description": "The location of the resource group to which the resource belongs."
+          "description": "The location of the resource group to which the resource belongs.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         }
       }
     },
@@ -31482,7 +31450,11 @@
         },
         "location": {
           "type": "string",
-          "description": "The location of the resource group to which the resource belongs."
+          "description": "The location of the resource group to which the resource belongs.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         }
       }
     },

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/readme.md
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/readme.md
@@ -1123,6 +1123,14 @@ directive:
     from: cosmos-db.json
     where: $.definitions.MaterializedViewDetails.properties._rid
     reason: _rid is a backend property
+  - suppress: DefinitionsPropertiesNamesCamelCase
+    from: openapi.json
+    where: $.definitions.SoftDeletedSqlDatabaseResource.properties._rid
+    reason: _rid is a backend property
+  - suppress: DefinitionsPropertiesNamesCamelCase
+    from: openapi.json
+    where: $.definitions.SoftDeletedSqlContainerResource.properties._rid
+    reason: _rid is a backend property
 ```
 
 ---


### PR DESCRIPTION
Port soft delete swagger changes from azure-rest-api-specs-pr PR #25529 to TypeSpec.

Changes:
- Add SoftDeleteConfiguration model with softDeletionEnabled, minMinutesBeforePermanentDeletionAllowed, and softDeleteRetentionPeriodInMinutes
- Add softDeleteConfiguration property to DatabaseAccountGetProperties, DatabaseAccountCreateUpdateProperties, and DatabaseAccountUpdateProperties
- Create SoftDeletedResources.tsp with operations for:
  - SoftDeletedDatabaseAccounts (Get, ListByLocation, ListByResourceGroupAndLocation, Delete)
  - SoftDeletedSqlDatabases (Get, List, Delete)
  - SoftDeletedSqlContainers (Get, List, Delete)
- Add 13 example JSON files for 2026-04-01-preview
- All new types versioned with @added(Versions.v2026_04_01_preview)
- Generated swagger output verified

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
