### PR TITLE
fix: deduplicate hero-scenarios guidelines and upgrade gh-aw to v0.67.1

### DIFF
--- a/.github/.prettierignore
+++ b/.github/.prettierignore
@@ -21,3 +21,6 @@ PULL_REQUEST_TEMPLATE
 
 # lock files for agent workflows
 **/*.lock.yml
+
+# synced from external repos
+workflows/post-apiview.yml

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,3 +1,7 @@
+self-hosted-runner:
+  labels:
+    - 1ES.Pool=azsdk-pool-github-runners
+
 paths:
   .github/workflows/*.lock.yml:
     ignore:

--- a/.github/agents/hero-scenarios.agent.md
+++ b/.github/agents/hero-scenarios.agent.md
@@ -5,39 +5,5 @@ tools: ["read", "search", "bash"]
 
 # Hero Scenarios Agent
 
-Follow the full guidelines in [hero-scenarios-guidelines.md](../prompts/hero-scenarios-guidelines.md).
-
-## Quick-Reference Checklist
-
-When generating hero scenarios, verify:
-
-1. **Business outcome** — every scenario is driven by a real customer
-   goal, not CRUD operations ("Monitor SQL databases and alert on
-   failure" not "Create, get, update, delete a watcher")
-2. **Multi-resource composition** — each scenario weaves multiple
-   resource types into a single cohesive workflow where each step
-   depends on the previous one
-3. **Cross-service integration** — include calls to other Azure services
-   when the spec references them (Key Vault, Azure Monitor, Managed
-   Identity, VNet, Storage)
-4. **Complete HTTP round-trips** — every code block shows request AND
-   response with status, headers, and a representative body
-5. **Full resource paths** — never abbreviate with `...` or ellipsis;
-   use full ARM or data-plane paths with placeholder variables
-6. **Honest count** — let the API surface drive how many scenarios you
-   generate; never pad with filler
-
-## Scope
-
-- Only analyze **API specification files** (`.tsp`, `tspconfig.yaml`).
-  Ignore examples, CI, docs.
-- Only use cross-service references **explicit in the spec** — do not
-  browse the wider repository for integration points.
-- For multi-service PRs, generate separate suggestions per service.
-
-## Output Format
-
-Post a suggested `README.md` (or README addition) as a PR comment using
-`add-comment`. Include: service name, one-paragraph description, and
-hero scenarios with title, persona paragraph, prerequisites, and API
-call sequence in `http` fenced code blocks.
+Before starting any work, read the detailed guidelines from
+`.github/prompts/hero-scenarios-guidelines.md` and follow them precisely.

--- a/.github/aw/actions-lock.json
+++ b/.github/aw/actions-lock.json
@@ -1,8 +1,8 @@
 {
   "entries": {
-    "actions/checkout@v6.0.2": {
+    "actions/checkout@v6": {
       "repo": "actions/checkout",
-      "version": "v6.0.2",
+      "version": "v6",
       "sha": "de0fac2e4500dabe0009e67214ff5f5447ce83dd"
     },
     "actions/github-script@v7": {
@@ -19,11 +19,6 @@
       "repo": "github/gh-aw-actions/setup",
       "version": "v0.67.1",
       "sha": "80471a493be8c528dd27daf73cd644242a7965e0"
-    },
-    "github/gh-aw-actions/setup@v0.67.3": {
-      "repo": "github/gh-aw-actions/setup",
-      "version": "v0.67.3",
-      "sha": "eef369c24101e76a5bf51579c26798b28f666813"
     }
   }
 }

--- a/.github/prompts/hero-scenarios-guidelines.md
+++ b/.github/prompts/hero-scenarios-guidelines.md
@@ -1,5 +1,3 @@
-# Hero Scenarios — Guidelines
-
 ## Step 0 — Identify the Spec Surface
 
 1. List the files changed in the pull request using the GitHub API.

--- a/.github/workflows/hero-scenarios.lock.yml
+++ b/.github/workflows/hero-scenarios.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"020c15347b95bd3c66e9a6740206564ee68ce81dd13766393f5607e59dceb047","compiler_version":"v0.67.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"b8c984fe69570e8538cfc539310f7b6f08bc5c0d2b7036629ee7c0f2ef8ddae4","compiler_version":"v0.67.1","strict":true,"agent_id":"copilot"}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -22,6 +22,10 @@
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
 # Hero Scenarios: Suggest a service README with hero scenarios for API specifications
+#
+# Resolved workflow manifest:
+#   Imports:
+#     - ../prompts/hero-scenarios-guidelines.md
 #
 # Secrets used:
 #   - COPILOT_GITHUB_TOKEN
@@ -166,16 +170,16 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_dbbb6fdadfb7954f_EOF'
+          cat << 'GH_AW_PROMPT_ce4e70927d7760db_EOF'
           <system>
-          GH_AW_PROMPT_dbbb6fdadfb7954f_EOF
+          GH_AW_PROMPT_ce4e70927d7760db_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/repo_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_dbbb6fdadfb7954f_EOF'
+          cat << 'GH_AW_PROMPT_ce4e70927d7760db_EOF'
           <safe-output-tools>
           Tools: add_comment, create_pull_request_review_comment(max:5), submit_pull_request_review, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -207,12 +211,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_dbbb6fdadfb7954f_EOF
+          GH_AW_PROMPT_ce4e70927d7760db_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_dbbb6fdadfb7954f_EOF'
+          cat << 'GH_AW_PROMPT_ce4e70927d7760db_EOF'
           </system>
+          {{#runtime-import .github/prompts/hero-scenarios-guidelines.md}}
           {{#runtime-import .github/workflows/hero-scenarios.md}}
-          GH_AW_PROMPT_dbbb6fdadfb7954f_EOF
+          GH_AW_PROMPT_ce4e70927d7760db_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -418,12 +423,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_fb2fcff676075528_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_253170e3a0c0097d_EOF'
           {"add_comment":{"max":1,"target":"${{ github.event.pull_request.number }}"},"create_pull_request_review_comment":{"max":5,"side":"RIGHT","target":"${{ github.event.pull_request.number }}"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_repo_memory":{"memories":[{"dir":"/tmp/gh-aw/repo-memory/default","id":"default","max_file_count":100,"max_file_size":10240,"max_patch_size":10240}]},"report_incomplete":{},"submit_pull_request_review":{"footer":"if-body","max":1,"target":"${{ github.event.pull_request.number }}"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_fb2fcff676075528_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_253170e3a0c0097d_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_9c4e627817289cf5_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_3ec828f40e1cde53_EOF'
           {
             "description_suffixes": {
               "add_comment": " CONSTRAINTS: Maximum 1 comment(s) can be added. Target: ${{ github.event.pull_request.number }}.",
@@ -433,8 +438,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_9c4e627817289cf5_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_bbe88c37a9d2ad64_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_3ec828f40e1cde53_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_d42810456f722f95_EOF'
           {
             "add_comment": {
               "defaultMax": 1,
@@ -583,7 +588,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_bbe88c37a9d2ad64_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_d42810456f722f95_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -651,7 +656,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.14'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_bbe465fd2d632f96_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_60fbec613accb8c9_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -695,7 +700,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_bbe465fd2d632f96_EOF
+          GH_AW_MCP_CONFIG_60fbec613accb8c9_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/hero-scenarios.md
+++ b/.github/workflows/hero-scenarios.md
@@ -15,6 +15,8 @@ tools:
   bash: ["cat", "echo", "grep", "head", "ls", "pwd", "sort", "tail", "wc"]
   cache-memory:
   repo-memory:
+imports:
+  - ../prompts/hero-scenarios-guidelines.md
 safe-outputs:
   add-comment:
     max: 1
@@ -40,4 +42,4 @@ timeout-minutes: 10
 Review pull request #${{ github.event.pull_request.number }} and suggest
 a service README with hero scenarios based on the API surface changed.
 
-Follow the procedure in [hero-scenarios-guidelines.md](../prompts/hero-scenarios-guidelines.md).
+Follow the hero-scenarios guidelines imported above.

--- a/.github/workflows/sdk-generation-agent.lock.yml
+++ b/.github/workflows/sdk-generation-agent.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"f6a1937b32eff04fbcdc41ec34c8355bda584a9eca5ead34405ee9d247ba41e7","compiler_version":"v0.67.1","agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"d604f341d43879e18b1d6aaff1a7f2a8d69a60f87944079854acc2b3108875ec","compiler_version":"v0.67.1","agent_id":"copilot"}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -199,14 +199,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_7885ec20ff4cc837_EOF'
+          cat << 'GH_AW_PROMPT_0c4f38fce7eccc1a_EOF'
           <system>
-          GH_AW_PROMPT_7885ec20ff4cc837_EOF
+          GH_AW_PROMPT_0c4f38fce7eccc1a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_7885ec20ff4cc837_EOF'
+          cat << 'GH_AW_PROMPT_0c4f38fce7eccc1a_EOF'
           <safe-output-tools>
           Tools: add_comment(max:15), missing_tool, missing_data, noop
           </safe-output-tools>
@@ -238,19 +238,21 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_7885ec20ff4cc837_EOF
+          GH_AW_PROMPT_0c4f38fce7eccc1a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_7885ec20ff4cc837_EOF'
+          cat << 'GH_AW_PROMPT_0c4f38fce7eccc1a_EOF'
           </system>
           {{#runtime-import .github/workflows/shared-github-aw-imports/install_azsdk_cli_import.md}}
           {{#runtime-import .github/workflows/shared-github-aw-imports/global_networks_auth_import.md}}
           {{#runtime-import .github/workflows/sdk-generation-agent.md}}
-          GH_AW_PROMPT_7885ec20ff4cc837_EOF
+          GH_AW_PROMPT_0c4f38fce7eccc1a_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
+          GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
+          GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -408,13 +410,16 @@ jobs:
           GH_HOST: github.com
       - name: Install AWF binary
         run: bash ${RUNNER_TEMP}/gh-aw/actions/install_awf_binary.sh v0.25.13
-      - name: Parse integrity filter lists
-        id: parse-guard-vars
+      - name: Determine automatic lockdown mode for GitHub MCP Server
+        id: determine-automatic-lockdown
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
-          GH_AW_BLOCKED_USERS_VAR: ${{ vars.GH_AW_GITHUB_BLOCKED_USERS || '' }}
-          GH_AW_TRUSTED_USERS_VAR: ${{ vars.GH_AW_GITHUB_TRUSTED_USERS || '' }}
-          GH_AW_APPROVAL_LABELS_VAR: ${{ vars.GH_AW_GITHUB_APPROVAL_LABELS || '' }}
-        run: bash ${RUNNER_TEMP}/gh-aw/actions/parse_guard_list.sh
+          GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
+          GH_AW_GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
+        with:
+          script: |
+            const determineAutomaticLockdown = require('${{ runner.temp }}/gh-aw/actions/determine_automatic_lockdown.cjs');
+            await determineAutomaticLockdown(github, context, core);
       - name: Download container images
         run: bash ${RUNNER_TEMP}/gh-aw/actions/download_docker_images.sh ghcr.io/github/gh-aw-firewall/agent:0.25.13 ghcr.io/github/gh-aw-firewall/api-proxy:0.25.13 ghcr.io/github/gh-aw-firewall/squid:0.25.13 ghcr.io/github/gh-aw-mcpg:v0.2.14 ghcr.io/github/github-mcp-server:v0.32.0 node:lts-alpine
       - name: Write Safe Outputs Config
@@ -422,12 +427,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_580d469d20ff1408_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_ff65ec1f7916889d_EOF'
           {"add_comment":{"hide_older_comments":true,"max":15},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_580d469d20ff1408_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_ff65ec1f7916889d_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_a41e6417086e246a_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_97b82606d84a6815_EOF'
           {
             "description_suffixes": {
               "add_comment": " CONSTRAINTS: Maximum 15 comment(s) can be added."
@@ -435,8 +440,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_a41e6417086e246a_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_9316a02e31892cd0_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_97b82606d84a6815_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_76cf636c2ba35b29_EOF'
           {
             "add_comment": {
               "defaultMax": 1,
@@ -530,7 +535,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_9316a02e31892cd0_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_76cf636c2ba35b29_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -578,6 +583,8 @@ jobs:
           GH_AW_SAFE_OUTPUTS: ${{ steps.set-runtime-paths.outputs.GH_AW_SAFE_OUTPUTS }}
           GH_AW_SAFE_OUTPUTS_API_KEY: ${{ steps.safe-outputs-start.outputs.api_key }}
           GH_AW_SAFE_OUTPUTS_PORT: ${{ steps.safe-outputs-start.outputs.port }}
+          GITHUB_MCP_GUARD_MIN_INTEGRITY: ${{ steps.determine-automatic-lockdown.outputs.min_integrity }}
+          GITHUB_MCP_GUARD_REPOS: ${{ steps.determine-automatic-lockdown.outputs.repos }}
           GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -eo pipefail
@@ -598,7 +605,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.14'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_68f097b02d6af6f8_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_2d847c13f9ea7567_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -612,11 +619,8 @@ jobs:
                 },
                 "guard-policies": {
                   "allow-only": {
-                    "approval-labels": ${{ steps.parse-guard-vars.outputs.approval_labels }},
-                    "blocked-users": ${{ steps.parse-guard-vars.outputs.blocked_users }},
-                    "min-integrity": "approved",
-                    "repos": "all",
-                    "trusted-users": ${{ steps.parse-guard-vars.outputs.trusted_users }}
+                    "min-integrity": "$GITHUB_MCP_GUARD_MIN_INTEGRITY",
+                    "repos": "$GITHUB_MCP_GUARD_REPOS"
                   }
                 }
               },
@@ -642,7 +646,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_68f097b02d6af6f8_EOF
+          GH_AW_MCP_CONFIG_2d847c13f9ea7567_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -654,7 +658,7 @@ jobs:
       - name: Execute GitHub Copilot CLI
         id: agentic_execution
         # Copilot CLI tool arguments (sorted):
-        timeout-minutes: 60
+        timeout-minutes: 20
         run: |
           set -o pipefail
           touch /tmp/gh-aw/agent-step-summary.md
@@ -817,8 +821,6 @@ jobs:
             /tmp/gh-aw/sandbox/agent/logs/
             /tmp/gh-aw/redacted-urls.log
             /tmp/gh-aw/mcp-logs/
-            /tmp/gh-aw/proxy-logs/
-            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent_usage.json
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/agent/
@@ -945,7 +947,7 @@ jobs:
           GH_AW_SAFE_OUTPUT_MESSAGES: "{\"runStarted\":\"[{workflow_name}]({run_url}) started for Azure sdk generation.\"}"
           GH_AW_GROUP_REPORTS: "false"
           GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
-          GH_AW_TIMEOUT_MINUTES: "60"
+          GH_AW_TIMEOUT_MINUTES: "20"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
## What this PR does

Fixes the hero-scenarios workflow so the agent can find the guidelines at runtime, and eliminates content duplication between the workflow and the Copilot agent.

### Problem

The hero-scenarios guidelines were duplicated across two files (workflow prompt and agent definition), and the previous approach using markdown links did not resolve at runtime — the agent could not find the guidelines file.

### Fix

Move the shared guidelines into a single source of truth (`hero-scenarios-guidelines.md`) and wire both consumers to it:

- **Workflow** (`hero-scenarios.md`): uses gh-aw `imports:` field, which generates a `{{#runtime-import}}` directive that inlines the file content into the agent prompt at runtime
- **Copilot agent** (`hero-scenarios.agent.md`): instructs the agent to read the guidelines file (it has `read`/`bash` tools)

### Files changed

- `.github/prompts/hero-scenarios-guidelines.md` — removed redundant heading
- `.github/workflows/hero-scenarios.md` — added `imports:` field, slimmed body
- `.github/agents/hero-scenarios.agent.md` — replaced 34-line checklist with file reference
- `.github/workflows/hero-scenarios.lock.yml` — recompiled
- `.github/workflows/sdk-generation-agent.lock.yml` — recompiled with gh-aw v0.67.1
- `.github/aw/actions-lock.json` — consolidated action SHA pins
