### PR TITLE
The current code emitted code to expect 201.  But service expect 200.…

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/src/skills/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/skills/routes.tsp
@@ -30,7 +30,7 @@ interface Skills {
   @extension("x-ms-foundry-meta", SkillsRequiredPreviews)
   createSkillFromPackage is FoundryDataPlaneOperation<
     CreateSkillFromPackageRequest & SkillsPreviewHeader,
-    ResourceCreatedResponse<SkillObject>
+    Azure.Core.Foundations.ResourceCreatedOrOkResponse<SkillObject>
   >;
 
   /**


### PR DESCRIPTION
The current code emitted code to expect 201, but service expect 200.    So I create this PR.  I found  there are 3 routes expect 201 and service does expect 201 that work.  Many routes expect 200 and service expect 200 that also works.  I also found many routes accept 200 and 201, I think this is a better option, so I use this.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
