### PR TITLE
Replace ProxyResource in ServiceFabric

### DIFF
--- a/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/ServiceFabric/ApplicationResource.tsp
+++ b/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/ServiceFabric/ApplicationResource.tsp
@@ -13,20 +13,37 @@ namespace Microsoft.ServiceFabric;
 /**
  * The application resource.
  */
-#suppress "@azure-tools/typespec-azure-core/no-private-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-#suppress "@azure-tools/typespec-azure-resource-manager/arm-custom-resource-usage-discourage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-#suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-@Http.Private.includeInapplicableMetadataInPayload(false)
 @parentResource(Cluster)
-model ApplicationResource extends ProxyResource {
-  properties?: ApplicationResourceProperties;
+model ApplicationResource
+  is Azure.ResourceManager.ProxyResource<ApplicationResourceProperties> {
+  ...ResourceNameParameter<
+    Resource = ApplicationResource,
+    KeyName = "applicationName",
+    SegmentName = "applications",
+    NamePattern = ""
+  >;
 
+  /**
+   * It will be deprecated in New API, resource location depends on the parent resource.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+  @visibility(Lifecycle.Create, Lifecycle.Read)
+  location?: string;
+
+  /**
+   * Azure resource tags.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+  @visibility(Lifecycle.Create, Lifecycle.Read)
+  tags?: Record<string>;
+
+  /**
+   * Azure resource etag.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
   @visibility(Lifecycle.Read)
-  @path
-  @key("applicationName")
-  @segment("applications")
-  name: string;
+  etag?: string;
 
   /**
    * The managed service identities assigned to this resource.
@@ -378,7 +395,7 @@ model ApplicationUserAssignedIdentity {
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "For backward compatibility"
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-custom-resource-no-key" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-custom-resource-usage-discourage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-model ApplicationResourceUpdate extends ProxyResource {
+model ApplicationResourceUpdate extends PatchProxyResource {
   /**
    * The application resource properties for patch operations.
    */

--- a/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/ServiceFabric/ApplicationTypeResource.tsp
+++ b/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/ServiceFabric/ApplicationTypeResource.tsp
@@ -13,20 +13,37 @@ namespace Microsoft.ServiceFabric;
 /**
  * The application type name resource
  */
-#suppress "@azure-tools/typespec-azure-core/no-private-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-#suppress "@azure-tools/typespec-azure-resource-manager/arm-custom-resource-usage-discourage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-#suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-@Http.Private.includeInapplicableMetadataInPayload(false)
 @parentResource(Cluster)
-model ApplicationTypeResource extends ProxyResource {
-  properties?: ApplicationTypeResourceProperties;
+model ApplicationTypeResource
+  is Azure.ResourceManager.ProxyResource<ApplicationTypeResourceProperties> {
+  ...ResourceNameParameter<
+    Resource = ApplicationTypeResource,
+    KeyName = "applicationTypeName",
+    SegmentName = "applicationTypes",
+    NamePattern = ""
+  >;
 
+  /**
+   * It will be deprecated in New API, resource location depends on the parent resource.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+  @visibility(Lifecycle.Create, Lifecycle.Read)
+  location?: string;
+
+  /**
+   * Azure resource tags.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+  @visibility(Lifecycle.Create, Lifecycle.Read)
+  tags?: Record<string>;
+
+  /**
+   * Azure resource etag.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
   @visibility(Lifecycle.Read)
-  @path
-  @key("applicationTypeName")
-  @segment("applicationTypes")
-  name: string;
+  etag?: string;
 }
 
 @armResourceOperations(#{ omitTags: true })

--- a/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/ServiceFabric/ApplicationTypeVersionResource.tsp
+++ b/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/ServiceFabric/ApplicationTypeVersionResource.tsp
@@ -14,20 +14,37 @@ namespace Microsoft.ServiceFabric;
 /**
  * An application type version resource for the specified application type name resource.
  */
-#suppress "@azure-tools/typespec-azure-core/no-private-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-#suppress "@azure-tools/typespec-azure-resource-manager/arm-custom-resource-usage-discourage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-#suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-@Http.Private.includeInapplicableMetadataInPayload(false)
 @parentResource(ApplicationTypeResource)
-model ApplicationTypeVersionResource extends ProxyResource {
-  properties?: ApplicationTypeVersionResourceProperties;
+model ApplicationTypeVersionResource
+  is Azure.ResourceManager.ProxyResource<ApplicationTypeVersionResourceProperties> {
+  ...ResourceNameParameter<
+    Resource = ApplicationTypeVersionResource,
+    KeyName = "version",
+    SegmentName = "versions",
+    NamePattern = ""
+  >;
 
+  /**
+   * It will be deprecated in New API, resource location depends on the parent resource.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+  @visibility(Lifecycle.Create, Lifecycle.Read)
+  location?: string;
+
+  /**
+   * Azure resource tags.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+  @visibility(Lifecycle.Create, Lifecycle.Read)
+  tags?: Record<string>;
+
+  /**
+   * Azure resource etag.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
   @visibility(Lifecycle.Read)
-  @path
-  @key("version")
-  @segment("versions")
-  name: string;
+  etag?: string;
 }
 
 @armResourceOperations(#{ omitTags: true })

--- a/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/ServiceFabric/ServiceResource.tsp
+++ b/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/ServiceFabric/ServiceResource.tsp
@@ -14,20 +14,37 @@ namespace Microsoft.ServiceFabric;
 /**
  * The service resource.
  */
-#suppress "@azure-tools/typespec-azure-core/no-private-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-#suppress "@azure-tools/typespec-azure-resource-manager/arm-custom-resource-usage-discourage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-#suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-@Http.Private.includeInapplicableMetadataInPayload(false)
 @parentResource(ApplicationResource)
-model ServiceResource extends ProxyResource {
-  properties?: ServiceResourceProperties;
+model ServiceResource
+  is Azure.ResourceManager.ProxyResource<ServiceResourceProperties> {
+  ...ResourceNameParameter<
+    Resource = ServiceResource,
+    KeyName = "serviceName",
+    SegmentName = "services",
+    NamePattern = ""
+  >;
 
+  /**
+   * It will be deprecated in New API, resource location depends on the parent resource.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+  @visibility(Lifecycle.Create, Lifecycle.Read)
+  location?: string;
+
+  /**
+   * Azure resource tags.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+  @visibility(Lifecycle.Create, Lifecycle.Read)
+  tags?: Record<string>;
+
+  /**
+   * Azure resource etag.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
   @visibility(Lifecycle.Read)
-  @path
-  @key("serviceName")
-  @segment("services")
-  name: string;
+  etag?: string;
 }
 
 @armResourceOperations(#{ omitTags: true })
@@ -254,7 +271,7 @@ model ServicePlacementPolicyDescription {
 #suppress "@azure-tools/typespec-azure-resource-manager/patch-envelope" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-custom-resource-no-key" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-custom-resource-usage-discourage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-model ServiceResourceUpdate extends ProxyResource {
+model ServiceResourceUpdate extends PatchProxyResource {
   /**
    * The RP-specific properties for this resource.
    */

--- a/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/ServiceFabric/models.tsp
+++ b/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/ServiceFabric/models.tsp
@@ -43,7 +43,7 @@ model ErrorModelError {
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-custom-resource-no-key" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-custom-resource-usage-discourage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @Azure.ResourceManager.Legacy.customAzureResource
-model ProxyResource {
+model PatchProxyResource {
   /**
    * Azure resource identifier.
    */

--- a/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/ServiceFabric/preview/2023-11-01-preview/servicefabric.json
+++ b/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/ServiceFabric/preview/2023-11-01-preview/servicefabric.json
@@ -2115,6 +2115,30 @@
           "description": "The application resource properties.",
           "x-ms-client-flatten": true
         },
+        "location": {
+          "type": "string",
+          "description": "It will be deprecated in New API, resource location depends on the parent resource.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "tags": {
+          "type": "object",
+          "description": "Azure resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "etag": {
+          "type": "string",
+          "description": "Azure resource etag.",
+          "readOnly": true
+        },
         "identity": {
           "$ref": "#/definitions/ManagedIdentity",
           "description": "The managed service identities assigned to this resource."
@@ -2122,7 +2146,7 @@
       },
       "allOf": [
         {
-          "$ref": "#/definitions/ProxyResource"
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
         }
       ]
     },
@@ -2179,7 +2203,7 @@
       },
       "allOf": [
         {
-          "$ref": "#/definitions/ProxyResource"
+          "$ref": "#/definitions/PatchProxyResource"
         }
       ]
     },
@@ -2243,11 +2267,35 @@
           "$ref": "#/definitions/ApplicationTypeResourceProperties",
           "description": "The application type name properties",
           "x-ms-client-flatten": true
+        },
+        "location": {
+          "type": "string",
+          "description": "It will be deprecated in New API, resource location depends on the parent resource.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "tags": {
+          "type": "object",
+          "description": "Azure resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "etag": {
+          "type": "string",
+          "description": "Azure resource etag.",
+          "readOnly": true
         }
       },
       "allOf": [
         {
-          "$ref": "#/definitions/ProxyResource"
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
         }
       ]
     },
@@ -2291,11 +2339,35 @@
           "$ref": "#/definitions/ApplicationTypeVersionResourceProperties",
           "description": "The properties of the application type version resource.",
           "x-ms-client-flatten": true
+        },
+        "location": {
+          "type": "string",
+          "description": "It will be deprecated in New API, resource location depends on the parent resource.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "tags": {
+          "type": "object",
+          "description": "Azure resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "etag": {
+          "type": "string",
+          "description": "Azure resource etag.",
+          "readOnly": true
         }
       },
       "allOf": [
         {
-          "$ref": "#/definitions/ProxyResource"
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
         }
       ]
     },
@@ -3942,44 +4014,7 @@
         "partitionScheme"
       ]
     },
