### PR TITLE
Fix naming issues in DesktopVirtualization client.tsp per SDK review

### DIFF
--- a/specification/desktopvirtualization/resource-manager/Microsoft.DesktopVirtualization/DesktopVirtualization/client.tsp
+++ b/specification/desktopvirtualization/resource-manager/Microsoft.DesktopVirtualization/DesktopVirtualization/client.tsp
@@ -173,7 +173,7 @@ using Microsoft.DesktopVirtualization;
 );
 
 @@clientName(AllowRDPShortPathWithPrivateLink,
-  "AllowRdpShortPathWithPrivateLink",
+  "DesktopVirtualizationAllowRdpShortPathWithPrivateLink",
   "csharp"
 );
 
@@ -690,7 +690,7 @@ using Microsoft.DesktopVirtualization;
 );
 @@clientName(PublicUDP, "DesktopVirtualizationPublicUdp", "csharp");
 @@clientName(ProvisioningStateSHC,
-  "ProvisioningStateSessionHostConfiguration",
+  "SessionHostConfigurationProvisioningState",
   "csharp"
 );
 @@clientName(RegistrationTokenList,
@@ -727,7 +727,7 @@ using Microsoft.DesktopVirtualization;
   "csharp"
 );
 @@clientName(FailedSessionHostCleanupPolicySHC,
-  "FailedSessionHostCleanupPolicySessionHostConfiguration",
+  "SessionHostConfigurationFailedSessionHostCleanupPolicy",
   "csharp"
 );
 
@@ -768,5 +768,36 @@ using Microsoft.DesktopVirtualization;
 );
 @@alternateType(SessionHostConfigurationPatchProperties.vmLocation,
   Azure.Core.azureLocation,
+  "csharp"
+);
+
+// Fix generic names — add DesktopVirtualization prefix
+@@clientName(ActiveDirectoryInfoProperties,
+  "DesktopVirtualizationActiveDirectoryInfoProperties",
+  "csharp"
+);
+@@clientName(BootDiagnosticsInfoProperties,
+  "DesktopVirtualizationBootDiagnosticsInfoProperties",
+  "csharp"
+);
+@@clientName(BootDiagnosticsInfoPatchProperties,
+  "DesktopVirtualizationBootDiagnosticsInfoPatchProperties",
+  "csharp"
+);
+@@clientName(MarketplaceInfoProperties,
+  "DesktopVirtualizationMarketplaceInfoProperties",
+  "csharp"
+);
+@@clientName(MarketplaceInfoPatchProperties,
+  "DesktopVirtualizationMarketplaceInfoPatchProperties",
+  "csharp"
+);
+// Fix ScopedRegistrationTokenProperties — POST body should use Content suffix
+@@clientName(ScopedRegistrationTokenProperties,
+  "ScopedRegistrationTokenContent",
+  "csharp"
+);
+@@clientName(ScopedRegistrationTokenProperties.expirationTimeInUtc,
+  "ExpirationOn",
   "csharp"
 );


### PR DESCRIPTION
- Fix inverted enum names: ProvisioningStateSessionHostConfiguration -> SessionHostConfigurationProvisioningState, FailedSessionHostCleanupPolicySessionHostConfiguration -> SessionHostConfigurationFailedSessionHostCleanupPolicy
- Add DesktopVirtualization prefix to generic types: ActiveDirectoryInfoProperties, BootDiagnosticsInfoProperties, MarketplaceInfoProperties, AllowRdpShortPathWithPrivateLink
- Rename ScopedRegistrationTokenProperties to ScopedRegistrationTokenContent (POST body)
- Rename ExpirationTimeInUtc to ExpirationOn (DateTimeOffset convention)

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
