### PR TITLE
CloudHealth: fix JS sample generation for DiscoveryRules create

### DIFF
--- a/specification/cloudhealth/CloudHealth.Management/examples/2026-01-01-preview/DiscoveryRules_CreateOrUpdate.json
+++ b/specification/cloudhealth/CloudHealth.Management/examples/2026-01-01-preview/DiscoveryRules_CreateOrUpdate.json
@@ -13,6 +13,7 @@
         "displayName": "myDisplayName",
         "discoverRelationships": "Enabled",
         "addRecommendedSignals": "Enabled",
+        "entityName": "f1f0ef5e-a5b5-4d02-b69c-7145f4658829",
         "specification": {
           "kind": "ResourceGraphQuery",
           "resourceGraphQuery": "resources | where subscriptionId == '7ddfffd7-9b32-40df-1234-828cbd55d6f4' | where resourceGroup == 'my-rg'"


### PR DESCRIPTION
## What this fixes\nAdds missing required `entityName` to the request payload in `DiscoveryRules_CreateOrUpdate` example for `2026-01-01-preview`.\n\n## Why\nJavaScript SDK generation fails during sample compilation with TS2741 because `DiscoveryRuleProperties.entityName` is required but absent from the create/update sample request body.\n\n## Validation\n- Root cause confirmed from failed SDK generation pipelines 6124371 and 6124400.\n- Re-run JavaScript SDK generation after merging this PR.