-    "ProvisioningState": {
-      "type": "string",
-      "description": "The provisioning state of the cluster resource.",
-      "enum": [
-        "Updating",
-        "Succeeded",
-        "Failed",
-        "Canceled"
-      ],
-      "x-ms-enum": {
-        "name": "ProvisioningState",
-        "modelAsString": true,
-        "values": [
-          {
-            "name": "Updating",
-            "value": "Updating",
-            "description": "Cluster is updating."
-          },
-          {
-            "name": "Succeeded",
-            "value": "Succeeded",
-            "description": "Cluster provisioning succeeded."
-          },
-          {
-            "name": "Failed",
-            "value": "Failed",
-            "description": "Cluster provisioning failed."
-          },
-          {
-            "name": "Canceled",
-            "value": "Canceled",
-            "description": "Cluster provisioning was canceled."
-          }
-        ]
-      },
-      "readOnly": true
-    },
-    "ProxyResource": {
+    "PatchProxyResource": {
       "type": "object",
       "description": "The resource model definition for proxy-only resource.",
       "properties": {
@@ -4027,6 +4062,43 @@
           "description": "Metadata pertaining to creation and last modification of the resource."
         }
       }
+    },
+    "ProvisioningState": {
+      "type": "string",
+      "description": "The provisioning state of the cluster resource.",
+      "enum": [
+        "Updating",
+        "Succeeded",
+        "Failed",
+        "Canceled"
+      ],
+      "x-ms-enum": {
+        "name": "ProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Cluster is updating."
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Cluster provisioning succeeded."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Cluster provisioning failed."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Cluster provisioning was canceled."
+          }
+        ]
+      },
+      "readOnly": true
     },
     "ReliabilityLevel": {
       "type": "string",
@@ -4329,11 +4401,35 @@
         "properties": {
           "$ref": "#/definitions/ServiceResourceProperties",
           "description": "The service resource properties."
+        },
+        "location": {
+          "type": "string",
+          "description": "It will be deprecated in New API, resource location depends on the parent resource.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "tags": {
+          "type": "object",
+          "description": "Azure resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "etag": {
+          "type": "string",
+          "description": "Azure resource etag.",
+          "readOnly": true
         }
       },
       "allOf": [
         {
-          "$ref": "#/definitions/ProxyResource"
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
         }
       ]
     },
@@ -4446,7 +4542,7 @@
       },
       "allOf": [
         {
-          "$ref": "#/definitions/ProxyResource"
+          "$ref": "#/definitions/PatchProxyResource"
         }
       ]
     },

--- a/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/ServiceFabric/preview/2026-03-01-preview/servicefabric.json
+++ b/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/ServiceFabric/preview/2026-03-01-preview/servicefabric.json
@@ -2115,6 +2115,30 @@
           "description": "The application resource properties.",
           "x-ms-client-flatten": true
         },
+        "location": {
+          "type": "string",
+          "description": "It will be deprecated in New API, resource location depends on the parent resource.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "tags": {
+          "type": "object",
+          "description": "Azure resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "etag": {
+          "type": "string",
+          "description": "Azure resource etag.",
+          "readOnly": true
+        },
         "identity": {
           "$ref": "#/definitions/ManagedIdentity",
           "description": "The managed service identities assigned to this resource."
@@ -2122,7 +2146,7 @@
       },
       "allOf": [
         {
-          "$ref": "#/definitions/ProxyResource"
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
         }
       ]
     },
@@ -2179,7 +2203,7 @@
       },
       "allOf": [
         {
-          "$ref": "#/definitions/ProxyResource"
+          "$ref": "#/definitions/PatchProxyResource"
         }
       ]
     },
@@ -2243,11 +2267,35 @@
           "$ref": "#/definitions/ApplicationTypeResourceProperties",
           "description": "The application type name properties",
           "x-ms-client-flatten": true
+        },
+        "location": {
+          "type": "string",
+          "description": "It will be deprecated in New API, resource location depends on the parent resource.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "tags": {
+          "type": "object",
+          "description": "Azure resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "etag": {
+          "type": "string",
+          "description": "Azure resource etag.",
+          "readOnly": true
         }
       },
       "allOf": [
         {
-          "$ref": "#/definitions/ProxyResource"
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
         }
       ]
     },
@@ -2291,11 +2339,35 @@
           "$ref": "#/definitions/ApplicationTypeVersionResourceProperties",
           "description": "The properties of the application type version resource.",
           "x-ms-client-flatten": true
+        },
+        "location": {
+          "type": "string",
+          "description": "It will be deprecated in New API, resource location depends on the parent resource.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "tags": {
+          "type": "object",
+          "description": "Azure resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "etag": {
+          "type": "string",
+          "description": "Azure resource etag.",
+          "readOnly": true
         }
       },
       "allOf": [
         {
-          "$ref": "#/definitions/ProxyResource"
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
         }
       ]
     },
@@ -3942,44 +4014,7 @@
         "partitionScheme"
       ]
     },
-    "ProvisioningState": {
-      "type": "string",
-      "description": "The provisioning state of the cluster resource.",
-      "enum": [
-        "Updating",
-        "Succeeded",
-        "Failed",
-        "Canceled"
-      ],
-      "x-ms-enum": {
-        "name": "ProvisioningState",
-        "modelAsString": true,
-        "values": [
-          {
-            "name": "Updating",
-            "value": "Updating",
-            "description": "Cluster is updating."
-          },
-          {
-            "name": "Succeeded",
-            "value": "Succeeded",
-            "description": "Cluster provisioning succeeded."
-          },
-          {
-            "name": "Failed",
-            "value": "Failed",
-            "description": "Cluster provisioning failed."
-          },
-          {
-            "name": "Canceled",
-            "value": "Canceled",
-            "description": "Cluster provisioning was canceled."
-          }
-        ]
-      },
-      "readOnly": true
-    },
-    "ProxyResource": {
+    "PatchProxyResource": {
       "type": "object",
       "description": "The resource model definition for proxy-only resource.",
       "properties": {
@@ -4027,6 +4062,43 @@
           "description": "Metadata pertaining to creation and last modification of the resource."
         }
       }
+    },
+    "ProvisioningState": {
+      "type": "string",
+      "description": "The provisioning state of the cluster resource.",
+      "enum": [
+        "Updating",
+        "Succeeded",
+        "Failed",
+        "Canceled"
+      ],
+      "x-ms-enum": {
+        "name": "ProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Cluster is updating."
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Cluster provisioning succeeded."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Cluster provisioning failed."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Cluster provisioning was canceled."
+          }
+        ]
+      },
+      "readOnly": true
     },
     "ReliabilityLevel": {
       "type": "string",
@@ -4329,11 +4401,35 @@
         "properties": {
           "$ref": "#/definitions/ServiceResourceProperties",
           "description": "The service resource properties."
+        },
+        "location": {
+          "type": "string",
+          "description": "It will be deprecated in New API, resource location depends on the parent resource.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "tags": {
+          "type": "object",
+          "description": "Azure resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "etag": {
+          "type": "string",
+          "description": "Azure resource etag.",
+          "readOnly": true
         }
       },
       "allOf": [
         {
-          "$ref": "#/definitions/ProxyResource"
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
         }
       ]
     },
@@ -4446,7 +4542,7 @@
       },
       "allOf": [
         {
-          "$ref": "#/definitions/ProxyResource"
+          "$ref": "#/definitions/PatchProxyResource"
         }
       ]
     },


### PR DESCRIPTION
The custom resource model `ProxyResource` should be only needed for the patch model. But during the tsp migration we got naming conflicts between the common `ProxyResource` and the user-defined `ProxyRsource`, so we let the resource models all extends the user-defined `ProxyRsource` during the tsp migration. 
This PR has 2 kinds of breaking changes:
- corrects them to use the common `ProxyResource` for the resource models. This kind of breaking change is expected during tsp migration.
- renaming of the custom `ProxyResource` to avoid naming conflicts and property structure change