### PR TITLE
Add controlPlane metrics to stable API version 2026-03-01

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
@@ -3679,7 +3679,7 @@ model ManagedClusterAzureMonitorProfileMetrics {
   /**
    * Control plane metrics collection profile for the Azure Managed Prometheus addon. Configures collection of operational runtime metrics from managed control plane components (kube-apiserver, etcd, etc). See aka.ms/aks/controlplane-metrics for an overview.
    */
-  @added(Versions.v2026_02_02_preview)
+  @added(Versions.v2026_03_01)
   controlPlane?: ManagedClusterAzureMonitorProfileMetricsControlPlane;
 }
 
@@ -3701,7 +3701,7 @@ model ManagedClusterAzureMonitorProfileKubeStateMetrics {
 /**
  * Control plane metrics collection profile for the Azure Managed Prometheus addon. Configures collection of operational runtime metrics from managed control plane components (kube-apiserver, etcd, etc). See aka.ms/aks/controlplane-metrics for an overview.
  */
-@added(Versions.v2026_02_02_preview)
+@added(Versions.v2026_03_01)
 model ManagedClusterAzureMonitorProfileMetricsControlPlane {
   /**
    * Whether to enable or disable collection of control plane metrics by the Azure Managed Prometheus addon. Defaults to disabled. See aka.ms/aks/controlplane-metrics for details.

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/main.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/main.tsp
@@ -69,6 +69,11 @@ enum Versions {
   v2026_02_01: "2026-02-01",
 
   /**
+   * The 2026-03-01 API version.
+   */
+  v2026_03_01: "2026-03-01",
+
+  /**
    * The 2026-02-02-preview API version.
    */
   @previewVersion

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/readme.md
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/readme.md
@@ -34,7 +34,16 @@ These are the global settings for the ContainerServices API.
 
 ``` yaml
 openapi-type: arm
-tag: package-2026-02
+tag: package-2026-03
+```
+
+### Tag: package-2026-03
+
+These settings apply only when `--tag=package-2026-03` is specified on the command line.
+
+``` yaml $(tag) == 'package-2026-03'
+input-file:
+  - stable/2026-03-01/managedClusters.json
 ```
 
 ### Tag: package-2026-02

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AdvancedNetworkingTransitEncryption.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AdvancedNetworkingTransitEncryption.json
@@ -1,0 +1,267 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "parameters": {
+      "location": "location1",
+      "properties": {
+        "addonProfiles": {},
+        "agentPoolProfiles": [
+          {
+            "name": "nodepool1",
+            "type": "VirtualMachineScaleSets",
+            "count": 3,
+            "enableNodePublicIP": true,
+            "mode": "System",
+            "osType": "Linux",
+            "vmSize": "Standard_DS2_v2"
+          }
+        ],
+        "dnsPrefix": "dnsprefix1",
+        "enableRBAC": true,
+        "kubernetesVersion": "",
+        "linuxProfile": {
+          "adminUsername": "azureuser",
+          "ssh": {
+            "publicKeys": [
+              {
+                "keyData": "keydata"
+              }
+            ]
+          }
+        },
+        "networkProfile": {
+          "advancedNetworking": {
+            "enabled": true,
+            "observability": {
+              "enabled": false
+            },
+            "security": {
+              "advancedNetworkPolicies": "FQDN",
+              "enabled": true,
+              "transitEncryption": {
+                "type": "WireGuard"
+              }
+            }
+          },
+          "loadBalancerProfile": {
+            "managedOutboundIPs": {
+              "count": 2
+            }
+          },
+          "loadBalancerSku": "standard",
+          "networkDataplane": "cilium",
+          "networkPlugin": "azure",
+          "networkPluginMode": "overlay",
+          "outboundType": "loadBalancer"
+        },
+        "servicePrincipalProfile": {
+          "clientId": "clientid",
+          "secret": "secret"
+        }
+      },
+      "sku": {
+        "name": "Basic",
+        "tier": "Free"
+      },
+      "tags": {
+        "archv2": "",
+        "tier": "production"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "nodeImageVersion": "AKSUbuntu:1604:2020.03.11",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Succeeded",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "advancedNetworking": {
+              "enabled": true,
+              "observability": {
+                "enabled": false
+              },
+              "security": {
+                "advancedNetworkPolicies": "FQDN",
+                "enabled": true,
+                "transitEncryption": {
+                  "type": "WireGuard"
+                }
+              }
+            },
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "standard",
+            "networkDataplane": "cilium",
+            "networkPlugin": "azure",
+            "networkPluginMode": "overlay",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "nodeImageVersion": "AKSUbuntu:1604:2020.03.11",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Succeeded",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "advancedNetworking": {
+              "enabled": true,
+              "observability": {
+                "enabled": false
+              },
+              "security": {
+                "advancedNetworkPolicies": "FQDN",
+                "enabled": true,
+                "transitEncryption": {
+                  "type": "WireGuard"
+                }
+              }
+            },
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "standard",
+            "networkDataplane": "cilium",
+            "networkPlugin": "azure",
+            "networkPluginMode": "overlay",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    }
+  },
+  "operationId": "ManagedClusters_CreateOrUpdate",
+  "title": "Create Managed Cluster with Advanced Networking Transit Encryption"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsAbortOperation.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsAbortOperation.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-03-01",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operationStatus/00000000-0000-0000-0000-000000000000?api-version=2026-03-01",
+        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/00000000-0000-0000-0000-000000000000?api-version=2026-03-01"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "AgentPools_AbortLatestOperation",
+  "title": "Abort operation on agent pool"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsCreate_CRG.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsCreate_CRG.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-03-01",
+    "parameters": {
+      "properties": {
+        "capacityReservationGroupID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/CapacityReservationGroups/crg1",
+        "count": 3,
+        "orchestratorVersion": "",
+        "osType": "Linux",
+        "vmSize": "Standard_DS2_v2"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "capacityReservationGroupID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/CapacityReservationGroups/crg1",
+          "count": 3,
+          "currentOrchestratorVersion": "1.9.6",
+          "maxPods": 110,
+          "orchestratorVersion": "1.9.6",
+          "osType": "Linux",
+          "provisioningState": "Succeeded",
+          "vmSize": "Standard_DS2_v2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "capacityReservationGroupID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/CapacityReservationGroups/crg1",
+          "count": 3,
+          "currentOrchestratorVersion": "1.9.6",
+          "maxPods": 110,
+          "orchestratorVersion": "1.9.6",
+          "osType": "Linux",
+          "provisioningState": "Creating",
+          "vmSize": "Standard_DS2_v2"
+        }
+      }
+    }
+  },
+  "operationId": "AgentPools_CreateOrUpdate",
+  "title": "Create Agent Pool with Capacity Reservation Group"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsCreate_CustomNodeConfig.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsCreate_CustomNodeConfig.json
@@ -1,0 +1,126 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-03-01",
+    "parameters": {
+      "properties": {
+        "count": 3,
+        "kubeletConfig": {
+          "allowedUnsafeSysctls": [
+            "kernel.msg*",
+            "net.core.somaxconn"
+          ],
+          "cpuCfsQuota": true,
+          "cpuCfsQuotaPeriod": "200ms",
+          "cpuManagerPolicy": "static",
+          "failSwapOn": false,
+          "imageGcHighThreshold": 90,
+          "imageGcLowThreshold": 70,
+          "topologyManagerPolicy": "best-effort"
+        },
+        "linuxOSConfig": {
+          "swapFileSizeMB": 1500,
+          "sysctls": {
+            "kernelThreadsMax": 99999,
+            "netCoreWmemDefault": 12345,
+            "netIpv4IpLocalPortRange": "20000 60000",
+            "netIpv4TcpTwReuse": true
+          },
+          "transparentHugePageDefrag": "madvise",
+          "transparentHugePageEnabled": "always"
+        },
+        "orchestratorVersion": "",
+        "osType": "Linux",
+        "vmSize": "Standard_DS2_v2"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "currentOrchestratorVersion": "1.17.8",
+          "kubeletConfig": {
+            "allowedUnsafeSysctls": [
+              "kernel.msg*",
+              "net.core.somaxconn"
+            ],
+            "cpuCfsQuota": true,
+            "cpuCfsQuotaPeriod": "200ms",
+            "cpuManagerPolicy": "static",
+            "failSwapOn": false,
+            "imageGcHighThreshold": 90,
+            "imageGcLowThreshold": 70,
+            "topologyManagerPolicy": "best-effort"
+          },
+          "linuxOSConfig": {
+            "swapFileSizeMB": 1500,
+            "sysctls": {
+              "kernelThreadsMax": 99999,
+              "netCoreWmemDefault": 12345,
+              "netIpv4IpLocalPortRange": "20000 60000",
+              "netIpv4TcpTwReuse": true
+            },
+            "transparentHugePageDefrag": "madvise",
+            "transparentHugePageEnabled": "always"
+          },
+          "maxPods": 110,
+          "orchestratorVersion": "1.17.8",
+          "osType": "Linux",
+          "provisioningState": "Succeeded",
+          "vmSize": "Standard_DS2_v2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "currentOrchestratorVersion": "1.17.8",
+          "kubeletConfig": {
+            "allowedUnsafeSysctls": [
+              "kernel.msg*",
+              "net.core.somaxconn"
+            ],
+            "cpuCfsQuota": true,
+            "cpuCfsQuotaPeriod": "200ms",
+            "cpuManagerPolicy": "static",
+            "failSwapOn": false,
+            "imageGcHighThreshold": 90,
+            "imageGcLowThreshold": 70,
+            "podMaxPids": 100,
+            "topologyManagerPolicy": "best-effort"
+          },
+          "linuxOSConfig": {
+            "swapFileSizeMB": 1500,
+            "sysctls": {
+              "kernelThreadsMax": 99999,
+              "netCoreWmemDefault": 65536,
+              "netIpv4IpLocalPortRange": "20000 60000",
+              "netIpv4TcpTwReuse": true
+            },
+            "transparentHugePageDefrag": "madvise",
+            "transparentHugePageEnabled": "always"
+          },
+          "maxPods": 110,
+          "orchestratorVersion": "1.17.8",
+          "osType": "Linux",
+          "provisioningState": "Creating",
+          "vmSize": "Standard_DS2_v2"
+        }
+      }
+    }
+  },
+  "operationId": "AgentPools_CreateOrUpdate",
+  "title": "Create Agent Pool with KubeletConfig and LinuxOSConfig"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsCreate_DedicatedHostGroup.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsCreate_DedicatedHostGroup.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-03-01",
+    "parameters": {
+      "properties": {
+        "count": 3,
+        "hostGroupID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Compute/hostGroups/hostgroup1",
+        "orchestratorVersion": "",
+        "osType": "Linux",
+        "vmSize": "Standard_DS2_v2"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "hostGroupID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Compute/hostGroups/hostgroup1",
+          "maxPods": 110,
+          "orchestratorVersion": "1.19.6",
+          "osType": "Linux",
+          "provisioningState": "Succeeded",
+          "vmSize": "Standard_DS2_v2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "hostGroupID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Compute/hostGroups/hostgroup1",
+          "maxPods": 110,
+          "orchestratorVersion": "1.19.6",
+          "osType": "Linux",
+          "provisioningState": "Creating",
+          "vmSize": "Standard_DS2_v2"
+        }
+      }
+    }
+  },
+  "operationId": "AgentPools_CreateOrUpdate",
+  "title": "Create Agent Pool with Dedicated Host Group"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsCreate_EnableEncryptionAtHost.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsCreate_EnableEncryptionAtHost.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-03-01",
+    "parameters": {
+      "properties": {
+        "count": 3,
+        "enableEncryptionAtHost": true,
+        "orchestratorVersion": "",
+        "osType": "Linux",
+        "vmSize": "Standard_DS2_v2"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "currentOrchestratorVersion": "1.17.13",
+          "enableEncryptionAtHost": true,
+          "maxPods": 110,
+          "orchestratorVersion": "1.17.13",
+          "osType": "Linux",
+          "provisioningState": "Succeeded",
+          "vmSize": "Standard_DS2_v2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "currentOrchestratorVersion": "1.17.13",
+          "enableEncryptionAtHost": true,
+          "maxPods": 110,
+          "orchestratorVersion": "1.17.13",
+          "osType": "Linux",
+          "provisioningState": "Creating",
+          "vmSize": "Standard_DS2_v2"
+        }
+      }
+    }
+  },
+  "operationId": "AgentPools_CreateOrUpdate",
+  "title": "Create Agent Pool with EncryptionAtHost enabled"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsCreate_EnableFIPS.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsCreate_EnableFIPS.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-03-01",
+    "parameters": {
+      "properties": {
+        "count": 3,
+        "enableFIPS": true,
+        "orchestratorVersion": "",
+        "osType": "Linux",
+        "vmSize": "Standard_DS2_v2"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "currentOrchestratorVersion": "1.19.6",
+          "enableFIPS": true,
+          "maxPods": 110,
+          "orchestratorVersion": "1.19.6",
+          "osType": "Linux",
+          "provisioningState": "Succeeded",
+          "vmSize": "Standard_DS2_v2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "currentOrchestratorVersion": "1.19.6",
+          "enableFIPS": true,
+          "maxPods": 110,
+          "orchestratorVersion": "1.19.6",
+          "osType": "Linux",
+          "provisioningState": "Creating",
+          "vmSize": "Standard_DS2_v2"
+        }
+      }
+    }
+  },
+  "operationId": "AgentPools_CreateOrUpdate",
+  "title": "Create Agent Pool with FIPS enabled OS"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsCreate_EnableUltraSSD.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsCreate_EnableUltraSSD.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-03-01",
+    "parameters": {
+      "properties": {
+        "count": 3,
+        "enableUltraSSD": true,
+        "orchestratorVersion": "",
+        "osType": "Linux",
+        "vmSize": "Standard_DS2_v2"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "currentOrchestratorVersion": "1.17.13",
+          "enableUltraSSD": true,
+          "maxPods": 110,
+          "orchestratorVersion": "1.17.13",
+          "osType": "Linux",
+          "provisioningState": "Succeeded",
+          "vmSize": "Standard_DS2_v2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "currentOrchestratorVersion": "1.17.13",
+          "enableUltraSSD": true,
+          "maxPods": 110,
+          "orchestratorVersion": "1.17.13",
+          "osType": "Linux",
+          "provisioningState": "Creating",
+          "vmSize": "Standard_DS2_v2"
+        }
+      }
+    }
+  },
+  "operationId": "AgentPools_CreateOrUpdate",
+  "title": "Create Agent Pool with UltraSSD enabled"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsCreate_Ephemeral.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsCreate_Ephemeral.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-03-01",
+    "parameters": {
+      "properties": {
+        "count": 3,
+        "orchestratorVersion": "",
+        "osDiskSizeGB": 64,
+        "osDiskType": "Ephemeral",
+        "osType": "Linux",
+        "vmSize": "Standard_DS2_v2"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "currentOrchestratorVersion": "1.17.8",
+          "maxPods": 110,
+          "orchestratorVersion": "1.17.8",
+          "osDiskSizeGB": 64,
+          "osDiskType": "Ephemeral",
+          "osType": "Linux",
+          "provisioningState": "Succeeded",
+          "vmSize": "Standard_DS2_v2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "currentOrchestratorVersion": "1.17.8",
+          "kubeletDiskType": "OS",
+          "maxPods": 110,
+          "orchestratorVersion": "1.17.8",
+          "osDiskSizeGB": 64,
+          "osDiskType": "Ephemeral",
+          "osType": "Linux",
+          "provisioningState": "Creating",
+          "vmSize": "Standard_DS2_v2"
+        }
+      }
+    }
+  },
+  "operationId": "AgentPools_CreateOrUpdate",
+  "title": "Create Agent Pool with Ephemeral OS Disk"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsCreate_GPUMIG.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsCreate_GPUMIG.json
@@ -1,0 +1,129 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-03-01",
+    "parameters": {
+      "properties": {
+        "count": 3,
+        "gpuInstanceProfile": "MIG2g",
+        "kubeletConfig": {
+          "allowedUnsafeSysctls": [
+            "kernel.msg*",
+            "net.core.somaxconn"
+          ],
+          "cpuCfsQuota": true,
+          "cpuCfsQuotaPeriod": "200ms",
+          "cpuManagerPolicy": "static",
+          "failSwapOn": false,
+          "imageGcHighThreshold": 90,
+          "imageGcLowThreshold": 70,
+          "topologyManagerPolicy": "best-effort"
+        },
+        "linuxOSConfig": {
+          "swapFileSizeMB": 1500,
+          "sysctls": {
+            "kernelThreadsMax": 99999,
+            "netCoreWmemDefault": 12345,
+            "netIpv4IpLocalPortRange": "20000 60000",
+            "netIpv4TcpTwReuse": true
+          },
+          "transparentHugePageDefrag": "madvise",
+          "transparentHugePageEnabled": "always"
+        },
+        "orchestratorVersion": "",
+        "osType": "Linux",
+        "vmSize": "Standard_ND96asr_v4"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "currentOrchestratorVersion": "1.17.8",
+          "gpuInstanceProfile": "MIG2g",
+          "kubeletConfig": {
+            "allowedUnsafeSysctls": [
+              "kernel.msg*",
+              "net.core.somaxconn"
+            ],
+            "cpuCfsQuota": true,
+            "cpuCfsQuotaPeriod": "200ms",
+            "cpuManagerPolicy": "static",
+            "failSwapOn": false,
+            "imageGcHighThreshold": 90,
+            "imageGcLowThreshold": 70,
+            "topologyManagerPolicy": "best-effort"
+          },
+          "linuxOSConfig": {
+            "swapFileSizeMB": 1500,
+            "sysctls": {
+              "kernelThreadsMax": 99999,
+              "netCoreWmemDefault": 12345,
+              "netIpv4IpLocalPortRange": "20000 60000",
+              "netIpv4TcpTwReuse": true
+            },
+            "transparentHugePageDefrag": "madvise",
+            "transparentHugePageEnabled": "always"
+          },
+          "maxPods": 110,
+          "orchestratorVersion": "1.17.8",
+          "osType": "Linux",
+          "provisioningState": "Succeeded",
+          "vmSize": "Standard_ND96asr_v4"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "currentOrchestratorVersion": "1.17.8",
+          "gpuInstanceProfile": "MIG2g",
+          "kubeletConfig": {
+            "allowedUnsafeSysctls": [
+              "kernel.msg*",
+              "net.core.somaxconn"
+            ],
+            "cpuCfsQuota": true,
+            "cpuCfsQuotaPeriod": "200ms",
+            "cpuManagerPolicy": "static",
+            "failSwapOn": false,
+            "imageGcHighThreshold": 90,
+            "imageGcLowThreshold": 70,
+            "podMaxPids": 100,
+            "topologyManagerPolicy": "best-effort"
+          },
+          "linuxOSConfig": {
+            "swapFileSizeMB": 1500,
+            "sysctls": {
+              "kernelThreadsMax": 99999,
+              "netCoreWmemDefault": 65536,
+              "netIpv4IpLocalPortRange": "20000 60000",
+              "netIpv4TcpTwReuse": true
+            },
+            "transparentHugePageDefrag": "madvise",
+            "transparentHugePageEnabled": "always"
+          },
+          "maxPods": 110,
+          "orchestratorVersion": "1.17.8",
+          "osType": "Linux",
+          "provisioningState": "Creating",
+          "vmSize": "Standard_ND96asr_v4"
+        }
+      }
+    }
+  },
+  "operationId": "AgentPools_CreateOrUpdate",
+  "title": "Create Agent Pool with GPUMIG"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsCreate_MessageOfTheDay.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsCreate_MessageOfTheDay.json
@@ -1,0 +1,62 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-03-01",
+    "parameters": {
+      "properties": {
+        "count": 3,
+        "messageOfTheDay": "Zm9vCg==",
+        "mode": "User",
+        "orchestratorVersion": "",
+        "osDiskSizeGB": 64,
+        "osType": "Linux",
+        "vmSize": "Standard_DS2_v2"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "currentOrchestratorVersion": "1.17.8",
+          "maxPods": 110,
+          "messageOfTheDay": "Zm9vCg==",
+          "mode": "User",
+          "orchestratorVersion": "1.17.8",
+          "osDiskSizeGB": 64,
+          "osType": "Linux",
+          "provisioningState": "Succeeded",
+          "vmSize": "Standard_DS2_v2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "currentOrchestratorVersion": "1.17.8",
+          "maxPods": 110,
+          "messageOfTheDay": "Zm9vCg==",
+          "mode": "User",
+          "orchestratorVersion": "1.17.8",
+          "osDiskSizeGB": 64,
+          "osType": "Linux",
+          "provisioningState": "Creating",
+          "vmSize": "Standard_DS2_v2"
+        }
+      }
+    }
+  },
+  "operationId": "AgentPools_CreateOrUpdate",
+  "title": "Create Agent Pool with Message of the Day"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsCreate_OSSKU.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsCreate_OSSKU.json
@@ -1,0 +1,129 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-03-01",
+    "parameters": {
+      "properties": {
+        "count": 3,
+        "kubeletConfig": {
+          "allowedUnsafeSysctls": [
+            "kernel.msg*",
+            "net.core.somaxconn"
+          ],
+          "cpuCfsQuota": true,
+          "cpuCfsQuotaPeriod": "200ms",
+          "cpuManagerPolicy": "static",
+          "failSwapOn": false,
+          "imageGcHighThreshold": 90,
+          "imageGcLowThreshold": 70,
+          "topologyManagerPolicy": "best-effort"
+        },
+        "linuxOSConfig": {
+          "swapFileSizeMB": 1500,
+          "sysctls": {
+            "kernelThreadsMax": 99999,
+            "netCoreWmemDefault": 12345,
+            "netIpv4IpLocalPortRange": "20000 60000",
+            "netIpv4TcpTwReuse": true
+          },
+          "transparentHugePageDefrag": "madvise",
+          "transparentHugePageEnabled": "always"
+        },
+        "orchestratorVersion": "",
+        "osSKU": "AzureLinux",
+        "osType": "Linux",
+        "vmSize": "Standard_DS2_v2"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "currentOrchestratorVersion": "1.17.8",
+          "kubeletConfig": {
+            "allowedUnsafeSysctls": [
+              "kernel.msg*",
+              "net.core.somaxconn"
+            ],
+            "cpuCfsQuota": true,
+            "cpuCfsQuotaPeriod": "200ms",
+            "cpuManagerPolicy": "static",
+            "failSwapOn": false,
+            "imageGcHighThreshold": 90,
+            "imageGcLowThreshold": 70,
+            "topologyManagerPolicy": "best-effort"
+          },
+          "linuxOSConfig": {
+            "swapFileSizeMB": 1500,
+            "sysctls": {
+              "kernelThreadsMax": 99999,
+              "netCoreWmemDefault": 12345,
+              "netIpv4IpLocalPortRange": "20000 60000",
+              "netIpv4TcpTwReuse": true
+            },
+            "transparentHugePageDefrag": "madvise",
+            "transparentHugePageEnabled": "always"
+          },
+          "maxPods": 110,
+          "orchestratorVersion": "1.17.8",
+          "osSKU": "AzureLinux",
+          "osType": "Linux",
+          "provisioningState": "Succeeded",
+          "vmSize": "Standard_DS2_v2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "currentOrchestratorVersion": "1.17.8",
+          "kubeletConfig": {
+            "allowedUnsafeSysctls": [
+              "kernel.msg*",
+              "net.core.somaxconn"
+            ],
+            "cpuCfsQuota": true,
+            "cpuCfsQuotaPeriod": "200ms",
+            "cpuManagerPolicy": "static",
+            "failSwapOn": false,
+            "imageGcHighThreshold": 90,
+            "imageGcLowThreshold": 70,
+            "podMaxPids": 100,
+            "topologyManagerPolicy": "best-effort"
+          },
+          "linuxOSConfig": {
+            "swapFileSizeMB": 1500,
+            "sysctls": {
+              "kernelThreadsMax": 99999,
+              "netCoreWmemDefault": 65536,
+              "netIpv4IpLocalPortRange": "20000 60000",
+              "netIpv4TcpTwReuse": true
+            },
+            "transparentHugePageDefrag": "madvise",
+            "transparentHugePageEnabled": "always"
+          },
+          "maxPods": 110,
+          "orchestratorVersion": "1.17.8",
+          "osSKU": "AzureLinux",
+          "osType": "Linux",
+          "provisioningState": "Creating",
+          "vmSize": "Standard_DS2_v2"
+        }
+      }
+    }
+  },
+  "operationId": "AgentPools_CreateOrUpdate",
+  "title": "Create Agent Pool with OSSKU"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsCreate_PPG.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsCreate_PPG.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-03-01",
+    "parameters": {
+      "properties": {
+        "count": 3,
+        "orchestratorVersion": "",
+        "osType": "Linux",
+        "proximityPlacementGroupID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/proximityPlacementGroups/ppg1",
+        "vmSize": "Standard_DS2_v2"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "currentOrchestratorVersion": "1.9.6",
+          "maxPods": 110,
+          "orchestratorVersion": "1.9.6",
+          "osType": "Linux",
+          "provisioningState": "Succeeded",
+          "proximityPlacementGroupID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/proximityPlacementGroups/ppg1",
+          "vmSize": "Standard_DS2_v2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "currentOrchestratorVersion": "1.9.6",
+          "maxPods": 110,
+          "orchestratorVersion": "1.9.6",
+          "osType": "Linux",
+          "provisioningState": "Creating",
+          "proximityPlacementGroupID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/proximityPlacementGroups/ppg1",
+          "vmSize": "Standard_DS2_v2"
+        }
+      }
+    }
+  },
+  "operationId": "AgentPools_CreateOrUpdate",
+  "title": "Create Agent Pool with PPG"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsCreate_Snapshot.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsCreate_Snapshot.json
@@ -1,0 +1,65 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-03-01",
+    "parameters": {
+      "properties": {
+        "count": 3,
+        "creationData": {
+          "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/snapshots/snapshot1"
+        },
+        "enableFIPS": true,
+        "orchestratorVersion": "",
+        "osType": "Linux",
+        "vmSize": "Standard_DS2_v2"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "creationData": {
+            "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/snapshots/snapshot1"
+          },
+          "currentOrchestratorVersion": "1.19.6",
+          "enableFIPS": true,
+          "maxPods": 110,
+          "orchestratorVersion": "1.19.6",
+          "osType": "Linux",
+          "provisioningState": "Succeeded",
+          "vmSize": "Standard_DS2_v2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "creationData": {
+            "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/snapshots/snapshot1"
+          },
+          "currentOrchestratorVersion": "1.19.6",
+          "enableFIPS": true,
+          "maxPods": 110,
+          "orchestratorVersion": "1.19.6",
+          "osType": "Linux",
+          "provisioningState": "Creating",
+          "vmSize": "Standard_DS2_v2"
+        }
+      }
+    }
+  },
+  "operationId": "AgentPools_CreateOrUpdate",
+  "title": "Create Agent Pool using an agent pool snapshot"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsCreate_Spot.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsCreate_Spot.json
@@ -1,0 +1,88 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-03-01",
+    "parameters": {
+      "properties": {
+        "count": 3,
+        "nodeLabels": {
+          "key1": "val1"
+        },
+        "nodeTaints": [
+          "Key1=Value1:NoSchedule"
+        ],
+        "orchestratorVersion": "",
+        "osType": "Linux",
+        "scaleSetEvictionPolicy": "Delete",
+        "scaleSetPriority": "Spot",
+        "tags": {
+          "name1": "val1"
+        },
+        "vmSize": "Standard_DS1_v2"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "currentOrchestratorVersion": "1.9.6",
+          "maxPods": 110,
+          "nodeLabels": {
+            "key1": "val1"
+          },
+          "nodeTaints": [
+            "Key1=Value1:NoSchedule"
+          ],
+          "orchestratorVersion": "1.9.6",
+          "osType": "Linux",
+          "provisioningState": "Succeeded",
+          "scaleSetEvictionPolicy": "Delete",
+          "scaleSetPriority": "Spot",
+          "spotMaxPrice": -1,
+          "tags": {
+            "name1": "val1"
+          },
+          "vmSize": "Standard_DS1_v2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "currentOrchestratorVersion": "1.9.6",
+          "maxPods": 110,
+          "nodeLabels": {
+            "key1": "val1"
+          },
+          "nodeTaints": [
+            "Key1=Value1:NoSchedule"
+          ],
+          "orchestratorVersion": "1.9.6",
+          "osType": "Linux",
+          "provisioningState": "Creating",
+          "scaleSetEvictionPolicy": "Delete",
+          "scaleSetPriority": "Spot",
+          "spotMaxPrice": -1,
+          "tags": {
+            "name1": "val1"
+          },
+          "vmSize": "Standard_DS1_v2"
+        }
+      }
+    }
+  },
+  "operationId": "AgentPools_CreateOrUpdate",
+  "title": "Create Spot Agent Pool"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsCreate_TypeVirtualMachines.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsCreate_TypeVirtualMachines.json
@@ -1,0 +1,141 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-03-01",
+    "parameters": {
+      "properties": {
+        "type": "VirtualMachines",
+        "nodeLabels": {
+          "key1": "val1"
+        },
+        "nodeTaints": [
+          "Key1=Value1:NoSchedule"
+        ],
+        "orchestratorVersion": "1.9.6",
+        "osType": "Linux",
+        "tags": {
+          "name1": "val1"
+        },
+        "virtualMachinesProfile": {
+          "scale": {
+            "manual": [
+              {
+                "count": 3,
+                "size": "Standard_D2_v2"
+              },
+              {
+                "count": 2,
+                "size": "Standard_D2_v3"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "type": "VirtualMachines",
+          "currentOrchestratorVersion": "1.9.6",
+          "maxPods": 110,
+          "nodeImageVersion": "AKSUbuntu-1804gen2containerd-2021.09.11",
+          "nodeLabels": {
+            "key1": "val1"
+          },
+          "nodeTaints": [
+            "Key1=Value1:NoSchedule"
+          ],
+          "orchestratorVersion": "1.9.6",
+          "osType": "Linux",
+          "provisioningState": "Succeeded",
+          "tags": {
+            "name1": "val1"
+          },
+          "virtualMachineNodesStatus": [
+            {
+              "count": 3,
+              "size": "Standard_D2_v2"
+            },
+            {
+              "count": 2,
+              "size": "Standard_D2_v3"
+            }
+          ],
+          "virtualMachinesProfile": {
+            "scale": {
+              "manual": [
+                {
+                  "count": 3,
+                  "size": "Standard_D2_v2"
+                },
+                {
+                  "count": 2,
+                  "size": "Standard_D2_v3"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "type": "VirtualMachines",
+          "currentOrchestratorVersion": "1.9.6",
+          "maxPods": 110,
+          "nodeImageVersion": "AKSUbuntu-1804gen2containerd-2021.09.11",
+          "nodeLabels": {
+            "key1": "val1"
+          },
+          "nodeTaints": [
+            "Key1=Value1:NoSchedule"
+          ],
+          "orchestratorVersion": "1.9.6",
+          "osType": "Linux",
+          "provisioningState": "Creating",
+          "tags": {
+            "name1": "val1"
+          },
+          "virtualMachineNodesStatus": [
+            {
+              "count": 3,
+              "size": "Standard_D2_v2"
+            },
+            {
+              "count": 2,
+              "size": "Standard_D2_v3"
+            }
+          ],
+          "virtualMachinesProfile": {
+            "scale": {
+              "manual": [
+                {
+                  "count": 3,
+                  "size": "Standard_D2_v2"
+                },
+                {
+                  "count": 2,
+                  "size": "Standard_D2_v3"
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "AgentPools_CreateOrUpdate",
+  "title": "Create Agent Pool with VirtualMachines pool type"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsCreate_Update.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsCreate_Update.json
@@ -1,0 +1,90 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-03-01",
+    "parameters": {
+      "properties": {
+        "count": 3,
+        "mode": "User",
+        "nodeLabels": {
+          "key1": "val1"
+        },
+        "nodeTaints": [
+          "Key1=Value1:NoSchedule"
+        ],
+        "orchestratorVersion": "",
+        "osType": "Linux",
+        "scaleSetEvictionPolicy": "Delete",
+        "scaleSetPriority": "Spot",
+        "tags": {
+          "name1": "val1"
+        },
+        "vmSize": "Standard_DS1_v2"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "currentOrchestratorVersion": "1.9.6",
+          "maxPods": 110,
+          "mode": "User",
+          "nodeImageVersion": "AKSUbuntu:1604:2020.03.11",
+          "nodeLabels": {
+            "key1": "val1"
+          },
+          "nodeTaints": [
+            "Key1=Value1:NoSchedule"
+          ],
+          "orchestratorVersion": "1.9.6",
+          "osType": "Linux",
+          "provisioningState": "Succeeded",
+          "scaleSetEvictionPolicy": "Delete",
+          "scaleSetPriority": "Spot",
+          "tags": {
+            "name1": "val1"
+          },
+          "vmSize": "Standard_DS1_v2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "currentOrchestratorVersion": "1.9.6",
+          "maxPods": 110,
+          "mode": "User",
+          "nodeLabels": {
+            "key1": "val1"
+          },
+          "nodeTaints": [
+            "Key1=Value1:NoSchedule"
+          ],
+          "orchestratorVersion": "1.9.6",
+          "osType": "Linux",
+          "provisioningState": "Creating",
+          "scaleSetEvictionPolicy": "Delete",
+          "scaleSetPriority": "Spot",
+          "tags": {
+            "name1": "val1"
+          },
+          "vmSize": "Standard_DS1_v2"
+        }
+      }
+    }
+  },
+  "operationId": "AgentPools_CreateOrUpdate",
+  "title": "Create/Update Agent Pool"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsCreate_WasmWasi.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsCreate_WasmWasi.json
@@ -1,0 +1,62 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-03-01",
+    "parameters": {
+      "properties": {
+        "count": 3,
+        "mode": "User",
+        "orchestratorVersion": "",
+        "osDiskSizeGB": 64,
+        "osType": "Linux",
+        "vmSize": "Standard_DS2_v2",
+        "workloadRuntime": "WasmWasi"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "currentOrchestratorVersion": "1.17.8",
+          "maxPods": 110,
+          "mode": "User",
+          "orchestratorVersion": "1.17.8",
+          "osDiskSizeGB": 64,
+          "osType": "Linux",
+          "provisioningState": "Succeeded",
+          "vmSize": "Standard_DS2_v2",
+          "workloadRuntime": "WasmWasi"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "currentOrchestratorVersion": "1.17.8",
+          "maxPods": 110,
+          "mode": "User",
+          "orchestratorVersion": "1.17.8",
+          "osDiskSizeGB": 64,
+          "osType": "Linux",
+          "provisioningState": "Creating",
+          "vmSize": "Standard_DS2_v2",
+          "workloadRuntime": "WasmWasi"
+        }
+      }
+    }
+  },
+  "operationId": "AgentPools_CreateOrUpdate",
+  "title": "Create Agent Pool with Krustlet and the WASI runtime"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsCreate_WindowsDisableOutboundNAT.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsCreate_WindowsDisableOutboundNAT.json
@@ -1,0 +1,65 @@
+{
+  "parameters": {
+    "agentPoolName": "wnp2",
+    "api-version": "2026-03-01",
+    "parameters": {
+      "properties": {
+        "count": 3,
+        "orchestratorVersion": "1.23.8",
+        "osSKU": "Windows2022",
+        "osType": "Windows",
+        "vmSize": "Standard_D4s_v3",
+        "windowsProfile": {
+          "disableOutboundNat": true
+        }
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "wnp2",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/wnp2",
+        "properties": {
+          "count": 3,
+          "currentOrchestratorVersion": "1.23.8",
+          "maxPods": 110,
+          "orchestratorVersion": "1.23.8",
+          "osSKU": "Windows2022",
+          "osType": "Windows",
+          "provisioningState": "Succeeded",
+          "vmSize": "Standard_D4s_v3",
+          "windowsProfile": {
+            "disableOutboundNat": true
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "wnp2",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/wnp2",
+        "properties": {
+          "count": 3,
+          "currentOrchestratorVersion": "1.23.8",
+          "maxPods": 110,
+          "orchestratorVersion": "1.23.8",
+          "osSKU": "Windows2022",
+          "osType": "Windows",
+          "provisioningState": "Creating",
+          "vmSize": "Standard_D4s_v3",
+          "windowsProfile": {
+            "disableOutboundNat": true
+          }
+        }
+      }
+    }
+  },
+  "operationId": "AgentPools_CreateOrUpdate",
+  "title": "Create Windows Agent Pool with disabling OutboundNAT"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsCreate_WindowsOSSKU.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsCreate_WindowsOSSKU.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "agentPoolName": "wnp2",
+    "api-version": "2026-03-01",
+    "parameters": {
+      "properties": {
+        "count": 3,
+        "orchestratorVersion": "1.23.3",
+        "osSKU": "Windows2022",
+        "osType": "Windows",
+        "vmSize": "Standard_D4s_v3"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "wnp2",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/wnp2",
+        "properties": {
+          "count": 3,
+          "currentOrchestratorVersion": "1.23.3",
+          "maxPods": 110,
+          "orchestratorVersion": "1.23.3",
+          "osSKU": "Windows2022",
+          "osType": "Windows",
+          "provisioningState": "Succeeded",
+          "vmSize": "Standard_D4s_v3"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "wnp2",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/wnp2",
+        "properties": {
+          "count": 3,
+          "currentOrchestratorVersion": "1.23.3",
+          "maxPods": 110,
+          "orchestratorVersion": "1.23.3",
+          "osSKU": "Windows2022",
+          "osType": "Windows",
+          "provisioningState": "Creating",
+          "vmSize": "Standard_D4s_v3"
+        }
+      }
+    }
+  },
+  "operationId": "AgentPools_CreateOrUpdate",
+  "title": "Create Agent Pool with Windows OSSKU"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsDelete.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsDelete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-03-01",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operationresults/00000000-0000-0000-0000-000000000000?api-version=2026-03-01"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "AgentPools_Delete",
+  "title": "Delete Agent Pool"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsDeleteMachines.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsDeleteMachines.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-03-01",
+    "machines": {
+      "machineNames": [
+        "aks-nodepool1-42263519-vmss00000a",
+        "aks-nodepool1-42263519-vmss00000b"
+      ]
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/subid1/providers/Microsoft.ContainerService/locations/eastus/operationresults/00000000-0000-0000-0000-000000000000?api-version=2026-03-01"
+      }
+    }
+  },
+  "operationId": "AgentPools_DeleteMachines",
+  "title": "Delete Specific Machines in an Agent Pool"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsGet.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsGet.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-03-01",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "agentpool1",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "currentOrchestratorVersion": "1.9.6",
+          "eTag": "ebwiyfneowv",
+          "maxPods": 110,
+          "nodeImageVersion": "AKSUbuntu:1604:2020.03.11",
+          "orchestratorVersion": "1.9.6",
+          "osType": "Linux",
+          "provisioningState": "Succeeded",
+          "upgradeSettings": {
+            "maxSurge": "33%"
+          },
+          "vmSize": "Standard_DS1_v2"
+        }
+      }
+    }
+  },
+  "operationId": "AgentPools_Get",
+  "title": "Get Agent Pool"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsGetAgentPoolAvailableVersions.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsGetAgentPoolAvailableVersions.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.ContainerService/managedClusters/availableAgentpoolVersions",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/availableagentpoolversions",
+        "properties": {
+          "agentPoolVersions": [
+            {
+              "kubernetesVersion": "1.12.7"
+            },
+            {
+              "kubernetesVersion": "1.12.8"
+            },
+            {
+              "default": true,
+              "isPreview": true,
+              "kubernetesVersion": "1.13.5"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "AgentPools_GetAvailableAgentPoolVersions",
+  "title": "Get available versions for agent pool"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsGetUpgradeProfile.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsGetUpgradeProfile.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-03-01",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools/upgradeProfiles",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1/upgradeprofiles/default",
+        "properties": {
+          "kubernetesVersion": "1.12.8",
+          "latestNodeImageVersion": "AKSUbuntu:1604:2020.03.11",
+          "osType": "Linux",
+          "upgrades": [
+            {
+              "kubernetesVersion": "1.13.5"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "AgentPools_GetUpgradeProfile",
+  "title": "Get Upgrade Profile for Agent Pool"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsList.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsList.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "agentpool1",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+            "properties": {
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "eTag": "ewnfuib",
+              "maxPods": 110,
+              "nodeImageVersion": "AKSUbuntu:1604:2020.03.11",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Succeeded",
+              "vmSize": "Standard_DS1_v2"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "AgentPools_List",
+  "title": "List Agent Pools by Managed Cluster"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsUpgradeNodeImageVersion.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPoolsUpgradeNodeImageVersion.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-03-01",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "body": {
+        "name": "agentpool1",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "currentOrchestratorVersion": "1.9.6",
+          "maxPods": 110,
+          "nodeImageVersion": "AKSUbuntu-1604-2020.03.11",
+          "orchestratorVersion": "1.9.6",
+          "osType": "Linux",
+          "provisioningState": "UpgradingNodeImageVersion",
+          "upgradeSettings": {
+            "maxSurge": "33%"
+          },
+          "vmSize": "Standard_DS1_v2"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/providers/Microsoft.ContainerService/locations/westus/operations/00000000-0000-0000-0000-000000000000?api-version=2018-07-31"
+      }
+    }
+  },
+  "operationId": "AgentPools_UpgradeNodeImageVersion",
+  "title": "Upgrade Agent Pool Node Image Version"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPools_Start.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPools_Start.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-03-01",
+    "parameters": {
+      "properties": {
+        "powerState": {
+          "code": "Running"
+        }
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 50,
+          "enableAutoScaling": true,
+          "maxCount": 55,
+          "minCount": 3,
+          "powerState": {
+            "code": "Running"
+          },
+          "provisioningState": "Starting"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 50,
+          "enableAutoScaling": true,
+          "maxCount": 55,
+          "minCount": 3,
+          "powerState": {
+            "code": "Running"
+          },
+          "provisioningState": "Starting"
+        }
+      }
+    }
+  },
+  "operationId": "AgentPools_CreateOrUpdate",
+  "title": "Start Agent Pool"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPools_Stop.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPools_Stop.json
@@ -1,0 +1,50 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-03-01",
+    "parameters": {
+      "properties": {
+        "powerState": {
+          "code": "Stopped"
+        }
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 0,
+          "enableAutoScaling": false,
+          "powerState": {
+            "code": "Stopped"
+          },
+          "provisioningState": "Stopping"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 0,
+          "enableAutoScaling": false,
+          "powerState": {
+            "code": "Stopped"
+          },
+          "provisioningState": "Stopping"
+        }
+      }
+    }
+  },
+  "operationId": "AgentPools_CreateOrUpdate",
+  "title": "Stop Agent Pool"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPools_Update.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/AgentPools_Update.json
@@ -1,0 +1,77 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-03-01",
+    "parameters": {
+      "properties": {
+        "count": 3,
+        "enableAutoScaling": true,
+        "maxCount": 2,
+        "minCount": 2,
+        "nodeTaints": [
+          "Key1=Value1:NoSchedule"
+        ],
+        "orchestratorVersion": "",
+        "osType": "Linux",
+        "scaleSetEvictionPolicy": "Delete",
+        "scaleSetPriority": "Spot",
+        "vmSize": "Standard_DS1_v2"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "currentOrchestratorVersion": "1.9.6",
+          "enableAutoScaling": true,
+          "maxCount": 2,
+          "maxPods": 110,
+          "minCount": 2,
+          "nodeTaints": [
+            "Key1=Value1:NoSchedule"
+          ],
+          "orchestratorVersion": "1.9.6",
+          "osType": "Linux",
+          "provisioningState": "Succeeded",
+          "scaleSetEvictionPolicy": "Delete",
+          "scaleSetPriority": "Spot",
+          "vmSize": "Standard_DS1_v2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "currentOrchestratorVersion": "1.9.6",
+          "enableAutoScaling": true,
+          "maxCount": 2,
+          "maxPods": 110,
+          "minCount": 2,
+          "nodeTaints": [
+            "Key1=Value1:NoSchedule"
+          ],
+          "orchestratorVersion": "1.9.6",
+          "osType": "Linux",
+          "provisioningState": "Updating",
+          "scaleSetEvictionPolicy": "Delete",
+          "scaleSetPriority": "Spot",
+          "vmSize": "Standard_DS1_v2"
+        }
+      }
+    }
+  },
+  "operationId": "AgentPools_CreateOrUpdate",
+  "title": "Update Agent Pool"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/KubernetesVersions_List.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/KubernetesVersions_List.json
@@ -1,0 +1,99 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "location": "location1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "values": [
+          {
+            "capabilities": {
+              "supportPlan": [
+                "KubernetesOfficial"
+              ]
+            },
+            "patchVersions": {
+              "1.23.12": {
+                "upgrades": [
+                  "1.23.15",
+                  "1.24.6",
+                  "1.24.9"
+                ]
+              },
+              "1.23.15": {
+                "upgrades": [
+                  "1.24.6",
+                  "1.24.9"
+                ]
+              }
+            },
+            "version": "1.23"
+          },
+          {
+            "capabilities": {
+              "supportPlan": [
+                "KubernetesOfficial"
+              ]
+            },
+            "isDefault": true,
+            "patchVersions": {
+              "1.24.6": {
+                "upgrades": [
+                  "1.24.9",
+                  "1.25.4",
+                  "1.25.5"
+                ]
+              },
+              "1.24.9": {
+                "upgrades": [
+                  "1.25.4",
+                  "1.25.5"
+                ]
+              }
+            },
+            "version": "1.24"
+          },
+          {
+            "capabilities": {
+              "supportPlan": [
+                "KubernetesOfficial"
+              ]
+            },
+            "patchVersions": {
+              "1.25.4": {
+                "upgrades": [
+                  "1.25.5",
+                  "1.26.0"
+                ]
+              },
+              "1.25.5": {
+                "upgrades": [
+                  "1.26.0"
+                ]
+              }
+            },
+            "version": "1.25"
+          },
+          {
+            "capabilities": {
+              "supportPlan": [
+                "KubernetesOfficial"
+              ]
+            },
+            "isPreview": true,
+            "patchVersions": {
+              "1.26.0": {
+                "upgrades": []
+              }
+            },
+            "version": "1.26"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ManagedClusters_ListKubernetesVersions",
+  "title": "List Kubernetes Versions"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/MachineGet.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/MachineGet.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-03-01",
+    "machineName": "aks-nodepool1-42263519-vmss00000t",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "26fe00f8-9173-4872-9134-bb1d2e00343a"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "aks-nodepool1-25481572-vmss000000",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools/machines",
+        "id": "/subscriptions/26fe00f8-9173-4872-9134-bb1d2e00343a/resourceGroups/dummyRG/providers/Microsoft.ContainerService/managedClusters/round/agentPools/nodepool1/machines/aks-nodepool1-25481572-vmss000000",
+        "properties": {
+          "network": {
+            "ipAddresses": [
+              {
+                "family": "IPv4",
+                "ip": "172.20.2.4"
+              },
+              {
+                "family": "IPv4",
+                "ip": "10.0.0.1"
+              }
+            ]
+          },
+          "resourceId": "/subscriptions/26fe00f8-9173-4872-9134-bb1d2e00343a/resourceGroups/dummyRG/providers/Microsoft.Compute/virtualMachineScaleSets/aks-nodepool1-25481572-vmss/virtualMachines/0"
+        },
+        "zones": [
+          "1"
+        ]
+      }
+    }
+  },
+  "operationId": "Machines_Get",
+  "title": "Get a Machine in an Agent Pools by Managed Cluster"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/MachineList.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/MachineList.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-03-01",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "26fe00f8-9173-4872-9134-bb1d2e00343a"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "http://xxxx.azure.com?encodedToken=c2tpcFRva2VuPTE",
+        "value": [
+          {
+            "name": "aks-nodepool1-25481572-vmss000000",
+            "type": "Microsoft.ContainerService/managedClusters/agentPools/machines",
+            "id": "/subscriptions/26fe00f8-9173-4872-9134-bb1d2e00343a/resourceGroups/dummyRG/providers/Microsoft.ContainerService/managedClusters/round/agentPools/nodepool1/machines/aks-nodepool1-25481572-vmss000000",
+            "properties": {
+              "network": {
+                "ipAddresses": [
+                  {
+                    "family": "IPv4",
+                    "ip": "172.20.2.4"
+                  },
+                  {
+                    "family": "IPv4",
+                    "ip": "10.0.0.1"
+                  }
+                ]
+              },
+              "resourceId": "/subscriptions/26fe00f8-9173-4872-9134-bb1d2e00343a/resourceGroups/dummyRG/providers/Microsoft.Compute/virtualMachineScaleSets/aks-nodepool1-25481572-vmss/virtualMachines/0"
+            },
+            "zones": [
+              "1"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Machines_List",
+  "title": "List Machines in an Agentpool by Managed Cluster"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/MaintenanceConfigurationsCreate_Update_MaintenanceWindow.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/MaintenanceConfigurationsCreate_Update_MaintenanceWindow.json
@@ -1,0 +1,100 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "configName": "aksManagedAutoUpgradeSchedule",
+    "parameters": {
+      "properties": {
+        "maintenanceWindow": {
+          "durationHours": 10,
+          "notAllowedDates": [
+            {
+              "end": "2023-02-25",
+              "start": "2023-02-18"
+            },
+            {
+              "end": "2024-01-05",
+              "start": "2023-12-23"
+            }
+          ],
+          "schedule": {
+            "relativeMonthly": {
+              "dayOfWeek": "Monday",
+              "intervalMonths": 3,
+              "weekIndex": "First"
+            }
+          },
+          "startDate": "2023-01-01",
+          "startTime": "08:30",
+          "utcOffset": "+05:30"
+        }
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "aksManagedAutoUpgradeSchedule",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/maintenanceConfigurations/aksManagedAutoUpgradeSchedule",
+        "properties": {
+          "maintenanceWindow": {
+            "durationHours": 10,
+            "notAllowedDates": [
+              {
+                "end": "2023-02-25",
+                "start": "2023-02-18"
+              },
+              {
+                "end": "2024-01-05",
+                "start": "2023-12-23"
+              }
+            ],
+            "schedule": {
+              "weekly": {
+                "dayOfWeek": "Monday",
+                "intervalWeeks": 3
+              }
+            },
+            "startDate": "2023-01-01",
+            "startTime": "08:30",
+            "utcOffset": "+05:30"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "aksManagedAutoUpgradeSchedule",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/maintenanceConfigurations/aksManagedAutoUpgradeSchedule",
+        "properties": {
+          "maintenanceWindow": {
+            "durationHours": 10,
+            "notAllowedDates": [
+              {
+                "end": "2023-02-25",
+                "start": "2023-02-18"
+              },
+              {
+                "end": "2024-01-05",
+                "start": "2023-12-23"
+              }
+            ],
+            "schedule": {
+              "weekly": {
+                "dayOfWeek": "Monday",
+                "intervalWeeks": 3
+              }
+            },
+            "startDate": "2023-01-01",
+            "startTime": "08:30",
+            "utcOffset": "+05:30"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "MaintenanceConfigurations_CreateOrUpdate",
+  "title": "Create/Update Maintenance Configuration with Maintenance Window"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/MaintenanceConfigurationsDelete_MaintenanceWindow.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/MaintenanceConfigurationsDelete_MaintenanceWindow.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "configName": "aksManagedNodeOSUpgradeSchedule",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "MaintenanceConfigurations_Delete",
+  "title": "Delete Maintenance Configuration For Node OS Upgrade"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/MaintenanceConfigurationsGet_MaintenanceWindow.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/MaintenanceConfigurationsGet_MaintenanceWindow.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "configName": "aksManagedNodeOSUpgradeSchedule",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "aksManagedNodeOSUpgradeSchedule",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/maintenanceConfigurations/aksManagedNodeOSUpgradeSchedule",
+        "properties": {
+          "maintenanceWindow": {
+            "durationHours": 4,
+            "notAllowedDates": [
+              {
+                "end": "2023-02-25",
+                "start": "2023-02-18"
+              },
+              {
+                "end": "2024-01-05",
+                "start": "2023-12-23"
+              }
+            ],
+            "schedule": {
+              "daily": {
+                "intervalDays": 3
+              }
+            },
+            "startDate": "2023-01-01",
+            "startTime": "09:30",
+            "utcOffset": "-07:00"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "MaintenanceConfigurations_Get",
+  "title": "Get Maintenance Configuration Configured With Maintenance Window"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/MaintenanceConfigurationsList_MaintenanceWindow.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/MaintenanceConfigurationsList_MaintenanceWindow.json
@@ -1,0 +1,63 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "aksManagedNodeOSUpgradeSchedule",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/maintenanceConfigurations/aksManagedNodeOSUpgradeSchedule",
+            "properties": {
+              "maintenanceWindow": {
+                "durationHours": 10,
+                "schedule": {
+                  "daily": {
+                    "intervalDays": 5
+                  }
+                },
+                "startDate": "2023-01-01",
+                "startTime": "13:30",
+                "utcOffset": "-07:00"
+              }
+            }
+          },
+          {
+            "name": "aksManagedAutoUpgradeSchedule",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/maintenanceConfigurations/aksManagedAutoUpgradeSchedule",
+            "properties": {
+              "maintenanceWindow": {
+                "durationHours": 5,
+                "notAllowedDates": [
+                  {
+                    "end": "2023-02-25",
+                    "start": "2023-02-18"
+                  },
+                  {
+                    "end": "2024-01-05",
+                    "start": "2023-12-23"
+                  }
+                ],
+                "schedule": {
+                  "absoluteMonthly": {
+                    "dayOfMonth": 15,
+                    "intervalMonths": 3
+                  }
+                },
+                "startDate": "2023-01-01",
+                "startTime": "08:30",
+                "utcOffset": "+00:00"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "MaintenanceConfigurations_ListByManagedCluster",
+  "title": "List maintenance configurations configured with maintenance window by Managed Cluster"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersAbortOperation.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersAbortOperation.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operationStatus/00000000-0000-0000-0000-000000000000?api-version=2026-03-01",
+        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/00000000-0000-0000-0000-000000000000?api-version=2026-03-01"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ManagedClusters_AbortLatestOperation",
+  "title": "Abort operation on managed cluster"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_AzureKeyvaultSecretsProvider.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_AzureKeyvaultSecretsProvider.json
@@ -1,0 +1,258 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "parameters": {
+      "location": "location1",
+      "properties": {
+        "addonProfiles": {
+          "azureKeyvaultSecretsProvider": {
+            "config": {
+              "enableSecretRotation": "true",
+              "rotationPollInterval": "2m"
+            },
+            "enabled": true
+          }
+        },
+        "agentPoolProfiles": [
+          {
+            "name": "nodepool1",
+            "type": "VirtualMachineScaleSets",
+            "count": 3,
+            "enableNodePublicIP": true,
+            "mode": "System",
+            "osType": "Linux",
+            "vmSize": "Standard_DS2_v2"
+          }
+        ],
+        "autoScalerProfile": {
+          "scale-down-delay-after-add": "15m",
+          "scan-interval": "20s"
+        },
+        "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+        "dnsPrefix": "dnsprefix1",
+        "enableRBAC": true,
+        "kubernetesVersion": "",
+        "linuxProfile": {
+          "adminUsername": "azureuser",
+          "ssh": {
+            "publicKeys": [
+              {
+                "keyData": "keydata"
+              }
+            ]
+          }
+        },
+        "networkProfile": {
+          "loadBalancerProfile": {
+            "managedOutboundIPs": {
+              "count": 2
+            }
+          },
+          "loadBalancerSku": "standard",
+          "outboundType": "loadBalancer"
+        },
+        "servicePrincipalProfile": {
+          "clientId": "clientid",
+          "secret": "secret"
+        },
+        "windowsProfile": {
+          "adminPassword": "replacePassword1234$",
+          "adminUsername": "azureuser"
+        }
+      },
+      "sku": {
+        "name": "Basic",
+        "tier": "Free"
+      },
+      "tags": {
+        "archv2": "",
+        "tier": "production"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "addonProfiles": {
+            "azureKeyvaultSecretsProvider": {
+              "config": {
+                "enableSecretRotation": "true",
+                "rotationPollInterval": "2m"
+              },
+              "enabled": true
+            }
+          },
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "enableEncryptionAtHost": true,
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "nodeImageVersion": "AKSUbuntu:1604:2020.03.11",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Succeeded",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "basic",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "serviceCidr": "10.0.0.0/16"
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Succeeded",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "addonProfiles": {
+            "azureKeyvaultSecretsProvider": {
+              "config": {
+                "enableSecretRotation": "true",
+                "rotationPollInterval": "2m"
+              },
+              "enabled": true
+            }
+          },
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "enableEncryptionAtHost": true,
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Creating",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "standard",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "serviceCidr": "10.0.0.0/16"
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Creating",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    }
+  },
+  "operationId": "ManagedClusters_CreateOrUpdate",
+  "title": "Create Managed Cluster with Azure KeyVault Secrets Provider Addon"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_AzureServiceMesh.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_AzureServiceMesh.json
@@ -1,0 +1,351 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "parameters": {
+      "location": "location1",
+      "properties": {
+        "addonProfiles": {
+          "azureKeyvaultSecretsProvider": {
+            "config": {
+              "enableSecretRotation": "true",
+              "rotationPollInterval": "2m"
+            },
+            "enabled": true
+          }
+        },
+        "agentPoolProfiles": [
+          {
+            "name": "nodepool1",
+            "type": "VirtualMachineScaleSets",
+            "count": 3,
+            "enableNodePublicIP": true,
+            "mode": "System",
+            "osType": "Linux",
+            "vmSize": "Standard_DS2_v2"
+          }
+        ],
+        "autoScalerProfile": {
+          "scale-down-delay-after-add": "15m",
+          "scan-interval": "20s"
+        },
+        "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+        "dnsPrefix": "dnsprefix1",
+        "enableRBAC": true,
+        "kubernetesVersion": "",
+        "linuxProfile": {
+          "adminUsername": "azureuser",
+          "ssh": {
+            "publicKeys": [
+              {
+                "keyData": "keydata"
+              }
+            ]
+          }
+        },
+        "networkProfile": {
+          "loadBalancerProfile": {
+            "managedOutboundIPs": {
+              "count": 2
+            }
+          },
+          "loadBalancerSku": "standard",
+          "outboundType": "loadBalancer"
+        },
+        "serviceMeshProfile": {
+          "istio": {
+            "certificateAuthority": {
+              "plugin": {
+                "certChainObjectName": "cert-chain",
+                "certObjectName": "ca-cert",
+                "keyObjectName": "ca-key",
+                "keyVaultId": "/subscriptions/854c9ddb-fe9e-4aea-8d58-99ed88282881/resourceGroups/ddama-test/providers/Microsoft.KeyVault/vaults/my-akv",
+                "rootCertObjectName": "root-cert"
+              }
+            },
+            "components": {
+              "egressGateways": [
+                {
+                  "name": "test-istio-egress",
+                  "enabled": true,
+                  "gatewayConfigurationName": "test-gateway-configuration"
+                }
+              ],
+              "ingressGateways": [
+                {
+                  "enabled": true,
+                  "mode": "Internal"
+                }
+              ]
+            }
+          },
+          "mode": "Istio"
+        },
+        "servicePrincipalProfile": {
+          "clientId": "clientid",
+          "secret": "secret"
+        },
+        "windowsProfile": {
+          "adminPassword": "replacePassword1234$",
+          "adminUsername": "azureuser"
+        }
+      },
+      "sku": {
+        "name": "Basic",
+        "tier": "Free"
+      },
+      "tags": {
+        "archv2": "",
+        "tier": "production"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "addonProfiles": {
+            "azureKeyvaultSecretsProvider": {
+              "config": {
+                "enableSecretRotation": "true",
+                "rotationPollInterval": "2m"
+              },
+              "enabled": true
+            }
+          },
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "enableEncryptionAtHost": true,
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "nodeImageVersion": "AKSUbuntu:1604:2020.03.11",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Succeeded",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "basic",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "serviceCidr": "10.0.0.0/16"
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Succeeded",
+          "serviceMeshProfile": {
+            "istio": {
+              "certificateAuthority": {
+                "plugin": {
+                  "certChainObjectName": "cert-chain",
+                  "certObjectName": "ca-cert",
+                  "keyObjectName": "ca-key",
+                  "keyVaultId": "/subscriptions/854c9ddb-fe9e-4aea-8d58-99ed88282881/resourceGroups/ddama-test/providers/Microsoft.KeyVault/vaults/my-akv",
+                  "rootCertObjectName": "root-cert"
+                }
+              },
+              "components": {
+                "egressGateways": [
+                  {
+                    "name": "test-istio-egress",
+                    "enabled": true,
+                    "gatewayConfigurationName": "test-gateway-configuration"
+                  }
+                ],
+                "ingressGateways": [
+                  {
+                    "enabled": true,
+                    "mode": "Internal"
+                  }
+                ]
+              },
+              "revisions": [
+                "asm-1-17"
+              ]
+            },
+            "mode": "Istio"
+          },
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "addonProfiles": {
+            "azureKeyvaultSecretsProvider": {
+              "config": {
+                "enableSecretRotation": "true",
+                "rotationPollInterval": "2m"
+              },
+              "enabled": true
+            }
+          },
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "enableEncryptionAtHost": true,
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Creating",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "standard",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "serviceCidr": "10.0.0.0/16"
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Creating",
+          "serviceMeshProfile": {
+            "istio": {
+              "certificateAuthority": {
+                "plugin": {
+                  "certChainObjectName": "cert-chain",
+                  "certObjectName": "ca-cert",
+                  "keyObjectName": "ca-key",
+                  "keyVaultId": "/subscriptions/854c9ddb-fe9e-4aea-8d58-99ed88282881/resourceGroups/ddama-test/providers/Microsoft.KeyVault/vaults/my-akv",
+                  "rootCertObjectName": "root-cert"
+                }
+              },
+              "components": {
+                "egressGateways": [
+                  {
+                    "name": "test-istio-egress",
+                    "enabled": true,
+                    "gatewayConfigurationName": "test-gateway-configuration"
+                  }
+                ],
+                "ingressGateways": [
+                  {
+                    "enabled": true,
+                    "mode": "Internal"
+                  }
+                ]
+              },
+              "revisions": [
+                "asm-1-17"
+              ]
+            },
+            "mode": "Istio"
+          },
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    }
+  },
+  "operationId": "ManagedClusters_CreateOrUpdate",
+  "title": "Create/Update Managed Cluster with Azure Service Mesh"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_CRG.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_CRG.json
@@ -1,0 +1,253 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "parameters": {
+      "location": "location1",
+      "properties": {
+        "addonProfiles": {},
+        "agentPoolProfiles": [
+          {
+            "name": "nodepool1",
+            "type": "VirtualMachineScaleSets",
+            "capacityReservationGroupID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/capacityReservationGroups/crg1",
+            "count": 3,
+            "enableNodePublicIP": true,
+            "mode": "System",
+            "osType": "Linux",
+            "vmSize": "Standard_DS2_v2"
+          }
+        ],
+        "autoScalerProfile": {
+          "scale-down-delay-after-add": "15m",
+          "scan-interval": "20s"
+        },
+        "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+        "dnsPrefix": "dnsprefix1",
+        "enableRBAC": true,
+        "kubernetesVersion": "",
+        "linuxProfile": {
+          "adminUsername": "azureuser",
+          "ssh": {
+            "publicKeys": [
+              {
+                "keyData": "keydata"
+              }
+            ]
+          }
+        },
+        "networkProfile": {
+          "loadBalancerProfile": {
+            "managedOutboundIPs": {
+              "count": 2
+            }
+          },
+          "loadBalancerSku": "standard",
+          "outboundType": "loadBalancer"
+        },
+        "servicePrincipalProfile": {
+          "clientId": "clientid",
+          "secret": "secret"
+        },
+        "windowsProfile": {
+          "adminPassword": "replacePassword1234$",
+          "adminUsername": "azureuser"
+        }
+      },
+      "sku": {
+        "name": "Basic",
+        "tier": "Free"
+      },
+      "tags": {
+        "archv2": "",
+        "tier": "production"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "capacityReservationGroupID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/capacityReservationGroups/crg1",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "nodeImageVersion": "AKSUbuntu:1604:2020.03.11",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Succeeded",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "basic",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Succeeded",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "capacityReservationGroupID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/capacityReservationGroups/crg1",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Creating",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "standard",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Creating",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    }
+  },
+  "operationId": "ManagedClusters_CreateOrUpdate",
+  "title": "Create Managed Cluster with Capacity Reservation Group"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_CustomCATrustCertificates.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_CustomCATrustCertificates.json
@@ -1,0 +1,265 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "parameters": {
+      "location": "location1",
+      "properties": {
+        "addonProfiles": {},
+        "agentPoolProfiles": [
+          {
+            "name": "nodepool1",
+            "type": "VirtualMachineScaleSets",
+            "count": 3,
+            "enableNodePublicIP": true,
+            "mode": "System",
+            "osType": "Linux",
+            "vmSize": "Standard_DS2_v2"
+          }
+        ],
+        "autoScalerProfile": {
+          "scale-down-delay-after-add": "15m",
+          "scan-interval": "20s"
+        },
+        "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+        "dnsPrefix": "dnsprefix1",
+        "enableRBAC": true,
+        "kubernetesVersion": "",
+        "linuxProfile": {
+          "adminUsername": "azureuser",
+          "ssh": {
+            "publicKeys": [
+              {
+                "keyData": "keydata"
+              }
+            ]
+          }
+        },
+        "networkProfile": {
+          "loadBalancerProfile": {
+            "managedOutboundIPs": {
+              "count": 2
+            }
+          },
+          "loadBalancerSku": "standard",
+          "outboundType": "loadBalancer"
+        },
+        "securityProfile": {
+          "customCATrustCertificates": [
+            "ZHVtbXlFeGFtcGxlVGVzdFZhbHVlRm9yQ2VydGlmaWNhdGVUb0JlQWRkZWQ="
+          ]
+        },
+        "servicePrincipalProfile": {
+          "clientId": "clientid",
+          "secret": "secret"
+        },
+        "windowsProfile": {
+          "adminPassword": "replacePassword1234$",
+          "adminUsername": "azureuser"
+        }
+      },
+      "sku": {
+        "name": "Basic",
+        "tier": "Free"
+      },
+      "tags": {
+        "archv2": "",
+        "tier": "production"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "nodeImageVersion": "AKSUbuntu:1604:2020.03.11",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Succeeded",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "basic",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Succeeded",
+          "securityProfile": {
+            "customCATrustCertificates": [
+              "ZHVtbXlFeGFtcGxlVGVzdFZhbHVlRm9yQ2VydGlmaWNhdGVUb0JlQWRkZWQ="
+            ]
+          },
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Creating",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "standard",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Creating",
+          "securityProfile": {
+            "customCATrustCertificates": [
+              "ZHVtbXlFeGFtcGxlVGVzdFZhbHVlRm9yQ2VydGlmaWNhdGVUb0JlQWRkZWQ="
+            ]
+          },
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    }
+  },
+  "operationId": "ManagedClusters_CreateOrUpdate",
+  "title": "Create Managed Cluster with Custom CA Trust Certificates"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_DedicatedHostGroup.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_DedicatedHostGroup.json
@@ -1,0 +1,248 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "parameters": {
+      "location": "location1",
+      "properties": {
+        "addonProfiles": {},
+        "agentPoolProfiles": [
+          {
+            "name": "nodepool1",
+            "type": "VirtualMachineScaleSets",
+            "count": 3,
+            "enableNodePublicIP": true,
+            "hostGroupID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Compute/hostGroups/hostgroup1",
+            "osType": "Linux",
+            "vmSize": "Standard_DS2_v2"
+          }
+        ],
+        "autoScalerProfile": {
+          "scale-down-delay-after-add": "15m",
+          "scan-interval": "20s"
+        },
+        "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+        "dnsPrefix": "dnsprefix1",
+        "enableRBAC": true,
+        "kubernetesVersion": "",
+        "linuxProfile": {
+          "adminUsername": "azureuser",
+          "ssh": {
+            "publicKeys": [
+              {
+                "keyData": "keydata"
+              }
+            ]
+          }
+        },
+        "networkProfile": {
+          "loadBalancerProfile": {
+            "managedOutboundIPs": {
+              "count": 2
+            }
+          },
+          "loadBalancerSku": "standard",
+          "outboundType": "loadBalancer"
+        },
+        "servicePrincipalProfile": {
+          "clientId": "clientid",
+          "secret": "secret"
+        },
+        "windowsProfile": {
+          "adminPassword": "replacePassword1234$",
+          "adminUsername": "azureuser"
+        }
+      },
+      "sku": {
+        "name": "Basic",
+        "tier": "Free"
+      },
+      "tags": {
+        "archv2": "",
+        "tier": "production"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "enableNodePublicIP": true,
+              "hostGroupID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Compute/hostGroups/hostgroup1",
+              "maxPods": 110,
+              "nodeImageVersion": "AKSUbuntu:1604:2020.03.11",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Succeeded",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "basic",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Succeeded",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "enableNodePublicIP": true,
+              "hostGroupID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Compute/hostGroups/hostgroup1",
+              "maxPods": 110,
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Creating",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "standard",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Creating",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    }
+  },
+  "operationId": "ManagedClusters_CreateOrUpdate",
+  "title": "Create Managed Cluster with Dedicated Host Group"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_DisableRunCommand.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_DisableRunCommand.json
@@ -1,0 +1,266 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "parameters": {
+      "location": "location1",
+      "properties": {
+        "addonProfiles": {},
+        "agentPoolProfiles": [
+          {
+            "name": "nodepool1",
+            "type": "VirtualMachineScaleSets",
+            "count": 3,
+            "enableEncryptionAtHost": true,
+            "enableNodePublicIP": true,
+            "mode": "System",
+            "osType": "Linux",
+            "vmSize": "Standard_DS2_v2"
+          }
+        ],
+        "apiServerAccessProfile": {
+          "disableRunCommand": true
+        },
+        "autoScalerProfile": {
+          "scale-down-delay-after-add": "15m",
+          "scan-interval": "20s"
+        },
+        "dnsPrefix": "dnsprefix1",
+        "enableRBAC": true,
+        "kubernetesVersion": "",
+        "linuxProfile": {
+          "adminUsername": "azureuser",
+          "ssh": {
+            "publicKeys": [
+              {
+                "keyData": "keydata"
+              }
+            ]
+          }
+        },
+        "networkProfile": {
+          "loadBalancerProfile": {
+            "managedOutboundIPs": {
+              "count": 2
+            }
+          },
+          "loadBalancerSku": "standard",
+          "outboundType": "loadBalancer"
+        },
+        "servicePrincipalProfile": {
+          "clientId": "clientid",
+          "secret": "secret"
+        },
+        "windowsProfile": {
+          "adminPassword": "replacePassword1234$",
+          "adminUsername": "azureuser"
+        }
+      },
+      "sku": {
+        "name": "Basic",
+        "tier": "Free"
+      },
+      "tags": {
+        "archv2": "",
+        "tier": "production"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableEncryptionAtHost": true,
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "nodeImageVersion": "AKSUbuntu:1604:2020.03.11",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Succeeded",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "apiServerAccessProfile": {
+            "disableRunCommand": true
+          },
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "currentKubernetesVersion": "1.9.6",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "fqdn": "dnsprefix1-ee788a1f.hcp.location1.azmk8s.io",
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "basic",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "privateFQDN": "dnsprefix1-aae7e0f0.5cef6058-b6b5-414d-8cb1-4bd14eb0b15c.privatelink.location1.azmk8s.io",
+          "provisioningState": "Succeeded",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "supportPlan": "KubernetesOfficial",
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableEncryptionAtHost": true,
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Creating",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "apiServerAccessProfile": {
+            "disableRunCommand": true
+          },
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "currentKubernetesVersion": "1.9.6",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "fqdn": "dnsprefix1-ee788a1f.hcp.location1.azmk8s.io",
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "standard",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "privateFQDN": "dnsprefix1-aae7e0f0.5cef6058-b6b5-414d-8cb1-4bd14eb0b15c.privatelink.location1.azmk8s.io",
+          "provisioningState": "Creating",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "supportPlan": "KubernetesOfficial",
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    }
+  },
+  "operationId": "ManagedClusters_CreateOrUpdate",
+  "title": "Create Managed Cluster with RunCommand disabled"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_DualStackNetworking.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_DualStackNetworking.json
@@ -1,0 +1,322 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "parameters": {
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgName1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1": {}
+        }
+      },
+      "location": "location1",
+      "properties": {
+        "addonProfiles": {},
+        "agentPoolProfiles": [
+          {
+            "name": "nodepool1",
+            "type": "VirtualMachineScaleSets",
+            "availabilityZones": [
+              "1",
+              "2",
+              "3"
+            ],
+            "count": 3,
+            "enableNodePublicIP": true,
+            "mode": "System",
+            "osType": "Linux",
+            "scaleDownMode": "Deallocate",
+            "vmSize": "Standard_DS1_v2"
+          }
+        ],
+        "autoScalerProfile": {
+          "balance-similar-node-groups": "true",
+          "expander": "priority",
+          "max-node-provision-time": "15m",
+          "new-pod-scale-up-delay": "1m",
+          "scale-down-delay-after-add": "15m",
+          "scan-interval": "20s",
+          "skip-nodes-with-system-pods": "false"
+        },
+        "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+        "dnsPrefix": "dnsprefix1",
+        "enableRBAC": true,
+        "kubernetesVersion": "",
+        "linuxProfile": {
+          "adminUsername": "azureuser",
+          "ssh": {
+            "publicKeys": [
+              {
+                "keyData": "keydata"
+              }
+            ]
+          }
+        },
+        "networkProfile": {
+          "ipFamilies": [
+            "IPv4",
+            "IPv6"
+          ],
+          "loadBalancerProfile": {
+            "managedOutboundIPs": {
+              "count": 2
+            }
+          },
+          "loadBalancerSku": "standard",
+          "outboundType": "loadBalancer"
+        },
+        "servicePrincipalProfile": {
+          "clientId": "clientid",
+          "secret": "secret"
+        },
+        "windowsProfile": {
+          "adminPassword": "replacePassword1234$",
+          "adminUsername": "azureuser"
+        }
+      },
+      "sku": {
+        "name": "Basic",
+        "tier": "Free"
+      },
+      "tags": {
+        "archv2": "",
+        "tier": "production"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgName1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1": {
+              "clientId": "clientId1",
+              "principalId": "principalId1"
+            }
+          }
+        },
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "availabilityZones": [
+                "1",
+                "2",
+                "3"
+              ],
+              "count": 3,
+              "currentOrchestratorVersion": "1.22.1",
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "nodeImageVersion": "AKSUbuntu:1604:2020.03.11",
+              "orchestratorVersion": "1.22.1",
+              "osType": "Linux",
+              "provisioningState": "Succeeded",
+              "scaleDownMode": "Deallocate",
+              "vmSize": "Standard_DS1_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "balance-similar-node-groups": "true",
+            "expander": "priority",
+            "max-node-provision-time": "15m",
+            "new-pod-scale-up-delay": "1m",
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s",
+            "skip-nodes-with-system-pods": "false"
+          },
+          "currentKubernetesVersion": "1.22.1",
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
+          "kubernetesVersion": "1.22.1",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4",
+              "IPv6"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip3-ipv6"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2,
+                "countIPv6": 1
+              }
+            },
+            "loadBalancerSku": "basic",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16",
+              "fd11:1234::/64"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16",
+              "fd00:1234::/108"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Succeeded",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgName1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1": {
+              "clientId": "clientId1",
+              "principalId": "principalId1"
+            }
+          }
+        },
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "availabilityZones": [
+                "1",
+                "2",
+                "3"
+              ],
+              "count": 3,
+              "currentOrchestratorVersion": "1.22.1",
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "orchestratorVersion": "1.22.1",
+              "osType": "Linux",
+              "provisioningState": "Creating",
+              "scaleDownMode": "Deallocate",
+              "vmSize": "Standard_DS1_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "currentKubernetesVersion": "1.22.1",
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "kubernetesVersion": "1.22.1",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4",
+              "IPv6"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip3-ipv6"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2,
+                "countIPv6": 1
+              }
+            },
+            "loadBalancerSku": "standard",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16",
+              "fd11:1234::/64"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16",
+              "fd00:1234::/108"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Creating",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    }
+  },
+  "operationId": "ManagedClusters_CreateOrUpdate",
+  "title": "Create/Update Managed Cluster with dual-stack networking"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_EnableEncryptionAtHost.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_EnableEncryptionAtHost.json
@@ -1,0 +1,255 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "parameters": {
+      "location": "location1",
+      "properties": {
+        "addonProfiles": {},
+        "agentPoolProfiles": [
+          {
+            "name": "nodepool1",
+            "type": "VirtualMachineScaleSets",
+            "count": 3,
+            "enableEncryptionAtHost": true,
+            "enableNodePublicIP": true,
+            "mode": "System",
+            "osType": "Linux",
+            "vmSize": "Standard_DS2_v2"
+          }
+        ],
+        "autoScalerProfile": {
+          "scale-down-delay-after-add": "15m",
+          "scan-interval": "20s"
+        },
+        "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+        "dnsPrefix": "dnsprefix1",
+        "enableRBAC": true,
+        "kubernetesVersion": "",
+        "linuxProfile": {
+          "adminUsername": "azureuser",
+          "ssh": {
+            "publicKeys": [
+              {
+                "keyData": "keydata"
+              }
+            ]
+          }
+        },
+        "networkProfile": {
+          "loadBalancerProfile": {
+            "managedOutboundIPs": {
+              "count": 2
+            }
+          },
+          "loadBalancerSku": "standard",
+          "outboundType": "loadBalancer"
+        },
+        "servicePrincipalProfile": {
+          "clientId": "clientid",
+          "secret": "secret"
+        },
+        "windowsProfile": {
+          "adminPassword": "replacePassword1234$",
+          "adminUsername": "azureuser"
+        }
+      },
+      "sku": {
+        "name": "Basic",
+        "tier": "Free"
+      },
+      "tags": {
+        "archv2": "",
+        "tier": "production"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableEncryptionAtHost": true,
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "nodeImageVersion": "AKSUbuntu:1604:2020.03.11",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Succeeded",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "currentKubernetesVersion": "1.9.6",
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "basic",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Succeeded",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableEncryptionAtHost": true,
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Creating",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "currentKubernetesVersion": "1.9.6",
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "standard",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Creating",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    }
+  },
+  "operationId": "ManagedClusters_CreateOrUpdate",
+  "title": "Create Managed Cluster with EncryptionAtHost enabled"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_EnableUltraSSD.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_EnableUltraSSD.json
@@ -1,0 +1,255 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "parameters": {
+      "location": "location1",
+      "properties": {
+        "addonProfiles": {},
+        "agentPoolProfiles": [
+          {
+            "name": "nodepool1",
+            "type": "VirtualMachineScaleSets",
+            "count": 3,
+            "enableNodePublicIP": true,
+            "enableUltraSSD": true,
+            "mode": "System",
+            "osType": "Linux",
+            "vmSize": "Standard_DS2_v2"
+          }
+        ],
+        "autoScalerProfile": {
+          "scale-down-delay-after-add": "15m",
+          "scan-interval": "20s"
+        },
+        "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+        "dnsPrefix": "dnsprefix1",
+        "enableRBAC": true,
+        "kubernetesVersion": "",
+        "linuxProfile": {
+          "adminUsername": "azureuser",
+          "ssh": {
+            "publicKeys": [
+              {
+                "keyData": "keydata"
+              }
+            ]
+          }
+        },
+        "networkProfile": {
+          "loadBalancerProfile": {
+            "managedOutboundIPs": {
+              "count": 2
+            }
+          },
+          "loadBalancerSku": "standard",
+          "outboundType": "loadBalancer"
+        },
+        "servicePrincipalProfile": {
+          "clientId": "clientid",
+          "secret": "secret"
+        },
+        "windowsProfile": {
+          "adminPassword": "replacePassword1234$",
+          "adminUsername": "azureuser"
+        }
+      },
+      "sku": {
+        "name": "Basic",
+        "tier": "Free"
+      },
+      "tags": {
+        "archv2": "",
+        "tier": "production"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableNodePublicIP": true,
+              "enableUltraSSD": true,
+              "maxPods": 110,
+              "mode": "System",
+              "nodeImageVersion": "AKSUbuntu:1604:2020.03.11",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Succeeded",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "currentKubernetesVersion": "1.9.6",
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "basic",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Succeeded",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableNodePublicIP": true,
+              "enableUltraSSD": true,
+              "maxPods": 110,
+              "mode": "System",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Creating",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "currentKubernetesVersion": "1.9.6",
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "standard",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Creating",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    }
+  },
+  "operationId": "ManagedClusters_CreateOrUpdate",
+  "title": "Create Managed Cluster with UltraSSD enabled"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_EnabledFIPS.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_EnabledFIPS.json
@@ -1,0 +1,255 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "parameters": {
+      "location": "location1",
+      "properties": {
+        "addonProfiles": {},
+        "agentPoolProfiles": [
+          {
+            "name": "nodepool1",
+            "type": "VirtualMachineScaleSets",
+            "count": 3,
+            "enableFIPS": true,
+            "enableNodePublicIP": true,
+            "mode": "System",
+            "osType": "Linux",
+            "vmSize": "Standard_DS2_v2"
+          }
+        ],
+        "autoScalerProfile": {
+          "scale-down-delay-after-add": "15m",
+          "scan-interval": "20s"
+        },
+        "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+        "dnsPrefix": "dnsprefix1",
+        "enableRBAC": true,
+        "kubernetesVersion": "",
+        "linuxProfile": {
+          "adminUsername": "azureuser",
+          "ssh": {
+            "publicKeys": [
+              {
+                "keyData": "keydata"
+              }
+            ]
+          }
+        },
+        "networkProfile": {
+          "loadBalancerProfile": {
+            "managedOutboundIPs": {
+              "count": 2
+            }
+          },
+          "loadBalancerSku": "standard",
+          "outboundType": "loadBalancer"
+        },
+        "servicePrincipalProfile": {
+          "clientId": "clientid",
+          "secret": "secret"
+        },
+        "windowsProfile": {
+          "adminPassword": "replacePassword1234$",
+          "adminUsername": "azureuser"
+        }
+      },
+      "sku": {
+        "name": "Basic",
+        "tier": "Free"
+      },
+      "tags": {
+        "archv2": "",
+        "tier": "production"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableFIPS": true,
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "nodeImageVersion": "AKSUbuntu:1604:2020.03.11",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Succeeded",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "currentKubernetesVersion": "1.9.6",
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "basic",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Succeeded",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableFIPS": true,
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Creating",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "currentKubernetesVersion": "1.9.6",
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "standard",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Creating",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    }
+  },
+  "operationId": "ManagedClusters_CreateOrUpdate",
+  "title": "Create Managed Cluster with FIPS enabled OS"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_GPUMIG.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_GPUMIG.json
@@ -1,0 +1,282 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "parameters": {
+      "location": "location1",
+      "properties": {
+        "addonProfiles": {},
+        "agentPoolProfiles": [
+          {
+            "name": "nodepool1",
+            "type": "VirtualMachineScaleSets",
+            "count": 3,
+            "enableNodePublicIP": true,
+            "gpuInstanceProfile": "MIG3g",
+            "mode": "System",
+            "osType": "Linux",
+            "vmSize": "Standard_ND96asr_v4"
+          }
+        ],
+        "autoScalerProfile": {
+          "scale-down-delay-after-add": "15m",
+          "scan-interval": "20s"
+        },
+        "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+        "dnsPrefix": "dnsprefix1",
+        "enableRBAC": true,
+        "httpProxyConfig": {
+          "httpProxy": "http://myproxy.server.com:8080",
+          "httpsProxy": "https://myproxy.server.com:8080",
+          "noProxy": [
+            "localhost",
+            "127.0.0.1"
+          ],
+          "trustedCa": "Q29uZ3JhdHMhIFlvdSBoYXZlIGZvdW5kIGEgaGlkZGVuIG1lc3NhZ2U="
+        },
+        "kubernetesVersion": "",
+        "linuxProfile": {
+          "adminUsername": "azureuser",
+          "ssh": {
+            "publicKeys": [
+              {
+                "keyData": "keydata"
+              }
+            ]
+          }
+        },
+        "networkProfile": {
+          "loadBalancerProfile": {
+            "managedOutboundIPs": {
+              "count": 2
+            }
+          },
+          "loadBalancerSku": "standard",
+          "outboundType": "loadBalancer"
+        },
+        "servicePrincipalProfile": {
+          "clientId": "clientid",
+          "secret": "secret"
+        },
+        "windowsProfile": {
+          "adminPassword": "replacePassword1234$",
+          "adminUsername": "azureuser"
+        }
+      },
+      "sku": {
+        "name": "Basic",
+        "tier": "Free"
+      },
+      "tags": {
+        "archv2": "",
+        "tier": "production"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableNodePublicIP": true,
+              "gpuInstanceProfile": "MIG3g",
+              "maxPods": 110,
+              "mode": "System",
+              "nodeImageVersion": "AKSUbuntu:1604:2020.03.11",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Succeeded",
+              "vmSize": "Standard_ND96asr_v4"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "currentKubernetesVersion": "1.9.6",
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
+          "httpProxyConfig": {
+            "httpProxy": "http://myproxy.server.com:8080",
+            "httpsProxy": "https://myproxy.server.com:8080",
+            "noProxy": [
+              "localhost",
+              "127.0.0.1"
+            ],
+            "trustedCa": "Q29uZ3JhdHMhIFlvdSBoYXZlIGZvdW5kIGEgaGlkZGVuIG1lc3NhZ2U="
+          },
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "basic",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Succeeded",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableNodePublicIP": true,
+              "gpuInstanceProfile": "MIG3g",
+              "maxPods": 110,
+              "mode": "System",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Creating",
+              "vmSize": "Standard_ND96asr_v4"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "currentKubernetesVersion": "1.9.6",
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "httpProxyConfig": {
+            "httpProxy": "http://myproxy.server.com:8080",
+            "httpsProxy": "https://myproxy.server.com:8080",
+            "noProxy": [
+              "localhost",
+              "127.0.0.1"
+            ],
+            "trustedCa": "Q29uZ3JhdHMhIFlvdSBoYXZlIGZvdW5kIGEgaGlkZGVuIG1lc3NhZ2U="
+          },
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "standard",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Creating",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    }
+  },
+  "operationId": "ManagedClusters_CreateOrUpdate",
+  "title": "Create Managed Cluster with GPUMIG"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_HTTPProxy.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_HTTPProxy.json
@@ -1,0 +1,279 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "parameters": {
+      "location": "location1",
+      "properties": {
+        "addonProfiles": {},
+        "agentPoolProfiles": [
+          {
+            "name": "nodepool1",
+            "type": "VirtualMachineScaleSets",
+            "count": 3,
+            "enableNodePublicIP": true,
+            "mode": "System",
+            "osType": "Linux",
+            "vmSize": "Standard_DS2_v2"
+          }
+        ],
+        "autoScalerProfile": {
+          "scale-down-delay-after-add": "15m",
+          "scan-interval": "20s"
+        },
+        "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+        "dnsPrefix": "dnsprefix1",
+        "enableRBAC": true,
+        "httpProxyConfig": {
+          "httpProxy": "http://myproxy.server.com:8080",
+          "httpsProxy": "https://myproxy.server.com:8080",
+          "noProxy": [
+            "localhost",
+            "127.0.0.1"
+          ],
+          "trustedCa": "Q29uZ3JhdHMhIFlvdSBoYXZlIGZvdW5kIGEgaGlkZGVuIG1lc3NhZ2U="
+        },
+        "kubernetesVersion": "",
+        "linuxProfile": {
+          "adminUsername": "azureuser",
+          "ssh": {
+            "publicKeys": [
+              {
+                "keyData": "keydata"
+              }
+            ]
+          }
+        },
+        "networkProfile": {
+          "loadBalancerProfile": {
+            "managedOutboundIPs": {
+              "count": 2
+            }
+          },
+          "loadBalancerSku": "standard",
+          "outboundType": "loadBalancer"
+        },
+        "servicePrincipalProfile": {
+          "clientId": "clientid",
+          "secret": "secret"
+        },
+        "windowsProfile": {
+          "adminPassword": "replacePassword1234$",
+          "adminUsername": "azureuser"
+        }
+      },
+      "sku": {
+        "name": "Basic",
+        "tier": "Free"
+      },
+      "tags": {
+        "archv2": "",
+        "tier": "production"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "nodeImageVersion": "AKSUbuntu:1604:2020.03.11",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Succeeded",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "currentKubernetesVersion": "1.9.6",
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
+          "httpProxyConfig": {
+            "httpProxy": "http://myproxy.server.com:8080",
+            "httpsProxy": "https://myproxy.server.com:8080",
+            "noProxy": [
+              "localhost",
+              "127.0.0.1"
+            ],
+            "trustedCa": "Q29uZ3JhdHMhIFlvdSBoYXZlIGZvdW5kIGEgaGlkZGVuIG1lc3NhZ2U="
+          },
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "basic",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Succeeded",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Creating",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "currentKubernetesVersion": "1.9.6",
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "httpProxyConfig": {
+            "httpProxy": "http://myproxy.server.com:8080",
+            "httpsProxy": "https://myproxy.server.com:8080",
+            "noProxy": [
+              "localhost",
+              "127.0.0.1"
+            ],
+            "trustedCa": "Q29uZ3JhdHMhIFlvdSBoYXZlIGZvdW5kIGEgaGlkZGVuIG1lc3NhZ2U="
+          },
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "standard",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Creating",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    }
+  },
+  "operationId": "ManagedClusters_CreateOrUpdate",
+  "title": "Create Managed Cluster with HTTP proxy configured"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_IngressProfile_WebAppRouting.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_IngressProfile_WebAppRouting.json
@@ -1,0 +1,249 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "parameters": {
+      "location": "location1",
+      "properties": {
+        "agentPoolProfiles": [
+          {
+            "name": "nodepool1",
+            "type": "VirtualMachineScaleSets",
+            "count": 3,
+            "enableNodePublicIP": true,
+            "mode": "System",
+            "osType": "Linux",
+            "vmSize": "Standard_DS2_v2"
+          }
+        ],
+        "dnsPrefix": "dnsprefix1",
+        "ingressProfile": {
+          "webAppRouting": {
+            "dnsZoneResourceIds": [
+              "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/dnszones/DNS_ZONE_NAME"
+            ],
+            "enabled": true
+          }
+        },
+        "kubernetesVersion": "",
+        "linuxProfile": {
+          "adminUsername": "azureuser",
+          "ssh": {
+            "publicKeys": [
+              {
+                "keyData": "keydata"
+              }
+            ]
+          }
+        },
+        "networkProfile": {
+          "loadBalancerProfile": {
+            "managedOutboundIPs": {
+              "count": 2
+            }
+          },
+          "loadBalancerSku": "standard",
+          "outboundType": "loadBalancer"
+        }
+      },
+      "sku": {
+        "name": "Basic",
+        "tier": "Free"
+      },
+      "tags": {
+        "archv2": "",
+        "tier": "production"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "nodeImageVersion": "AKSUbuntu:1604:2020.03.11",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Succeeded",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
+          "ingressProfile": {
+            "webAppRouting": {
+              "dnsZoneResourceIds": [
+                "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/dnszones/DNS_ZONE_NAME"
+              ],
+              "enabled": true
+            }
+          },
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "basic",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Succeeded",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Creating",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "ingressProfile": {
+            "webAppRouting": {
+              "dnsZoneResourceIds": [
+                "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/dnszones/DNS_ZONE_NAME"
+              ],
+              "enabled": true
+            }
+          },
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "standard",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Creating",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    }
+  },
+  "operationId": "ManagedClusters_CreateOrUpdate",
+  "title": "Create Managed Cluster with Web App Routing Ingress Profile configured"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_ManagedNATGateway.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_ManagedNATGateway.json
@@ -1,0 +1,232 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "parameters": {
+      "location": "location1",
+      "properties": {
+        "addonProfiles": {},
+        "agentPoolProfiles": [
+          {
+            "name": "nodepool1",
+            "type": "VirtualMachineScaleSets",
+            "count": 3,
+            "enableNodePublicIP": false,
+            "mode": "System",
+            "osType": "Linux",
+            "vmSize": "Standard_DS2_v2"
+          }
+        ],
+        "autoScalerProfile": {
+          "scale-down-delay-after-add": "15m",
+          "scan-interval": "20s"
+        },
+        "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+        "dnsPrefix": "dnsprefix1",
+        "enableRBAC": true,
+        "kubernetesVersion": "",
+        "linuxProfile": {
+          "adminUsername": "azureuser",
+          "ssh": {
+            "publicKeys": [
+              {
+                "keyData": "keydata"
+              }
+            ]
+          }
+        },
+        "networkProfile": {
+          "loadBalancerSku": "standard",
+          "natGatewayProfile": {
+            "managedOutboundIPProfile": {
+              "count": 2
+            }
+          },
+          "outboundType": "managedNATGateway"
+        },
+        "servicePrincipalProfile": {
+          "clientId": "clientid",
+          "secret": "secret"
+        },
+        "windowsProfile": {
+          "adminPassword": "replacePassword1234$",
+          "adminUsername": "azureuser"
+        }
+      },
+      "sku": {
+        "name": "Basic",
+        "tier": "Free"
+      },
+      "tags": {
+        "archv2": "",
+        "tier": "production"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableNodePublicIP": false,
+              "maxPods": 110,
+              "mode": "System",
+              "nodeImageVersion": "AKSUbuntu:1604:2020.03.11",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Succeeded",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "currentKubernetesVersion": "1.9.6",
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "loadBalancerSku": "basic",
+            "natGatewayProfile": {
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 4,
+              "managedOutboundIPProfile": {
+                "count": 2
+              }
+            },
+            "networkPlugin": "kubenet",
+            "outboundType": "managedNATGateway",
+            "podCidr": "10.244.0.0/16",
+            "serviceCidr": "10.0.0.0/16"
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Succeeded",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableNodePublicIP": false,
+              "maxPods": 110,
+              "mode": "System",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Creating",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "currentKubernetesVersion": "1.9.6",
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "loadBalancerSku": "standard",
+            "natGatewayProfile": {
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 4,
+              "managedOutboundIPProfile": {
+                "count": 2
+              }
+            },
+            "networkPlugin": "kubenet",
+            "outboundType": "managedNATGateway",
+            "podCidr": "10.244.0.0/16",
+            "serviceCidr": "10.0.0.0/16"
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Creating",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    }
+  },
+  "operationId": "ManagedClusters_CreateOrUpdate",
+  "title": "Create Managed Cluster with AKS-managed NAT gateway as outbound type"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_NodePublicIPPrefix.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_NodePublicIPPrefix.json
@@ -1,0 +1,255 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "parameters": {
+      "location": "location1",
+      "properties": {
+        "addonProfiles": {},
+        "agentPoolProfiles": [
+          {
+            "name": "nodepool1",
+            "type": "VirtualMachineScaleSets",
+            "count": 3,
+            "enableNodePublicIP": true,
+            "mode": "System",
+            "nodePublicIPPrefixID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/public-ip-prefix",
+            "osType": "Linux",
+            "vmSize": "Standard_DS2_v2"
+          }
+        ],
+        "autoScalerProfile": {
+          "scale-down-delay-after-add": "15m",
+          "scan-interval": "20s"
+        },
+        "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+        "dnsPrefix": "dnsprefix1",
+        "enableRBAC": true,
+        "kubernetesVersion": "",
+        "linuxProfile": {
+          "adminUsername": "azureuser",
+          "ssh": {
+            "publicKeys": [
+              {
+                "keyData": "keydata"
+              }
+            ]
+          }
+        },
+        "networkProfile": {
+          "loadBalancerProfile": {
+            "managedOutboundIPs": {
+              "count": 2
+            }
+          },
+          "loadBalancerSku": "standard",
+          "outboundType": "loadBalancer"
+        },
+        "servicePrincipalProfile": {
+          "clientId": "clientid",
+          "secret": "secret"
+        },
+        "windowsProfile": {
+          "adminPassword": "replacePassword1234$",
+          "adminUsername": "azureuser"
+        }
+      },
+      "sku": {
+        "name": "Basic",
+        "tier": "Free"
+      },
+      "tags": {
+        "archv2": "",
+        "tier": "production"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "nodeImageVersion": "AKSUbuntu:1604:2020.03.11",
+              "nodePublicIPPrefixID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/public-ip-prefix",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Succeeded",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "currentKubernetesVersion": "1.9.6",
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "basic",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Succeeded",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "nodePublicIPPrefixID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/publicIPPrefixes/public-ip-prefix",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Creating",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "currentKubernetesVersion": "1.9.6",
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "standard",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Creating",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    }
+  },
+  "operationId": "ManagedClusters_CreateOrUpdate",
+  "title": "Create Managed Cluster with Node Public IP Prefix"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_OSSKU.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_OSSKU.json
@@ -1,0 +1,282 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "parameters": {
+      "location": "location1",
+      "properties": {
+        "addonProfiles": {},
+        "agentPoolProfiles": [
+          {
+            "name": "nodepool1",
+            "type": "VirtualMachineScaleSets",
+            "count": 3,
+            "enableNodePublicIP": true,
+            "mode": "System",
+            "osSKU": "AzureLinux",
+            "osType": "Linux",
+            "vmSize": "Standard_DS2_v2"
+          }
+        ],
+        "autoScalerProfile": {
+          "scale-down-delay-after-add": "15m",
+          "scan-interval": "20s"
+        },
+        "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+        "dnsPrefix": "dnsprefix1",
+        "enableRBAC": true,
+        "httpProxyConfig": {
+          "httpProxy": "http://myproxy.server.com:8080",
+          "httpsProxy": "https://myproxy.server.com:8080",
+          "noProxy": [
+            "localhost",
+            "127.0.0.1"
+          ],
+          "trustedCa": "Q29uZ3JhdHMhIFlvdSBoYXZlIGZvdW5kIGEgaGlkZGVuIG1lc3NhZ2U="
+        },
+        "kubernetesVersion": "",
+        "linuxProfile": {
+          "adminUsername": "azureuser",
+          "ssh": {
+            "publicKeys": [
+              {
+                "keyData": "keydata"
+              }
+            ]
+          }
+        },
+        "networkProfile": {
+          "loadBalancerProfile": {
+            "managedOutboundIPs": {
+              "count": 2
+            }
+          },
+          "loadBalancerSku": "standard",
+          "outboundType": "loadBalancer"
+        },
+        "servicePrincipalProfile": {
+          "clientId": "clientid",
+          "secret": "secret"
+        },
+        "windowsProfile": {
+          "adminPassword": "replacePassword1234$",
+          "adminUsername": "azureuser"
+        }
+      },
+      "sku": {
+        "name": "Basic",
+        "tier": "Free"
+      },
+      "tags": {
+        "archv2": "",
+        "tier": "production"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "nodeImageVersion": "AKSUbuntu:1604:2020.03.11",
+              "orchestratorVersion": "1.9.6",
+              "osSKU": "AzureLinux",
+              "osType": "Linux",
+              "provisioningState": "Succeeded",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "currentKubernetesVersion": "1.9.6",
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
+          "httpProxyConfig": {
+            "httpProxy": "http://myproxy.server.com:8080",
+            "httpsProxy": "https://myproxy.server.com:8080",
+            "noProxy": [
+              "localhost",
+              "127.0.0.1"
+            ],
+            "trustedCa": "Q29uZ3JhdHMhIFlvdSBoYXZlIGZvdW5kIGEgaGlkZGVuIG1lc3NhZ2U="
+          },
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "basic",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Succeeded",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "orchestratorVersion": "1.9.6",
+              "osSKU": "AzureLinux",
+              "osType": "Linux",
+              "provisioningState": "Creating",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "currentKubernetesVersion": "1.9.6",
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "httpProxyConfig": {
+            "httpProxy": "http://myproxy.server.com:8080",
+            "httpsProxy": "https://myproxy.server.com:8080",
+            "noProxy": [
+              "localhost",
+              "127.0.0.1"
+            ],
+            "trustedCa": "Q29uZ3JhdHMhIFlvdSBoYXZlIGZvdW5kIGEgaGlkZGVuIG1lc3NhZ2U="
+          },
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "standard",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Creating",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    }
+  },
+  "operationId": "ManagedClusters_CreateOrUpdate",
+  "title": "Create Managed Cluster with OSSKU"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_PPG.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_PPG.json
@@ -1,0 +1,255 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "parameters": {
+      "location": "location1",
+      "properties": {
+        "addonProfiles": {},
+        "agentPoolProfiles": [
+          {
+            "name": "nodepool1",
+            "type": "VirtualMachineScaleSets",
+            "count": 3,
+            "enableNodePublicIP": true,
+            "mode": "System",
+            "osType": "Linux",
+            "proximityPlacementGroupID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/proximityPlacementGroups/ppg1",
+            "vmSize": "Standard_DS2_v2"
+          }
+        ],
+        "autoScalerProfile": {
+          "scale-down-delay-after-add": "15m",
+          "scan-interval": "20s"
+        },
+        "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+        "dnsPrefix": "dnsprefix1",
+        "enableRBAC": true,
+        "kubernetesVersion": "",
+        "linuxProfile": {
+          "adminUsername": "azureuser",
+          "ssh": {
+            "publicKeys": [
+              {
+                "keyData": "keydata"
+              }
+            ]
+          }
+        },
+        "networkProfile": {
+          "loadBalancerProfile": {
+            "managedOutboundIPs": {
+              "count": 2
+            }
+          },
+          "loadBalancerSku": "standard",
+          "outboundType": "loadBalancer"
+        },
+        "servicePrincipalProfile": {
+          "clientId": "clientid",
+          "secret": "secret"
+        },
+        "windowsProfile": {
+          "adminPassword": "replacePassword1234$",
+          "adminUsername": "azureuser"
+        }
+      },
+      "sku": {
+        "name": "Basic",
+        "tier": "Free"
+      },
+      "tags": {
+        "archv2": "",
+        "tier": "production"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "nodeImageVersion": "AKSUbuntu:1604:2020.03.11",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Succeeded",
+              "proximityPlacementGroupID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/proximityPlacementGroups/ppg1",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "currentKubernetesVersion": "1.9.6",
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "basic",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Succeeded",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Creating",
+              "proximityPlacementGroupID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/proximityPlacementGroups/ppg1",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "currentKubernetesVersion": "1.9.6",
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "standard",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Creating",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    }
+  },
+  "operationId": "ManagedClusters_CreateOrUpdate",
+  "title": "Create Managed Cluster with PPG"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_PodIdentity.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_PodIdentity.json
@@ -1,0 +1,264 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "parameters": {
+      "location": "location1",
+      "properties": {
+        "addonProfiles": {},
+        "agentPoolProfiles": [
+          {
+            "name": "nodepool1",
+            "type": "VirtualMachineScaleSets",
+            "count": 3,
+            "enableNodePublicIP": true,
+            "mode": "System",
+            "osType": "Linux",
+            "vmSize": "Standard_DS2_v2"
+          }
+        ],
+        "autoScalerProfile": {
+          "scale-down-delay-after-add": "15m",
+          "scan-interval": "20s"
+        },
+        "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+        "dnsPrefix": "dnsprefix1",
+        "enableRBAC": true,
+        "kubernetesVersion": "",
+        "linuxProfile": {
+          "adminUsername": "azureuser",
+          "ssh": {
+            "publicKeys": [
+              {
+                "keyData": "keydata"
+              }
+            ]
+          }
+        },
+        "networkProfile": {
+          "loadBalancerProfile": {
+            "managedOutboundIPs": {
+              "count": 2
+            }
+          },
+          "loadBalancerSku": "standard",
+          "outboundType": "loadBalancer"
+        },
+        "podIdentityProfile": {
+          "allowNetworkPluginKubenet": true,
+          "enabled": true
+        },
+        "servicePrincipalProfile": {
+          "clientId": "clientid",
+          "secret": "secret"
+        },
+        "windowsProfile": {
+          "adminPassword": "replacePassword1234$",
+          "adminUsername": "azureuser"
+        }
+      },
+      "sku": {
+        "name": "Basic",
+        "tier": "Free"
+      },
+      "tags": {
+        "archv2": "",
+        "tier": "production"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "nodeImageVersion": "AKSUbuntu:1604:2020.03.11",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Succeeded",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "currentKubernetesVersion": "1.9.6",
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "basic",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "podIdentityProfile": {
+            "allowNetworkPluginKubenet": true,
+            "enabled": true
+          },
+          "provisioningState": "Succeeded",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Creating",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "currentKubernetesVersion": "1.9.6",
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "standard",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "podIdentityProfile": {
+            "allowNetworkPluginKubenet": true,
+            "enabled": true
+          },
+          "provisioningState": "Creating",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    }
+  },
+  "operationId": "ManagedClusters_CreateOrUpdate",
+  "title": "Create Managed Cluster with PodIdentity enabled"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_Premium.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_Premium.json
@@ -1,0 +1,273 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "parameters": {
+      "location": "location1",
+      "properties": {
+        "addonProfiles": {},
+        "agentPoolProfiles": [
+          {
+            "name": "nodepool1",
+            "type": "VirtualMachineScaleSets",
+            "count": 3,
+            "enableEncryptionAtHost": true,
+            "enableNodePublicIP": true,
+            "mode": "System",
+            "osType": "Linux",
+            "vmSize": "Standard_DS2_v2"
+          }
+        ],
+        "apiServerAccessProfile": {
+          "disableRunCommand": true
+        },
+        "autoScalerProfile": {
+          "scale-down-delay-after-add": "15m",
+          "scan-interval": "20s"
+        },
+        "dnsPrefix": "dnsprefix1",
+        "enableRBAC": true,
+        "kubernetesVersion": "",
+        "linuxProfile": {
+          "adminUsername": "azureuser",
+          "ssh": {
+            "publicKeys": [
+              {
+                "keyData": "keydata"
+              }
+            ]
+          }
+        },
+        "networkProfile": {
+          "loadBalancerProfile": {
+            "managedOutboundIPs": {
+              "count": 2
+            }
+          },
+          "loadBalancerSku": "standard",
+          "outboundType": "loadBalancer"
+        },
+        "servicePrincipalProfile": {
+          "clientId": "clientid",
+          "secret": "secret"
+        },
+        "supportPlan": "AKSLongTermSupport",
+        "windowsProfile": {
+          "adminPassword": "replacePassword1234$",
+          "adminUsername": "azureuser"
+        }
+      },
+      "sku": {
+        "name": "Base",
+        "tier": "Premium"
+      },
+      "tags": {
+        "archv2": "",
+        "tier": "production"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableEncryptionAtHost": true,
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "nodeImageVersion": "AKSUbuntu:1604:2020.03.11",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Succeeded",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "apiServerAccessProfile": {
+            "disableRunCommand": true
+          },
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "fqdn": "dnsprefix1-ee788a1f.hcp.location1.azmk8s.io",
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "basic",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "privateFQDN": "dnsprefix1-aae7e0f0.5cef6058-b6b5-414d-8cb1-4bd14eb0b15c.privatelink.location1.azmk8s.io",
+          "provisioningState": "Succeeded",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "supportPlan": "AKSLongTermSupport",
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "sku": {
+          "name": "Base",
+          "tier": "Premium"
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableEncryptionAtHost": true,
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Creating",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "apiServerAccessProfile": {
+            "disableRunCommand": true
+          },
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "fqdn": "dnsprefix1-ee788a1f.hcp.location1.azmk8s.io",
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "standard",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "privateFQDN": "dnsprefix1-aae7e0f0.5cef6058-b6b5-414d-8cb1-4bd14eb0b15c.privatelink.location1.azmk8s.io",
+          "provisioningState": "Creating",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "supportPlan": "AKSLongTermSupport",
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "sku": {
+          "name": "Base",
+          "tier": "Premium"
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    }
+  },
+  "operationId": "ManagedClusters_CreateOrUpdate",
+  "title": "Create Managed Cluster with LongTermSupport"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_PrivateClusterFQDNSubdomain.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_PrivateClusterFQDNSubdomain.json
@@ -1,0 +1,265 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "parameters": {
+      "location": "location1",
+      "properties": {
+        "addonProfiles": {},
+        "agentPoolProfiles": [
+          {
+            "name": "nodepool1",
+            "type": "VirtualMachineScaleSets",
+            "count": 3,
+            "enableEncryptionAtHost": true,
+            "enableNodePublicIP": true,
+            "mode": "System",
+            "osType": "Linux",
+            "vmSize": "Standard_DS2_v2"
+          }
+        ],
+        "apiServerAccessProfile": {
+          "enablePrivateCluster": true,
+          "privateDNSZone": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/privateDnsZones/privatelink.location1.azmk8s.io"
+        },
+        "autoScalerProfile": {
+          "scale-down-delay-after-add": "15m",
+          "scan-interval": "20s"
+        },
+        "enableRBAC": true,
+        "fqdnSubdomain": "domain1",
+        "kubernetesVersion": "",
+        "linuxProfile": {
+          "adminUsername": "azureuser",
+          "ssh": {
+            "publicKeys": [
+              {
+                "keyData": "keydata"
+              }
+            ]
+          }
+        },
+        "networkProfile": {
+          "loadBalancerProfile": {
+            "managedOutboundIPs": {
+              "count": 2
+            }
+          },
+          "loadBalancerSku": "standard",
+          "outboundType": "loadBalancer"
+        },
+        "servicePrincipalProfile": {
+          "clientId": "clientid",
+          "secret": "secret"
+        },
+        "windowsProfile": {
+          "adminPassword": "replacePassword1234$",
+          "adminUsername": "azureuser"
+        }
+      },
+      "sku": {
+        "name": "Basic",
+        "tier": "Free"
+      },
+      "tags": {
+        "archv2": "",
+        "tier": "production"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableEncryptionAtHost": true,
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "nodeImageVersion": "AKSUbuntu:1604:2020.03.11",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Succeeded",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "apiServerAccessProfile": {
+            "enablePrivateCluster": true,
+            "privateDNSZone": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/privateDnsZones/privatelink.location1.azmk8s.io"
+          },
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "currentKubernetesVersion": "1.9.6",
+          "enableRBAC": true,
+          "fqdnSubdomain": "domain1",
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "basic",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "privateFQDN": "domain1.privatelink.location1.azmk8s.io",
+          "provisioningState": "Succeeded",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableEncryptionAtHost": true,
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Creating",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "apiServerAccessProfile": {
+            "enablePrivateCluster": true,
+            "privateDNSZone": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/privateDnsZones/privatelink.location1.azmk8s.io"
+          },
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "currentKubernetesVersion": "1.9.6",
+          "enableRBAC": true,
+          "fqdnSubdomain": "domain1",
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "standard",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "privateFQDN": "domain1.privatelink.location1.azmk8s.io",
+          "provisioningState": "Creating",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    }
+  },
+  "operationId": "ManagedClusters_CreateOrUpdate",
+  "title": "Create Managed Private Cluster with fqdn subdomain specified"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_PrivateClusterPublicFQDN.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_PrivateClusterPublicFQDN.json
@@ -1,0 +1,269 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "parameters": {
+      "location": "location1",
+      "properties": {
+        "addonProfiles": {},
+        "agentPoolProfiles": [
+          {
+            "name": "nodepool1",
+            "type": "VirtualMachineScaleSets",
+            "count": 3,
+            "enableEncryptionAtHost": true,
+            "enableNodePublicIP": true,
+            "mode": "System",
+            "osType": "Linux",
+            "vmSize": "Standard_DS2_v2"
+          }
+        ],
+        "apiServerAccessProfile": {
+          "enablePrivateCluster": true,
+          "enablePrivateClusterPublicFQDN": true
+        },
+        "autoScalerProfile": {
+          "scale-down-delay-after-add": "15m",
+          "scan-interval": "20s"
+        },
+        "dnsPrefix": "dnsprefix1",
+        "enableRBAC": true,
+        "kubernetesVersion": "",
+        "linuxProfile": {
+          "adminUsername": "azureuser",
+          "ssh": {
+            "publicKeys": [
+              {
+                "keyData": "keydata"
+              }
+            ]
+          }
+        },
+        "networkProfile": {
+          "loadBalancerProfile": {
+            "managedOutboundIPs": {
+              "count": 2
+            }
+          },
+          "loadBalancerSku": "standard",
+          "outboundType": "loadBalancer"
+        },
+        "servicePrincipalProfile": {
+          "clientId": "clientid",
+          "secret": "secret"
+        },
+        "windowsProfile": {
+          "adminPassword": "replacePassword1234$",
+          "adminUsername": "azureuser"
+        }
+      },
+      "sku": {
+        "name": "Basic",
+        "tier": "Free"
+      },
+      "tags": {
+        "archv2": "",
+        "tier": "production"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableEncryptionAtHost": true,
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "nodeImageVersion": "AKSUbuntu:1604:2020.03.11",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Succeeded",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "apiServerAccessProfile": {
+            "enablePrivateCluster": true,
+            "enablePrivateClusterPublicFQDN": true,
+            "privateDNSZone": "system"
+          },
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "currentKubernetesVersion": "1.9.6",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "fqdn": "dnsprefix1-ee788a1f.hcp.location1.azmk8s.io",
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "basic",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "privateFQDN": "dnsprefix1-aae7e0f0.5cef6058-b6b5-414d-8cb1-4bd14eb0b15c.privatelink.location1.azmk8s.io",
+          "provisioningState": "Succeeded",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableEncryptionAtHost": true,
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Creating",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "apiServerAccessProfile": {
+            "enablePrivateCluster": true,
+            "enablePrivateClusterPublicFQDN": true,
+            "privateDNSZone": "system"
+          },
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "currentKubernetesVersion": "1.9.6",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "fqdn": "dnsprefix1-ee788a1f.hcp.location1.azmk8s.io",
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "standard",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "privateFQDN": "dnsprefix1-aae7e0f0.5cef6058-b6b5-414d-8cb1-4bd14eb0b15c.privatelink.location1.azmk8s.io",
+          "provisioningState": "Creating",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    }
+  },
+  "operationId": "ManagedClusters_CreateOrUpdate",
+  "title": "Create Managed Private Cluster with Public FQDN specified"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_SecurityProfile.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_SecurityProfile.json
@@ -1,0 +1,262 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "parameters": {
+      "location": "location1",
+      "properties": {
+        "agentPoolProfiles": [
+          {
+            "name": "nodepool1",
+            "type": "VirtualMachineScaleSets",
+            "count": 3,
+            "enableNodePublicIP": true,
+            "mode": "System",
+            "osType": "Linux",
+            "vmSize": "Standard_DS2_v2"
+          }
+        ],
+        "dnsPrefix": "dnsprefix1",
+        "kubernetesVersion": "",
+        "linuxProfile": {
+          "adminUsername": "azureuser",
+          "ssh": {
+            "publicKeys": [
+              {
+                "keyData": "keydata"
+              }
+            ]
+          }
+        },
+        "networkProfile": {
+          "loadBalancerProfile": {
+            "managedOutboundIPs": {
+              "count": 2
+            }
+          },
+          "loadBalancerSku": "standard",
+          "outboundType": "loadBalancer"
+        },
+        "securityProfile": {
+          "defender": {
+            "logAnalyticsWorkspaceResourceId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/microsoft.operationalinsights/workspaces/WORKSPACE_NAME",
+            "securityMonitoring": {
+              "enabled": true
+            }
+          },
+          "workloadIdentity": {
+            "enabled": true
+          }
+        }
+      },
+      "sku": {
+        "name": "Basic",
+        "tier": "Free"
+      },
+      "tags": {
+        "archv2": "",
+        "tier": "production"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "nodeImageVersion": "AKSUbuntu:1604:2020.03.11",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Succeeded",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "currentKubernetesVersion": "1.9.6",
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "basic",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Succeeded",
+          "securityProfile": {
+            "defender": {
+              "logAnalyticsWorkspaceResourceId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/microsoft.operationalinsights/workspaces/WORKSPACE_NAME",
+              "securityMonitoring": {
+                "enabled": true
+              }
+            },
+            "workloadIdentity": {
+              "enabled": true
+            }
+          },
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Creating",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "currentKubernetesVersion": "1.9.6",
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "standard",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Creating",
+          "securityProfile": {
+            "defender": {
+              "logAnalyticsWorkspaceResourceId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/microsoft.operationalinsights/workspaces/WORKSPACE_NAME",
+              "securityMonitoring": {
+                "enabled": true
+              }
+            },
+            "workloadIdentity": {
+              "enabled": true
+            }
+          },
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    }
+  },
+  "operationId": "ManagedClusters_CreateOrUpdate",
+  "title": "Create Managed Cluster with Security Profile configured"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_Snapshot.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_Snapshot.json
@@ -1,0 +1,264 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "parameters": {
+      "location": "location1",
+      "properties": {
+        "addonProfiles": {},
+        "agentPoolProfiles": [
+          {
+            "name": "nodepool1",
+            "type": "VirtualMachineScaleSets",
+            "count": 3,
+            "creationData": {
+              "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/snapshots/snapshot1"
+            },
+            "enableFIPS": true,
+            "enableNodePublicIP": true,
+            "mode": "System",
+            "osType": "Linux",
+            "vmSize": "Standard_DS2_v2"
+          }
+        ],
+        "autoScalerProfile": {
+          "scale-down-delay-after-add": "15m",
+          "scan-interval": "20s"
+        },
+        "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+        "dnsPrefix": "dnsprefix1",
+        "enableRBAC": true,
+        "kubernetesVersion": "",
+        "linuxProfile": {
+          "adminUsername": "azureuser",
+          "ssh": {
+            "publicKeys": [
+              {
+                "keyData": "keydata"
+              }
+            ]
+          }
+        },
+        "networkProfile": {
+          "loadBalancerProfile": {
+            "managedOutboundIPs": {
+              "count": 2
+            }
+          },
+          "loadBalancerSku": "standard",
+          "outboundType": "loadBalancer"
+        },
+        "servicePrincipalProfile": {
+          "clientId": "clientid",
+          "secret": "secret"
+        },
+        "windowsProfile": {
+          "adminPassword": "replacePassword1234$",
+          "adminUsername": "azureuser"
+        }
+      },
+      "sku": {
+        "name": "Basic",
+        "tier": "Free"
+      },
+      "tags": {
+        "archv2": "",
+        "tier": "production"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "creationData": {
+                "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/snapshots/snapshot1"
+              },
+              "currentOrchestratorVersion": "1.9.6",
+              "enableFIPS": true,
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "nodeImageVersion": "AKSUbuntu:1604:2020.03.11",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Succeeded",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "currentKubernetesVersion": "1.9.6",
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "basic",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Succeeded",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "creationData": {
+                "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/snapshots/snapshot1"
+              },
+              "currentOrchestratorVersion": "1.9.6",
+              "enableFIPS": true,
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Creating",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "currentKubernetesVersion": "1.9.6",
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "standard",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Creating",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    }
+  },
+  "operationId": "ManagedClusters_CreateOrUpdate",
+  "title": "Create Managed Cluster using an agent pool snapshot"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_Update.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_Update.json
@@ -1,0 +1,316 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "parameters": {
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgName1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1": {}
+        }
+      },
+      "location": "location1",
+      "properties": {
+        "addonProfiles": {},
+        "agentPoolProfiles": [
+          {
+            "name": "nodepool1",
+            "type": "VirtualMachineScaleSets",
+            "availabilityZones": [
+              "1",
+              "2",
+              "3"
+            ],
+            "count": 3,
+            "enableNodePublicIP": true,
+            "mode": "System",
+            "osType": "Linux",
+            "scaleDownMode": "Deallocate",
+            "vmSize": "Standard_DS1_v2"
+          }
+        ],
+        "autoScalerProfile": {
+          "balance-similar-node-groups": "true",
+          "expander": "priority",
+          "max-node-provision-time": "15m",
+          "new-pod-scale-up-delay": "1m",
+          "scale-down-delay-after-add": "15m",
+          "scan-interval": "20s",
+          "skip-nodes-with-system-pods": "false"
+        },
+        "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+        "dnsPrefix": "dnsprefix1",
+        "enableRBAC": true,
+        "kubernetesVersion": "",
+        "linuxProfile": {
+          "adminUsername": "azureuser",
+          "ssh": {
+            "publicKeys": [
+              {
+                "keyData": "keydata"
+              }
+            ]
+          }
+        },
+        "networkProfile": {
+          "loadBalancerProfile": {
+            "managedOutboundIPs": {
+              "count": 2
+            }
+          },
+          "loadBalancerSku": "standard",
+          "outboundType": "loadBalancer"
+        },
+        "servicePrincipalProfile": {
+          "clientId": "clientid",
+          "secret": "secret"
+        },
+        "upgradeSettings": {
+          "overrideSettings": {
+            "forceUpgrade": false,
+            "until": "2022-11-01T13:00:00Z"
+          }
+        },
+        "windowsProfile": {
+          "adminPassword": "replacePassword1234$",
+          "adminUsername": "azureuser"
+        }
+      },
+      "sku": {
+        "name": "Basic",
+        "tier": "Free"
+      },
+      "tags": {
+        "archv2": "",
+        "tier": "production"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgName1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1": {
+              "clientId": "clientId1",
+              "principalId": "principalId1"
+            }
+          }
+        },
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "availabilityZones": [
+                "1",
+                "2",
+                "3"
+              ],
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "nodeImageVersion": "AKSUbuntu:1604:2020.03.11",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Succeeded",
+              "scaleDownMode": "Deallocate",
+              "vmSize": "Standard_DS1_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "balance-similar-node-groups": "true",
+            "expander": "priority",
+            "max-node-provision-time": "15m",
+            "new-pod-scale-up-delay": "1m",
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s",
+            "skip-nodes-with-system-pods": "false"
+          },
+          "currentKubernetesVersion": "1.9.6",
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "basic",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Succeeded",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "upgradeSettings": {
+            "overrideSettings": {
+              "forceUpgrade": false,
+              "until": "2022-11-01T13:00:00Z"
+            }
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgName1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1": {
+              "clientId": "clientId1",
+              "principalId": "principalId1"
+            }
+          }
+        },
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "availabilityZones": [
+                "1",
+                "2",
+                "3"
+              ],
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Creating",
+              "scaleDownMode": "Deallocate",
+              "vmSize": "Standard_DS1_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "currentKubernetesVersion": "1.9.6",
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "standard",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Creating",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    }
+  },
+  "operationId": "ManagedClusters_CreateOrUpdate",
+  "title": "Create/Update Managed Cluster"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_UpdateWindowsGmsa.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_UpdateWindowsGmsa.json
@@ -1,0 +1,300 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "parameters": {
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgName1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1": {}
+        }
+      },
+      "location": "location1",
+      "properties": {
+        "addonProfiles": {},
+        "agentPoolProfiles": [
+          {
+            "name": "nodepool1",
+            "type": "VirtualMachineScaleSets",
+            "availabilityZones": [
+              "1",
+              "2",
+              "3"
+            ],
+            "count": 3,
+            "enableNodePublicIP": true,
+            "mode": "System",
+            "osType": "Linux",
+            "vmSize": "Standard_DS1_v2"
+          }
+        ],
+        "autoScalerProfile": {
+          "scale-down-delay-after-add": "15m",
+          "scan-interval": "20s"
+        },
+        "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+        "dnsPrefix": "dnsprefix1",
+        "enableRBAC": true,
+        "kubernetesVersion": "",
+        "linuxProfile": {
+          "adminUsername": "azureuser",
+          "ssh": {
+            "publicKeys": [
+              {
+                "keyData": "keydata"
+              }
+            ]
+          }
+        },
+        "networkProfile": {
+          "loadBalancerProfile": {
+            "managedOutboundIPs": {
+              "count": 2
+            }
+          },
+          "loadBalancerSku": "standard",
+          "outboundType": "loadBalancer"
+        },
+        "servicePrincipalProfile": {
+          "clientId": "clientid",
+          "secret": "secret"
+        },
+        "windowsProfile": {
+          "adminPassword": "replacePassword1234$",
+          "adminUsername": "azureuser",
+          "gmsaProfile": {
+            "enabled": true
+          }
+        }
+      },
+      "sku": {
+        "name": "Basic",
+        "tier": "Free"
+      },
+      "tags": {
+        "archv2": "",
+        "tier": "production"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgName1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1": {
+              "clientId": "clientId1",
+              "principalId": "principalId1"
+            }
+          }
+        },
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "availabilityZones": [
+                "1",
+                "2",
+                "3"
+              ],
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "nodeImageVersion": "AKSUbuntu:1604:2020.03.11",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Succeeded",
+              "vmSize": "Standard_DS1_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "currentKubernetesVersion": "1.9.6",
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "basic",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Succeeded",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser",
+            "gmsaProfile": {
+              "enabled": true
+            }
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgName1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1": {
+              "clientId": "clientId1",
+              "principalId": "principalId1"
+            }
+          }
+        },
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "availabilityZones": [
+                "1",
+                "2",
+                "3"
+              ],
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Creating",
+              "vmSize": "Standard_DS1_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "currentKubernetesVersion": "1.9.6",
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "standard",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Creating",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser",
+            "gmsaProfile": {
+              "enabled": true
+            }
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    }
+  },
+  "operationId": "ManagedClusters_CreateOrUpdate",
+  "title": "Create/Update Managed Cluster with Windows gMSA enabled"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_UpdateWithAHUB.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_UpdateWithAHUB.json
@@ -1,0 +1,294 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "parameters": {
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgName1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1": {}
+        }
+      },
+      "location": "location1",
+      "properties": {
+        "addonProfiles": {},
+        "agentPoolProfiles": [
+          {
+            "name": "nodepool1",
+            "type": "VirtualMachineScaleSets",
+            "availabilityZones": [
+              "1",
+              "2",
+              "3"
+            ],
+            "count": 3,
+            "enableNodePublicIP": true,
+            "mode": "System",
+            "osType": "Linux",
+            "vmSize": "Standard_DS1_v2"
+          }
+        ],
+        "autoScalerProfile": {
+          "scale-down-delay-after-add": "15m",
+          "scan-interval": "20s"
+        },
+        "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+        "dnsPrefix": "dnsprefix1",
+        "enableRBAC": true,
+        "kubernetesVersion": "",
+        "linuxProfile": {
+          "adminUsername": "azureuser",
+          "ssh": {
+            "publicKeys": [
+              {
+                "keyData": "keydata"
+              }
+            ]
+          }
+        },
+        "networkProfile": {
+          "loadBalancerProfile": {
+            "managedOutboundIPs": {
+              "count": 2
+            }
+          },
+          "loadBalancerSku": "standard",
+          "outboundType": "loadBalancer"
+        },
+        "servicePrincipalProfile": {
+          "clientId": "clientid",
+          "secret": "secret"
+        },
+        "windowsProfile": {
+          "adminPassword": "replacePassword1234$",
+          "adminUsername": "azureuser",
+          "licenseType": "Windows_Server"
+        }
+      },
+      "sku": {
+        "name": "Basic",
+        "tier": "Free"
+      },
+      "tags": {
+        "archv2": "",
+        "tier": "production"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgName1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1": {
+              "clientId": "clientId1",
+              "principalId": "principalId1"
+            }
+          }
+        },
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "availabilityZones": [
+                "1",
+                "2",
+                "3"
+              ],
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "nodeImageVersion": "AKSUbuntu:1604:2020.03.11",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Succeeded",
+              "vmSize": "Standard_DS1_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "currentKubernetesVersion": "1.9.6",
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "basic",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Succeeded",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser",
+            "licenseType": "Windows_Server"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgName1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1": {
+              "clientId": "clientId1",
+              "principalId": "principalId1"
+            }
+          }
+        },
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "availabilityZones": [
+                "1",
+                "2",
+                "3"
+              ],
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Creating",
+              "vmSize": "Standard_DS1_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "currentKubernetesVersion": "1.9.6",
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "standard",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Creating",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser",
+            "licenseType": "Windows_Server"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    }
+  },
+  "operationId": "ManagedClusters_CreateOrUpdate",
+  "title": "Create/Update Managed Cluster with EnableAHUB"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_UpdateWithEnableAzureRBAC.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_UpdateWithEnableAzureRBAC.json
@@ -1,0 +1,283 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "parameters": {
+      "location": "location1",
+      "properties": {
+        "aadProfile": {
+          "enableAzureRBAC": true,
+          "managed": true
+        },
+        "addonProfiles": {},
+        "agentPoolProfiles": [
+          {
+            "name": "nodepool1",
+            "type": "VirtualMachineScaleSets",
+            "availabilityZones": [
+              "1",
+              "2",
+              "3"
+            ],
+            "count": 3,
+            "enableNodePublicIP": true,
+            "mode": "System",
+            "osType": "Linux",
+            "vmSize": "Standard_DS1_v2"
+          }
+        ],
+        "autoScalerProfile": {
+          "scale-down-delay-after-add": "15m",
+          "scan-interval": "20s"
+        },
+        "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+        "dnsPrefix": "dnsprefix1",
+        "enableRBAC": true,
+        "kubernetesVersion": "",
+        "linuxProfile": {
+          "adminUsername": "azureuser",
+          "ssh": {
+            "publicKeys": [
+              {
+                "keyData": "keydata"
+              }
+            ]
+          }
+        },
+        "networkProfile": {
+          "loadBalancerProfile": {
+            "managedOutboundIPs": {
+              "count": 2
+            }
+          },
+          "loadBalancerSku": "standard",
+          "outboundType": "loadBalancer"
+        },
+        "servicePrincipalProfile": {
+          "clientId": "clientid",
+          "secret": "secret"
+        },
+        "windowsProfile": {
+          "adminPassword": "replacePassword1234$",
+          "adminUsername": "azureuser"
+        }
+      },
+      "sku": {
+        "name": "Basic",
+        "tier": "Free"
+      },
+      "tags": {
+        "archv2": "",
+        "tier": "production"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "aadProfile": {
+            "adminGroupObjectIDs": null,
+            "enableAzureRBAC": true,
+            "managed": true,
+            "tenantID": "tenantID"
+          },
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "availabilityZones": [
+                "1",
+                "2",
+                "3"
+              ],
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "nodeImageVersion": "AKSUbuntu:1604:2020.03.11",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Succeeded",
+              "vmSize": "Standard_DS1_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "currentKubernetesVersion": "1.9.6",
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "basic",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Succeeded",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "aadProfile": {
+            "adminGroupObjectIDs": null,
+            "enableAzureRBAC": true,
+            "managed": true,
+            "tenantID": "tenantID"
+          },
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "availabilityZones": [
+                "1",
+                "2",
+                "3"
+              ],
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableNodePublicIP": true,
+              "maxPods": 110,
+              "mode": "System",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Creating",
+              "vmSize": "Standard_DS1_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "currentKubernetesVersion": "1.9.6",
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "managedOutboundIPs": {
+                "count": 2
+              }
+            },
+            "loadBalancerSku": "standard",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Creating",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    }
+  },
+  "operationId": "ManagedClusters_CreateOrUpdate",
+  "title": "Create/Update AAD Managed Cluster with EnableAzureRBAC"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_UserAssignedNATGateway.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersCreate_UserAssignedNATGateway.json
@@ -1,0 +1,199 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "parameters": {
+      "location": "location1",
+      "properties": {
+        "addonProfiles": {},
+        "agentPoolProfiles": [
+          {
+            "name": "nodepool1",
+            "type": "VirtualMachineScaleSets",
+            "count": 3,
+            "enableNodePublicIP": false,
+            "mode": "System",
+            "osType": "Linux",
+            "vmSize": "Standard_DS2_v2"
+          }
+        ],
+        "autoScalerProfile": {
+          "scale-down-delay-after-add": "15m",
+          "scan-interval": "20s"
+        },
+        "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+        "dnsPrefix": "dnsprefix1",
+        "enableRBAC": true,
+        "kubernetesVersion": "",
+        "linuxProfile": {
+          "adminUsername": "azureuser",
+          "ssh": {
+            "publicKeys": [
+              {
+                "keyData": "keydata"
+              }
+            ]
+          }
+        },
+        "networkProfile": {
+          "loadBalancerSku": "standard",
+          "outboundType": "userAssignedNATGateway"
+        },
+        "servicePrincipalProfile": {
+          "clientId": "clientid",
+          "secret": "secret"
+        },
+        "windowsProfile": {
+          "adminPassword": "replacePassword1234$",
+          "adminUsername": "azureuser"
+        }
+      },
+      "sku": {
+        "name": "Basic",
+        "tier": "Free"
+      },
+      "tags": {
+        "archv2": "",
+        "tier": "production"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableNodePublicIP": false,
+              "maxPods": 110,
+              "mode": "System",
+              "nodeImageVersion": "AKSUbuntu:1604:2020.03.11",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Succeeded",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "currentKubernetesVersion": "1.9.6",
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "loadBalancerSku": "basic",
+            "networkPlugin": "kubenet",
+            "outboundType": "userAssignedNATGateway",
+            "podCidr": "10.244.0.0/16",
+            "serviceCidr": "10.0.0.0/16"
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Succeeded",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "type": "VirtualMachineScaleSets",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "enableNodePublicIP": false,
+              "maxPods": 110,
+              "mode": "System",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Creating",
+              "vmSize": "Standard_DS2_v2"
+            }
+          ],
+          "autoScalerProfile": {
+            "scale-down-delay-after-add": "15m",
+            "scan-interval": "20s"
+          },
+          "currentKubernetesVersion": "1.9.6",
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": true,
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "loadBalancerSku": "standard",
+            "networkPlugin": "kubenet",
+            "outboundType": "userAssignedNATGateway",
+            "podCidr": "10.244.0.0/16",
+            "serviceCidr": "10.0.0.0/16"
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Creating",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    }
+  },
+  "operationId": "ManagedClusters_CreateOrUpdate",
+  "title": "Create Managed Cluster with user-assigned NAT gateway as outbound type"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersDelete.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersDelete.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operationresults/00000000-0000-0000-0000-000000000000?api-version=2026-03-01"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ManagedClusters_Delete",
+  "title": "Delete Managed Cluster"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersGet.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersGet.json
@@ -1,0 +1,117 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "eTag": "beywbwei",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "availabilityZones": [
+                "1",
+                "2",
+                "3"
+              ],
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "eTag": "nvewbvoi",
+              "maxPods": 110,
+              "nodeImageVersion": "AKSUbuntu:1604:2020.03.11",
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Succeeded",
+              "upgradeSettings": {
+                "maxSurge": "33%"
+              },
+              "vmSize": "Standard_DS1_v2"
+            }
+          ],
+          "azurePortalFQDN": "dnsprefix1-abcd1234.portal.hcp.eastus.azmk8s.io",
+          "currentKubernetesVersion": "1.9.6",
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": false,
+          "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "maxAgentPools": 1,
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "ipFamilies": [
+              "IPv4"
+            ],
+            "loadBalancerProfile": {
+              "allocatedOutboundPorts": 2000,
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip1"
+                },
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg1/providers/Microsoft.Network/publicIPAddresses/mgdoutboundip2"
+                }
+              ],
+              "idleTimeoutInMinutes": 10,
+              "outboundIPs": {
+                "publicIPs": [
+                  {
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/customeroutboundip1"
+                  },
+                  {
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/customeroutboundip2"
+                  }
+                ]
+              }
+            },
+            "loadBalancerSku": "standard",
+            "networkPlugin": "kubenet",
+            "outboundType": "loadBalancer",
+            "podCidr": "10.244.0.0/16",
+            "podCidrs": [
+              "10.244.0.0/16"
+            ],
+            "serviceCidr": "10.0.0.0/16",
+            "serviceCidrs": [
+              "10.0.0.0/16"
+            ]
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Succeeded",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          },
+          "upgradeSettings": {
+            "overrideSettings": {
+              "forceUpgrade": true,
+              "until": "2022-11-01T13:00:00Z"
+            }
+          }
+        },
+        "tags": {
+          "archv2": "",
+          "tier": "production"
+        }
+      }
+    }
+  },
+  "operationId": "ManagedClusters_Get",
+  "title": "Get Managed Cluster"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersGetAccessProfile.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersGetAccessProfile.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "roleName": "clusterUser",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "clusterUser",
+        "type": "Microsoft.ContainerService/managedClusters/accessProfiles",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/accessProfiles/clusterUser",
+        "location": "location1",
+        "properties": {
+          "kubeConfig": "a3ViZUNvbmZpZzE="
+        }
+      }
+    }
+  },
+  "operationId": "ManagedClusters_GetAccessProfile",
+  "title": "Get Managed Cluster"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersGetUpgradeProfile.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersGetUpgradeProfile.json
@@ -1,0 +1,51 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.ContainerService/managedClusters/upgradeprofiles",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/upgradeprofiles/default",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "agent",
+              "kubernetesVersion": "1.7.7",
+              "osType": "Linux",
+              "upgrades": [
+                {
+                  "kubernetesVersion": "1.7.9"
+                },
+                {
+                  "isPreview": true,
+                  "kubernetesVersion": "1.7.11"
+                }
+              ]
+            }
+          ],
+          "controlPlaneProfile": {
+            "name": "master",
+            "kubernetesVersion": "1.7.7",
+            "osType": "Linux",
+            "upgrades": [
+              {
+                "isPreview": true,
+                "kubernetesVersion": "1.7.9"
+              },
+              {
+                "kubernetesVersion": "1.7.11"
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ManagedClusters_GetUpgradeProfile",
+  "title": "Get Upgrade Profile for Managed Cluster"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersGet_MeshRevisionProfile.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersGet_MeshRevisionProfile.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "location": "location1",
+    "mode": "istio",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "istio",
+        "type": "Microsoft.ContainerService/locations/meshRevisionProfiles",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/location1/meshRevisionProfiles/istio",
+        "properties": {
+          "meshRevisions": [
+            {
+              "compatibleWith": [
+                {
+                  "name": "kubernetes",
+                  "versions": [
+                    "1.23",
+                    "1.24",
+                    "1.25",
+                    "1.26"
+                  ]
+                }
+              ],
+              "revision": "asm-1-17",
+              "upgrades": [
+                "asm-1-18"
+              ]
+            },
+            {
+              "compatibleWith": [
+                {
+                  "name": "kubernetes",
+                  "versions": [
+                    "1.24",
+                    "1.25",
+                    "1.26",
+                    "1.27"
+                  ]
+                }
+              ],
+              "revision": "asm-1-18",
+              "upgrades": []
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "ManagedClusters_GetMeshRevisionProfile",
+  "title": "Get a mesh revision profile for a mesh mode"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersGet_MeshUpgradeProfile.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersGet_MeshUpgradeProfile.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "mode": "istio",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "istio",
+        "type": "Microsoft.ContainerService/managedClusters/meshUpgradeProfiles",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/meshUpgradeProfiles/istio",
+        "properties": {
+          "compatibleWith": [
+            {
+              "name": "kubernetes",
+              "versions": [
+                "1.23",
+                "1.24",
+                "1.25",
+                "1.26"
+              ]
+            }
+          ],
+          "revision": "asm-1-17",
+          "upgrades": [
+            "asm-1-18"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "ManagedClusters_GetMeshUpgradeProfile",
+  "title": "Gets version compatibility and upgrade profile for a service mesh in a cluster"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersList.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersList.json
@@ -1,0 +1,70 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "clustername1",
+            "type": "Microsoft.ContainerService/managedClusters",
+            "eTag": "nvweuib",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+            "location": "location1",
+            "properties": {
+              "agentPoolProfiles": [
+                {
+                  "name": "nodepool1",
+                  "count": 3,
+                  "currentOrchestratorVersion": "1.9.6",
+                  "eTag": "byuefvwi",
+                  "maxPods": 110,
+                  "orchestratorVersion": "1.9.6",
+                  "osType": "Linux",
+                  "provisioningState": "Succeeded",
+                  "vmSize": "Standard_DS1_v2"
+                }
+              ],
+              "currentKubernetesVersion": "1.9.6",
+              "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+              "dnsPrefix": "dnsprefix1",
+              "enableRBAC": false,
+              "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
+              "kubernetesVersion": "1.9.6",
+              "linuxProfile": {
+                "adminUsername": "azureuser",
+                "ssh": {
+                  "publicKeys": [
+                    {
+                      "keyData": "keydata"
+                    }
+                  ]
+                }
+              },
+              "maxAgentPools": 1,
+              "networkProfile": {
+                "dnsServiceIP": "10.0.0.10",
+                "networkPlugin": "kubenet",
+                "podCidr": "10.244.0.0/16",
+                "serviceCidr": "10.0.0.0/16"
+              },
+              "nodeResourceGroup": "MC_rg1_clustername1_location1",
+              "provisioningState": "Succeeded",
+              "servicePrincipalProfile": {
+                "clientId": "clientid"
+              }
+            },
+            "tags": {
+              "archv2": "",
+              "tier": "production"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ManagedClusters_List",
+  "title": "List Managed Clusters"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersListByResourceGroup.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersListByResourceGroup.json
@@ -1,0 +1,69 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "clustername1",
+            "type": "Microsoft.ContainerService/managedClusters",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+            "location": "location1",
+            "properties": {
+              "agentPoolProfiles": [
+                {
+                  "name": "nodepool1",
+                  "count": 3,
+                  "currentOrchestratorVersion": "1.9.6",
+                  "maxPods": 110,
+                  "orchestratorVersion": "1.9.6",
+                  "osType": "Linux",
+                  "provisioningState": "Succeeded",
+                  "vmSize": "Standard_DS1_v2"
+                }
+              ],
+              "currentKubernetesVersion": "1.9.6",
+              "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+              "dnsPrefix": "dnsprefix1",
+              "enableRBAC": false,
+              "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
+              "kubernetesVersion": "1.9.6",
+              "linuxProfile": {
+                "adminUsername": "azureuser",
+                "ssh": {
+                  "publicKeys": [
+                    {
+                      "keyData": "keydata"
+                    }
+                  ]
+                }
+              },
+              "maxAgentPools": 1,
+              "networkProfile": {
+                "dnsServiceIP": "10.0.0.10",
+                "networkPlugin": "kubenet",
+                "podCidr": "10.244.0.0/16",
+                "serviceCidr": "10.0.0.0/16"
+              },
+              "nodeResourceGroup": "MC_rg1_clustername1_location1",
+              "provisioningState": "Succeeded",
+              "servicePrincipalProfile": {
+                "clientId": "clientid"
+              }
+            },
+            "tags": {
+              "archv2": "",
+              "tier": "production"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ManagedClusters_ListByResourceGroup",
+  "title": "Get Managed Clusters by Resource Group"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersListClusterAdminCredentials.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersListClusterAdminCredentials.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "kubeconfigs": [
+          {
+            "name": "credentialName1",
+            "value": "Y3JlZGVudGlhbFZhbHVlMQ=="
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ManagedClusters_ListClusterAdminCredentials",
+  "title": "Get Managed Cluster"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersListClusterMonitoringUserCredentials.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersListClusterMonitoringUserCredentials.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "kubeconfigs": [
+          {
+            "name": "credentialName1",
+            "value": "Y3JlZGVudGlhbFZhbHVlMQ=="
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ManagedClusters_ListClusterMonitoringUserCredentials",
+  "title": "Get Managed Cluster"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersListClusterUserCredentials.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersListClusterUserCredentials.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "kubeconfigs": [
+          {
+            "name": "credentialName1",
+            "value": "Y3JlZGVudGlhbFZhbHVlMQ=="
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ManagedClusters_ListClusterUserCredentials",
+  "title": "Get Managed Cluster"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersList_MeshRevisionProfiles.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersList_MeshRevisionProfiles.json
@@ -1,0 +1,58 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "location": "location1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "istio",
+            "type": "Microsoft.ContainerService/locations/meshRevisionProfiles",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/location1/meshRevisionProfiles/istio",
+            "properties": {
+              "meshRevisions": [
+                {
+                  "compatibleWith": [
+                    {
+                      "name": "kubernetes",
+                      "versions": [
+                        "1.23",
+                        "1.24",
+                        "1.25",
+                        "1.26"
+                      ]
+                    }
+                  ],
+                  "revision": "asm-1-17",
+                  "upgrades": [
+                    "asm-1-18"
+                  ]
+                },
+                {
+                  "compatibleWith": [
+                    {
+                      "name": "kubernetes",
+                      "versions": [
+                        "1.24",
+                        "1.25",
+                        "1.26",
+                        "1.27"
+                      ]
+                    }
+                  ],
+                  "revision": "asm-1-18",
+                  "upgrades": []
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ManagedClusters_ListMeshRevisionProfiles",
+  "title": "List mesh revision profiles in a location"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersList_MeshUpgradeProfiles.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersList_MeshUpgradeProfiles.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "istio",
+            "type": "Microsoft.ContainerService/managedClusters/meshUpgradeProfiles",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/meshUpgradeProfiles/istio",
+            "properties": {
+              "compatibleWith": [
+                {
+                  "name": "kubernetes",
+                  "versions": [
+                    "1.23",
+                    "1.24",
+                    "1.25",
+                    "1.26"
+                  ]
+                }
+              ],
+              "revision": "asm-1-17",
+              "upgrades": [
+                "asm-1-18"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ManagedClusters_ListMeshUpgradeProfiles",
+  "title": "Lists version compatibility and upgrade profile for all service meshes in a cluster"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersResetAADProfile.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersResetAADProfile.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "parameters": {
+      "clientAppID": "clientappid",
+      "serverAppID": "serverappid",
+      "serverAppSecret": "serverappsecret",
+      "tenantID": "tenantid"
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operationresults/00000000-0000-0000-0000-000000000000?api-version=2026-03-01"
+      }
+    }
+  },
+  "operationId": "ManagedClusters_ResetAADProfile",
+  "title": "Reset AAD Profile"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersResetServicePrincipalProfile.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersResetServicePrincipalProfile.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "parameters": {
+      "clientId": "clientid",
+      "secret": "secret"
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operationresults/00000000-0000-0000-0000-000000000000?api-version=2026-03-01"
+      }
+    }
+  },
+  "operationId": "ManagedClusters_ResetServicePrincipalProfile",
+  "title": "Reset Service Principal Profile"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersRotateClusterCertificates.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersRotateClusterCertificates.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operationresults/00000000-0000-0000-0000-000000000000?api-version=2026-03-01"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ManagedClusters_RotateClusterCertificates",
+  "title": "Rotate Cluster Certificates"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersRotateServiceAccountSigningKeys.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersRotateServiceAccountSigningKeys.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operationresults/00000000-0000-0000-0000-000000000000?api-version=2026-03-01"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ManagedClusters_RotateServiceAccountSigningKeys",
+  "title": "Rotate Cluster Service Account Signing Keys"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersStart.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersStart.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operationresults/00000000-0000-0000-0000-000000000000?api-version=2026-03-01"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ManagedClusters_Start",
+  "title": "Start Managed Cluster"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersStop.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersStop.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operationresults/00000000-0000-0000-0000-000000000000?api-version=2026-03-01"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ManagedClusters_Stop",
+  "title": "Stop Managed Cluster"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersUpdateTags.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedClustersUpdateTags.json
@@ -1,0 +1,75 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "parameters": {
+      "tags": {
+        "archv3": "",
+        "tier": "testing"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "clustername1",
+        "type": "Microsoft.ContainerService/managedClusters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1",
+        "location": "location1",
+        "properties": {
+          "agentPoolProfiles": [
+            {
+              "name": "nodepool1",
+              "count": 3,
+              "currentOrchestratorVersion": "1.9.6",
+              "maxPods": 110,
+              "orchestratorVersion": "1.9.6",
+              "osType": "Linux",
+              "provisioningState": "Succeeded",
+              "vmSize": "Standard_DS1_v2"
+            }
+          ],
+          "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
+          "dnsPrefix": "dnsprefix1",
+          "enableRBAC": false,
+          "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
+          "kubernetesVersion": "1.9.6",
+          "linuxProfile": {
+            "adminUsername": "azureuser",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "keydata"
+                }
+              ]
+            }
+          },
+          "networkProfile": {
+            "dnsServiceIP": "10.0.0.10",
+            "networkPlugin": "kubenet",
+            "podCidr": "10.244.0.0/16",
+            "serviceCidr": "10.0.0.0/16"
+          },
+          "nodeResourceGroup": "MC_rg1_clustername1_location1",
+          "provisioningState": "Succeeded",
+          "servicePrincipalProfile": {
+            "clientId": "clientid"
+          }
+        },
+        "tags": {
+          "archv3": "",
+          "tier": "testing"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operationresults/00000000-0000-0000-0000-000000000000?api-version=2026-03-01"
+      }
+    }
+  },
+  "operationId": "ManagedClusters_UpdateTags",
+  "title": "Update Managed Cluster Tags"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedNamespacesCreate_Update.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedNamespacesCreate_Update.json
@@ -1,0 +1,103 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "managedNamespaceName": "namespace1",
+    "parameters": {
+      "location": "eastus2",
+      "properties": {
+        "adoptionPolicy": "IfIdentical",
+        "annotations": {
+          "annatationKey": "annatationValue"
+        },
+        "defaultNetworkPolicy": {
+          "egress": "AllowAll",
+          "ingress": "AllowSameNamespace"
+        },
+        "defaultResourceQuota": {
+          "cpuLimit": "3m",
+          "cpuRequest": "3m",
+          "memoryLimit": "5Gi",
+          "memoryRequest": "5Gi"
+        },
+        "deletePolicy": "Keep",
+        "labels": {
+          "kubernetes.io/metadata.name": "true"
+        }
+      },
+      "tags": {
+        "tagKey1": "tagValue1"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "namespace1",
+        "type": "Microsoft.ContainerService/managedClusters/managedNamespaces",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/managedNamespaces/namespace1",
+        "location": "eastus2",
+        "properties": {
+          "adoptionPolicy": "IfIdentical",
+          "annotations": {
+            "annatationKey": "annatationValue"
+          },
+          "defaultNetworkPolicy": {
+            "egress": "AllowAll",
+            "ingress": "AllowSameNamespace"
+          },
+          "defaultResourceQuota": {
+            "cpuLimit": "3m",
+            "cpuRequest": "3m",
+            "memoryLimit": "5Gi",
+            "memoryRequest": "5Gi"
+          },
+          "deletePolicy": "Keep",
+          "labels": {
+            "kubernetes.io/metadata.name": "true"
+          },
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "tagKey1": "tagValue1"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "namespace1",
+        "type": "Microsoft.ContainerService/managedClusters/managedNamespaces",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/managedNamespaces/namespace1",
+        "location": "eastus2",
+        "properties": {
+          "adoptionPolicy": "IfIdentical",
+          "annotations": {
+            "annatationKey": "annatationValue"
+          },
+          "defaultNetworkPolicy": {
+            "egress": "AllowAll",
+            "ingress": "AllowSameNamespace"
+          },
+          "defaultResourceQuota": {
+            "cpuLimit": "3m",
+            "cpuRequest": "3m",
+            "memoryLimit": "5Gi",
+            "memoryRequest": "5Gi"
+          },
+          "deletePolicy": "Keep",
+          "labels": {
+            "kubernetes.io/metadata.name": "true"
+          },
+          "provisioningState": "Updating"
+        },
+        "tags": {
+          "tagKey1": "tagValue1"
+        }
+      }
+    }
+  },
+  "operationId": "ManagedNamespaces_CreateOrUpdate",
+  "title": "Create/Update Managed Namespace"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedNamespacesDelete.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedNamespacesDelete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "managedNamespaceName": "namespace1",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus2/operations/00000000-0000-0000-0000-000000000000?api-version=2026-03-01"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ManagedNamespaces_Delete",
+  "title": "Delete Managed Namespace"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedNamespacesGet.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedNamespacesGet.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "managedNamespaceName": "namespace1",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "namespace1",
+        "type": "Microsoft.ContainerService/managedClusters/managedNamespaces",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/managedNamespaces/namespace1",
+        "location": "eastus2",
+        "properties": {
+          "adoptionPolicy": "IfIdentical",
+          "annotations": {
+            "annatationKey": "annatationValue"
+          },
+          "defaultNetworkPolicy": {
+            "egress": "AllowAll",
+            "ingress": "AllowSameNamespace"
+          },
+          "defaultResourceQuota": {
+            "cpuLimit": "3m",
+            "cpuRequest": "3m",
+            "memoryLimit": "5Gi",
+            "memoryRequest": "5Gi"
+          },
+          "deletePolicy": "Keep",
+          "labels": {
+            "kubernetes.azure.com/managedByArm": "true"
+          },
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "tagKey1": "tagValue1"
+        }
+      }
+    }
+  },
+  "operationId": "ManagedNamespaces_Get",
+  "title": "Get Managed Namespace"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedNamespacesList.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedNamespacesList.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "managedNamespaceName": "namespace1",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "namespace1",
+            "type": "Microsoft.ContainerService/managedClusters/managedNamespaces",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/managedNamespaces/namespace1",
+            "location": "eastus2",
+            "properties": {
+              "adoptionPolicy": "IfIdentical",
+              "annotations": {
+                "annatationKey": "annatationValue"
+              },
+              "defaultNetworkPolicy": {
+                "egress": "AllowAll",
+                "ingress": "AllowSameNamespace"
+              },
+              "defaultResourceQuota": {
+                "cpuLimit": "3m",
+                "cpuRequest": "3m",
+                "memoryLimit": "5Gi",
+                "memoryRequest": "5Gi"
+              },
+              "deletePolicy": "Keep",
+              "labels": {
+                "kubernetes.azure.com/managedByArm": "true"
+              },
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "tagKey1": "tagValue1"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ManagedNamespaces_ListByManagedCluster",
+  "title": "List namespaces by Managed Cluster"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedNamespacesListCredentialResult.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedNamespacesListCredentialResult.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "managedNamespaceName": "namespace1",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "kubeconfigs": [
+          {
+            "name": "credentialName1",
+            "value": "Y3JlZGVudGlhbFZhbHVlMQ=="
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ManagedNamespaces_ListCredential",
+  "title": "List managed namespace credentials"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedNamespacesUpdateTags.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ManagedNamespacesUpdateTags.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "managedNamespaceName": "namespace1",
+    "parameters": {
+      "tags": {
+        "tagKey1": "tagValue1",
+        "tagKey2": "tagValue2"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "location": "eastus2",
+        "properties": {
+          "adoptionPolicy": "IfIdentical",
+          "annotations": {
+            "annatationKey": "annatationValue"
+          },
+          "defaultNetworkPolicy": {
+            "egress": "AllowAll",
+            "ingress": "AllowSameNamespace"
+          },
+          "defaultResourceQuota": {
+            "cpuLimit": "3m",
+            "cpuRequest": "3m",
+            "memoryLimit": "5Gi",
+            "memoryRequest": "5Gi"
+          },
+          "deletePolicy": "Keep",
+          "labels": {
+            "kubernetes.azure.com/managedByArm": "true"
+          },
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "tagKey1": "tagValue1",
+          "tagKey2": "tagValue2"
+        }
+      }
+    }
+  },
+  "operationId": "ManagedNamespaces_Update",
+  "title": "Update Managed Namespace Tags"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/Operation_List.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/Operation_List.json
@@ -1,0 +1,3575 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.ContainerService/locations/operations/read",
+            "display": {
+              "description": "Gets the status of an asynchronous operation",
+              "operation": "Get Operation",
+              "provider": "Microsoft Container Service",
+              "resource": "Operation"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/locations/orchestrators/read",
+            "display": {
+              "description": "Lists the supported orchestrators",
+              "operation": "List Orchestrators",
+              "provider": "Microsoft Container Service",
+              "resource": "Orchestrator"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/operations/read",
+            "display": {
+              "description": "Lists operations available on Microsoft.ContainerService resource provider",
+              "operation": "List Available Container Service Operations",
+              "provider": "Microsoft Container Service",
+              "resource": "Available Container Service Operations"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/register/action",
+            "display": {
+              "description": "Registers Subscription with Microsoft.ContainerService resource provider",
+              "operation": "Register Subscription for Container Service",
+              "provider": "Microsoft Container Service",
+              "resource": "Container Service Register Subscription"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/unregister/action",
+            "display": {
+              "description": "Unregisters Subscription with Microsoft.ContainerService resource provider",
+              "operation": "Unregister Subscription for Container Service",
+              "provider": "Microsoft Container Service",
+              "resource": "Container Service Unregister Subscription"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/locations/operationresults/read",
+            "display": {
+              "description": "Gets the status of an asynchronous operation result",
+              "operation": "Get Operation Result",
+              "provider": "Microsoft Container Service",
+              "resource": "OperationResult"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/containerServices/read",
+            "display": {
+              "description": "Get a container service",
+              "operation": "Get Container Service",
+              "provider": "Microsoft Container Service",
+              "resource": "Container Services"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/containerServices/write",
+            "display": {
+              "description": "Creates a new container service or updates an existing one",
+              "operation": "Create or Update Container Service",
+              "provider": "Microsoft Container Service",
+              "resource": "Container Services"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/containerServices/delete",
+            "display": {
+              "description": "Deletes a container service",
+              "operation": "Delete Container Service",
+              "provider": "Microsoft Container Service",
+              "resource": "Container Services"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/read",
+            "display": {
+              "description": "Get a managed cluster",
+              "operation": "Get Managed Cluster",
+              "provider": "Microsoft Container Service",
+              "resource": "Managed Clusters"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/write",
+            "display": {
+              "description": "Creates a new managed cluster or updates an existing one",
+              "operation": "Create or Update Managed Cluster",
+              "provider": "Microsoft Container Service",
+              "resource": "Managed Clusters"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/delete",
+            "display": {
+              "description": "Deletes a managed cluster",
+              "operation": "Delete Managed Cluster",
+              "provider": "Microsoft Container Service",
+              "resource": "Managed Clusters"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/start/action",
+            "display": {
+              "description": "Starts a managed cluster",
+              "operation": "Start Managed Cluster",
+              "provider": "Microsoft Container Service",
+              "resource": "Managed Clusters"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/stop/action",
+            "display": {
+              "description": "Stops a managed cluster",
+              "operation": "Stop Managed Cluster",
+              "provider": "Microsoft Container Service",
+              "resource": "Managed Clusters"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/maintenanceConfigurations/read",
+            "display": {
+              "description": "Gets a maintenance configuration",
+              "operation": "Get a maintenance configuration",
+              "provider": "Microsoft Container Service",
+              "resource": "Maintenance Configurations"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/maintenanceConfigurations/write",
+            "display": {
+              "description": "Creates a new MaintenanceConfiguration or updates an existing one",
+              "operation": "Create or Update maintenance configuratio",
+              "provider": "Microsoft Container Service",
+              "resource": "Maintenance Configurations"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/maintenanceConfigurations/delete",
+            "display": {
+              "description": "Deletes a maintenance configuration",
+              "operation": "Delete Maintenance Configuration",
+              "provider": "Microsoft Container Service",
+              "resource": "Maintenance Configurations"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/agentPools/read",
+            "display": {
+              "description": "Gets an agent pool",
+              "operation": "Get Agent Pool",
+              "provider": "Microsoft Container Service",
+              "resource": "Agent Pools"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/agentPools/write",
+            "display": {
+              "description": "Creates a new agent pool or updates an existing one",
+              "operation": "Create or Update Agent Pool",
+              "provider": "Microsoft Container Service",
+              "resource": "Agent Pools"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/agentPools/delete",
+            "display": {
+              "description": "Deletes an agent pool",
+              "operation": "Delete Agent Pool",
+              "provider": "Microsoft Container Service",
+              "resource": "Agent Pools"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/agentPools/upgradeProfiles/read",
+            "display": {
+              "description": "Gets the upgrade profile of the Agent Pool",
+              "operation": "Get Agent Pool UpgradeProfile",
+              "provider": "Microsoft Container Service",
+              "resource": "Agent Pools"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/agentPools/upgradeNodeImageVersion/write",
+            "display": {
+              "description": "Upgrade the node image version of agent pool",
+              "operation": "Upgrade agent pool node image version",
+              "provider": "Microsoft Container Service",
+              "resource": "Agent Pools"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/availableAgentPoolVersions/read",
+            "display": {
+              "description": "Gets the available agent pool versions of the cluster",
+              "operation": "Get Available Agent Pool Versions",
+              "provider": "Microsoft Container Service",
+              "resource": "Managed Clusters"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/accessProfiles/read",
+            "display": {
+              "description": "Get a managed cluster access profile by role name",
+              "operation": "Get Managed Cluster AccessProfile",
+              "provider": "Microsoft Container Service",
+              "resource": "Managed Clusters"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/accessProfiles/listCredential/action",
+            "display": {
+              "description": "Get a managed cluster access profile by role name using list credential",
+              "operation": "Get Managed Cluster AccessProfile by List Credential",
+              "provider": "Microsoft Container Service",
+              "resource": "Managed Clusters"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/upgradeProfiles/read",
+            "display": {
+              "description": "Gets the upgrade profile of the cluster",
+              "operation": "Get UpgradeProfile",
+              "provider": "Microsoft Container Service",
+              "resource": "UpgradeProfile"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/listClusterAdminCredential/action",
+            "display": {
+              "description": "List the clusterAdmin credential of a managed cluster",
+              "operation": "List clusterAdmin credential",
+              "provider": "Microsoft Container Service",
+              "resource": "Managed Clusters"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/listClusterUserCredential/action",
+            "display": {
+              "description": "List the clusterUser credential of a managed cluster",
+              "operation": "List clusterUser credential",
+              "provider": "Microsoft Container Service",
+              "resource": "Managed Clusters"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/listClusterMonitoringUserCredential/action",
+            "display": {
+              "description": "List the clusterMonitoringUser credential of a managed cluster",
+              "operation": "List clusterMonitoringUser credential",
+              "provider": "Microsoft Container Service",
+              "resource": "Managed Clusters"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/resetServicePrincipalProfile/action",
+            "display": {
+              "description": "Reset the service principal profile of a managed cluster",
+              "operation": "Reset service principal profile",
+              "provider": "Microsoft Container Service",
+              "resource": "Managed Clusters"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/resolvePrivateLinkServiceId/action",
+            "display": {
+              "description": "Resolve the private link service id of a managed cluster",
+              "operation": "Resolve private link service id",
+              "provider": "Microsoft Container Service",
+              "resource": "Managed Clusters"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/resetAADProfile/action",
+            "display": {
+              "description": "Reset the AAD profile of a managed cluster",
+              "operation": "Reset AAD profile",
+              "provider": "Microsoft Container Service",
+              "resource": "Managed Clusters"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/rotateClusterCertificates/action",
+            "display": {
+              "description": "Rotate certificates of a managed cluster",
+              "operation": "Rotate certificates of the cluster",
+              "provider": "Microsoft Container Service",
+              "resource": "Managed Clusters"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/runCommand/action",
+            "display": {
+              "description": "Run user issued command against managed kubernetes server.",
+              "operation": "RunCommand",
+              "provider": "Microsoft Container Service",
+              "resource": "Managed Clusters"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/commandResults/read",
+            "display": {
+              "description": "Retrieve result from previous issued command.",
+              "operation": "CommandResult",
+              "provider": "Microsoft Container Service",
+              "resource": "Managed Clusters"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/providers/Microsoft.Insights/diagnosticSettings/read",
+            "display": {
+              "description": "Get the diagnostic setting for a managed cluster resource",
+              "operation": "Read Diagnostic Setting",
+              "provider": "Microsoft Container Service",
+              "resource": "Managed Clusters"
+            },
+            "origin": "system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/providers/Microsoft.Insights/diagnosticSettings/write",
+            "display": {
+              "description": "Creates or updates the diagnostic setting for a managed cluster resource",
+              "operation": "Write Diagnostic Setting",
+              "provider": "Microsoft Container Service",
+              "resource": "Managed Clusters"
+            },
+            "origin": "system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/detectors/read",
+            "display": {
+              "description": "Get Managed Cluster Detector",
+              "operation": "Get Managed Cluster Detector",
+              "provider": "Microsoft Container Service",
+              "resource": "Managed Cluster Detector"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/diagnosticsState/read",
+            "display": {
+              "description": "Gets the diagnostics state of the cluster",
+              "operation": "Get Diagnostics State",
+              "provider": "Microsoft Container Service",
+              "resource": "Diagnostics State"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/privateEndpointConnectionsApproval/action",
+            "display": {
+              "description": "Determines if user is allowed to approve a private endpoint connection",
+              "operation": "Approve Private Endpoint Connections",
+              "provider": "Microsoft Container Service",
+              "resource": "Approve Private Endpoint Connections"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/privateEndpointConnections/read",
+            "display": {
+              "description": "Get private endpoint connection",
+              "operation": "Get private endpoint connection",
+              "provider": "Microsoft Container Service",
+              "resource": "Private Endpoint Connections"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/privateEndpointConnections/write",
+            "display": {
+              "description": "Approve or Reject a private endpoint connection",
+              "operation": "Update private endpoint connection",
+              "provider": "Microsoft Container Service",
+              "resource": "Private Endpoint Connections"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/privateEndpointConnections/delete",
+            "display": {
+              "description": "Delete private endpoint connection",
+              "operation": "Delete private endpoint connection",
+              "provider": "Microsoft Container Service",
+              "resource": "Private Endpoint Connections"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/extensionaddons/read",
+            "display": {
+              "description": "Gets an extension addon",
+              "operation": "Get an extension addon",
+              "provider": "Microsoft Container Service",
+              "resource": "ExtensionAddons"
+            },
+            "origin": "system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/extensionaddons/write",
+            "display": {
+              "description": "Creates a new extension addon or updates an existing one",
+              "operation": "Create or Update extension addon",
+              "provider": "Microsoft Container Service",
+              "resource": "ExtensionAddons"
+            },
+            "origin": "system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/extensionaddons/delete",
+            "display": {
+              "description": "Deletes an extension addon",
+              "operation": "Delete an extension addon",
+              "provider": "Microsoft Container Service",
+              "resource": "ExtensionAddons"
+            },
+            "origin": "system"
+          },
+          {
+            "name": "Microsoft.ContainerService/snapshots/read",
+            "display": {
+              "description": "Get a snapshot",
+              "operation": "Get Snapshot",
+              "provider": "Microsoft Container Service",
+              "resource": "Snapshots"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/snapshots/write",
+            "display": {
+              "description": "Creates a new snapshot",
+              "operation": "Create Snapshot",
+              "provider": "Microsoft Container Service",
+              "resource": "Snapshots"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/snapshots/delete",
+            "display": {
+              "description": "Deletes a snapshot",
+              "operation": "Delete Snapshot",
+              "provider": "Microsoft Container Service",
+              "resource": "Snapshots"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/eventGridFilters/read",
+            "display": {
+              "description": "Get eventgrid filter",
+              "operation": "Get eventgrid filter",
+              "provider": "Microsoft Container Service",
+              "resource": "EventGridFilters"
+            },
+            "origin": "system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/eventGridFilters/write",
+            "display": {
+              "description": "Create or Update eventgrid filter",
+              "operation": "Create or Update eventgrid filter",
+              "provider": "Microsoft Container Service",
+              "resource": "EventGridFilters"
+            },
+            "origin": "system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/eventGridFilters/delete",
+            "display": {
+              "description": "Delete an eventgrid filter",
+              "operation": "Delete an eventgrid filter",
+              "provider": "Microsoft Container Service",
+              "resource": "EventGridFilters"
+            },
+            "origin": "system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/admissionregistration.k8s.io/initializerconfigurations/read",
+            "display": {
+              "description": "Reads initializerconfigurations",
+              "operation": "Gets/List initializerconfigurations resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Initializerconfigurations"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/admissionregistration.k8s.io/initializerconfigurations/write",
+            "display": {
+              "description": "Writes initializerconfigurations",
+              "operation": "Creates/Updates initializerconfigurations resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Initializerconfigurations"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/admissionregistration.k8s.io/initializerconfigurations/delete",
+            "display": {
+              "description": "Deletes/DeletesCollection initializerconfigurations resource",
+              "operation": "Initializerconfigurations",
+              "provider": "Microsoft Container Service",
+              "resource": "Initializerconfigurations"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/admissionregistration.k8s.io/mutatingwebhookconfigurations/read",
+            "display": {
+              "description": "Reads mutatingwebhookconfigurations",
+              "operation": "Gets/List mutatingwebhookconfigurations resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Mutatingwebhookconfigurations"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/admissionregistration.k8s.io/mutatingwebhookconfigurations/write",
+            "display": {
+              "description": "Writes mutatingwebhookconfigurations",
+              "operation": "Creates/Updates mutatingwebhookconfigurations resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Mutatingwebhookconfigurations"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/admissionregistration.k8s.io/mutatingwebhookconfigurations/delete",
+            "display": {
+              "description": "Deletes mutatingwebhookconfigurations",
+              "operation": "Deletes/DeletesCollection mutatingwebhookconfigurations resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Mutatingwebhookconfigurations"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/admissionregistration.k8s.io/validatingwebhookconfigurations/read",
+            "display": {
+              "description": "Reads validatingwebhookconfigurations",
+              "operation": "Gets/List validatingwebhookconfigurations resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Validatingwebhookconfigurations"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/admissionregistration.k8s.io/validatingwebhookconfigurations/write",
+            "display": {
+              "description": "Writes validatingwebhookconfigurations",
+              "operation": "Creates/Updates validatingwebhookconfigurations resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Validatingwebhookconfigurations"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/admissionregistration.k8s.io/validatingwebhookconfigurations/delete",
+            "display": {
+              "description": "Deletes validatingwebhookconfigurations",
+              "operation": "Deletes/DeletesCollection validatingwebhookconfigurations resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Validatingwebhookconfigurations"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apiextensions.k8s.io/customresourcedefinitions/read",
+            "display": {
+              "description": "Reads customresourcedefinitions",
+              "operation": "Gets/List customresourcedefinitions resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Customresourcedefinitions"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apiextensions.k8s.io/customresourcedefinitions/write",
+            "display": {
+              "description": "Writes customresourcedefinitions",
+              "operation": "Creates/Updates customresourcedefinitions resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Customresourcedefinitions"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apiextensions.k8s.io/customresourcedefinitions/delete",
+            "display": {
+              "description": "Deletes customresourcedefinitions",
+              "operation": "Deletes/DeletesCollection customresourcedefinitions resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Customresourcedefinitions"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apiregistration.k8s.io/apiservices/read",
+            "display": {
+              "description": "Reads apiservices",
+              "operation": "Gets/List apiservices resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Apiservices"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apiregistration.k8s.io/apiservices/write",
+            "display": {
+              "description": "Writes apiservices",
+              "operation": "Creates/Updates apiservices resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Apiservices"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apiregistration.k8s.io/apiservices/delete",
+            "display": {
+              "description": "Deletes apiservices",
+              "operation": "Deletes/DeletesCollection apiservices resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Apiservices"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apps/controllerrevisions/read",
+            "display": {
+              "description": "Reads controllerrevisions",
+              "operation": "Gets/List controllerrevisions resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Controllerrevisions"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apps/controllerrevisions/write",
+            "display": {
+              "description": "Writes controllerrevisions",
+              "operation": "Creates/Updates controllerrevisions resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Controllerrevisions"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apps/controllerrevisions/delete",
+            "display": {
+              "description": "Deletes controllerrevisions",
+              "operation": "Deletes/DeletesCollection controllerrevisions resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Controllerrevisions"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apps/daemonsets/read",
+            "display": {
+              "description": "Reads daemonsets",
+              "operation": "Gets/List daemonsets resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Daemonsets"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apps/daemonsets/write",
+            "display": {
+              "description": "Writes daemonsets",
+              "operation": "Creates/Updates daemonsets resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Daemonsets"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apps/daemonsets/delete",
+            "display": {
+              "description": "Deletes daemonsets",
+              "operation": "Deletes/DeletesCollection daemonsets resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Daemonsets"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apps/deployments/read",
+            "display": {
+              "description": "Reads deployments",
+              "operation": "Gets/List deployments resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Deployments"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apps/deployments/write",
+            "display": {
+              "description": "Writes deployments",
+              "operation": "Creates/Updates deployments resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Deployments"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apps/deployments/delete",
+            "display": {
+              "description": "Deletes deployments",
+              "operation": "Deletes/DeletesCollection deployments resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Deployments"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apps/replicasets/read",
+            "display": {
+              "description": "Reads replicasets",
+              "operation": "Gets/List replicasets resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Replicasets"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apps/replicasets/write",
+            "display": {
+              "description": "Writes replicasets",
+              "operation": "Creates/Updates replicasets resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Replicasets"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apps/replicasets/delete",
+            "display": {
+              "description": "Deletes replicasets",
+              "operation": "Deletes/DeletesCollection replicasets resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Replicasets"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apps/statefulsets/read",
+            "display": {
+              "description": "Reads statefulsets",
+              "operation": "Gets/List statefulsets resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Statefulsets"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apps/statefulsets/write",
+            "display": {
+              "description": "Writes statefulsets",
+              "operation": "Creates/Updates statefulsets resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Statefulsets"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apps/statefulsets/delete",
+            "display": {
+              "description": "Deletes statefulsets",
+              "operation": "Deletes/DeletesCollection statefulsets resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Statefulsets"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/authentication.k8s.io/tokenreviews/write",
+            "display": {
+              "description": "Writes tokenreviews",
+              "operation": "Creates/Updates tokenreviews resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Tokenreviews"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/authorization.k8s.io/localsubjectaccessreviews/write",
+            "display": {
+              "description": "Writes localsubjectaccessreviews",
+              "operation": "Creates/Updates localsubjectaccessreviews resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Localsubjectaccessreviews"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/authorization.k8s.io/selfsubjectaccessreviews/write",
+            "display": {
+              "description": "Writes selfsubjectaccessreviews",
+              "operation": "Creates/Updates selfsubjectaccessreviews resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Selfsubjectaccessreviews"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/authorization.k8s.io/selfsubjectrulesreviews/write",
+            "display": {
+              "description": "Writes selfsubjectrulesreviews",
+              "operation": "Creates/Updates selfsubjectrulesreviews resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Selfsubjectrulesreviews"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/authorization.k8s.io/subjectaccessreviews/write",
+            "display": {
+              "description": "Writes subjectaccessreviews",
+              "operation": "Creates/Updates subjectaccessreviews resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Subjectaccessreviews"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/autoscaling/horizontalpodautoscalers/read",
+            "display": {
+              "description": "Reads horizontalpodautoscalers",
+              "operation": "Gets/List horizontalpodautoscalers resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Horizontalpodautoscalers"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/autoscaling/horizontalpodautoscalers/write",
+            "display": {
+              "description": "Writes horizontalpodautoscalers",
+              "operation": "Creates/Updates horizontalpodautoscalers resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Horizontalpodautoscalers"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/autoscaling/horizontalpodautoscalers/delete",
+            "display": {
+              "description": "Deletes horizontalpodautoscalers",
+              "operation": "Deletes/DeletesCollection horizontalpodautoscalers resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Horizontalpodautoscalers"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/batch/cronjobs/read",
+            "display": {
+              "description": "Reads cronjobs",
+              "operation": "Gets/List cronjobs resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Cronjobs"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/batch/cronjobs/write",
+            "display": {
+              "description": "Writes cronjobs",
+              "operation": "Creates/Updates cronjobs resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Cronjobs"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/batch/cronjobs/delete",
+            "display": {
+              "description": "Deletes cronjobs",
+              "operation": "Deletes/DeletesCollection cronjobs resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Cronjobs"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/batch/jobs/read",
+            "display": {
+              "description": "Reads jobs",
+              "operation": "Gets/List jobs resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Jobs"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/batch/jobs/write",
+            "display": {
+              "description": "Writes jobs",
+              "operation": "Creates/Updates jobs resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Jobs"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/batch/jobs/delete",
+            "display": {
+              "description": "Deletes jobs",
+              "operation": "Deletes/DeletesCollection jobs resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Jobs"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/certificates.k8s.io/certificatesigningrequests/read",
+            "display": {
+              "description": "Reads certificatesigningrequests",
+              "operation": "Gets/List certificatesigningrequests resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Certificatesigningrequests"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/certificates.k8s.io/certificatesigningrequests/write",
+            "display": {
+              "description": "Writes certificatesigningrequests",
+              "operation": "Creates/Updates certificatesigningrequests resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Certificatesigningrequests"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/certificates.k8s.io/certificatesigningrequests/delete",
+            "display": {
+              "description": "Deletes certificatesigningrequests",
+              "operation": "Deletes/DeletesCollection certificatesigningrequests resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Certificatesigningrequests"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/coordination.k8s.io/leases/read",
+            "display": {
+              "description": "Reads leases",
+              "operation": "Gets/List leases resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Leases"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/coordination.k8s.io/leases/write",
+            "display": {
+              "description": "Writes leases",
+              "operation": "Creates/Updates leases resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Leases"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/coordination.k8s.io/leases/delete",
+            "display": {
+              "description": "Deletes leases",
+              "operation": "Deletes/DeletesCollection leases resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Leases"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/bindings/write",
+            "display": {
+              "description": "Writes bindings",
+              "operation": "Creates/Updates bindings resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Bindings"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/componentstatuses/read",
+            "display": {
+              "description": "Reads componentstatuses",
+              "operation": "Gets/List componentstatuses resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Componentstatuses"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/componentstatuses/write",
+            "display": {
+              "description": "Writes componentstatuses",
+              "operation": "Creates/Updates componentstatuses resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Componentstatuses"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/componentstatuses/delete",
+            "display": {
+              "description": "Deletes componentstatuses",
+              "operation": "Deletes/DeletesCollection componentstatuses resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Componentstatuses"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/configmaps/read",
+            "display": {
+              "description": "Reads configmaps",
+              "operation": "Gets/List configmaps resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Configmaps"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/configmaps/write",
+            "display": {
+              "description": "Writes configmaps",
+              "operation": "Creates/Updates configmaps resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Configmaps"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/configmaps/delete",
+            "display": {
+              "description": "Deletes configmaps",
+              "operation": "Deletes/DeletesCollection configmaps resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Configmaps"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/endpoints/read",
+            "display": {
+              "description": "Reads endpoints",
+              "operation": "Gets/List endpoints resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Endpoints"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/endpoints/write",
+            "display": {
+              "description": "Writes endpoints",
+              "operation": "Creates/Updates endpoints resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Endpoints"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/endpoints/delete",
+            "display": {
+              "description": "Deletes endpoints",
+              "operation": "Deletes/DeletesCollection endpoints resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Endpoints"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/events/read",
+            "display": {
+              "description": "Reads events",
+              "operation": "Gets/List events resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Events"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/events/write",
+            "display": {
+              "description": "Writes events",
+              "operation": "Creates/Updates events resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Events"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/events/delete",
+            "display": {
+              "description": "Deletes events",
+              "operation": "Deletes/DeletesCollection events resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Events"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/limitranges/read",
+            "display": {
+              "description": "Reads limitranges",
+              "operation": "Gets/List limitranges resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Limitranges"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/limitranges/write",
+            "display": {
+              "description": "Writes limitranges",
+              "operation": "Creates/Updates limitranges resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Limitranges"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/limitranges/delete",
+            "display": {
+              "description": "Deletes limitranges",
+              "operation": "Deletes/DeletesCollection limitranges resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Limitranges"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/namespaces/read",
+            "display": {
+              "description": "Reads namespaces",
+              "operation": "Gets/List namespaces resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Namespaces"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/namespaces/write",
+            "display": {
+              "description": "Writes namespaces",
+              "operation": "Creates/Updates namespaces resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Namespaces"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/namespaces/delete",
+            "display": {
+              "description": "Deletes namespaces",
+              "operation": "Deletes/DeletesCollection namespaces resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Namespaces"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/nodes/read",
+            "display": {
+              "description": "Reads nodes",
+              "operation": "Gets/List nodes resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Nodes"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/nodes/write",
+            "display": {
+              "description": "Writes nodes",
+              "operation": "Creates/Updates nodes resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Nodes"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/nodes/delete",
+            "display": {
+              "description": "Deletes nodes",
+              "operation": "Deletes/DeletesCollection nodes resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Nodes"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/persistentvolumeclaims/read",
+            "display": {
+              "description": "Reads persistentvolumeclaims",
+              "operation": "Gets/List persistentvolumeclaims resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Persistentvolumeclaims"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/persistentvolumeclaims/write",
+            "display": {
+              "description": "Writes persistentvolumeclaims",
+              "operation": "Creates/Updates persistentvolumeclaims resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Persistentvolumeclaims"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/persistentvolumeclaims/delete",
+            "display": {
+              "description": "Deletes persistentvolumeclaims",
+              "operation": "Deletes/DeletesCollection persistentvolumeclaims resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Persistentvolumeclaims"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/persistentvolumes/read",
+            "display": {
+              "description": "Reads persistentvolumes",
+              "operation": "Gets/List persistentvolumes resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Persistentvolumes"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/persistentvolumes/write",
+            "display": {
+              "description": "Writes persistentvolumes",
+              "operation": "Creates/Updates persistentvolumes resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Persistentvolumes"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/persistentvolumes/delete",
+            "display": {
+              "description": "Deletes persistentvolumes",
+              "operation": "Deletes/DeletesCollection persistentvolumes resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Persistentvolumes"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/pods/read",
+            "display": {
+              "description": "Reads pods",
+              "operation": "Gets/List pods resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Pods"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/pods/write",
+            "display": {
+              "description": "Writes pods",
+              "operation": "Creates/Updates pods resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Pods"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/pods/delete",
+            "display": {
+              "description": "Deletes pods",
+              "operation": "Deletes/DeletesCollection pods resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Pods"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/pods/exec/action",
+            "display": {
+              "description": "Exec into pods resource",
+              "operation": "Exec into pods resource ",
+              "provider": "Microsoft Container Service",
+              "resource": "Pods"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/podtemplates/read",
+            "display": {
+              "description": "Reads podtemplates",
+              "operation": "Gets/List podtemplates resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Podtemplates"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/podtemplates/write",
+            "display": {
+              "description": "Writes podtemplates",
+              "operation": "Creates/Updates podtemplates resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Podtemplates"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/podtemplates/delete",
+            "display": {
+              "description": "Deletes podtemplates",
+              "operation": "Deletes/DeletesCollection podtemplates resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Podtemplates"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/replicationcontrollers/read",
+            "display": {
+              "description": "Reads replicationcontrollers",
+              "operation": "Gets/List replicationcontrollers resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Replicationcontrollers"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/replicationcontrollers/write",
+            "display": {
+              "description": "Writes replicationcontrollers",
+              "operation": "Creates/Updates replicationcontrollers resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Replicationcontrollers"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/replicationcontrollers/delete",
+            "display": {
+              "description": "Deletes replicationcontrollers",
+              "operation": "Deletes/DeletesCollection replicationcontrollers resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Replicationcontrollers"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/resourcequotas/read",
+            "display": {
+              "description": "Reads resourcequotas",
+              "operation": "Gets/List resourcequotas resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Resourcequotas"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/resourcequotas/write",
+            "display": {
+              "description": "Writes resourcequotas",
+              "operation": "Creates/Updates resourcequotas resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Resourcequotas"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/resourcequotas/delete",
+            "display": {
+              "description": "Deletes resourcequotas",
+              "operation": "Deletes/DeletesCollection resourcequotas resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Resourcequotas"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/secrets/read",
+            "display": {
+              "description": "Reads secrets",
+              "operation": "Gets/List secrets resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Secrets"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/secrets/write",
+            "display": {
+              "description": "Writes secrets",
+              "operation": "Creates/Updates secrets resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Secrets"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/secrets/delete",
+            "display": {
+              "description": "Deletes secrets",
+              "operation": "Deletes/DeletesCollection secrets resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Secrets"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/serviceaccounts/read",
+            "display": {
+              "description": "Reads serviceaccounts",
+              "operation": "Gets/List serviceaccounts resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Serviceaccounts"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/serviceaccounts/write",
+            "display": {
+              "description": "Writes serviceaccounts",
+              "operation": "Creates/Updates serviceaccounts resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Serviceaccounts"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/serviceaccounts/delete",
+            "display": {
+              "description": "Deletes serviceaccounts",
+              "operation": "Deletes/DeletesCollection serviceaccounts resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Serviceaccounts"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/services/read",
+            "display": {
+              "description": "Reads services",
+              "operation": "Gets/List services resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Services"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/services/write",
+            "display": {
+              "description": "Writes services",
+              "operation": "Creates/Updates services resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Services"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/services/delete",
+            "display": {
+              "description": "Deletes services",
+              "operation": "Deletes/DeletesCollection services resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Services"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/events.k8s.io/events/read",
+            "display": {
+              "description": "Reads events",
+              "operation": "Gets/List events resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Events"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/events.k8s.io/events/write",
+            "display": {
+              "description": "Writes events",
+              "operation": "Creates/Updates events resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Events"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/events.k8s.io/events/delete",
+            "display": {
+              "description": "Deletes events",
+              "operation": "Deletes/DeletesCollection events resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Events"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/extensions/daemonsets/read",
+            "display": {
+              "description": "Reads daemonsets",
+              "operation": "Gets/List daemonsets resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Daemonsets"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/extensions/daemonsets/write",
+            "display": {
+              "description": "Writes daemonsets",
+              "operation": "Creates/Updates daemonsets resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Daemonsets"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/extensions/daemonsets/delete",
+            "display": {
+              "description": "Deletes daemonsets",
+              "operation": "Deletes/DeletesCollection daemonsets resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Daemonsets"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/extensions/deployments/read",
+            "display": {
+              "description": "Reads deployments",
+              "operation": "Gets/List deployments resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Deployments"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/extensions/deployments/write",
+            "display": {
+              "description": "Writes deployments",
+              "operation": "Creates/Updates deployments resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Deployments"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/extensions/deployments/delete",
+            "display": {
+              "description": "Deletes deployments",
+              "operation": "Deletes/DeletesCollection deployments resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Deployments"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/extensions/ingresses/read",
+            "display": {
+              "description": "Reads ingresses",
+              "operation": "Gets/List ingresses resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Ingresses"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/extensions/ingresses/write",
+            "display": {
+              "description": "Writes ingresses",
+              "operation": "Creates/Updates ingresses resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Ingresses"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/extensions/ingresses/delete",
+            "display": {
+              "description": "Deletes ingresses",
+              "operation": "Deletes/DeletesCollection ingresses resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Ingresses"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/extensions/networkpolicies/read",
+            "display": {
+              "description": "Reads networkpolicies",
+              "operation": "Gets/List networkpolicies resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Networkpolicies"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/extensions/networkpolicies/write",
+            "display": {
+              "description": "Writes networkpolicies",
+              "operation": "Creates/Updates networkpolicies resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Networkpolicies"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/extensions/networkpolicies/delete",
+            "display": {
+              "description": "Deletes networkpolicies",
+              "operation": "Deletes/DeletesCollection networkpolicies resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Networkpolicies"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/extensions/podsecuritypolicies/read",
+            "display": {
+              "description": "Reads podsecuritypolicies",
+              "operation": "Gets/List podsecuritypolicies resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Podsecuritypolicies"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/extensions/podsecuritypolicies/write",
+            "display": {
+              "description": "Writes podsecuritypolicies",
+              "operation": "Creates/Updates podsecuritypolicies resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Podsecuritypolicies"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/extensions/podsecuritypolicies/delete",
+            "display": {
+              "description": "Deletes podsecuritypolicies",
+              "operation": "Deletes/DeletesCollection podsecuritypolicies resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Podsecuritypolicies"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/extensions/replicasets/read",
+            "display": {
+              "description": "Reads replicasets",
+              "operation": "Gets/List replicasets resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Replicasets"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/extensions/replicasets/write",
+            "display": {
+              "description": "Writes replicasets",
+              "operation": "Creates/Updates replicasets resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Replicasets"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/extensions/replicasets/delete",
+            "display": {
+              "description": "Deletes replicasets",
+              "operation": "Deletes/DeletesCollection replicasets resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Replicasets"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/metrics.k8s.io/pods/read",
+            "display": {
+              "description": "Reads pods",
+              "operation": "Gets/List pods resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Pods"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/metrics.k8s.io/nodes/read",
+            "display": {
+              "description": "Reads nodes",
+              "operation": "Gets/List nodes resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Nodes"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/networking.k8s.io/networkpolicies/read",
+            "display": {
+              "description": "Reads networkpolicies",
+              "operation": "Gets/List networkpolicies resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Networkpolicies"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/networking.k8s.io/networkpolicies/write",
+            "display": {
+              "description": "Writes networkpolicies",
+              "operation": "Creates/Updates networkpolicies resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Networkpolicies"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/networking.k8s.io/networkpolicies/delete",
+            "display": {
+              "description": "Deletes networkpolicies",
+              "operation": "Deletes/DeletesCollection networkpolicies resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Networkpolicies"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/networking.k8s.io/ingresses/read",
+            "display": {
+              "description": "Reads ingresses",
+              "operation": "Gets/List ingresses resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Ingresses"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/networking.k8s.io/ingresses/write",
+            "display": {
+              "description": "Writes ingresses",
+              "operation": "Creates/Updates ingresses resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Ingresses"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/networking.k8s.io/ingresses/delete",
+            "display": {
+              "description": "Deletes ingresses",
+              "operation": "Deletes/DeletesCollection ingresses resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Ingresses"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/node.k8s.io/runtimeclasses/read",
+            "display": {
+              "description": "Reads runtimeclasses",
+              "operation": "Gets/List runtimeclasses resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Runtimeclasses"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/node.k8s.io/runtimeclasses/write",
+            "display": {
+              "description": "Writes runtimeclasses",
+              "operation": "Creates/Updates runtimeclasses resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Runtimeclasses"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/node.k8s.io/runtimeclasses/delete",
+            "display": {
+              "description": "Deletes runtimeclasses",
+              "operation": "Deletes/DeletesCollection runtimeclasses resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Runtimeclasses"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/api/read",
+            "display": {
+              "description": "Reads api",
+              "operation": "Gets/List api resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Api"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/api/v1/read",
+            "display": {
+              "description": "Reads api/v1",
+              "operation": "Gets/List api/v1 resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Api/V1"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/read",
+            "display": {
+              "description": "Reads apis",
+              "operation": "Gets/List apis resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Apis"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/admissionregistration.k8s.io/read",
+            "display": {
+              "description": "Reads admissionregistration.k8s.io",
+              "operation": "Gets/List admissionregistration.k8s.io resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Admissionregistration.K8s.Io"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/admissionregistration.k8s.io/v1/read",
+            "display": {
+              "description": "Reads admissionregistration.k8s.io/v1",
+              "operation": "Gets/List admissionregistration.k8s.io/v1 resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Admissionregistration.K8s.Io/V1"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/admissionregistration.k8s.io/v1beta1/read",
+            "display": {
+              "description": "Reads admissionregistration.k8s.io/v1beta1",
+              "operation": "Gets/List admissionregistration.k8s.io/v1beta1 resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Admissionregistration.K8s.Io/V1beta1"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/apiextensions.k8s.io/read",
+            "display": {
+              "description": "Reads apiextensions.k8s.io",
+              "operation": "Gets/List apiextensions.k8s.io resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Apiextensions.K8s.Io"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/apiextensions.k8s.io/v1/read",
+            "display": {
+              "description": "Reads apiextensions.k8s.io/v1",
+              "operation": "Gets/List apiextensions.k8s.io/v1 resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Apiextensions.K8s.Io/V1"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/apiextensions.k8s.io/v1beta1/read",
+            "display": {
+              "description": "Reads apiextensions.k8s.io/v1beta1",
+              "operation": "Gets/List apiextensions.k8s.io/v1beta1 resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Apiextensions.K8s.Io/V1beta1"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/apiregistration.k8s.io/read",
+            "display": {
+              "description": "Reads apiregistration.k8s.io",
+              "operation": "Gets/List apiregistration.k8s.io resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Apiregistration.K8s.Io"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/apiregistration.k8s.io/v1/read",
+            "display": {
+              "description": "Reads apiregistration.k8s.io/v1",
+              "operation": "Gets/List apiregistration.k8s.io/v1 resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Apiregistration.K8s.Io/V1"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/apiregistration.k8s.io/v1beta1/read",
+            "display": {
+              "description": "Reads apiregistration.k8s.io/v1beta1",
+              "operation": "Gets/List apiregistration.k8s.io/v1beta1 resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Apiregistration.K8s.Io/V1beta1"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/apps/read",
+            "display": {
+              "description": "Reads apps",
+              "operation": "Gets/List apps resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Apps"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/apps/v1/read",
+            "display": {
+              "description": "Reads apps/v1",
+              "operation": "Gets/List apps/v1 resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Apps/V1"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/apps/v1beta1/read",
+            "display": {
+              "description": "Reads apps/v1beta1",
+              "operation": "Gets/List apps/v1beta1 resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Apps/V1beta1"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/apps/v1beta2/read",
+            "display": {
+              "description": "Reads apps/v1beta2",
+              "operation": "Gets/List apps/v1beta2 resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Apps/V1beta2"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/authentication.k8s.io/read",
+            "display": {
+              "description": "Reads authentication.k8s.io",
+              "operation": "Gets/List authentication.k8s.io resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Authentication.K8s.Io"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/authentication.k8s.io/v1/read",
+            "display": {
+              "description": "Reads authentication.k8s.io/v1",
+              "operation": "Gets/List authentication.k8s.io/v1 resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Authentication.K8s.Io/V1"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/authentication.k8s.io/v1beta1/read",
+            "display": {
+              "description": "Reads authentication.k8s.io/v1beta1",
+              "operation": "Gets/List authentication.k8s.io/v1beta1 resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Authentication.K8s.Io/V1beta1"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/authorization.k8s.io/read",
+            "display": {
+              "description": "Reads authorization.k8s.io",
+              "operation": "Gets/List authorization.k8s.io resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Authorization.K8s.Io"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/authorization.k8s.io/v1/read",
+            "display": {
+              "description": "Reads authorization.k8s.io/v1",
+              "operation": "Gets/List authorization.k8s.io/v1 resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Authorization.K8s.Io/V1"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/authorization.k8s.io/v1beta1/read",
+            "display": {
+              "description": "Reads authorization.k8s.io/v1beta1",
+              "operation": "Gets/List authorization.k8s.io/v1beta1 resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Authorization.K8s.Io/V1beta1"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/autoscaling/read",
+            "display": {
+              "description": "Reads autoscaling",
+              "operation": "Gets/List autoscaling resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Autoscaling"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/autoscaling/v1/read",
+            "display": {
+              "description": "Reads autoscaling/v1",
+              "operation": "Gets/List autoscaling/v1 resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Autoscaling/V1"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/autoscaling/v2beta1/read",
+            "display": {
+              "description": "Reads autoscaling/v2beta1",
+              "operation": "Gets/List autoscaling/v2beta1 resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Autoscaling/V2beta1"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/autoscaling/v2beta2/read",
+            "display": {
+              "description": "Reads autoscaling/v2beta2",
+              "operation": "Gets/List autoscaling/v2beta2 resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Autoscaling/V2beta2"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/batch/read",
+            "display": {
+              "description": "Reads batch",
+              "operation": "Gets/List batch resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Batch"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/batch/v1/read",
+            "display": {
+              "description": "Reads batch/v1",
+              "operation": "Gets/List batch/v1 resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Batch/V1"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/batch/v1beta1/read",
+            "display": {
+              "description": "Reads batch/v1beta1",
+              "operation": "Gets/List batch/v1beta1 resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Batch/V1beta1"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/certificates.k8s.io/read",
+            "display": {
+              "description": "Reads certificates.k8s.io",
+              "operation": "Gets/List certificates.k8s.io resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Certificates.K8s.Io"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/certificates.k8s.io/v1beta1/read",
+            "display": {
+              "description": "Reads certificates.k8s.io/v1beta1",
+              "operation": "Gets/List certificates.k8s.io/v1beta1 resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Certificates.K8s.Io/V1beta1"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/coordination.k8s.io/read",
+            "display": {
+              "description": "Reads coordination.k8s.io",
+              "operation": "Gets/List coordination.k8s.io resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Coordination.K8s.Io"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/coordination.k8s.io/v1/read",
+            "display": {
+              "description": "Reads coordination/v1",
+              "operation": "Gets/List coordination/v1 resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Coordination.K8s.Io/V1"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/coordination.k8s.io/v1beta1/read",
+            "display": {
+              "description": "Reads coordination.k8s.io/v1beta1",
+              "operation": "Gets/List coordination.k8s.io/v1beta1 resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Coordination.K8s.Io/V1beta1"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/events.k8s.io/read",
+            "display": {
+              "description": "Reads events.k8s.io",
+              "operation": "Gets/List events.k8s.io resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Events.K8s.Io"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/events.k8s.io/v1beta1/read",
+            "display": {
+              "description": "Reads events.k8s.io/v1beta1",
+              "operation": "Gets/List events.k8s.io/v1beta1 resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Events.K8s.Io/V1beta1"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/extensions/read",
+            "display": {
+              "description": "Reads extensions",
+              "operation": "Gets/List extensions resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Extensions"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/extensions/v1beta1/read",
+            "display": {
+              "description": "Reads extensions/v1beta1",
+              "operation": "Gets/List extensions/v1beta1 resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Extensions/V1beta1"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/metrics.k8s.io/read",
+            "display": {
+              "description": "Reads metrics.k8s.io",
+              "operation": "Gets/List metrics.k8s.io resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Metrics.K8s.Io"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/metrics.k8s.io/v1beta1/read",
+            "display": {
+              "description": "Reads metrics.k8s.io/v1beta1",
+              "operation": "Gets/List metrics.k8s.io/v1beta1 resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Metrics.K8s.Io/V1beta1"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/networking.k8s.io/read",
+            "display": {
+              "description": "Reads networking.k8s.io",
+              "operation": "Gets/List networking.k8s.io resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Networking.K8s.Io"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/networking.k8s.io/v1/read",
+            "display": {
+              "description": "Reads networking/v1",
+              "operation": "Gets/List networking/v1 resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Networking.K8s.Io/V1"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/networking.k8s.io/v1beta1/read",
+            "display": {
+              "description": "Reads networking.k8s.io/v1beta1",
+              "operation": "Gets/List networking.k8s.io/v1beta1 resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Networking.K8s.Io/V1beta1"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/node.k8s.io/read",
+            "display": {
+              "description": "Reads node.k8s.io",
+              "operation": "Gets/List node.k8s.io resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Node.K8s.Io"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/node.k8s.io/v1beta1/read",
+            "display": {
+              "description": "Reads node.k8s.io/v1beta1",
+              "operation": "Gets/List node.k8s.io/v1beta1 resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Node.K8s.Io/V1beta1"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/policy/read",
+            "display": {
+              "description": "Reads policy",
+              "operation": "Gets/List policy resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Policy"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/policy/v1beta1/read",
+            "display": {
+              "description": "Reads policy/v1beta1",
+              "operation": "Gets/List policy/v1beta1 resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Policy/V1beta1"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/rbac.authorization.k8s.io/read",
+            "display": {
+              "description": "Reads rbac.authorization.k8s.io",
+              "operation": "Gets/List rbac.authorization.k8s.io resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Rbac.Authorization.K8s.Io"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/rbac.authorization.k8s.io/v1/read",
+            "display": {
+              "description": "Reads rbac.authorization/v1",
+              "operation": "Gets/List rbac.authorization/v1 resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Rbac.Authorization.K8s.Io/V1"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/rbac.authorization.k8s.io/v1beta1/read",
+            "display": {
+              "description": "Reads rbac.authorization.k8s.io/v1beta1",
+              "operation": "Gets/List rbac.authorization.k8s.io/v1beta1 resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Rbac.Authorization.K8s.Io/V1beta1"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/scheduling.k8s.io/read",
+            "display": {
+              "description": "Reads scheduling.k8s.io",
+              "operation": "Gets/List scheduling.k8s.io resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Scheduling.K8s.Io"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/scheduling.k8s.io/v1/read",
+            "display": {
+              "description": "Reads scheduling/v1",
+              "operation": "Gets/List scheduling/v1 resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Scheduling.K8s.Io/V1"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/scheduling.k8s.io/v1beta1/read",
+            "display": {
+              "description": "Reads scheduling.k8s.io/v1beta1",
+              "operation": "Gets/List scheduling.k8s.io/v1beta1 resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Scheduling.K8s.Io/V1beta1"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/storage.k8s.io/read",
+            "display": {
+              "description": "Reads storage.k8s.io",
+              "operation": "Gets/List storage.k8s.io resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Storage.K8s.Io"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/storage.k8s.io/v1/read",
+            "display": {
+              "description": "Reads storage/v1",
+              "operation": "Gets/List storage/v1 resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Storage.K8s.Io/V1"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/apis/storage.k8s.io/v1beta1/read",
+            "display": {
+              "description": "Reads storage.k8s.io/v1beta1",
+              "operation": "Gets/List storage.k8s.io/v1beta1 resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Storage.K8s.Io/V1beta1"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/healthz/read",
+            "display": {
+              "description": "Reads healthz",
+              "operation": "Gets/List healthz resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Healthz"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/healthz/autoregister-completion/read",
+            "display": {
+              "description": "Reads autoregister-completion",
+              "operation": "Gets/List autoregister-completion resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Healthz/Autoregister-Completion"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/healthz/etcd/read",
+            "display": {
+              "description": "Reads etcd",
+              "operation": "Gets/List etcd resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Healthz/Etcd"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/healthz/log/read",
+            "display": {
+              "description": "Reads log",
+              "operation": "Gets/List log resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Healthz/Log"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/healthz/ping/read",
+            "display": {
+              "description": "Reads ping",
+              "operation": "Gets/List ping resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Healthz/Ping"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/healthz/poststarthook/apiservice-openapi-controller/read",
+            "display": {
+              "description": "Reads apiservice-openapi-controller",
+              "operation": "Gets/List apiservice-openapi-controller resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Healthz/Poststarthook/Apiservice-Openapi-Controller"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/healthz/poststarthook/apiservice-registration-controller/read",
+            "display": {
+              "description": "Reads apiservice-registration-controller",
+              "operation": "Gets/List apiservice-registration-controller resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Healthz/Poststarthook/Apiservice-Registration-Controller"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/healthz/poststarthook/apiservice-status-available-controller/read",
+            "display": {
+              "description": "Reads apiservice-status-available-controller",
+              "operation": "Gets/List apiservice-status-available-controller resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Healthz/Poststarthook/Apiservice-Status-Available-Controller"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/healthz/poststarthook/bootstrap-controller/read",
+            "display": {
+              "description": "Reads bootstrap-controller",
+              "operation": "Gets/List bootstrap-controller resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Healthz/Poststarthook/Bootstrap-Controller"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/healthz/poststarthook/ca-registration/read",
+            "display": {
+              "description": "Reads ca-registration",
+              "operation": "Gets/List ca-registration resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Healthz/Poststarthook/Ca-Registration"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/healthz/poststarthook/crd-informer-synced/read",
+            "display": {
+              "description": "Reads crd-informer-synced",
+              "operation": "Gets/List crd-informer-synced resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Healthz/Poststarthook/Crd-Informer-Synced"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/healthz/poststarthook/generic-apiserver-start-informers/read",
+            "display": {
+              "description": "Reads generic-apiserver-start-informers",
+              "operation": "Gets/List generic-apiserver-start-informers resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Healthz/Poststarthook/Generic-Apiserver-Start-Informers"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/healthz/poststarthook/kube-apiserver-autoregistration/read",
+            "display": {
+              "description": "Reads kube-apiserver-autoregistration",
+              "operation": "Gets/List kube-apiserver-autoregistration resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Healthz/Poststarthook/Kube-Apiserver-Autoregistration"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/healthz/poststarthook/rbac/bootstrap-roles/read",
+            "display": {
+              "description": "Reads bootstrap-roles",
+              "operation": "Gets/List bootstrap-roles resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Healthz/Poststarthook/Bootstrap-Roles"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/healthz/poststarthook/scheduling/bootstrap-system-priority-classes/read",
+            "display": {
+              "description": "Reads bootstrap-system-priority-classes",
+              "operation": "Gets/List bootstrap-system-priority-classes resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Healthz/Poststarthook/Bootstrap-System-Priority-Classes"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/healthz/poststarthook/start-apiextensions-controllers/read",
+            "display": {
+              "description": "Reads start-apiextensions-controllers",
+              "operation": "Gets/List start-apiextensions-controllers resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Healthz/Poststarthook/Start-Apiextensions-Controllers"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/healthz/poststarthook/start-apiextensions-informers/read",
+            "display": {
+              "description": "Reads start-apiextensions-informers",
+              "operation": "Gets/List start-apiextensions-informers resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Healthz/Poststarthook/Start-Apiextensions-Informers"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/healthz/poststarthook/start-kube-aggregator-informers/read",
+            "display": {
+              "description": "Reads start-kube-aggregator-informers",
+              "operation": "Gets/List start-kube-aggregator-informers resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Healthz/Poststarthook/Start-Kube-Aggregator-Informers"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/healthz/poststarthook/start-kube-apiserver-admission-initializer/read",
+            "display": {
+              "description": "Reads start-kube-apiserver-admission-initializer",
+              "operation": "Gets/List start-kube-apiserver-admission-initializer resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Healthz/Poststarthook/Start-Kube-Apiserver-Admission-Initializer"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/livez/read",
+            "display": {
+              "description": "Reads livez",
+              "operation": "Gets/List livez resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Livez"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/livez/autoregister-completion/read",
+            "display": {
+              "description": "Reads autoregister-completion",
+              "operation": "Gets/List autoregister-completion resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Livez/Autoregister-Completion"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/livez/etcd/read",
+            "display": {
+              "description": "Reads etcd",
+              "operation": "Gets/List etcd resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Livez/Etcd"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/livez/log/read",
+            "display": {
+              "description": "Reads log",
+              "operation": "Gets/List log resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Livez/Log"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/livez/ping/read",
+            "display": {
+              "description": "Reads ping",
+              "operation": "Gets/List ping resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Livez/Ping"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/livez/poststarthook/apiservice-openapi-controller/read",
+            "display": {
+              "description": "Reads apiservice-openapi-controller",
+              "operation": "Gets/List apiservice-openapi-controller resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Livez/Poststarthook/Apiservice-Openapi-Controller"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/livez/poststarthook/apiservice-registration-controller/read",
+            "display": {
+              "description": "Reads apiservice-registration-controller",
+              "operation": "Gets/List apiservice-registration-controller resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Livez/Poststarthook/Apiservice-Registration-Controller"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/livez/poststarthook/apiservice-status-available-controller/read",
+            "display": {
+              "description": "Reads apiservice-status-available-controller",
+              "operation": "Gets/List apiservice-status-available-controller resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Livez/Poststarthook/Apiservice-Status-Available-Controller"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/livez/poststarthook/bootstrap-controller/read",
+            "display": {
+              "description": "Reads bootstrap-controller",
+              "operation": "Gets/List bootstrap-controller resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Livez/Poststarthook/Bootstrap-Controller"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/livez/poststarthook/ca-registration/read",
+            "display": {
+              "description": "Reads ca-registration",
+              "operation": "Gets/List ca-registration resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Livez/Poststarthook/Ca-Registration"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/livez/poststarthook/crd-informer-synced/read",
+            "display": {
+              "description": "Reads crd-informer-synced",
+              "operation": "Gets/List crd-informer-synced resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Livez/Poststarthook/Crd-Informer-Synced"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/livez/poststarthook/generic-apiserver-start-informers/read",
+            "display": {
+              "description": "Reads generic-apiserver-start-informers",
+              "operation": "Gets/List generic-apiserver-start-informers resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Livez/Poststarthook/Generic-Apiserver-Start-Informers"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/livez/poststarthook/kube-apiserver-autoregistration/read",
+            "display": {
+              "description": "Reads kube-apiserver-autoregistration",
+              "operation": "Gets/List kube-apiserver-autoregistration resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Livez/Poststarthook/Kube-Apiserver-Autoregistration"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/livez/poststarthook/rbac/bootstrap-roles/read",
+            "display": {
+              "description": "Reads bootstrap-roles",
+              "operation": "Gets/List bootstrap-roles resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Livez/Poststarthook/Bootstrap-Roles"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/livez/poststarthook/scheduling/bootstrap-system-priority-classes/read",
+            "display": {
+              "description": "Reads bootstrap-system-priority-classes",
+              "operation": "Gets/List bootstrap-system-priority-classes resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Livez/Poststarthook/Bootstrap-System-Priority-Classes"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/livez/poststarthook/start-apiextensions-controllers/read",
+            "display": {
+              "description": "Reads start-apiextensions-controllers",
+              "operation": "Gets/List start-apiextensions-controllers resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Livez/Poststarthook/Start-Apiextensions-Controllers"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/livez/poststarthook/start-apiextensions-informers/read",
+            "display": {
+              "description": "Reads start-apiextensions-informers",
+              "operation": "Gets/List start-apiextensions-informers resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Livez/Poststarthook/Start-Apiextensions-Informers"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/livez/poststarthook/start-kube-aggregator-informers/read",
+            "display": {
+              "description": "Reads start-kube-aggregator-informers",
+              "operation": "Gets/List start-kube-aggregator-informers resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Livez/Poststarthook/Start-Kube-Aggregator-Informers"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/livez/poststarthook/start-kube-apiserver-admission-initializer/read",
+            "display": {
+              "description": "Reads start-kube-apiserver-admission-initializer",
+              "operation": "Gets/List start-kube-apiserver-admission-initializer resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Livez/Poststarthook/Start-Kube-Apiserver-Admission-Initializer"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/logs/read",
+            "display": {
+              "description": "Reads logs",
+              "operation": "Gets/List logs resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Logs"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/metrics/read",
+            "display": {
+              "description": "Reads metrics",
+              "operation": "Gets/List metrics resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Metrics"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/openapi/v2/read",
+            "display": {
+              "description": "Reads v2",
+              "operation": "Gets/List v2 resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Openapi/V2"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/readyz/read",
+            "display": {
+              "description": "Reads readyz",
+              "operation": "Gets/List readyz resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Readyz"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/readyz/autoregister-completion/read",
+            "display": {
+              "description": "Reads autoregister-completion",
+              "operation": "Gets/List autoregister-completion resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Readyz/Autoregister-Completion"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/readyz/etcd/read",
+            "display": {
+              "description": "Reads etcd",
+              "operation": "Gets/List etcd resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Readyz/Etcd"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/readyz/log/read",
+            "display": {
+              "description": "Reads log",
+              "operation": "Gets/List log resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Readyz/Log"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/readyz/ping/read",
+            "display": {
+              "description": "Reads ping",
+              "operation": "Gets/List ping resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Readyz/Ping"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/readyz/poststarthook/apiservice-openapi-controller/read",
+            "display": {
+              "description": "Reads apiservice-openapi-controller",
+              "operation": "Gets/List apiservice-openapi-controller resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Readyz/Poststarthook/Apiservice-Openapi-Controller"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/readyz/poststarthook/apiservice-registration-controller/read",
+            "display": {
+              "description": "Reads apiservice-registration-controller",
+              "operation": "Gets/List apiservice-registration-controller resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Readyz/Poststarthook/Apiservice-Registration-Controller"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/readyz/poststarthook/apiservice-status-available-controller/read",
+            "display": {
+              "description": "Reads apiservice-status-available-controller",
+              "operation": "Gets/List apiservice-status-available-controller resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Readyz/Poststarthook/Apiservice-Status-Available-Controller"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/readyz/poststarthook/bootstrap-controller/read",
+            "display": {
+              "description": "Reads bootstrap-controller",
+              "operation": "Gets/List bootstrap-controller resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Readyz/Poststarthook/Bootstrap-Controller"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/readyz/poststarthook/ca-registration/read",
+            "display": {
+              "description": "Reads ca-registration",
+              "operation": "Gets/List ca-registration resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Readyz/Poststarthook/Ca-Registration"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/readyz/poststarthook/crd-informer-synced/read",
+            "display": {
+              "description": "Reads crd-informer-synced",
+              "operation": "Gets/List crd-informer-synced resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Readyz/Poststarthook/Crd-Informer-Synced"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/readyz/poststarthook/generic-apiserver-start-informers/read",
+            "display": {
+              "description": "Reads generic-apiserver-start-informers",
+              "operation": "Gets/List generic-apiserver-start-informers resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Readyz/Poststarthook/Generic-Apiserver-Start-Informers"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/readyz/poststarthook/kube-apiserver-autoregistration/read",
+            "display": {
+              "description": "Reads kube-apiserver-autoregistration",
+              "operation": "Gets/List kube-apiserver-autoregistration resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Readyz/Poststarthook/Kube-Apiserver-Autoregistration"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/readyz/poststarthook/rbac/bootstrap-roles/read",
+            "display": {
+              "description": "Reads bootstrap-roles",
+              "operation": "Gets/List bootstrap-roles resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Readyz/Poststarthook/Bootstrap-Roles"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/readyz/poststarthook/scheduling/bootstrap-system-priority-classes/read",
+            "display": {
+              "description": "Reads bootstrap-system-priority-classes",
+              "operation": "Gets/List bootstrap-system-priority-classes resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Readyz/Poststarthook/Bootstrap-System-Priority-Classes"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/readyz/poststarthook/start-apiextensions-controllers/read",
+            "display": {
+              "description": "Reads start-apiextensions-controllers",
+              "operation": "Gets/List start-apiextensions-controllers resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Readyz/Poststarthook/Start-Apiextensions-Controllers"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/readyz/poststarthook/start-apiextensions-informers/read",
+            "display": {
+              "description": "Reads start-apiextensions-informers",
+              "operation": "Gets/List start-apiextensions-informers resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Readyz/Poststarthook/Start-Apiextensions-Informers"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/readyz/poststarthook/start-kube-aggregator-informers/read",
+            "display": {
+              "description": "Reads start-kube-aggregator-informers",
+              "operation": "Gets/List start-kube-aggregator-informers resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Readyz/Poststarthook/Start-Kube-Aggregator-Informers"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/readyz/poststarthook/start-kube-apiserver-admission-initializer/read",
+            "display": {
+              "description": "Reads start-kube-apiserver-admission-initializer",
+              "operation": "Gets/List start-kube-apiserver-admission-initializer resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Readyz/Poststarthook/Start-Kube-Apiserver-Admission-Initializer"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/readyz/shutdown/read",
+            "display": {
+              "description": "Reads shutdown",
+              "operation": "Gets/List shutdown resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Readyz/Shutdown"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/resetMetrics/read",
+            "display": {
+              "description": "Reads resetMetrics",
+              "operation": "Gets/List resetMetrics resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Resetmetrics"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/swagger-ui/read",
+            "display": {
+              "description": "Reads swagger-ui",
+              "operation": "Gets/List swagger-ui resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Swagger-Ui"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/swagger-api/read",
+            "display": {
+              "description": "Reads swagger-api",
+              "operation": "Gets/List swagger-api resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Swagger-Api"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/ui/read",
+            "display": {
+              "description": "Reads ui",
+              "operation": "Gets/List ui resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Ui"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/version/read",
+            "display": {
+              "description": "Reads version",
+              "operation": "Gets/List version resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Version"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/policy/poddisruptionbudgets/read",
+            "display": {
+              "description": "Reads poddisruptionbudgets",
+              "operation": "Gets/List poddisruptionbudgets resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Poddisruptionbudgets"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/policy/poddisruptionbudgets/write",
+            "display": {
+              "description": "Writes poddisruptionbudgets",
+              "operation": "Creates/Updates poddisruptionbudgets resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Poddisruptionbudgets"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/policy/poddisruptionbudgets/delete",
+            "display": {
+              "description": "Deletes poddisruptionbudgets",
+              "operation": "Deletes/DeletesCollection poddisruptionbudgets resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Poddisruptionbudgets"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/policy/podsecuritypolicies/read",
+            "display": {
+              "description": "Reads podsecuritypolicies",
+              "operation": "Gets/List podsecuritypolicies resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Podsecuritypolicies"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/policy/podsecuritypolicies/write",
+            "display": {
+              "description": "Writes podsecuritypolicies",
+              "operation": "Creates/Updates podsecuritypolicies resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Podsecuritypolicies"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/policy/podsecuritypolicies/delete",
+            "display": {
+              "description": "Deletes podsecuritypolicies",
+              "operation": "Deletes/DeletesCollection podsecuritypolicies resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Podsecuritypolicies"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/rbac.authorization.k8s.io/clusterrolebindings/read",
+            "display": {
+              "description": "Reads clusterrolebindings",
+              "operation": "Gets/List clusterrolebindings resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Clusterrolebindings"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/rbac.authorization.k8s.io/clusterrolebindings/write",
+            "display": {
+              "description": "Writes clusterrolebindings",
+              "operation": "Creates/Updates clusterrolebindings resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Clusterrolebindings"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/rbac.authorization.k8s.io/clusterrolebindings/delete",
+            "display": {
+              "description": "Deletes clusterrolebindings",
+              "operation": "Deletes/DeletesCollection clusterrolebindings resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Clusterrolebindings"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/rbac.authorization.k8s.io/clusterroles/read",
+            "display": {
+              "description": "Reads clusterroles",
+              "operation": "Gets/List clusterroles resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Clusterroles"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/rbac.authorization.k8s.io/clusterroles/write",
+            "display": {
+              "description": "Writes clusterroles",
+              "operation": "Creates/Updates clusterroles resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Clusterroles"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/rbac.authorization.k8s.io/clusterroles/delete",
+            "display": {
+              "description": "Deletes clusterroles",
+              "operation": "Deletes/DeletesCollection clusterroles resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Clusterroles"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/rbac.authorization.k8s.io/rolebindings/read",
+            "display": {
+              "description": "Reads rolebindings",
+              "operation": "Gets/List rolebindings resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Rolebindings"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/rbac.authorization.k8s.io/rolebindings/write",
+            "display": {
+              "description": "Writes rolebindings",
+              "operation": "Creates/Updates rolebindings resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Rolebindings"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/rbac.authorization.k8s.io/rolebindings/delete",
+            "display": {
+              "description": "Deletes rolebindings",
+              "operation": "Deletes/DeletesCollection rolebindings resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Rolebindings"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/rbac.authorization.k8s.io/roles/read",
+            "display": {
+              "description": "Reads roles",
+              "operation": "Gets/List roles resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Roles"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/rbac.authorization.k8s.io/roles/write",
+            "display": {
+              "description": "Writes roles",
+              "operation": "Creates/Updates roles resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Roles"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/rbac.authorization.k8s.io/roles/delete",
+            "display": {
+              "description": "Deletes roles",
+              "operation": "Deletes/DeletesCollection roles resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Roles"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/scheduling.k8s.io/priorityclasses/read",
+            "display": {
+              "description": "Reads priorityclasses",
+              "operation": "Gets/List priorityclasses resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Priorityclasses"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/scheduling.k8s.io/priorityclasses/write",
+            "display": {
+              "description": "Writes priorityclasses",
+              "operation": "Creates/Updates priorityclasses resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Priorityclasses"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/scheduling.k8s.io/priorityclasses/delete",
+            "display": {
+              "description": "Deletes priorityclasses",
+              "operation": "Deletes/DeletesCollection priorityclasses resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Priorityclasses"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/policy/podsecuritypolicies/use/action",
+            "display": {
+              "description": "Use action on podsecuritypolicies",
+              "operation": "Use podsecuritypolicies resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Podsecuritypolicies"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/rbac.authorization.k8s.io/clusterroles/bind/action",
+            "display": {
+              "description": "Binds clusterroles",
+              "operation": "Bind clusterroles resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Clusterroles"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/rbac.authorization.k8s.io/clusterroles/escalate/action",
+            "display": {
+              "description": "Escalates",
+              "operation": "Escalate clusterroles resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Clusterroles"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/rbac.authorization.k8s.io/roles/bind/action",
+            "display": {
+              "description": "Binds roles",
+              "operation": "Bind roles resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Roles"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/rbac.authorization.k8s.io/roles/escalate/action",
+            "display": {
+              "description": "Escalates roles",
+              "operation": "Escalate roles resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Roles"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/serviceaccounts/impersonate/action",
+            "display": {
+              "description": "Impersonate serviceaccounts",
+              "operation": "Impersonate serviceaccounts resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Serviceaccounts"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/users/impersonate/action",
+            "display": {
+              "description": "Impersonate users",
+              "operation": "Impersonate users resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Users"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/groups/impersonate/action",
+            "display": {
+              "description": "Impersonate groups",
+              "operation": "Impersonate groups resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Groups"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/authentication.k8s.io/userextras/impersonate/action",
+            "display": {
+              "description": "Impersonate userextras",
+              "operation": "Impersonate userextras resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Userextras"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/storage.k8s.io/storageclasses/read",
+            "display": {
+              "description": "Reads storageclasses",
+              "operation": "Gets/List storageclasses resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Storageclasses"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/storage.k8s.io/storageclasses/write",
+            "display": {
+              "description": "Writes storageclasses",
+              "operation": "Creates/Updates storageclasses resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Storageclasses"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/storage.k8s.io/storageclasses/delete",
+            "display": {
+              "description": "Deletes storageclasses",
+              "operation": "Deletes/DeletesCollection storageclasses resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Storageclasses"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/storage.k8s.io/volumeattachments/read",
+            "display": {
+              "description": "Reads volumeattachments",
+              "operation": "Gets/List volumeattachments resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Volumeattachments"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/storage.k8s.io/volumeattachments/write",
+            "display": {
+              "description": "Writes volumeattachments",
+              "operation": "Creates/Updates volumeattachments resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Volumeattachments"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/storage.k8s.io/volumeattachments/delete",
+            "display": {
+              "description": "Deletes volumeattachments",
+              "operation": "Deletes/DeletesCollection volumeattachments resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Volumeattachments"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/storage.k8s.io/csidrivers/read",
+            "display": {
+              "description": "Reads csidrivers",
+              "operation": "Gets/List csidrivers resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Csidrivers"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/storage.k8s.io/csidrivers/write",
+            "display": {
+              "description": "Writes csidrivers",
+              "operation": "Creates/Updates csidrivers resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Csidrivers"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/storage.k8s.io/csidrivers/delete",
+            "display": {
+              "description": "Deletes csidrivers",
+              "operation": "Deletes/DeletesCollection csidrivers resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Csidrivers"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/storage.k8s.io/csinodes/read",
+            "display": {
+              "description": "Reads csinodes",
+              "operation": "Gets/List csinodes resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Csinodes"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/storage.k8s.io/csinodes/write",
+            "display": {
+              "description": "Writes csinodes",
+              "operation": "Creates/Updates csinodes resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Csinodes"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/storage.k8s.io/csinodes/delete",
+            "display": {
+              "description": "Deletes csinodes",
+              "operation": "Deletes/DeletesCollection csinodes resource",
+              "provider": "Microsoft Container Service",
+              "resource": "Csinodes"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/providers/Microsoft.Insights/metricDefinitions/read",
+            "display": {
+              "description": "Gets the available metrics for Managed Cluster",
+              "operation": "Read Managed Cluster metric definitions",
+              "provider": "Microsoft Container Service",
+              "resource": "The metric definition of Managed Cluster"
+            },
+            "origin": "system"
+          },
+          {
+            "name": "Microsoft.ContainerService/managedClusters/providers/Microsoft.Insights/logDefinitions/read",
+            "display": {
+              "description": "Gets the available logs for Managed Cluster",
+              "operation": "Read Managed Cluster log definitions",
+              "provider": "Microsoft Container Service",
+              "resource": "The log definition of Managed Cluster"
+            },
+            "origin": "system"
+          },
+          {
+            "name": "Microsoft.ContainerService/openShiftManagedClusters/read",
+            "display": {
+              "description": "Get a Open Shift Managed Cluster",
+              "operation": "Get Open Shift Managed Cluster",
+              "provider": "Microsoft Container Service",
+              "resource": "Open Shift Managed Cluster"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/openShiftManagedClusters/write",
+            "display": {
+              "description": "Creates a new Open Shift Managed Cluster or updates an existing one",
+              "operation": "Create or Update Open Shift Managed Cluster",
+              "provider": "Microsoft Container Service",
+              "resource": "Open Shift Managed Cluster"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/openShiftManagedClusters/delete",
+            "display": {
+              "description": "Delete a Open Shift Managed Cluster",
+              "operation": "Delete Open Shift Managed Cluster",
+              "provider": "Microsoft Container Service",
+              "resource": "Open Shift Managed Cluster"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/openShiftClusters/read",
+            "display": {
+              "description": "Get a Open Shift Cluster",
+              "operation": "Get Open Shift Cluster",
+              "provider": "Microsoft Container Service",
+              "resource": "Open Shift Cluster"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/openShiftClusters/write",
+            "display": {
+              "description": "Creates a new Open Shift Cluster or updates an existing one",
+              "operation": "Create or Update Open Shift Cluster",
+              "provider": "Microsoft Container Service",
+              "resource": "Open Shift Cluster"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.ContainerService/openShiftClusters/delete",
+            "display": {
+              "description": "Delete a Open Shift Cluster",
+              "operation": "Delete Open Shift Cluster",
+              "provider": "Microsoft Container Service",
+              "resource": "Open Shift Cluster"
+            },
+            "origin": "user,system"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Operations_List",
+  "title": "List available operations for the container service resource provider"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/OutboundNetworkDependenciesEndpointsList.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/OutboundNetworkDependenciesEndpointsList.json
@@ -1,0 +1,244 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "category": "azure-resource-management",
+            "endpoints": [
+              {
+                "domainName": "management.azure.com",
+                "endpointDetails": [
+                  {
+                    "port": 443,
+                    "protocol": "Https"
+                  }
+                ]
+              },
+              {
+                "domainName": "login.microsoftonline.com",
+                "endpointDetails": [
+                  {
+                    "port": 443,
+                    "protocol": "Https"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "category": "images",
+            "endpoints": [
+              {
+                "domainName": "mcr.microsoft.com",
+                "endpointDetails": [
+                  {
+                    "port": 443,
+                    "protocol": "Https"
+                  }
+                ]
+              },
+              {
+                "domainName": "*.data.mcr.microsoft.com",
+                "endpointDetails": [
+                  {
+                    "description": "mcr cdn",
+                    "port": 443,
+                    "protocol": "Https"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "category": "artifacts",
+            "endpoints": [
+              {
+                "domainName": "packages.microsoft.com",
+                "endpointDetails": [
+                  {
+                    "port": 443,
+                    "protocol": "Https"
+                  }
+                ]
+              },
+              {
+                "domainName": "acs-mirror.azureedge.net",
+                "endpointDetails": [
+                  {
+                    "port": 443,
+                    "protocol": "Https"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "category": "time-sync",
+            "endpoints": [
+              {
+                "domainName": "ntp.ubuntu.com",
+                "endpointDetails": [
+                  {
+                    "port": 123,
+                    "protocol": "UDP"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "category": "ubuntu-optional",
+            "endpoints": [
+              {
+                "domainName": "security.ubuntu.com",
+                "endpointDetails": [
+                  {
+                    "port": 80,
+                    "protocol": "Http"
+                  }
+                ]
+              },
+              {
+                "domainName": "azure.archive.ubuntu.com",
+                "endpointDetails": [
+                  {
+                    "port": 80,
+                    "protocol": "Http"
+                  }
+                ]
+              },
+              {
+                "domainName": "changelogs.ubuntu.com",
+                "endpointDetails": [
+                  {
+                    "port": 80,
+                    "protocol": "Http"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "category": "gpu",
+            "endpoints": [
+              {
+                "domainName": "nvidia.github.io",
+                "endpointDetails": [
+                  {
+                    "port": 443,
+                    "protocol": "Https"
+                  }
+                ]
+              },
+              {
+                "domainName": "us.download.nvidia.com",
+                "endpointDetails": [
+                  {
+                    "port": 443,
+                    "protocol": "Https"
+                  }
+                ]
+              },
+              {
+                "domainName": "apt.dockerproject.org",
+                "endpointDetails": [
+                  {
+                    "port": 443,
+                    "protocol": "Https"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "category": "windows",
+            "endpoints": [
+              {
+                "domainName": "onegetcdn.azureedge.net",
+                "endpointDetails": [
+                  {
+                    "port": 443,
+                    "protocol": "Https"
+                  }
+                ]
+              },
+              {
+                "domainName": "go.microsoft.com",
+                "endpointDetails": [
+                  {
+                    "port": 443,
+                    "protocol": "Https"
+                  }
+                ]
+              },
+              {
+                "domainName": "*.mp.microsoft.com",
+                "endpointDetails": [
+                  {
+                    "port": 80,
+                    "protocol": "Http"
+                  }
+                ]
+              },
+              {
+                "domainName": "www.msftconnecttest.com",
+                "endpointDetails": [
+                  {
+                    "port": 80,
+                    "protocol": "Http"
+                  }
+                ]
+              },
+              {
+                "domainName": "ctldl.windowsupdate.com",
+                "endpointDetails": [
+                  {
+                    "port": 80,
+                    "protocol": "Http"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "category": "apiserver",
+            "endpoints": [
+              {
+                "domainName": "*.azmk8s.io",
+                "endpointDetails": [
+                  {
+                    "port": 443,
+                    "protocol": "Https"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "category": "tunnel-classic",
+            "endpoints": [
+              {
+                "domainName": "*.azmk8s.io",
+                "endpointDetails": [
+                  {
+                    "port": 9000,
+                    "protocol": "TCP"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ManagedClusters_ListOutboundNetworkDependenciesEndpoints",
+  "title": "List OutboundNetworkDependenciesEndpoints by Managed Cluster"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/PrivateEndpointConnectionsDelete.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/PrivateEndpointConnectionsDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "privateEndpointConnectionName": "privateendpointconnection1",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "PrivateEndpointConnections_Delete",
+  "title": "Delete Private Endpoint Connection"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/PrivateEndpointConnectionsGet.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/PrivateEndpointConnectionsGet.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "privateEndpointConnectionName": "privateendpointconnection1",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "privateendpointconnection1",
+        "type": "Microsoft.Network/privateLinkServices/privateEndpointConnections",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedCluster/clustername1/privateEndpointConnections/privateendpointconnection1",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/subid2/resourceGroups/rg2/providers/Microsoft.Network/privateEndpoints/pe2"
+          },
+          "privateLinkServiceConnectionState": {
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_Get",
+  "title": "Get Private Endpoint Connection"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/PrivateEndpointConnectionsList.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/PrivateEndpointConnectionsList.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "privateendpointconnection1",
+            "type": "Microsoft.Network/privateLinkServices/privateEndpointConnections",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedCluster/clustername1/privateEndpointConnections/privateendpointconnection1",
+            "properties": {
+              "privateEndpoint": {
+                "id": "/subscriptions/subid2/resourceGroups/rg2/providers/Microsoft.Network/privateEndpoints/pe2"
+              },
+              "privateLinkServiceConnectionState": {
+                "status": "Approved"
+              },
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_List",
+  "title": "List Private Endpoint Connections by Managed Cluster"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/PrivateEndpointConnectionsUpdate.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/PrivateEndpointConnectionsUpdate.json
@@ -1,0 +1,52 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "parameters": {
+      "properties": {
+        "privateLinkServiceConnectionState": {
+          "status": "Approved"
+        }
+      }
+    },
+    "privateEndpointConnectionName": "privateendpointconnection1",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "privateendpointconnection1",
+        "type": "Microsoft.ContainerService/managedClusters/privateEndpointConnections",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/privateEndpointConnections/privateendpointconnection1",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/subid2/resourceGroups/rg2/providers/Microsoft.Network/privateEndpoints/pe2"
+          },
+          "privateLinkServiceConnectionState": {
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "privateendpointconnection1",
+        "type": "Microsoft.ContainerService/managedClusters/privateEndpointConnections",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/privateEndpointConnections/privateendpointconnection1",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/subid2/resourceGroups/rg2/providers/Microsoft.Network/privateEndpoints/pe2"
+          },
+          "privateLinkServiceConnectionState": {
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_Update",
+  "title": "Update Private Endpoint Connection"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/PrivateLinkResourcesList.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/PrivateLinkResourcesList.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "management",
+            "type": "Microsoft.ContainerService/managedClusters/privateLinkResources",
+            "groupId": "management",
+            "privateLinkServiceID": "/subscriptions/subid2/resourceGroups/rg2/providers/Microsoft.Network/privateLinkServices/plsName",
+            "requiredMembers": [
+              "management"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PrivateLinkResources_List",
+  "title": "List Private Link Resources by Managed Cluster"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ResolvePrivateLinkServiceId.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/ResolvePrivateLinkServiceId.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "parameters": {
+      "name": "management"
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "privateLinkServiceID": "/subscriptions/subid2/resourceGroups/rg2/providers/Microsoft.Network/privateLinkServices/plsName"
+      }
+    }
+  },
+  "operationId": "ResolvePrivateLinkServiceId_POST",
+  "title": "Resolve the Private Link Service ID for Managed Cluster"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/RunCommandRequest.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/RunCommandRequest.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "requestPayload": {
+      "clusterToken": "",
+      "command": "kubectl apply -f ns.yaml",
+      "context": ""
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "def7b3ea71bd4f7e9d226ddbc0f00ad9",
+        "properties": {
+          "exitCode": 0,
+          "finishedAt": "2021-02-17T00:28:33Z",
+          "logs": "namespace dummy created",
+          "provisioningState": "succeeded",
+          "startedAt": "2021-02-17T00:28:20Z"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/commandResults/0e9872e6629349dc865e27ee6f8bab2d?api-version=2026-03-01"
+      }
+    }
+  },
+  "operationId": "ManagedClusters_RunCommand",
+  "title": "submitNewCommand"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/RunCommandResultFailed.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/RunCommandResultFailed.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "commandId": "def7b3ea71bd4f7e9d226ddbc0f00ad9",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "def7b3ea71bd4f7e9d226ddbc0f00ad9",
+        "properties": {
+          "provisioningState": "failed",
+          "reason": "ImagePullBackoff"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/commandResults/0e9872e6629349dc865e27ee6f8bab2d?api-version=2026-03-01"
+      }
+    }
+  },
+  "operationId": "ManagedClusters_GetCommandResult",
+  "title": "commandFailedResult"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/RunCommandResultSucceed.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/RunCommandResultSucceed.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "commandId": "def7b3ea71bd4f7e9d226ddbc0f00ad9",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "def7b3ea71bd4f7e9d226ddbc0f00ad9",
+        "properties": {
+          "exitCode": 0,
+          "finishedAt": "2021-02-17T00:28:33Z",
+          "logs": "namespace dummy created",
+          "provisioningState": "succeeded",
+          "startedAt": "2021-02-17T00:28:20Z"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/commandResults/0e9872e6629349dc865e27ee6f8bab2d?api-version=2026-03-01"
+      }
+    }
+  },
+  "operationId": "ManagedClusters_GetCommandResult",
+  "title": "commandSucceedResult"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/SnapshotsCreate.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/SnapshotsCreate.json
@@ -1,0 +1,82 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "parameters": {
+      "location": "westus",
+      "properties": {
+        "creationData": {
+          "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/cluster1/agentPools/pool0"
+        }
+      },
+      "tags": {
+        "key1": "val1",
+        "key2": "val2"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "snapshot1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "snapshot1",
+        "type": "Microsoft.ContainerService/snapshots",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/snapshots/snapshot1",
+        "location": "westus",
+        "properties": {
+          "creationData": {
+            "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/cluster1/agentPools/pool0"
+          },
+          "enableFIPS": false,
+          "kubernetesVersion": "1.20.5",
+          "nodeImageVersion": "AKSUbuntu-1804gen2containerd-2021.09.11",
+          "osSku": "Ubuntu",
+          "osType": "Linux",
+          "snapshotType": "NodePool",
+          "vmSize": "Standard_D2s_v3"
+        },
+        "systemData": {
+          "createdAt": "2021-08-09T20:13:23.298420761Z",
+          "createdBy": "user1",
+          "createdByType": "User"
+        },
+        "tags": {
+          "key1": "val1",
+          "key2": "val2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "snapshot1",
+        "type": "Microsoft.ContainerService/snapshots",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/snapshots/snapshot1",
+        "location": "westus",
+        "properties": {
+          "creationData": {
+            "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/cluster1/agentPools/pool0"
+          },
+          "enableFIPS": false,
+          "kubernetesVersion": "1.20.5",
+          "nodeImageVersion": "AKSUbuntu-1804gen2containerd-2021.09.11",
+          "osSku": "Ubuntu",
+          "osType": "Linux",
+          "snapshotType": "NodePool",
+          "vmSize": "Standard_D2s_v3"
+        },
+        "systemData": {
+          "createdAt": "2021-08-09T20:13:23.298420761Z",
+          "createdBy": "user1",
+          "createdByType": "User"
+        },
+        "tags": {
+          "key1": "val1",
+          "key2": "val2"
+        }
+      }
+    }
+  },
+  "operationId": "Snapshots_CreateOrUpdate",
+  "title": "Create/Update Snapshot"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/SnapshotsDelete.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/SnapshotsDelete.json
@@ -1,0 +1,14 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "resourceGroupName": "rg1",
+    "resourceName": "snapshot1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "Snapshots_Delete",
+  "title": "Delete Snapshot"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/SnapshotsGet.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/SnapshotsGet.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "resourceGroupName": "rg1",
+    "resourceName": "snapshot1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "snapshot1",
+        "type": "Microsoft.ContainerService/snapshots",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/snapshots/snapshot1",
+        "location": "westus",
+        "properties": {
+          "creationData": {
+            "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/cluster1/agentPools/pool0"
+          },
+          "enableFIPS": false,
+          "kubernetesVersion": "1.20.5",
+          "nodeImageVersion": "AKSUbuntu-1804gen2containerd-2021.09.11",
+          "osSku": "Ubuntu",
+          "osType": "Linux",
+          "snapshotType": "NodePool",
+          "vmSize": "Standard_D2s_v3"
+        },
+        "systemData": {
+          "createdAt": "2021-08-09T20:13:23.298420761Z",
+          "createdBy": "user1",
+          "createdByType": "User"
+        },
+        "tags": {
+          "key1": "val1",
+          "key2": "val2"
+        }
+      }
+    }
+  },
+  "operationId": "Snapshots_Get",
+  "title": "Get Snapshot"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/SnapshotsList.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/SnapshotsList.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "snapshot1",
+            "type": "Microsoft.ContainerService/snapshots",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/snapshots/snapshot1",
+            "location": "westus",
+            "properties": {
+              "creationData": {
+                "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/cluster1/agentPools/pool0"
+              },
+              "enableFIPS": false,
+              "kubernetesVersion": "1.20.5",
+              "nodeImageVersion": "AKSUbuntu-1804gen2containerd-2021.09.11",
+              "osSku": "Ubuntu",
+              "osType": "Linux",
+              "snapshotType": "NodePool",
+              "vmSize": "Standard_D2s_v3"
+            },
+            "systemData": {
+              "createdAt": "2021-08-09T20:13:23.298420761Z",
+              "createdBy": "user1",
+              "createdByType": "User"
+            },
+            "tags": {
+              "key1": "val1",
+              "key2": "val2"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Snapshots_List",
+  "title": "List Snapshots"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/SnapshotsListByResourceGroup.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/SnapshotsListByResourceGroup.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "snapshot1",
+            "type": "Microsoft.ContainerService/snapshots",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/snapshots/snapshot1",
+            "location": "westus",
+            "properties": {
+              "creationData": {
+                "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/cluster1/agentPools/pool0"
+              },
+              "enableFIPS": false,
+              "kubernetesVersion": "1.20.5",
+              "nodeImageVersion": "AKSUbuntu-1804gen2containerd-2021.09.11",
+              "osSku": "Ubuntu",
+              "osType": "Linux",
+              "snapshotType": "NodePool",
+              "vmSize": "Standard_D2s_v3"
+            },
+            "systemData": {
+              "createdAt": "2021-08-09T20:13:23.298420761Z",
+              "createdBy": "user1",
+              "createdByType": "User"
+            },
+            "tags": {
+              "key1": "val1",
+              "key2": "val2"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Snapshots_ListByResourceGroup",
+  "title": "List Snapshots by Resource Group"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/SnapshotsUpdateTags.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/SnapshotsUpdateTags.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "parameters": {
+      "tags": {
+        "key2": "new-val2",
+        "key3": "val3"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "snapshot1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "snapshot1",
+        "type": "Microsoft.ContainerService/snapshots",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/snapshots/snapshot1",
+        "location": "westus",
+        "properties": {
+          "creationData": {
+            "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/cluster1/agentPools/pool0"
+          },
+          "enableFIPS": false,
+          "kubernetesVersion": "1.20.5",
+          "nodeImageVersion": "AKSUbuntu-1804gen2containerd-2021.09.11",
+          "osSku": "Ubuntu",
+          "osType": "Linux",
+          "snapshotType": "NodePool",
+          "vmSize": "Standard_D2s_v3"
+        },
+        "systemData": {
+          "createdAt": "2021-08-09T20:13:23.298420761Z",
+          "createdBy": "user1",
+          "createdByType": "User"
+        },
+        "tags": {
+          "key2": "new-val2",
+          "key3": "val3"
+        }
+      }
+    }
+  },
+  "operationId": "Snapshots_UpdateTags",
+  "title": "Update Snapshot Tags"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/TrustedAccessRoleBindings_CreateOrUpdate.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/TrustedAccessRoleBindings_CreateOrUpdate.json
@@ -1,0 +1,50 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "trustedAccessRoleBinding": {
+      "properties": {
+        "roles": [
+          "Microsoft.MachineLearningServices/workspaces/reader",
+          "Microsoft.MachineLearningServices/workspaces/writer"
+        ],
+        "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/b/providers/Microsoft.MachineLearningServices/workspaces/c"
+      }
+    },
+    "trustedAccessRoleBindingName": "binding1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "binding1",
+        "type": "Microsoft.ContainerService/managedClusters/trustedAccessRoleBindings",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/trustedAccessRoleBindings/binding1",
+        "properties": {
+          "roles": [
+            "Microsoft.MachineLearningServices/workspaces/reader",
+            "Microsoft.MachineLearningServices/workspaces/writer"
+          ],
+          "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/b/providers/Microsoft.MachineLearningServices/workspaces/c"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "binding1",
+        "type": "Microsoft.ContainerService/managedClusters/trustedAccessRoleBindings",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/trustedAccessRoleBindings/binding1",
+        "properties": {
+          "roles": [
+            "Microsoft.MachineLearningServices/workspaces/reader",
+            "Microsoft.MachineLearningServices/workspaces/writer"
+          ],
+          "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/b/providers/Microsoft.MachineLearningServices/workspaces/c"
+        }
+      }
+    }
+  },
+  "operationId": "TrustedAccessRoleBindings_CreateOrUpdate",
+  "title": "Create or update a trusted access role binding"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/TrustedAccessRoleBindings_Delete.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/TrustedAccessRoleBindings_Delete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "trustedAccessRoleBindingName": "binding1"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operationresults/00000000-0000-0000-0000-000000000000?api-version=2026-03-01"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "TrustedAccessRoleBindings_Delete",
+  "title": "Delete a trusted access role binding"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/TrustedAccessRoleBindings_Get.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/TrustedAccessRoleBindings_Get.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "trustedAccessRoleBindingName": "binding1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "binding1",
+        "type": "Microsoft.ContainerService/managedClusters/trustedAccessRoleBindings",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/trustedAccessRoleBindings/binding1",
+        "properties": {
+          "roles": [
+            "Microsoft.MachineLearningServices/workspaces/reader",
+            "Microsoft.MachineLearningServices/workspaces/writer"
+          ],
+          "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/b/providers/Microsoft.MachineLearningServices/workspaces/c"
+        }
+      }
+    }
+  },
+  "operationId": "TrustedAccessRoleBindings_Get",
+  "title": "Get a trusted access role binding"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/TrustedAccessRoleBindings_List.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/TrustedAccessRoleBindings_List.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "binding1",
+            "type": "Microsoft.ContainerService/managedClusters/trustedAccessRoleBindings",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/trustedAccessRoleBindings/binding1",
+            "properties": {
+              "roles": [
+                "Microsoft.MachineLearningServices/workspaces/reader",
+                "Microsoft.MachineLearningServices/workspaces/writer"
+              ],
+              "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/b/providers/Microsoft.MachineLearningServices/workspaces/c"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "TrustedAccessRoleBindings_List",
+  "title": "List trusted access role bindings"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/TrustedAccessRoles_List.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/examples/TrustedAccessRoles_List.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "api-version": "2026-03-01",
+    "location": "westus2",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "reader",
+            "rules": [
+              {
+                "apiGroups": [
+                  ""
+                ],
+                "nonResourceURLs": [],
+                "resourceNames": [],
+                "resources": [
+                  "pods"
+                ],
+                "verbs": [
+                  "get"
+                ]
+              }
+            ],
+            "sourceResourceType": "Microsoft.MachineLearningServices/workspaces"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "TrustedAccessRoles_List",
+  "title": "List trusted access roles"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/managedClusters.json
@@ -1,0 +1,10718 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "ContainerServiceClient",
+    "version": "2026-03-01",
+    "description": "The Container Service Client.",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "AgentPools"
+    },
+    {
+      "name": "ManagedClusters"
+    },
+    {
+      "name": "privateLinkResources"
+    },
+    {
+      "name": "resolvePrivateLinkServiceId"
+    },
+    {
+      "name": "MaintenanceConfigurations"
+    },
+    {
+      "name": "ManagedNamespaces"
+    },
+    {
+      "name": "Machines"
+    },
+    {
+      "name": "PrivateEndpointConnections"
+    },
+    {
+      "name": "Snapshots"
+    },
+    {
+      "name": "TrustedAccess"
+    }
+  ],
+  "paths": {
+    "/providers/Microsoft.ContainerService/operations": {
+      "get": {
+        "operationId": "Operations_List",
+        "tags": [
+          "ManagedClusters"
+        ],
+        "description": "Gets a list of operations.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/OperationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List available operations for the container service resource provider": {
+            "$ref": "./examples/Operation_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.ContainerService/locations/{location}/kubernetesVersions": {
+      "get": {
+        "operationId": "ManagedClusters_ListKubernetesVersions",
+        "tags": [
+          "ManagedClusters"
+        ],
+        "summary": "Gets a list of supported Kubernetes versions in the specified subscription.",
+        "description": "Contains extra metadata on the version, including supported patch versions, capabilities, available upgrades, and details on preview status of the version",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/KubernetesVersionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Kubernetes Versions": {
+            "$ref": "./examples/KubernetesVersions_List.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.ContainerService/locations/{location}/meshRevisionProfiles": {
+      "get": {
+        "operationId": "ManagedClusters_ListMeshRevisionProfiles",
+        "tags": [
+          "ManagedClusters"
+        ],
+        "summary": "Lists mesh revision profiles for all meshes in the specified location.",
+        "description": "Contains extra metadata on each revision, including supported revisions, cluster compatibility and available upgrades",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MeshRevisionProfileList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List mesh revision profiles in a location": {
+            "$ref": "./examples/ManagedClustersList_MeshRevisionProfiles.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.ContainerService/locations/{location}/meshRevisionProfiles/{mode}": {
+      "get": {
+        "operationId": "ManagedClusters_GetMeshRevisionProfile",
+        "tags": [
+          "ManagedClusters"
+        ],
+        "summary": "Gets a mesh revision profile for a specified mesh in the specified location.",
+        "description": "Contains extra metadata on the revision, including supported revisions, cluster compatibility and available upgrades",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "mode",
+            "in": "path",
+            "description": "The mode of the mesh.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 24,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MeshRevisionProfile"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get a mesh revision profile for a mesh mode": {
+            "$ref": "./examples/ManagedClustersGet_MeshRevisionProfile.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.ContainerService/locations/{location}/trustedAccessRoles": {
+      "get": {
+        "operationId": "TrustedAccessRoles_List",
+        "tags": [
+          "TrustedAccess"
+        ],
+        "description": "List supported trusted access roles.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/TrustedAccessRoleListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List trusted access roles": {
+            "$ref": "./examples/TrustedAccessRoles_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.ContainerService/managedClusters": {
+      "get": {
+        "operationId": "ManagedClusters_List",
+        "tags": [
+          "ManagedClusters"
+        ],
+        "description": "Gets a list of managed clusters in the specified subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ManagedClusterListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Managed Clusters": {
+            "$ref": "./examples/ManagedClustersList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.ContainerService/snapshots": {
+      "get": {
+        "operationId": "Snapshots_List",
+        "tags": [
+          "Snapshots"
+        ],
+        "description": "Gets a list of snapshots in the specified subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SnapshotListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Snapshots": {
+            "$ref": "./examples/SnapshotsList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters": {
+      "get": {
+        "operationId": "ManagedClusters_ListByResourceGroup",
+        "tags": [
+          "ManagedClusters"
+        ],
+        "description": "Lists managed clusters in the specified subscription and resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ManagedClusterListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Managed Clusters by Resource Group": {
+            "$ref": "./examples/ManagedClustersListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}": {
+      "get": {
+        "operationId": "ManagedClusters_Get",
+        "tags": [
+          "ManagedClusters"
+        ],
+        "description": "Gets a managed cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ManagedCluster"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Managed Cluster": {
+            "$ref": "./examples/ManagedClustersGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "ManagedClusters_CreateOrUpdate",
+        "tags": [
+          "ManagedClusters"
+        ],
+        "description": "Creates or updates a managed cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "if-match",
+            "in": "header",
+            "description": "The request should only proceed if an entity matches this string.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "ifMatch"
+          },
+          {
+            "name": "if-none-match",
+            "in": "header",
+            "description": "The request should only proceed if no entity matches this string.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "ifNoneMatch"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The managed cluster to create or update.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ManagedCluster"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ManagedCluster' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ManagedCluster"
+            }
+          },
+          "201": {
+            "description": "Resource 'ManagedCluster' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ManagedCluster"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create Managed Cluster using an agent pool snapshot": {
+            "$ref": "./examples/ManagedClustersCreate_Snapshot.json"
+          },
+          "Create Managed Cluster with AKS-managed NAT gateway as outbound type": {
+            "$ref": "./examples/ManagedClustersCreate_ManagedNATGateway.json"
+          },
+          "Create Managed Cluster with Advanced Networking Transit Encryption": {
+            "$ref": "./examples/AdvancedNetworkingTransitEncryption.json"
+          },
+          "Create Managed Cluster with Azure KeyVault Secrets Provider Addon": {
+            "$ref": "./examples/ManagedClustersCreate_AzureKeyvaultSecretsProvider.json"
+          },
+          "Create Managed Cluster with Capacity Reservation Group": {
+            "$ref": "./examples/ManagedClustersCreate_CRG.json"
+          },
+          "Create Managed Cluster with Custom CA Trust Certificates": {
+            "$ref": "./examples/ManagedClustersCreate_CustomCATrustCertificates.json"
+          },
+          "Create Managed Cluster with Dedicated Host Group": {
+            "$ref": "./examples/ManagedClustersCreate_DedicatedHostGroup.json"
+          },
+          "Create Managed Cluster with EncryptionAtHost enabled": {
+            "$ref": "./examples/ManagedClustersCreate_EnableEncryptionAtHost.json"
+          },
+          "Create Managed Cluster with FIPS enabled OS": {
+            "$ref": "./examples/ManagedClustersCreate_EnabledFIPS.json"
+          },
+          "Create Managed Cluster with GPUMIG": {
+            "$ref": "./examples/ManagedClustersCreate_GPUMIG.json"
+          },
+          "Create Managed Cluster with HTTP proxy configured": {
+            "$ref": "./examples/ManagedClustersCreate_HTTPProxy.json"
+          },
+          "Create Managed Cluster with LongTermSupport": {
+            "$ref": "./examples/ManagedClustersCreate_Premium.json"
+          },
+          "Create Managed Cluster with Node Public IP Prefix": {
+            "$ref": "./examples/ManagedClustersCreate_NodePublicIPPrefix.json"
+          },
+          "Create Managed Cluster with OSSKU": {
+            "$ref": "./examples/ManagedClustersCreate_OSSKU.json"
+          },
+          "Create Managed Cluster with PPG": {
+            "$ref": "./examples/ManagedClustersCreate_PPG.json"
+          },
+          "Create Managed Cluster with PodIdentity enabled": {
+            "$ref": "./examples/ManagedClustersCreate_PodIdentity.json"
+          },
+          "Create Managed Cluster with RunCommand disabled": {
+            "$ref": "./examples/ManagedClustersCreate_DisableRunCommand.json"
+          },
+          "Create Managed Cluster with Security Profile configured": {
+            "$ref": "./examples/ManagedClustersCreate_SecurityProfile.json"
+          },
+          "Create Managed Cluster with UltraSSD enabled": {
+            "$ref": "./examples/ManagedClustersCreate_EnableUltraSSD.json"
+          },
+          "Create Managed Cluster with Web App Routing Ingress Profile configured": {
+            "$ref": "./examples/ManagedClustersCreate_IngressProfile_WebAppRouting.json"
+          },
+          "Create Managed Cluster with user-assigned NAT gateway as outbound type": {
+            "$ref": "./examples/ManagedClustersCreate_UserAssignedNATGateway.json"
+          },
+          "Create Managed Private Cluster with Public FQDN specified": {
+            "$ref": "./examples/ManagedClustersCreate_PrivateClusterPublicFQDN.json"
+          },
+          "Create Managed Private Cluster with fqdn subdomain specified": {
+            "$ref": "./examples/ManagedClustersCreate_PrivateClusterFQDNSubdomain.json"
+          },
+          "Create/Update AAD Managed Cluster with EnableAzureRBAC": {
+            "$ref": "./examples/ManagedClustersCreate_UpdateWithEnableAzureRBAC.json"
+          },
+          "Create/Update Managed Cluster": {
+            "$ref": "./examples/ManagedClustersCreate_Update.json"
+          },
+          "Create/Update Managed Cluster with Azure Service Mesh": {
+            "$ref": "./examples/ManagedClustersCreate_AzureServiceMesh.json"
+          },
+          "Create/Update Managed Cluster with EnableAHUB": {
+            "$ref": "./examples/ManagedClustersCreate_UpdateWithAHUB.json"
+          },
+          "Create/Update Managed Cluster with Windows gMSA enabled": {
+            "$ref": "./examples/ManagedClustersCreate_UpdateWindowsGmsa.json"
+          },
+          "Create/Update Managed Cluster with dual-stack networking": {
+            "$ref": "./examples/ManagedClustersCreate_DualStackNetworking.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ManagedCluster"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "ManagedClusters_UpdateTags",
+        "tags": [
+          "ManagedClusters"
+        ],
+        "description": "Updates tags on a managed cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "if-match",
+            "in": "header",
+            "description": "The request should only proceed if an entity matches this string.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "ifMatch"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the Update Managed Cluster Tags operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ManagedCluster"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update Managed Cluster Tags": {
+            "$ref": "./examples/ManagedClustersUpdateTags.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ManagedCluster"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "ManagedClusters_Delete",
+        "tags": [
+          "ManagedClusters"
+        ],
+        "description": "Deletes a managed cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "if-match",
+            "in": "header",
+            "description": "The request should only proceed if an entity matches this string.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "ifMatch"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Managed Cluster": {
+            "$ref": "./examples/ManagedClustersDelete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/abort": {
+      "post": {
+        "operationId": "ManagedClusters_AbortLatestOperation",
+        "tags": [
+          "ManagedClusters"
+        ],
+        "summary": "Aborts last operation running on managed cluster.",
+        "description": "Aborts the currently running operation on the managed cluster. The Managed Cluster will be moved to a Canceling state and eventually to a Canceled state when cancellation finishes. If the operation completes before cancellation can take place, a 409 error code is returned.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Abort operation on managed cluster": {
+            "$ref": "./examples/ManagedClustersAbortOperation.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/accessProfiles/{roleName}/listCredential": {
+      "post": {
+        "operationId": "ManagedClusters_GetAccessProfile",
+        "tags": [
+          "ManagedClusters"
+        ],
+        "summary": "Gets an access profile of a managed cluster.",
+        "description": "**WARNING**: This API will be deprecated. Instead use [ListClusterUserCredentials](https://docs.microsoft.com/rest/api/aks/managedclusters/listclusterusercredentials) or [ListClusterAdminCredentials](https://docs.microsoft.com/rest/api/aks/managedclusters/listclusteradmincredentials) .",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "roleName",
+            "in": "path",
+            "description": "The name of the role for managed cluster accessProfile resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ManagedClusterAccessProfile"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "deprecated": true,
+        "x-ms-examples": {
+          "Get Managed Cluster": {
+            "$ref": "./examples/ManagedClustersGetAccessProfile.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/agentPools": {
+      "get": {
+        "operationId": "AgentPools_List",
+        "tags": [
+          "AgentPools"
+        ],
+        "description": "Gets a list of agent pools in the specified managed cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AgentPoolListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Agent Pools by Managed Cluster": {
+            "$ref": "./examples/AgentPoolsList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/agentPools/{agentPoolName}": {
+      "get": {
+        "operationId": "AgentPools_Get",
+        "tags": [
+          "AgentPools"
+        ],
+        "description": "Gets the specified managed cluster agent pool.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "agentPoolName",
+            "in": "path",
+            "description": "The name of the agent pool.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 12,
+            "pattern": "^[a-z][a-z0-9]{0,11}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AgentPool"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Agent Pool": {
+            "$ref": "./examples/AgentPoolsGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "AgentPools_CreateOrUpdate",
+        "tags": [
+          "AgentPools"
+        ],
+        "description": "Creates or updates an agent pool in the specified managed cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "agentPoolName",
+            "in": "path",
+            "description": "The name of the agent pool.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 12,
+            "pattern": "^[a-z][a-z0-9]{0,11}$"
+          },
+          {
+            "name": "if-match",
+            "in": "header",
+            "description": "The request should only proceed if an entity matches this string.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "ifMatch"
+          },
+          {
+            "name": "if-none-match",
+            "in": "header",
+            "description": "The request should only proceed if no entity matches this string.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "ifNoneMatch"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The agent pool to create or update.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AgentPool"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'AgentPool' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/AgentPool"
+            }
+          },
+          "201": {
+            "description": "Resource 'AgentPool' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/AgentPool"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create Agent Pool using an agent pool snapshot": {
+            "$ref": "./examples/AgentPoolsCreate_Snapshot.json"
+          },
+          "Create Agent Pool with Capacity Reservation Group": {
+            "$ref": "./examples/AgentPoolsCreate_CRG.json"
+          },
+          "Create Agent Pool with Dedicated Host Group": {
+            "$ref": "./examples/AgentPoolsCreate_DedicatedHostGroup.json"
+          },
+          "Create Agent Pool with EncryptionAtHost enabled": {
+            "$ref": "./examples/AgentPoolsCreate_EnableEncryptionAtHost.json"
+          },
+          "Create Agent Pool with Ephemeral OS Disk": {
+            "$ref": "./examples/AgentPoolsCreate_Ephemeral.json"
+          },
+          "Create Agent Pool with FIPS enabled OS": {
+            "$ref": "./examples/AgentPoolsCreate_EnableFIPS.json"
+          },
+          "Create Agent Pool with GPUMIG": {
+            "$ref": "./examples/AgentPoolsCreate_GPUMIG.json"
+          },
+          "Create Agent Pool with Krustlet and the WASI runtime": {
+            "$ref": "./examples/AgentPoolsCreate_WasmWasi.json"
+          },
+          "Create Agent Pool with KubeletConfig and LinuxOSConfig": {
+            "$ref": "./examples/AgentPoolsCreate_CustomNodeConfig.json"
+          },
+          "Create Agent Pool with Message of the Day": {
+            "$ref": "./examples/AgentPoolsCreate_MessageOfTheDay.json"
+          },
+          "Create Agent Pool with OSSKU": {
+            "$ref": "./examples/AgentPoolsCreate_OSSKU.json"
+          },
+          "Create Agent Pool with PPG": {
+            "$ref": "./examples/AgentPoolsCreate_PPG.json"
+          },
+          "Create Agent Pool with UltraSSD enabled": {
+            "$ref": "./examples/AgentPoolsCreate_EnableUltraSSD.json"
+          },
+          "Create Agent Pool with VirtualMachines pool type": {
+            "$ref": "./examples/AgentPoolsCreate_TypeVirtualMachines.json"
+          },
+          "Create Agent Pool with Windows OSSKU": {
+            "$ref": "./examples/AgentPoolsCreate_WindowsOSSKU.json"
+          },
+          "Create Spot Agent Pool": {
+            "$ref": "./examples/AgentPoolsCreate_Spot.json"
+          },
+          "Create Windows Agent Pool with disabling OutboundNAT": {
+            "$ref": "./examples/AgentPoolsCreate_WindowsDisableOutboundNAT.json"
+          },
+          "Create/Update Agent Pool": {
+            "$ref": "./examples/AgentPoolsCreate_Update.json"
+          },
+          "Start Agent Pool": {
+            "$ref": "./examples/AgentPools_Start.json"
+          },
+          "Stop Agent Pool": {
+            "$ref": "./examples/AgentPools_Stop.json"
+          },
+          "Update Agent Pool": {
+            "$ref": "./examples/AgentPools_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/AgentPool"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "AgentPools_Delete",
+        "tags": [
+          "AgentPools"
+        ],
+        "description": "Deletes an agent pool in the specified managed cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "agentPoolName",
+            "in": "path",
+            "description": "The name of the agent pool.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 12,
+            "pattern": "^[a-z][a-z0-9]{0,11}$"
+          },
+          {
+            "name": "ignore-pod-disruption-budget",
+            "in": "query",
+            "description": "ignore-pod-disruption-budget=true to delete those pods on a node without considering Pod Disruption Budget",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "if-match",
+            "in": "header",
+            "description": "The request should only proceed if an entity matches this string.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "ifMatch"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Agent Pool": {
+            "$ref": "./examples/AgentPoolsDelete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/agentPools/{agentPoolName}/abort": {
+      "post": {
+        "operationId": "AgentPools_AbortLatestOperation",
+        "tags": [
+          "AgentPools"
+        ],
+        "summary": "Aborts last operation running on agent pool.",
+        "description": "Aborts the currently running operation on the agent pool. The Agent Pool will be moved to a Canceling state and eventually to a Canceled state when cancellation finishes. If the operation completes before cancellation can take place, a 409 error code is returned.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "agentPoolName",
+            "in": "path",
+            "description": "The name of the agent pool.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 12,
+            "pattern": "^[a-z][a-z0-9]{0,11}$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Abort operation on agent pool": {
+            "$ref": "./examples/AgentPoolsAbortOperation.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/agentPools/{agentPoolName}/deleteMachines": {
+      "post": {
+        "operationId": "AgentPools_DeleteMachines",
+        "tags": [
+          "AgentPools"
+        ],
+        "description": "Deletes specific machines in an agent pool.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "agentPoolName",
+            "in": "path",
+            "description": "The name of the agent pool.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 12,
+            "pattern": "^[a-z][a-z0-9]{0,11}$"
+          },
+          {
+            "name": "machines",
+            "in": "body",
+            "description": "A list of machines from the agent pool to be deleted.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AgentPoolDeleteMachinesParameter"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Specific Machines in an Agent Pool": {
+            "$ref": "./examples/AgentPoolsDeleteMachines.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/agentPools/{agentPoolName}/machines": {
+      "get": {
+        "operationId": "Machines_List",
+        "tags": [
+          "Machines"
+        ],
+        "description": "Gets a list of machines in the specified agent pool.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "agentPoolName",
+            "in": "path",
+            "description": "The name of the agent pool.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 12,
+            "pattern": "^[a-z][a-z0-9]{0,11}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MachineListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Machines in an Agentpool by Managed Cluster": {
+            "$ref": "./examples/MachineList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/agentPools/{agentPoolName}/machines/{machineName}": {
+      "get": {
+        "operationId": "Machines_Get",
+        "tags": [
+          "Machines"
+        ],
+        "description": "Get a specific machine in the specified agent pool.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "agentPoolName",
+            "in": "path",
+            "description": "The name of the agent pool.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 12,
+            "pattern": "^[a-z][a-z0-9]{0,11}$"
+          },
+          {
+            "name": "machineName",
+            "in": "path",
+            "description": "Host name of the machine.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9]{0,11}$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,39}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Machine"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get a Machine in an Agent Pools by Managed Cluster": {
+            "$ref": "./examples/MachineGet.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/agentPools/{agentPoolName}/upgradeNodeImageVersion": {
+      "post": {
+        "operationId": "AgentPools_UpgradeNodeImageVersion",
+        "tags": [
+          "AgentPools"
+        ],
+        "summary": "Upgrades the node image version of an agent pool to the latest.",
+        "description": "Upgrading the node image version of an agent pool applies the newest OS and runtime updates to the nodes. AKS provides one new image per week with the latest updates. For more details on node image versions, see: https://docs.microsoft.com/azure/aks/node-image-upgrade",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "agentPoolName",
+            "in": "path",
+            "description": "The name of the agent pool.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 12,
+            "pattern": "^[a-z][a-z0-9]{0,11}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/AgentPool"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Upgrade Agent Pool Node Image Version": {
+            "$ref": "./examples/AgentPoolsUpgradeNodeImageVersion.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/agentPools/{agentPoolName}/upgradeProfiles/default": {
+      "get": {
+        "operationId": "AgentPools_GetUpgradeProfile",
+        "tags": [
+          "AgentPools"
+        ],
+        "description": "Gets the upgrade profile for an agent pool.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "agentPoolName",
+            "in": "path",
+            "description": "The name of the agent pool.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 12,
+            "pattern": "^[a-z][a-z0-9]{0,11}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AgentPoolUpgradeProfile"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Upgrade Profile for Agent Pool": {
+            "$ref": "./examples/AgentPoolsGetUpgradeProfile.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/availableAgentPoolVersions": {
+      "get": {
+        "operationId": "AgentPools_GetAvailableAgentPoolVersions",
+        "tags": [
+          "AgentPools"
+        ],
+        "summary": "Gets a list of supported Kubernetes versions for the specified agent pool.",
+        "description": "See [supported Kubernetes versions](https://docs.microsoft.com/azure/aks/supported-kubernetes-versions) for more details about the version lifecycle.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AgentPoolAvailableVersions"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get available versions for agent pool": {
+            "$ref": "./examples/AgentPoolsGetAgentPoolAvailableVersions.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/commandResults/{commandId}": {
+      "get": {
+        "operationId": "ManagedClusters_GetCommandResult",
+        "tags": [
+          "ManagedClusters"
+        ],
+        "description": "Gets the results of a command which has been run on the Managed Cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "commandId",
+            "in": "path",
+            "description": "Id of the command.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RunCommandResult"
+            }
+          },
+          "202": {
+            "description": "Azure operation completed successfully.",
+            "headers": {
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "commandFailedResult": {
+            "$ref": "./examples/RunCommandResultFailed.json"
+          },
+          "commandSucceedResult": {
+            "$ref": "./examples/RunCommandResultSucceed.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/listClusterAdminCredential": {
+      "post": {
+        "operationId": "ManagedClusters_ListClusterAdminCredentials",
+        "tags": [
+          "ManagedClusters"
+        ],
+        "description": "Lists the admin credentials of a managed cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "server-fqdn",
+            "in": "query",
+            "description": "server fqdn type for credentials to be returned",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CredentialResults"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Managed Cluster": {
+            "$ref": "./examples/ManagedClustersListClusterAdminCredentials.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/listClusterMonitoringUserCredential": {
+      "post": {
+        "operationId": "ManagedClusters_ListClusterMonitoringUserCredentials",
+        "tags": [
+          "ManagedClusters"
+        ],
+        "description": "Lists the cluster monitoring user credentials of a managed cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "server-fqdn",
+            "in": "query",
+            "description": "server fqdn type for credentials to be returned",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CredentialResults"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Managed Cluster": {
+            "$ref": "./examples/ManagedClustersListClusterMonitoringUserCredentials.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/listClusterUserCredential": {
+      "post": {
+        "operationId": "ManagedClusters_ListClusterUserCredentials",
+        "tags": [
+          "ManagedClusters"
+        ],
+        "description": "Lists the user credentials of a managed cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "server-fqdn",
+            "in": "query",
+            "description": "server fqdn type for credentials to be returned",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "description": "Only apply to AAD clusters, specifies the format of returned kubeconfig. Format 'azure' will return azure auth-provider kubeconfig; format 'exec' will return exec format kubeconfig, which requires kubelogin binary in the path.",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "azure",
+              "exec"
+            ],
+            "x-ms-enum": {
+              "name": "Format",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "azure",
+                  "value": "azure",
+                  "description": "Return azure auth-provider kubeconfig. This format is deprecated in v1.22 and will be fully removed in v1.26. See: https://aka.ms/k8s/changes-1-26."
+                },
+                {
+                  "name": "exec",
+                  "value": "exec",
+                  "description": "Return exec format kubeconfig. This format requires kubelogin binary in the path."
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CredentialResults"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Managed Cluster": {
+            "$ref": "./examples/ManagedClustersListClusterUserCredentials.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/maintenanceConfigurations": {
+      "get": {
+        "operationId": "MaintenanceConfigurations_ListByManagedCluster",
+        "tags": [
+          "MaintenanceConfigurations"
+        ],
+        "description": "Gets a list of maintenance configurations in the specified managed cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MaintenanceConfigurationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List maintenance configurations configured with maintenance window by Managed Cluster": {
+            "$ref": "./examples/MaintenanceConfigurationsList_MaintenanceWindow.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/maintenanceConfigurations/{configName}": {
+      "get": {
+        "operationId": "MaintenanceConfigurations_Get",
+        "tags": [
+          "MaintenanceConfigurations"
+        ],
+        "description": "Gets the specified maintenance configuration of a managed cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "configName",
+            "in": "path",
+            "description": "The name of the maintenance configuration. Supported values are 'default', 'aksManagedAutoUpgradeSchedule', or 'aksManagedNodeOSUpgradeSchedule'.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MaintenanceConfiguration"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Maintenance Configuration Configured With Maintenance Window": {
+            "$ref": "./examples/MaintenanceConfigurationsGet_MaintenanceWindow.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "MaintenanceConfigurations_CreateOrUpdate",
+        "tags": [
+          "MaintenanceConfigurations"
+        ],
+        "description": "Creates or updates a maintenance configuration in the specified managed cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "configName",
+            "in": "path",
+            "description": "The name of the maintenance configuration. Supported values are 'default', 'aksManagedAutoUpgradeSchedule', or 'aksManagedNodeOSUpgradeSchedule'.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The maintenance configuration to create or update.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/MaintenanceConfiguration"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'MaintenanceConfiguration' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/MaintenanceConfiguration"
+            }
+          },
+          "201": {
+            "description": "Resource 'MaintenanceConfiguration' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/MaintenanceConfiguration"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create/Update Maintenance Configuration with Maintenance Window": {
+            "$ref": "./examples/MaintenanceConfigurationsCreate_Update_MaintenanceWindow.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "MaintenanceConfigurations_Delete",
+        "tags": [
+          "MaintenanceConfigurations"
+        ],
+        "description": "Deletes a maintenance configuration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "configName",
+            "in": "path",
+            "description": "The name of the maintenance configuration. Supported values are 'default', 'aksManagedAutoUpgradeSchedule', or 'aksManagedNodeOSUpgradeSchedule'.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Maintenance Configuration For Node OS Upgrade": {
+            "$ref": "./examples/MaintenanceConfigurationsDelete_MaintenanceWindow.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/managedNamespaces": {
+      "get": {
+        "operationId": "ManagedNamespaces_ListByManagedCluster",
+        "tags": [
+          "ManagedNamespaces"
+        ],
+        "description": "Gets a list of managed namespaces in the specified managed cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ManagedNamespaceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List namespaces by Managed Cluster": {
+            "$ref": "./examples/ManagedNamespacesList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/managedNamespaces/{managedNamespaceName}": {
+      "get": {
+        "operationId": "ManagedNamespaces_Get",
+        "tags": [
+          "ManagedNamespaces"
+        ],
+        "description": "Gets the specified namespace of a managed cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "managedNamespaceName",
+            "in": "path",
+            "description": "The name of the managed namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "[a-z0-9]([-a-z0-9]*[a-z0-9])?"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ManagedNamespace"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Managed Namespace": {
+            "$ref": "./examples/ManagedNamespacesGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "ManagedNamespaces_CreateOrUpdate",
+        "tags": [
+          "ManagedNamespaces"
+        ],
+        "description": "Creates or updates a namespace managed by ARM for the specified managed cluster. Users can configure aspects like resource quotas, network ingress/egress policies, and more. See aka.ms/aks/managed-namespaces for more details.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "managedNamespaceName",
+            "in": "path",
+            "description": "The name of the managed namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "[a-z0-9]([-a-z0-9]*[a-z0-9])?"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The namespace to create or update.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ManagedNamespace"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ManagedNamespace' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ManagedNamespace"
+            }
+          },
+          "201": {
+            "description": "Resource 'ManagedNamespace' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ManagedNamespace"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create/Update Managed Namespace": {
+            "$ref": "./examples/ManagedNamespacesCreate_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ManagedNamespace"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "ManagedNamespaces_Update",
+        "tags": [
+          "ManagedNamespaces"
+        ],
+        "description": "Updates tags on a managed namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "managedNamespaceName",
+            "in": "path",
+            "description": "The name of the managed namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "[a-z0-9]([-a-z0-9]*[a-z0-9])?"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the patch namespace operation, we only support patch tags for now.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ManagedNamespace"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update Managed Namespace Tags": {
+            "$ref": "./examples/ManagedNamespacesUpdateTags.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "ManagedNamespaces_Delete",
+        "tags": [
+          "ManagedNamespaces"
+        ],
+        "description": "Deletes a namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "managedNamespaceName",
+            "in": "path",
+            "description": "The name of the managed namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "[a-z0-9]([-a-z0-9]*[a-z0-9])?"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Managed Namespace": {
+            "$ref": "./examples/ManagedNamespacesDelete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/managedNamespaces/{managedNamespaceName}/listCredential": {
+      "post": {
+        "operationId": "ManagedNamespaces_ListCredential",
+        "tags": [
+          "ManagedNamespaces"
+        ],
+        "description": "Lists the credentials of a namespace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "managedNamespaceName",
+            "in": "path",
+            "description": "The name of the managed namespace.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "[a-z0-9]([-a-z0-9]*[a-z0-9])?"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CredentialResults"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List managed namespace credentials": {
+            "$ref": "./examples/ManagedNamespacesListCredentialResult.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/meshUpgradeProfiles": {
+      "get": {
+        "operationId": "ManagedClusters_ListMeshUpgradeProfiles",
+        "tags": [
+          "ManagedClusters"
+        ],
+        "description": "Lists available upgrades for all service meshes in a specific cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MeshUpgradeProfileList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Lists version compatibility and upgrade profile for all service meshes in a cluster": {
+            "$ref": "./examples/ManagedClustersList_MeshUpgradeProfiles.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/meshUpgradeProfiles/{mode}": {
+      "get": {
+        "operationId": "ManagedClusters_GetMeshUpgradeProfile",
+        "tags": [
+          "ManagedClusters"
+        ],
+        "description": "Gets available upgrades for a service mesh in a cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "mode",
+            "in": "path",
+            "description": "The mode of the mesh.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 24,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MeshUpgradeProfile"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Gets version compatibility and upgrade profile for a service mesh in a cluster": {
+            "$ref": "./examples/ManagedClustersGet_MeshUpgradeProfile.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/outboundNetworkDependenciesEndpoints": {
+      "get": {
+        "operationId": "ManagedClusters_ListOutboundNetworkDependenciesEndpoints",
+        "tags": [
+          "ManagedClusters"
+        ],
+        "summary": "Gets a list of egress endpoints (network endpoints of all outbound dependencies) in the specified managed cluster.",
+        "description": "Gets a list of egress endpoints (network endpoints of all outbound dependencies) in the specified managed cluster. The operation returns properties of each egress endpoint.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/OutboundEnvironmentEndpointCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List OutboundNetworkDependenciesEndpoints by Managed Cluster": {
+            "$ref": "./examples/OutboundNetworkDependenciesEndpointsList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/privateEndpointConnections": {
+      "get": {
+        "operationId": "PrivateEndpointConnections_List",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "summary": "Gets a list of private endpoint connections in the specified managed cluster.",
+        "description": "To learn more about private clusters, see: https://docs.microsoft.com/azure/aks/private-clusters",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnectionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Private Endpoint Connections by Managed Cluster": {
+            "$ref": "./examples/PrivateEndpointConnectionsList.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/privateEndpointConnections/{privateEndpointConnectionName}": {
+      "get": {
+        "operationId": "PrivateEndpointConnections_Get",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "summary": "Gets the specified private endpoint connection.",
+        "description": "To learn more about private clusters, see: https://docs.microsoft.com/azure/aks/private-clusters",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The name of the private endpoint connection.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Private Endpoint Connection": {
+            "$ref": "./examples/PrivateEndpointConnectionsGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "PrivateEndpointConnections_Update",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "Updates a private endpoint connection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The name of the private endpoint connection.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The updated private endpoint connection.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'PrivateEndpointConnection' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "201": {
+            "description": "Resource 'PrivateEndpointConnection' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update Private Endpoint Connection": {
+            "$ref": "./examples/PrivateEndpointConnectionsUpdate.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "PrivateEndpointConnections_Delete",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "Deletes a private endpoint connection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The name of the private endpoint connection.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Private Endpoint Connection": {
+            "$ref": "./examples/PrivateEndpointConnectionsDelete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/privateLinkResources": {
+      "get": {
+        "operationId": "PrivateLinkResources_List",
+        "tags": [
+          "privateLinkResources"
+        ],
+        "summary": "Gets a list of private link resources in the specified managed cluster.",
+        "description": "To learn more about private clusters, see: https://docs.microsoft.com/azure/aks/private-clusters",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateLinkResourcesListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Private Link Resources by Managed Cluster": {
+            "$ref": "./examples/PrivateLinkResourcesList.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/resetAADProfile": {
+      "post": {
+        "operationId": "ManagedClusters_ResetAADProfile",
+        "tags": [
+          "ManagedClusters"
+        ],
+        "summary": "Reset the AAD Profile of a managed cluster.",
+        "description": "**WARNING**: This API will be deprecated. Please see [AKS-managed Azure Active Directory integration](https://aka.ms/aks-managed-aad) to update your cluster with AKS-managed Azure AD.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The AAD profile to set on the Managed Cluster",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ManagedClusterAADProfile"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "deprecated": true,
+        "x-ms-examples": {
+          "Reset AAD Profile": {
+            "$ref": "./examples/ManagedClustersResetAADProfile.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/resetServicePrincipalProfile": {
+      "post": {
+        "operationId": "ManagedClusters_ResetServicePrincipalProfile",
+        "tags": [
+          "ManagedClusters"
+        ],
+        "summary": "Reset the Service Principal Profile of a managed cluster.",
+        "description": "This action cannot be performed on a cluster that is not using a service principal",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The service principal profile to set on the managed cluster.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ManagedClusterServicePrincipalProfile"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Reset Service Principal Profile": {
+            "$ref": "./examples/ManagedClustersResetServicePrincipalProfile.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/resolvePrivateLinkServiceId": {
+      "post": {
+        "operationId": "ResolvePrivateLinkServiceId_POST",
+        "tags": [
+          "resolvePrivateLinkServiceId"
+        ],
+        "description": "Gets the private link service ID for the specified managed cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters required in order to resolve a private link service ID.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PrivateLinkResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateLinkResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Resolve the Private Link Service ID for Managed Cluster": {
+            "$ref": "./examples/ResolvePrivateLinkServiceId.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/rotateClusterCertificates": {
+      "post": {
+        "operationId": "ManagedClusters_RotateClusterCertificates",
+        "tags": [
+          "ManagedClusters"
+        ],
+        "summary": "Rotates the certificates of a managed cluster.",
+        "description": "See [Certificate rotation](https://docs.microsoft.com/azure/aks/certificate-rotation) for more details about rotating managed cluster certificates.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Rotate Cluster Certificates": {
+            "$ref": "./examples/ManagedClustersRotateClusterCertificates.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/rotateServiceAccountSigningKeys": {
+      "post": {
+        "operationId": "ManagedClusters_RotateServiceAccountSigningKeys",
+        "tags": [
+          "ManagedClusters"
+        ],
+        "description": "Rotates the service account signing keys of a managed cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Rotate Cluster Service Account Signing Keys": {
+            "$ref": "./examples/ManagedClustersRotateServiceAccountSigningKeys.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/runCommand": {
+      "post": {
+        "operationId": "ManagedClusters_RunCommand",
+        "tags": [
+          "ManagedClusters"
+        ],
+        "summary": "Submits a command to run against the Managed Cluster.",
+        "description": "AKS will create a pod to run the command. This is primarily useful for private clusters. For more information see [AKS Run Command](https://docs.microsoft.com/azure/aks/private-clusters#aks-run-command-preview).",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "requestPayload",
+            "in": "body",
+            "description": "The run command request",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RunCommandRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RunCommandResult"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "submitNewCommand": {
+            "$ref": "./examples/RunCommandRequest.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/RunCommandResult"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/start": {
+      "post": {
+        "operationId": "ManagedClusters_Start",
+        "tags": [
+          "ManagedClusters"
+        ],
+        "summary": "Starts a previously stopped Managed Cluster",
+        "description": "See [starting a cluster](https://docs.microsoft.com/azure/aks/start-stop-cluster) for more details about starting a cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Start Managed Cluster": {
+            "$ref": "./examples/ManagedClustersStart.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/stop": {
+      "post": {
+        "operationId": "ManagedClusters_Stop",
+        "tags": [
+          "ManagedClusters"
+        ],
+        "summary": "Stops a Managed Cluster",
+        "description": "This can only be performed on Azure Virtual Machine Scale set backed clusters. Stopping a cluster stops the control plane and agent nodes entirely, while maintaining all object and cluster state. A cluster does not accrue charges while it is stopped. See [stopping a cluster](https://docs.microsoft.com/azure/aks/start-stop-cluster) for more details about stopping a cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Stop Managed Cluster": {
+            "$ref": "./examples/ManagedClustersStop.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/trustedAccessRoleBindings": {
+      "get": {
+        "operationId": "TrustedAccessRoleBindings_List",
+        "tags": [
+          "TrustedAccess"
+        ],
+        "description": "List trusted access role bindings.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/TrustedAccessRoleBindingListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List trusted access role bindings": {
+            "$ref": "./examples/TrustedAccessRoleBindings_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/trustedAccessRoleBindings/{trustedAccessRoleBindingName}": {
+      "get": {
+        "operationId": "TrustedAccessRoleBindings_Get",
+        "tags": [
+          "TrustedAccess"
+        ],
+        "description": "Get a trusted access role binding.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "trustedAccessRoleBindingName",
+            "in": "path",
+            "description": "The name of trusted access role binding.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 24,
+            "pattern": "^([A-Za-z0-9-])+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/TrustedAccessRoleBinding"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get a trusted access role binding": {
+            "$ref": "./examples/TrustedAccessRoleBindings_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "TrustedAccessRoleBindings_CreateOrUpdate",
+        "tags": [
+          "TrustedAccess"
+        ],
+        "description": "Create or update a trusted access role binding",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "trustedAccessRoleBindingName",
+            "in": "path",
+            "description": "The name of trusted access role binding.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 24,
+            "pattern": "^([A-Za-z0-9-])+$"
+          },
+          {
+            "name": "trustedAccessRoleBinding",
+            "in": "body",
+            "description": "A trusted access role binding",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/TrustedAccessRoleBinding"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'TrustedAccessRoleBinding' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/TrustedAccessRoleBinding"
+            }
+          },
+          "201": {
+            "description": "Resource 'TrustedAccessRoleBinding' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/TrustedAccessRoleBinding"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create or update a trusted access role binding": {
+            "$ref": "./examples/TrustedAccessRoleBindings_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/TrustedAccessRoleBinding"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "TrustedAccessRoleBindings_Delete",
+        "tags": [
+          "TrustedAccess"
+        ],
+        "description": "Delete a trusted access role binding.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "trustedAccessRoleBindingName",
+            "in": "path",
+            "description": "The name of trusted access role binding.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 24,
+            "pattern": "^([A-Za-z0-9-])+$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete a trusted access role binding": {
+            "$ref": "./examples/TrustedAccessRoleBindings_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/upgradeProfiles/default": {
+      "get": {
+        "operationId": "ManagedClusters_GetUpgradeProfile",
+        "tags": [
+          "ManagedClusters"
+        ],
+        "description": "Gets the upgrade profile of a managed cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ManagedClusterUpgradeProfile"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Upgrade Profile for Managed Cluster": {
+            "$ref": "./examples/ManagedClustersGetUpgradeProfile.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/snapshots": {
+      "get": {
+        "operationId": "Snapshots_ListByResourceGroup",
+        "tags": [
+          "Snapshots"
+        ],
+        "description": "Lists snapshots in the specified subscription and resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SnapshotListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Snapshots by Resource Group": {
+            "$ref": "./examples/SnapshotsListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/snapshots/{resourceName}": {
+      "get": {
+        "operationId": "Snapshots_Get",
+        "tags": [
+          "Snapshots"
+        ],
+        "description": "Gets a snapshot.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Snapshot"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Snapshot": {
+            "$ref": "./examples/SnapshotsGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Snapshots_CreateOrUpdate",
+        "tags": [
+          "Snapshots"
+        ],
+        "description": "Creates or updates a snapshot.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The snapshot to create or update.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Snapshot"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Snapshot' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Snapshot"
+            }
+          },
+          "201": {
+            "description": "Resource 'Snapshot' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Snapshot"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create/Update Snapshot": {
+            "$ref": "./examples/SnapshotsCreate.json"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "Snapshots_UpdateTags",
+        "tags": [
+          "Snapshots"
+        ],
+        "description": "Updates tags on a snapshot.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the Update snapshot Tags operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Snapshot"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update Snapshot Tags": {
+            "$ref": "./examples/SnapshotsUpdateTags.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Snapshots_Delete",
+        "tags": [
+          "Snapshots"
+        ],
+        "description": "Deletes a snapshot.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Snapshot": {
+            "$ref": "./examples/SnapshotsDelete.json"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "AbsoluteMonthlySchedule": {
+      "type": "object",
+      "description": "For schedules like: 'recur every month on the 15th' or 'recur every 3 months on the 20th'.",
+      "properties": {
+        "intervalMonths": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Specifies the number of months between each set of occurrences.",
+          "minimum": 1,
+          "maximum": 6
+        },
+        "dayOfMonth": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The date of the month.",
+          "minimum": 1,
+          "maximum": 31
+        }
+      },
+      "required": [
+        "intervalMonths",
+        "dayOfMonth"
+      ]
+    },
+    "AccessProfile": {
+      "type": "object",
+      "description": "Profile for enabling a user to access a managed cluster.",
+      "properties": {
+        "kubeConfig": {
+          "type": "string",
+          "format": "byte",
+          "description": "Base64-encoded Kubernetes configuration file."
+        }
+      }
+    },
+    "AdoptionPolicy": {
+      "type": "string",
+      "description": "Action if Kubernetes namespace with same name already exists.",
+      "enum": [
+        "Never",
+        "IfIdentical",
+        "Always"
+      ],
+      "x-ms-enum": {
+        "name": "AdoptionPolicy",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Never",
+            "value": "Never",
+            "description": "If the namespace already exists in Kubernetes, attempts to create that same namespace in ARM will fail."
+          },
+          {
+            "name": "IfIdentical",
+            "value": "IfIdentical",
+            "description": "Take over the existing namespace to be managed by ARM, if there is no difference."
+          },
+          {
+            "name": "Always",
+            "value": "Always",
+            "description": "Always take over the existing namespace to be managed by ARM, some fields might be overwritten."
+          }
+        ]
+      }
+    },
+    "AdvancedNetworkPolicies": {
+      "type": "string",
+      "description": "Enable advanced network policies. This allows users to configure Layer 7 network policies (FQDN, HTTP, Kafka). Policies themselves must be configured via the Cilium Network Policy resources, see https://docs.cilium.io/en/latest/security/policy/index.html. This can be enabled only on cilium-based clusters. If not specified, the default value is FQDN if security.enabled is set to true.",
+      "enum": [
+        "L7",
+        "FQDN",
+        "None"
+      ],
+      "x-ms-enum": {
+        "name": "AdvancedNetworkPolicies",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "L7",
+            "value": "L7",
+            "description": "Enable Layer7 network policies (FQDN, HTTP/S, Kafka). This option is a superset of the FQDN option."
+          },
+          {
+            "name": "FQDN",
+            "value": "FQDN",
+            "description": "Enable FQDN based network policies"
+          },
+          {
+            "name": "None",
+            "value": "None",
+            "description": "Disable Layer 7 network policies (FQDN, HTTP/S, Kafka)"
+          }
+        ]
+      }
+    },
+    "AdvancedNetworking": {
+      "type": "object",
+      "description": "Advanced Networking profile for enabling observability and security feature suite on a cluster. For more information see aka.ms/aksadvancednetworking.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Indicates the enablement of Advanced Networking functionalities of observability and security on AKS clusters. When this is set to true, all observability and security features will be set to enabled unless explicitly disabled. If not specified, the default is false."
+        },
+        "observability": {
+          "$ref": "#/definitions/AdvancedNetworkingObservability",
+          "description": "Observability profile to enable advanced network metrics and flow logs with historical contexts."
+        },
+        "security": {
+          "$ref": "#/definitions/AdvancedNetworkingSecurity",
+          "description": "Security profile to enable security features on cilium based cluster."
+        },
+        "performance": {
+          "$ref": "#/definitions/AdvancedNetworkingPerformance",
+          "description": "Profile to enable performance-enhancing features on clusters that use Azure CNI powered by Cilium."
+        }
+      }
+    },
+    "AdvancedNetworkingObservability": {
+      "type": "object",
+      "description": "Observability profile to enable advanced network metrics and flow logs with historical contexts.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Indicates the enablement of Advanced Networking observability functionalities on clusters."
+        }
+      }
+    },
+    "AdvancedNetworkingPerformance": {
+      "type": "object",
+      "description": "Profile to enable performance-enhancing features on clusters that use Azure CNI powered by Cilium.",
+      "properties": {
+        "accelerationMode": {
+          "type": "string",
+          "description": "Enable advanced network acceleration options. This allows users to configure acceleration using BPF host routing. This can be enabled only with Cilium dataplane. If not specified, the default value is None (no acceleration). The acceleration mode can be changed on a pre-existing cluster. See https://aka.ms/acnsperformance for a detailed explanation",
+          "default": "None",
+          "enum": [
+            "BpfVeth",
+            "None"
+          ],
+          "x-ms-enum": {
+            "name": "AccelerationMode",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "BpfVeth",
+                "value": "BpfVeth",
+                "description": "Enable eBPF host routing with veth device mode."
+              },
+              {
+                "name": "None",
+                "value": "None",
+                "description": "Disable acceleration options."
+              }
+            ]
+          }
+        }
+      }
+    },
+    "AdvancedNetworkingSecurity": {
+      "type": "object",
+      "description": "Security profile to enable security features on cilium based cluster.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "This feature allows user to configure network policy based on DNS (FQDN) names. It can be enabled only on cilium based clusters. If not specified, the default is false."
+        },
+        "advancedNetworkPolicies": {
+          "$ref": "#/definitions/AdvancedNetworkPolicies",
+          "description": "Enable advanced network policies. This allows users to configure Layer 7 network policies (FQDN, HTTP, Kafka). Policies themselves must be configured via the Cilium Network Policy resources, see https://docs.cilium.io/en/latest/security/policy/index.html. This can be enabled only on cilium-based clusters. If not specified, the default value is FQDN if security.enabled is set to true."
+        },
+        "transitEncryption": {
+          "$ref": "#/definitions/AdvancedNetworkingSecurityTransitEncryption",
+          "description": "Encryption configuration for Cilium-based clusters. Once enabled all traffic between Cilium managed pods will be encrypted when it leaves the node boundary."
+        }
+      }
+    },
+    "AdvancedNetworkingSecurityTransitEncryption": {
+      "type": "object",
+      "description": "Encryption configuration for Cilium-based clusters. Once enabled all traffic between Cilium managed pods will be encrypted when it leaves the node boundary.",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/TransitEncryptionType",
+          "description": "Configures pod-to-pod encryption. This can be enabled only on Cilium-based clusters. If not specified, the default value is None."
+        }
+      }
+    },
+    "AgentPool": {
+      "type": "object",
+      "description": "Agent Pool.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ManagedClusterAgentPoolProfileProperties",
+          "description": "Properties of an agent pool.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "AgentPoolAvailableVersions": {
+      "type": "object",
+      "description": "The list of available versions for an agent pool.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The ID of the agent pool version list.",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the agent pool version list.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the agent pool version list.",
+          "readOnly": true
+        },
+        "properties": {
+          "$ref": "#/definitions/AgentPoolAvailableVersionsProperties",
+          "description": "Properties of agent pool available versions.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "required": [
+        "properties"
+      ]
+    },
+    "AgentPoolAvailableVersionsProperties": {
+      "type": "object",
+      "description": "The list of available agent pool versions.",
+      "properties": {
+        "agentPoolVersions": {
+          "type": "array",
+          "description": "List of versions available for agent pool.",
+          "items": {
+            "$ref": "#/definitions/AgentPoolAvailableVersionsPropertiesAgentPoolVersionsItem"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "AgentPoolAvailableVersionsPropertiesAgentPoolVersionsItem": {
+      "type": "object",
+      "description": "Available version information for an agent pool.",
+      "properties": {
+        "default": {
+          "type": "boolean",
+          "description": "Whether this version is the default agent pool version."
+        },
+        "kubernetesVersion": {
+          "type": "string",
+          "description": "The Kubernetes version (major.minor.patch)."
+        },
+        "isPreview": {
+          "type": "boolean",
+          "description": "Whether Kubernetes version is currently in preview."
+        }
+      }
+    },
+    "AgentPoolDeleteMachinesParameter": {
+      "type": "object",
+      "description": "Specifies a list of machine names from the agent pool to be deleted.",
+      "properties": {
+        "machineNames": {
+          "type": "array",
+          "description": "The agent pool machine names.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "machineNames"
+      ]
+    },
+    "AgentPoolGatewayProfile": {
+      "type": "object",
+      "description": "Profile of the managed cluster gateway agent pool.",
+      "properties": {
+        "publicIPPrefixSize": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The Gateway agent pool associates one public IPPrefix for each static egress gateway to provide public egress. The size of Public IPPrefix should be selected by the user. Each node in the agent pool is assigned with one IP from the IPPrefix. The IPPrefix size thus serves as a cap on the size of the Gateway agent pool. Due to Azure public IPPrefix size limitation, the valid value range is [28, 31] (/31 = 2 nodes/IPs, /30 = 4 nodes/IPs, /29 = 8 nodes/IPs, /28 = 16 nodes/IPs). The default value is 31.",
+          "default": 31,
+          "minimum": 28,
+          "maximum": 31
+        }
+      }
+    },
+    "AgentPoolListResult": {
+      "type": "object",
+      "description": "The response of a AgentPool list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The AgentPool items on this page",
+          "items": {
+            "$ref": "#/definitions/AgentPool"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "AgentPoolMode": {
+      "type": "string",
+      "description": "The mode of an agent pool. A cluster must have at least one 'System' Agent Pool at all times. For additional information on agent pool restrictions and best practices, see: https://docs.microsoft.com/azure/aks/use-system-pools",
+      "enum": [
+        "System",
+        "User",
+        "Gateway"
+      ],
+      "x-ms-enum": {
+        "name": "AgentPoolMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "System",
+            "value": "System",
+            "description": "System agent pools are primarily for hosting critical system pods such as CoreDNS and metrics-server. System agent pools osType must be Linux. System agent pools VM SKU must have at least 2vCPUs and 4GB of memory."
+          },
+          {
+            "name": "User",
+            "value": "User",
+            "description": "User agent pools are primarily for hosting your application pods."
+          },
+          {
+            "name": "Gateway",
+            "value": "Gateway",
+            "description": "Gateway agent pools are dedicated to providing static egress IPs to pods. For more details, see https://aka.ms/aks/static-egress-gateway."
+          }
+        ]
+      }
+    },
+    "AgentPoolNetworkProfile": {
+      "type": "object",
+      "description": "Network settings of an agent pool.",
+      "properties": {
+        "nodePublicIPTags": {
+          "type": "array",
+          "description": "IPTags of instance-level public IPs.",
+          "items": {
+            "$ref": "#/definitions/IPTag"
+          },
+          "x-ms-identifiers": []
+        },
+        "allowedHostPorts": {
+          "type": "array",
+          "description": "The port ranges that are allowed to access. The specified ranges are allowed to overlap.",
+          "items": {
+            "$ref": "#/definitions/PortRange"
+          },
+          "x-ms-identifiers": []
+        },
+        "applicationSecurityGroups": {
+          "type": "array",
+          "description": "The IDs of the application security groups which agent pool will associate when created.",
+          "items": {
+            "type": "string",
+            "format": "arm-id",
+            "description": "A type definition that refers the id to an Azure Resource Manager resource.",
+            "x-ms-arm-id-details": {
+              "allowedResources": [
+                {
+                  "type": "Microsoft.Network/applicationSecurityGroups"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "AgentPoolSSHAccess": {
+      "type": "string",
+      "description": "SSH access method of an agent pool.",
+      "enum": [
+        "LocalUser",
+        "Disabled"
+      ],
+      "x-ms-enum": {
+        "name": "AgentPoolSSHAccess",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "LocalUser",
+            "value": "LocalUser",
+            "description": "Can SSH onto the node as a local user using private key."
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "SSH service will be turned off on the node."
+          }
+        ]
+      }
+    },
+    "AgentPoolSecurityProfile": {
+      "type": "object",
+      "description": "The security settings of an agent pool.",
+      "properties": {
+        "enableVTPM": {
+          "type": "boolean",
+          "description": "vTPM is a Trusted Launch feature for configuring a dedicated secure vault for keys and measurements held locally on the node. For more details, see aka.ms/aks/trustedlaunch. If not specified, the default is false."
+        },
+        "enableSecureBoot": {
+          "type": "boolean",
+          "description": "Secure Boot is a feature of Trusted Launch which ensures that only signed operating systems and drivers can boot. For more details, see aka.ms/aks/trustedlaunch.  If not specified, the default is false."
+        },
+        "sshAccess": {
+          "$ref": "#/definitions/AgentPoolSSHAccess",
+          "description": "SSH access method of an agent pool."
+        }
+      }
+    },
+    "AgentPoolStatus": {
+      "type": "object",
+      "description": "Contains read-only information about the Agent Pool.",
+      "properties": {
+        "provisioningError": {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorDetail",
+          "description": "The error detail information of the agent pool. Preserves the detailed info of failure. If there was no error, this field is omitted.",
+          "readOnly": true
+        }
+      }
+    },
+    "AgentPoolType": {
+      "type": "string",
+      "description": "The type of Agent Pool.",
+      "enum": [
+        "VirtualMachineScaleSets",
+        "AvailabilitySet",
+        "VirtualMachines"
+      ],
+      "x-ms-enum": {
+        "name": "AgentPoolType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "VirtualMachineScaleSets",
+            "value": "VirtualMachineScaleSets",
+            "description": "Create an Agent Pool backed by a Virtual Machine Scale Set."
+          },
+          {
+            "name": "AvailabilitySet",
+            "value": "AvailabilitySet",
+            "description": "Use of this is strongly discouraged."
+          },
+          {
+            "name": "VirtualMachines",
+            "value": "VirtualMachines",
+            "description": "Create an Agent Pool backed by a Single Instance VM orchestration mode."
+          }
+        ]
+      }
+    },
+    "AgentPoolUpgradeProfile": {
+      "type": "object",
+      "description": "The list of available upgrades for an agent pool.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AgentPoolUpgradeProfileProperties",
+          "description": "The properties of the agent pool upgrade profile.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "AgentPoolUpgradeProfileProperties": {
+      "type": "object",
+      "description": "The list of available upgrade versions.",
+      "properties": {
+        "kubernetesVersion": {
+          "type": "string",
+          "description": "The Kubernetes version (major.minor.patch)."
+        },
+        "osType": {
+          "type": "string",
+          "description": "The operating system type. The default is Linux.",
+          "default": "Linux",
+          "enum": [
+            "Linux",
+            "Windows"
+          ],
+          "x-ms-enum": {
+            "name": "OSType",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Linux",
+                "value": "Linux",
+                "description": "Use Linux."
+              },
+              {
+                "name": "Windows",
+                "value": "Windows",
+                "description": "Use Windows."
+              }
+            ]
+          }
+        },
+        "upgrades": {
+          "type": "array",
+          "description": "List of orchestrator types and versions available for upgrade.",
+          "items": {
+            "$ref": "#/definitions/AgentPoolUpgradeProfilePropertiesUpgradesItem"
+          },
+          "x-ms-identifiers": []
+        },
+        "latestNodeImageVersion": {
+          "type": "string",
+          "description": "The latest AKS supported node image version."
+        }
+      },
+      "required": [
+        "kubernetesVersion",
+        "osType"
+      ]
+    },
+    "AgentPoolUpgradeProfilePropertiesUpgradesItem": {
+      "type": "object",
+      "description": "Available upgrades for an AgentPool.",
+      "properties": {
+        "kubernetesVersion": {
+          "type": "string",
+          "description": "The Kubernetes version (major.minor.patch)."
+        },
+        "isPreview": {
+          "type": "boolean",
+          "description": "Whether the Kubernetes version is currently in preview."
+        }
+      }
+    },
+    "AgentPoolUpgradeSettings": {
+      "type": "object",
+      "description": "Settings for upgrading an agentpool",
+      "properties": {
+        "maxSurge": {
+          "type": "string",
+          "description": "The maximum number or percentage of nodes that are surged during upgrade. This can either be set to an integer (e.g. '5') or a percentage (e.g. '50%'). If a percentage is specified, it is the percentage of the total agent pool size at the time of the upgrade. For percentages, fractional nodes are rounded up. If not specified, the default is 10%. For more information, including best practices, see: https://learn.microsoft.com/en-us/azure/aks/upgrade-cluster"
+        },
+        "maxUnavailable": {
+          "type": "string",
+          "description": "The maximum number or percentage of nodes that can be simultaneously unavailable during upgrade. This can either be set to an integer (e.g. '1') or a percentage (e.g. '5%'). If a percentage is specified, it is the percentage of the total agent pool size at the time of the upgrade. For percentages, fractional nodes are rounded up. If not specified, the default is 0. For more information, including best practices, see: https://learn.microsoft.com/en-us/azure/aks/upgrade-cluster"
+        },
+        "drainTimeoutInMinutes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The drain timeout for a node. The amount of time (in minutes) to wait on eviction of pods and graceful termination per node. This eviction wait time honors waiting on pod disruption budgets. If this time is exceeded, the upgrade fails. If not specified, the default is 30 minutes.",
+          "minimum": 1,
+          "maximum": 1440
+        },
+        "nodeSoakDurationInMinutes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The soak duration for a node. The amount of time (in minutes) to wait after draining a node and before reimaging it and moving on to next node. If not specified, the default is 0 minutes.",
+          "minimum": 0,
+          "maximum": 30
+        },
+        "undrainableNodeBehavior": {
+          "$ref": "#/definitions/UndrainableNodeBehavior",
+          "description": "Defines the behavior for undrainable nodes during upgrade. The most common cause of undrainable nodes is Pod Disruption Budgets (PDBs), but other issues, such as pod termination grace period is exceeding the remaining per-node drain timeout or pod is still being in a running state, can also cause undrainable nodes."
+        }
+      }
+    },
+    "AgentPoolWindowsProfile": {
+      "type": "object",
+      "description": "The Windows agent pool's specific profile.",
+      "properties": {
+        "disableOutboundNat": {
+          "type": "boolean",
+          "description": "Whether to disable OutboundNAT in windows nodes. The default value is false. Outbound NAT can only be disabled if the cluster outboundType is NAT Gateway and the Windows agent pool does not have node public IP enabled."
+        }
+      }
+    },
+    "AzureKeyVaultKms": {
+      "type": "object",
+      "description": "Azure Key Vault key management service settings for the security profile.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether to enable Azure Key Vault key management service. The default is false."
+        },
+        "keyId": {
+          "type": "string",
+          "description": "Identifier of Azure Key Vault key. See [key identifier format](https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name) for more details. When Azure Key Vault key management service is enabled, this field is required and must be a valid key identifier. When Azure Key Vault key management service is disabled, leave the field empty."
+        },
+        "keyVaultNetworkAccess": {
+          "type": "string",
+          "description": "Network access of the key vault. Network access of key vault. The possible values are `Public` and `Private`. `Public` means the key vault allows public access from all networks. `Private` means the key vault disables public access and enables private link. The default value is `Public`.",
+          "default": "Public",
+          "enum": [
+            "Public",
+            "Private"
+          ],
+          "x-ms-enum": {
+            "name": "KeyVaultNetworkAccessTypes",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Public",
+                "value": "Public",
+                "description": "Key vault allows public access from all networks."
+              },
+              {
+                "name": "Private",
+                "value": "Private",
+                "description": "Key vault disables public access and enables private link."
+              }
+            ]
+          }
+        },
+        "keyVaultResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Resource ID of key vault. When keyVaultNetworkAccess is `Private`, this field is required and must be a valid resource ID. When keyVaultNetworkAccess is `Public`, leave the field empty.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.KeyVault/vaults"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "ClusterUpgradeSettings": {
+      "type": "object",
+      "description": "Settings for upgrading a cluster.",
+      "properties": {
+        "overrideSettings": {
+          "$ref": "#/definitions/UpgradeOverrideSettings",
+          "description": "Settings for overrides."
+        }
+      }
+    },
+    "Code": {
+      "type": "string",
+      "description": "Tells whether the cluster is Running or Stopped",
+      "enum": [
+        "Running",
+        "Stopped"
+      ],
+      "x-ms-enum": {
+        "name": "Code",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Running",
+            "value": "Running",
+            "description": "The cluster is running."
+          },
+          {
+            "name": "Stopped",
+            "value": "Stopped",
+            "description": "The cluster is stopped."
+          }
+        ]
+      }
+    },
+    "CommandResultProperties": {
+      "type": "object",
+      "description": "The results of a run command",
+      "properties": {
+        "provisioningState": {
+          "type": "string",
+          "description": "provisioning State",
+          "readOnly": true
+        },
+        "exitCode": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The exit code of the command",
+          "readOnly": true
+        },
+        "startedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time when the command started.",
+          "readOnly": true
+        },
+        "finishedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time when the command finished.",
+          "readOnly": true
+        },
+        "logs": {
+          "type": "string",
+          "description": "The command output.",
+          "readOnly": true
+        },
+        "reason": {
+          "type": "string",
+          "description": "An explanation of why provisioningState is set to failed (if so).",
+          "readOnly": true
+        }
+      }
+    },
+    "CompatibleVersions": {
+      "type": "object",
+      "description": "Version information about a product/service that is compatible with a service mesh revision.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The product/service name."
+        },
+        "versions": {
+          "type": "array",
+          "description": "Product/service versions compatible with a service mesh add-on revision.",
+          "items": {
+            "$ref": "#/definitions/CompatibleVersionsVersionsType"
+          }
+        }
+      }
+    },
+    "CompatibleVersionsVersionsType": {
+      "type": "string",
+      "description": "A compatible product/service version."
+    },
+    "ConnectionStatus": {
+      "type": "string",
+      "description": "The private link service connection status.",
+      "enum": [
+        "Pending",
+        "Approved",
+        "Rejected",
+        "Disconnected"
+      ],
+      "x-ms-enum": {
+        "name": "ConnectionStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Pending",
+            "value": "Pending",
+            "description": "Connection is pending approval."
+          },
+          {
+            "name": "Approved",
+            "value": "Approved",
+            "description": "Connection is approved."
+          },
+          {
+            "name": "Rejected",
+            "value": "Rejected",
+            "description": "Connection is rejected."
+          },
+          {
+            "name": "Disconnected",
+            "value": "Disconnected",
+            "description": "Connection is disconnected."
+          }
+        ]
+      }
+    },
+    "ContainerServiceLinuxProfile": {
+      "type": "object",
+      "description": "Profile for Linux VMs in the container service cluster.",
+      "properties": {
+        "adminUsername": {
+          "type": "string",
+          "description": "The administrator username to use for Linux VMs.",
+          "pattern": "^[A-Za-z][-A-Za-z0-9_]*$"
+        },
+        "ssh": {
+          "$ref": "#/definitions/ContainerServiceSshConfiguration",
+          "description": "The SSH configuration for Linux-based VMs running on Azure."
+        }
+      },
+      "required": [
+        "adminUsername",
+        "ssh"
+      ]
+    },
+    "ContainerServiceNetworkProfile": {
+      "type": "object",
+      "description": "Profile of network configuration.",
+      "properties": {
+        "networkPlugin": {
+          "$ref": "#/definitions/NetworkPlugin",
+          "description": "Network plugin used for building the Kubernetes network."
+        },
+        "networkPluginMode": {
+          "$ref": "#/definitions/NetworkPluginMode",
+          "description": "The mode the network plugin should use."
+        },
+        "networkPolicy": {
+          "$ref": "#/definitions/NetworkPolicy",
+          "description": "Network policy used for building the Kubernetes network."
+        },
+        "networkMode": {
+          "$ref": "#/definitions/NetworkMode",
+          "description": "The network mode Azure CNI is configured with. This cannot be specified if networkPlugin is anything other than 'azure'."
+        },
+        "networkDataplane": {
+          "$ref": "#/definitions/NetworkDataplane",
+          "description": "Network dataplane used in the Kubernetes cluster."
+        },
+        "advancedNetworking": {
+          "$ref": "#/definitions/AdvancedNetworking",
+          "description": "Advanced Networking profile for enabling observability and security feature suite on a cluster. For more information see aka.ms/aksadvancednetworking."
+        },
+        "podCidr": {
+          "type": "string",
+          "description": "A CIDR notation IP range from which to assign pod IPs when kubenet is used.",
+          "default": "10.244.0.0/16",
+          "pattern": "^([0-9]{1,3}\\.){3}[0-9]{1,3}(\\/([0-9]|[1-2][0-9]|3[0-2]))?$"
+        },
+        "serviceCidr": {
+          "type": "string",
+          "description": "A CIDR notation IP range from which to assign service cluster IPs. It must not overlap with any Subnet IP ranges.",
+          "default": "10.0.0.0/16",
+          "pattern": "^([0-9]{1,3}\\.){3}[0-9]{1,3}(\\/([0-9]|[1-2][0-9]|3[0-2]))?$"
+        },
+        "dnsServiceIP": {
+          "type": "string",
+          "description": "An IP address assigned to the Kubernetes DNS service. It must be within the Kubernetes service address range specified in serviceCidr.",
+          "default": "10.0.0.10",
+          "pattern": "^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
+        },
+        "outboundType": {
+          "type": "string",
+          "description": "The outbound (egress) routing method. This can only be set at cluster creation time and cannot be changed later. For more information see [egress outbound type](https://docs.microsoft.com/azure/aks/egress-outboundtype).",
+          "default": "loadBalancer",
+          "enum": [
+            "loadBalancer",
+            "userDefinedRouting",
+            "managedNATGateway",
+            "userAssignedNATGateway",
+            "none"
+          ],
+          "x-ms-enum": {
+            "name": "OutboundType",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "loadBalancer",
+                "value": "loadBalancer",
+                "description": "The load balancer is used for egress through an AKS assigned public IP. This supports Kubernetes services of type 'loadBalancer'. For more information see [outbound type loadbalancer](https://docs.microsoft.com/azure/aks/egress-outboundtype#outbound-type-of-loadbalancer)."
+              },
+              {
+                "name": "userDefinedRouting",
+                "value": "userDefinedRouting",
+                "description": "Egress paths must be defined by the user. This is an advanced scenario and requires proper network configuration. For more information see [outbound type userDefinedRouting](https://docs.microsoft.com/azure/aks/egress-outboundtype#outbound-type-of-userdefinedrouting)."
+              },
+              {
+                "name": "managedNATGateway",
+                "value": "managedNATGateway",
+                "description": "The AKS-managed NAT gateway is used for egress."
+              },
+              {
+                "name": "userAssignedNATGateway",
+                "value": "userAssignedNATGateway",
+                "description": "The user-assigned NAT gateway associated to the cluster subnet is used for egress. This is an advanced scenario and requires proper network configuration."
+              },
+              {
+                "name": "none",
+                "value": "none",
+                "description": "The AKS cluster is not set with any outbound-type. All AKS nodes follows Azure VM default outbound behavior. Please refer to https://azure.microsoft.com/en-us/updates/default-outbound-access-for-vms-in-azure-will-be-retired-transition-to-a-new-method-of-internet-access/"
+              }
+            ]
+          }
+        },
+        "loadBalancerSku": {
+          "$ref": "#/definitions/LoadBalancerSku",
+          "description": "The load balancer sku for the managed cluster. The default is 'standard'. See [Azure Load Balancer SKUs](https://docs.microsoft.com/azure/load-balancer/skus) for more information about the differences between load balancer SKUs."
+        },
+        "loadBalancerProfile": {
+          "$ref": "#/definitions/ManagedClusterLoadBalancerProfile",
+          "description": "Profile of the cluster load balancer."
+        },
+        "natGatewayProfile": {
+          "$ref": "#/definitions/ManagedClusterNATGatewayProfile",
+          "description": "Profile of the cluster NAT gateway."
+        },
+        "staticEgressGatewayProfile": {
+          "$ref": "#/definitions/ManagedClusterStaticEgressGatewayProfile",
+          "description": "The profile for Static Egress Gateway addon. For more details about Static Egress Gateway, see https://aka.ms/aks/static-egress-gateway."
+        },
+        "podCidrs": {
+          "type": "array",
+          "description": "The CIDR notation IP ranges from which to assign pod IPs. One IPv4 CIDR is expected for single-stack networking. Two CIDRs, one for each IP family (IPv4/IPv6), is expected for dual-stack networking.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "serviceCidrs": {
+          "type": "array",
+          "description": "The CIDR notation IP ranges from which to assign service cluster IPs. One IPv4 CIDR is expected for single-stack networking. Two CIDRs, one for each IP family (IPv4/IPv6), is expected for dual-stack networking. They must not overlap with any Subnet IP ranges.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ipFamilies": {
+          "type": "array",
+          "description": "The IP families used to specify IP versions available to the cluster. IP families are used to determine single-stack or dual-stack clusters. For single-stack, the expected value is IPv4. For dual-stack, the expected values are IPv4 and IPv6.",
+          "items": {
+            "$ref": "#/definitions/IPFamily"
+          }
+        }
+      }
+    },
+    "ContainerServiceSshConfiguration": {
+      "type": "object",
+      "description": "SSH configuration for Linux-based VMs running on Azure.",
+      "properties": {
+        "publicKeys": {
+          "type": "array",
+          "description": "The list of SSH public keys used to authenticate with Linux-based VMs. A maximum of 1 key may be specified.",
+          "items": {
+            "$ref": "#/definitions/ContainerServiceSshPublicKey"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "required": [
+        "publicKeys"
+      ]
+    },
+    "ContainerServiceSshPublicKey": {
+      "type": "object",
+      "description": "Contains information about SSH certificate public key data.",
+      "properties": {
+        "keyData": {
+          "type": "string",
+          "description": "Certificate public key used to authenticate with VMs through SSH. The certificate must be in PEM format with or without headers."
+        }
+      },
+      "required": [
+        "keyData"
+      ]
+    },
+    "CreationData": {
+      "type": "object",
+      "description": "Data used when creating a target resource from a source resource.",
+      "properties": {
+        "sourceResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "This is the ARM ID of the source object to be used to create the target object."
+        }
+      }
+    },
+    "CredentialResult": {
+      "type": "object",
+      "description": "The credential result response.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the credential.",
+          "readOnly": true
+        },
+        "value": {
+          "type": "string",
+          "format": "byte",
+          "description": "Base64-encoded Kubernetes configuration file.",
+          "readOnly": true
+        }
+      }
+    },
+    "CredentialResults": {
+      "type": "object",
+      "description": "The list credential result response.",
+      "properties": {
+        "kubeconfigs": {
+          "type": "array",
+          "description": "Base64-encoded Kubernetes configuration file.",
+          "items": {
+            "$ref": "#/definitions/CredentialResult"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "DailySchedule": {
+      "type": "object",
+      "description": "For schedules like: 'recur every day' or 'recur every 3 days'.",
+      "properties": {
+        "intervalDays": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Specifies the number of days between each set of occurrences.",
+          "minimum": 1,
+          "maximum": 7
+        }
+      },
+      "required": [
+        "intervalDays"
+      ]
+    },
+    "DateSpan": {
+      "type": "object",
+      "description": "A date range. For example, between '2022-12-23' and '2023-01-05'.",
+      "properties": {
+        "start": {
+          "type": "string",
+          "format": "date",
+          "description": "The start date of the date span."
+        },
+        "end": {
+          "type": "string",
+          "format": "date",
+          "description": "The end date of the date span."
+        }
+      },
+      "required": [
+        "start",
+        "end"
+      ]
+    },
+    "DeletePolicy": {
+      "type": "string",
+      "description": "Delete options of a namespace.",
+      "enum": [
+        "Keep",
+        "Delete"
+      ],
+      "x-ms-enum": {
+        "name": "DeletePolicy",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Keep",
+            "value": "Keep",
+            "description": "Only delete the ARM resource, keep the Kubernetes namespace. Also delete the ManagedByARM label."
+          },
+          {
+            "name": "Delete",
+            "value": "Delete",
+            "description": "Delete both the ARM resource and the Kubernetes namespace together."
+          }
+        ]
+      }
+    },
+    "EndpointDependency": {
+      "type": "object",
+      "description": "A domain name that AKS agent nodes are reaching at.",
+      "properties": {
+        "domainName": {
+          "type": "string",
+          "description": "The domain name of the dependency."
+        },
+        "endpointDetails": {
+          "type": "array",
+          "description": "The Ports and Protocols used when connecting to domainName.",
+          "items": {
+            "$ref": "#/definitions/EndpointDetail"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "EndpointDetail": {
+      "type": "object",
+      "description": "connect information from the AKS agent nodes to a single endpoint.",
+      "properties": {
+        "ipAddress": {
+          "type": "string",
+          "description": "An IP Address that Domain Name currently resolves to."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The port an endpoint is connected to."
+        },
+        "protocol": {
+          "type": "string",
+          "description": "The protocol used for connection"
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the detail"
+        }
+      }
+    },
+    "Expander": {
+      "type": "string",
+      "description": "The expander to use when scaling up. If not specified, the default is 'random'. See [expanders](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-expanders) for more information.",
+      "enum": [
+        "least-waste",
+        "most-pods",
+        "priority",
+        "random"
+      ],
+      "x-ms-enum": {
+        "name": "Expander",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "least-waste",
+            "value": "least-waste",
+            "description": "Selects the node group that will have the least idle CPU (if tied, unused memory) after scale-up. This is useful when you have different classes of nodes, for example, high CPU or high memory nodes, and only want to expand those when there are pending pods that need a lot of those resources."
+          },
+          {
+            "name": "most-pods",
+            "value": "most-pods",
+            "description": "Selects the node group that would be able to schedule the most pods when scaling up. This is useful when you are using nodeSelector to make sure certain pods land on certain nodes. Note that this won't cause the autoscaler to select bigger nodes vs. smaller, as it can add multiple smaller nodes at once."
+          },
+          {
+            "name": "priority",
+            "value": "priority",
+            "description": "Selects the node group that has the highest priority assigned by the user. It's configuration is described in more details [here](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/expander/priority/readme.md)."
+          },
+          {
+            "name": "random",
+            "value": "random",
+            "description": "Used when you don't have a particular need for the node groups to scale differently."
+          }
+        ]
+      }
+    },
+    "ExtendedLocation": {
+      "type": "object",
+      "description": "The complex type of the extended location.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the extended location."
+        },
+        "type": {
+          "$ref": "#/definitions/ExtendedLocationTypes",
+          "description": "The type of the extended location."
+        }
+      }
+    },
+    "ExtendedLocationTypes": {
+      "type": "string",
+      "description": "The type of extendedLocation.",
+      "enum": [
+        "EdgeZone"
+      ],
+      "x-ms-enum": {
+        "name": "ExtendedLocationTypes",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "EdgeZone",
+            "value": "EdgeZone",
+            "description": "Azure Edge Zone extended location type."
+          }
+        ]
+      }
+    },
+    "GPUDriver": {
+      "type": "string",
+      "description": "Whether to install GPU drivers. When it's not specified, default is Install.",
+      "enum": [
+        "Install",
+        "None"
+      ],
+      "x-ms-enum": {
+        "name": "GPUDriver",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Install",
+            "value": "Install",
+            "description": "Install driver."
+          },
+          {
+            "name": "None",
+            "value": "None",
+            "description": "Skip driver install."
+          }
+        ]
+      }
+    },
+    "GPUInstanceProfile": {
+      "type": "string",
+      "description": "GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU.",
+      "enum": [
+        "MIG1g",
+        "MIG2g",
+        "MIG3g",
+        "MIG4g",
+        "MIG7g"
+      ],
+      "x-ms-enum": {
+        "name": "GPUInstanceProfile",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "MIG1g",
+            "value": "MIG1g",
+            "description": "MIG 1g GPU instance profile."
+          },
+          {
+            "name": "MIG2g",
+            "value": "MIG2g",
+            "description": "MIG 2g GPU instance profile."
+          },
+          {
+            "name": "MIG3g",
+            "value": "MIG3g",
+            "description": "MIG 3g GPU instance profile."
+          },
+          {
+            "name": "MIG4g",
+            "value": "MIG4g",
+            "description": "MIG 4g GPU instance profile."
+          },
+          {
+            "name": "MIG7g",
+            "value": "MIG7g",
+            "description": "MIG 7g GPU instance profile."
+          }
+        ]
+      }
+    },
+    "GPUProfile": {
+      "type": "object",
+      "description": "GPU settings for the Agent Pool.",
+      "properties": {
+        "driver": {
+          "$ref": "#/definitions/GPUDriver",
+          "description": "Whether to install GPU drivers. When it's not specified, default is Install."
+        }
+      }
+    },
+    "GatewayAPIIstioEnabled": {
+      "type": "string",
+      "description": "Whether to enable Istio as a Gateway API implementation for managed ingress with App Routing.",
+      "enum": [
+        "Enabled",
+        "Disabled"
+      ],
+      "x-ms-enum": {
+        "name": "GatewayAPIIstioEnabled",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Enabled",
+            "value": "Enabled",
+            "description": "Enables managed ingress via the Gateway API using a sidecar-less Istio controlplane."
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Disables the sidecar-less istio control plane for managed ingress via the Gateway API."
+          }
+        ]
+      }
+    },
+    "HourInDay": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Hour in a day.",
+      "minimum": 0,
+      "maximum": 23
+    },
+    "IPFamily": {
+      "type": "string",
+      "description": "To determine if address belongs IPv4 or IPv6 family",
+      "enum": [
+        "IPv4",
+        "IPv6"
+      ],
+      "x-ms-enum": {
+        "name": "IPFamily",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "IPv4",
+            "value": "IPv4",
+            "description": "IPv4 family"
+          },
+          {
+            "name": "IPv6",
+            "value": "IPv6",
+            "description": "IPv6 family"
+          }
+        ]
+      }
+    },
+    "IPTag": {
+      "type": "object",
+      "description": "Contains the IPTag associated with the object.",
+      "properties": {
+        "ipTagType": {
+          "type": "string",
+          "description": "The IP tag type. Example: RoutingPreference."
+        },
+        "tag": {
+          "type": "string",
+          "description": "The value of the IP tag associated with the public IP. Example: Internet."
+        }
+      }
+    },
+    "IstioCertificateAuthority": {
+      "type": "object",
+      "description": "Istio Service Mesh Certificate Authority (CA) configuration. For now, we only support plugin certificates as described here https://aka.ms/asm-plugin-ca",
+      "properties": {
+        "plugin": {
+          "$ref": "#/definitions/IstioPluginCertificateAuthority",
+          "description": "Plugin certificates information for Service Mesh."
+        }
+      }
+    },
+    "IstioComponents": {
+      "type": "object",
+      "description": "Istio components configuration.",
+      "properties": {
+        "ingressGateways": {
+          "type": "array",
+          "description": "Istio ingress gateways.",
+          "items": {
+            "$ref": "#/definitions/IstioIngressGateway"
+          },
+          "x-ms-identifiers": []
+        },
+        "egressGateways": {
+          "type": "array",
+          "description": "Istio egress gateways.",
+          "items": {
+            "$ref": "#/definitions/IstioEgressGateway"
+          },
+          "x-ms-identifiers": []
+        },
+        "proxyRedirectionMechanism": {
+          "$ref": "#/definitions/ProxyRedirectionMechanism",
+          "description": "Mode of traffic redirection."
+        }
+      }
+    },
+    "IstioEgressGateway": {
+      "type": "object",
+      "description": "Istio egress gateway configuration.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether to enable the egress gateway."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the Istio add-on egress gateway.",
+          "pattern": "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Namespace that the Istio add-on egress gateway should be deployed in. If unspecified, the default is aks-istio-egress."
+        },
+        "gatewayConfigurationName": {
+          "type": "string",
+          "description": "Name of the gateway configuration custom resource for the Istio add-on egress gateway. Must be specified when enabling the Istio egress gateway. Must be deployed in the same namespace that the Istio egress gateway will be deployed in."
+        }
+      },
+      "required": [
+        "enabled",
+        "name"
+      ]
+    },
+    "IstioIngressGateway": {
+      "type": "object",
+      "description": "Istio ingress gateway configuration. For now, we support up to one external ingress gateway named `aks-istio-ingressgateway-external` and one internal ingress gateway named `aks-istio-ingressgateway-internal`.",
+      "properties": {
+        "mode": {
+          "$ref": "#/definitions/IstioIngressGatewayMode",
+          "description": "Mode of an ingress gateway."
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether to enable the ingress gateway."
+        }
+      },
+      "required": [
+        "mode",
+        "enabled"
+      ]
+    },
+    "IstioIngressGatewayMode": {
+      "type": "string",
+      "description": "Mode of an ingress gateway.",
+      "enum": [
+        "External",
+        "Internal"
+      ],
+      "x-ms-enum": {
+        "name": "IstioIngressGatewayMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "External",
+            "value": "External",
+            "description": "The ingress gateway is assigned a public IP address and is publicly accessible."
+          },
+          {
+            "name": "Internal",
+            "value": "Internal",
+            "description": "The ingress gateway is assigned an internal IP address and cannot is accessed publicly."
+          }
+        ]
+      }
+    },
+    "IstioPluginCertificateAuthority": {
+      "type": "object",
+      "description": "Plugin certificates information for Service Mesh.",
+      "properties": {
+        "keyVaultId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The resource ID of the Key Vault.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.KeyVault/vaults"
+              }
+            ]
+          }
+        },
+        "certObjectName": {
+          "type": "string",
+          "description": "Intermediate certificate object name in Azure Key Vault."
+        },
+        "keyObjectName": {
+          "type": "string",
+          "description": "Intermediate certificate private key object name in Azure Key Vault."
+        },
+        "rootCertObjectName": {
+          "type": "string",
+          "description": "Root certificate object name in Azure Key Vault."
+        },
+        "certChainObjectName": {
+          "type": "string",
+          "description": "Certificate chain object name in Azure Key Vault."
+        }
+      }
+    },
+    "IstioServiceMesh": {
+      "type": "object",
+      "description": "Istio service mesh configuration.",
+      "properties": {
+        "components": {
+          "$ref": "#/definitions/IstioComponents",
+          "description": "Istio components configuration."
+        },
+        "certificateAuthority": {
+          "$ref": "#/definitions/IstioCertificateAuthority",
+          "description": "Istio Service Mesh Certificate Authority (CA) configuration. For now, we only support plugin certificates as described here https://aka.ms/asm-plugin-ca"
+        },
+        "revisions": {
+          "type": "array",
+          "description": "The list of revisions of the Istio control plane. When an upgrade is not in progress, this holds one value. When canary upgrade is in progress, this can only hold two consecutive values. For more information, see: https://learn.microsoft.com/en-us/azure/aks/istio-upgrade",
+          "maxItems": 2,
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "KubeletConfig": {
+      "type": "object",
+      "description": "Kubelet configurations of agent nodes. See [AKS custom node configuration](https://docs.microsoft.com/azure/aks/custom-node-configuration) for more details.",
+      "properties": {
+        "cpuManagerPolicy": {
+          "type": "string",
+          "description": "The CPU Manager policy to use. The default is 'none'. See [Kubernetes CPU management policies](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#cpu-management-policies) for more information. Allowed values are 'none' and 'static'."
+        },
+        "cpuCfsQuota": {
+          "type": "boolean",
+          "description": "If CPU CFS quota enforcement is enabled for containers that specify CPU limits. The default is true."
+        },
+        "cpuCfsQuotaPeriod": {
+          "type": "string",
+          "description": "The CPU CFS quota period value. The default is '100ms.' Valid values are a sequence of decimal numbers with an optional fraction and a unit suffix. For example: '300ms', '2h45m'. Supported units are 'ns', 'us', 'ms', 's', 'm', and 'h'."
+        },
+        "imageGcHighThreshold": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The percent of disk usage after which image garbage collection is always run. To disable image garbage collection, set to 100. The default is 85%"
+        },
+        "imageGcLowThreshold": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The percent of disk usage before which image garbage collection is never run. This cannot be set higher than imageGcHighThreshold. The default is 80%"
+        },
+        "topologyManagerPolicy": {
+          "type": "string",
+          "description": "The Topology Manager policy to use. For more information see [Kubernetes Topology Manager](https://kubernetes.io/docs/tasks/administer-cluster/topology-manager). The default is 'none'. Allowed values are 'none', 'best-effort', 'restricted', and 'single-numa-node'."
+        },
+        "allowedUnsafeSysctls": {
+          "type": "array",
+          "description": "Allowed list of unsafe sysctls or unsafe sysctl patterns (ending in `*`).",
+          "items": {
+            "type": "string"
+          }
+        },
+        "failSwapOn": {
+          "type": "boolean",
+          "description": "If set to true it will make the Kubelet fail to start if swap is enabled on the node."
+        },
+        "containerLogMaxSizeMB": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum size (e.g. 10Mi) of container log file before it is rotated."
+        },
+        "containerLogMaxFiles": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum number of container log files that can be present for a container. The number must be ≥ 2.",
+          "minimum": 2
+        },
+        "podMaxPids": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum number of processes per pod."
+        }
+      }
+    },
+    "KubeletDiskType": {
+      "type": "string",
+      "description": "Determines the placement of emptyDir volumes, container runtime data root, and Kubelet ephemeral storage.",
+      "enum": [
+        "OS",
+        "Temporary"
+      ],
+      "x-ms-enum": {
+        "name": "KubeletDiskType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "OS",
+            "value": "OS",
+            "description": "Kubelet will use the OS disk for its data."
+          },
+          {
+            "name": "Temporary",
+            "value": "Temporary",
+            "description": "Kubelet will use the temporary disk for its data."
+          }
+        ]
+      }
+    },
+    "KubernetesPatchVersion": {
+      "type": "object",
+      "description": "Kubernetes patch version profile",
+      "properties": {
+        "upgrades": {
+          "type": "array",
+          "description": "Possible upgrade path for given patch version",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "KubernetesSupportPlan": {
+      "type": "string",
+      "description": "Different support tiers for AKS managed clusters",
+      "enum": [
+        "KubernetesOfficial",
+        "AKSLongTermSupport"
+      ],
+      "x-ms-enum": {
+        "name": "KubernetesSupportPlan",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "KubernetesOfficial",
+            "value": "KubernetesOfficial",
+            "description": "Support for the version is the same as for the open source Kubernetes offering. Official Kubernetes open source community support versions for 1 year after release."
+          },
+          {
+            "name": "AKSLongTermSupport",
+            "value": "AKSLongTermSupport",
+            "description": "Support for the version extended past the KubernetesOfficial support of 1 year. AKS continues to patch CVEs for another 1 year, for a total of 2 years of support."
+          }
+        ]
+      }
+    },
+    "KubernetesVersion": {
+      "type": "object",
+      "description": "Kubernetes version profile for given major.minor release.",
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "major.minor version of Kubernetes release"
+        },
+        "capabilities": {
+          "$ref": "#/definitions/KubernetesVersionCapabilities",
+          "description": "Capabilities on this Kubernetes version."
+        },
+        "isDefault": {
+          "type": "boolean",
+          "description": "Whether this version is default."
+        },
+        "isPreview": {
+          "type": "boolean",
+          "description": "Whether this version is in preview mode."
+        },
+        "patchVersions": {
+          "type": "object",
+          "description": "Patch versions of Kubernetes release",
+          "additionalProperties": {
+            "$ref": "#/definitions/KubernetesPatchVersion"
+          }
+        }
+      }
+    },
+    "KubernetesVersionCapabilities": {
+      "type": "object",
+      "description": "Capabilities on this Kubernetes version.",
+      "properties": {
+        "supportPlan": {
+          "type": "array",
+          "description": "Kubernetes support plans available for this version.",
+          "items": {
+            "$ref": "#/definitions/KubernetesSupportPlan"
+          }
+        }
+      }
+    },
+    "KubernetesVersionListResult": {
+      "type": "object",
+      "description": "Hold values properties, which is array of KubernetesVersion",
+      "properties": {
+        "values": {
+          "type": "array",
+          "description": "Array of AKS supported Kubernetes versions.",
+          "items": {
+            "$ref": "#/definitions/KubernetesVersion"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "LicenseType": {
+      "type": "string",
+      "description": "The license type to use for Windows VMs. See [Azure Hybrid User Benefits](https://azure.microsoft.com/pricing/hybrid-benefit/faq/) for more details.",
+      "enum": [
+        "None",
+        "Windows_Server"
+      ],
+      "x-ms-enum": {
+        "name": "LicenseType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None",
+            "description": "No additional licensing is applied."
+          },
+          {
+            "name": "Windows_Server",
+            "value": "Windows_Server",
+            "description": "Enables Azure Hybrid User Benefits for Windows VMs."
+          }
+        ]
+      }
+    },
+    "LinuxOSConfig": {
+      "type": "object",
+      "description": "OS configurations of Linux agent nodes. See [AKS custom node configuration](https://docs.microsoft.com/azure/aks/custom-node-configuration) for more details.",
+      "properties": {
+        "sysctls": {
+          "$ref": "#/definitions/SysctlConfig",
+          "description": "Sysctl settings for Linux agent nodes."
+        },
+        "transparentHugePageEnabled": {
+          "type": "string",
+          "description": "Whether transparent hugepages are enabled. Valid values are 'always', 'madvise', and 'never'. The default is 'always'. For more information see [Transparent Hugepages](https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html#admin-guide-transhuge)."
+        },
+        "transparentHugePageDefrag": {
+          "type": "string",
+          "description": "Whether the kernel should make aggressive use of memory compaction to make more hugepages available. Valid values are 'always', 'defer', 'defer+madvise', 'madvise' and 'never'. The default is 'madvise'. For more information see [Transparent Hugepages](https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html#admin-guide-transhuge)."
+        },
+        "swapFileSizeMB": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The size in MB of a swap file that will be created on each node."
+        }
+      }
+    },
+    "LoadBalancerSku": {
+      "type": "string",
+      "description": "The load balancer sku for the managed cluster. The default is 'standard'. See [Azure Load Balancer SKUs](https://docs.microsoft.com/azure/load-balancer/skus) for more information about the differences between load balancer SKUs.",
+      "enum": [
+        "standard",
+        "basic"
+      ],
+      "x-ms-enum": {
+        "name": "LoadBalancerSku",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "standard",
+            "value": "standard",
+            "description": "Use a a standard Load Balancer. This is the recommended Load Balancer SKU. For more information about on working with the load balancer in the managed cluster, see the [standard Load Balancer](https://docs.microsoft.com/azure/aks/load-balancer-standard) article."
+          },
+          {
+            "name": "basic",
+            "value": "basic",
+            "description": "Use a basic Load Balancer with limited functionality."
+          }
+        ]
+      }
+    },
+    "LocalDNSOverride": {
+      "type": "object",
+      "description": "Overrides for localDNS profile.",
+      "properties": {
+        "queryLogging": {
+          "type": "string",
+          "description": "Log level for DNS queries in localDNS.",
+          "default": "Error",
+          "enum": [
+            "Error",
+            "Log"
+          ],
+          "x-ms-enum": {
+            "name": "LocalDNSQueryLogging",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Error",
+                "value": "Error",
+                "description": "Enables error logging in localDNS. See [errors plugin](https://coredns.io/plugins/errors) for more information."
+              },
+              {
+                "name": "Log",
+                "value": "Log",
+                "description": "Enables query logging in localDNS. See [log plugin](https://coredns.io/plugins/log) for more information."
+              }
+            ]
+          }
+        },
+        "protocol": {
+          "type": "string",
+          "description": "Enforce TCP or prefer UDP protocol for connections from localDNS to upstream DNS server.",
+          "default": "PreferUDP",
+          "enum": [
+            "PreferUDP",
+            "ForceTCP"
+          ],
+          "x-ms-enum": {
+            "name": "LocalDNSProtocol",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "PreferUDP",
+                "value": "PreferUDP",
+                "description": "Prefer UDP protocol for connections from localDNS to upstream DNS server."
+              },
+              {
+                "name": "ForceTCP",
+                "value": "ForceTCP",
+                "description": "Enforce TCP protocol for connections from localDNS to upstream DNS server."
+              }
+            ]
+          }
+        },
+        "forwardDestination": {
+          "type": "string",
+          "description": "Destination server for DNS queries to be forwarded from localDNS.",
+          "default": "ClusterCoreDNS",
+          "enum": [
+            "ClusterCoreDNS",
+            "VnetDNS"
+          ],
+          "x-ms-enum": {
+            "name": "LocalDNSForwardDestination",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "ClusterCoreDNS",
+                "value": "ClusterCoreDNS",
+                "description": "Forward DNS queries from localDNS to cluster CoreDNS."
+              },
+              {
+                "name": "VnetDNS",
+                "value": "VnetDNS",
+                "description": "Forward DNS queries from localDNS to DNS server configured in the VNET. A VNET can have multiple DNS servers configured."
+              }
+            ]
+          }
+        },
+        "forwardPolicy": {
+          "type": "string",
+          "description": "Forward policy for selecting upstream DNS server. See [forward plugin](https://coredns.io/plugins/forward) for more information.",
+          "default": "Sequential",
+          "enum": [
+            "Sequential",
+            "RoundRobin",
+            "Random"
+          ],
+          "x-ms-enum": {
+            "name": "LocalDNSForwardPolicy",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Sequential",
+                "value": "Sequential",
+                "description": "Implements sequential upstream DNS server selection. See [forward plugin](https://coredns.io/plugins/forward) for more information."
+              },
+              {
+                "name": "RoundRobin",
+                "value": "RoundRobin",
+                "description": "Implements round robin upstream DNS server selection. See [forward plugin](https://coredns.io/plugins/forward) for more information."
+              },
+              {
+                "name": "Random",
+                "value": "Random",
+                "description": "Implements random upstream DNS server selection. See [forward plugin](https://coredns.io/plugins/forward) for more information."
+              }
+            ]
+          }
+        },
+        "maxConcurrent": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of concurrent queries. See [forward plugin](https://coredns.io/plugins/forward) for more information.",
+          "default": 1000
+        },
+        "cacheDurationInSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Cache max TTL in seconds. See [cache plugin](https://coredns.io/plugins/cache) for more information.",
+          "default": 3600
+        },
+        "serveStaleDurationInSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Serve stale duration in seconds. See [cache plugin](https://coredns.io/plugins/cache) for more information.",
+          "default": 3600
+        },
+        "serveStale": {
+          "type": "string",
+          "description": "Policy for serving stale data. See [cache plugin](https://coredns.io/plugins/cache) for more information.",
+          "default": "Immediate",
+          "enum": [
+            "Verify",
+            "Immediate",
+            "Disable"
+          ],
+          "x-ms-enum": {
+            "name": "LocalDNSServeStale",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Verify",
+                "value": "Verify",
+                "description": "Serve stale data with verification. First verify that an entry is still unavailable from the source before sending the expired entry to the client. See [cache plugin](https://coredns.io/plugins/cache) for more information."
+              },
+              {
+                "name": "Immediate",
+                "value": "Immediate",
+                "description": "Serve stale data immediately. Send the expired entry to the client before checking to see if the entry is available from the source. See [cache plugin](https://coredns.io/plugins/cache) for more information."
+              },
+              {
+                "name": "Disable",
+                "value": "Disable",
+                "description": "Disable serving stale data."
+              }
+            ]
+          }
+        }
+      }
+    },
+    "LocalDNSProfile": {
+      "type": "object",
+      "description": "Configures the per-node local DNS, with VnetDNS and KubeDNS overrides. LocalDNS helps improve performance and reliability of DNS resolution in an AKS cluster. For more details see aka.ms/aks/localdns.",
+      "properties": {
+        "mode": {
+          "type": "string",
+          "description": "Mode of enablement for localDNS.",
+          "default": "Preferred",
+          "enum": [
+            "Preferred",
+            "Required",
+            "Disabled"
+          ],
+          "x-ms-enum": {
+            "name": "LocalDNSMode",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Preferred",
+                "value": "Preferred",
+                "description": "If the current orchestrator version supports this feature, prefer enabling localDNS."
+              },
+              {
+                "name": "Required",
+                "value": "Required",
+                "description": "Enable localDNS."
+              },
+              {
+                "name": "Disabled",
+                "value": "Disabled",
+                "description": "Disable localDNS."
+              }
+            ]
+          }
+        },
+        "state": {
+          "$ref": "#/definitions/LocalDNSState",
+          "description": "System-generated state of localDNS.",
+          "readOnly": true
+        },
+        "vnetDNSOverrides": {
+          "type": "object",
+          "description": "VnetDNS overrides apply to DNS traffic from pods with dnsPolicy:default or kubelet (referred to as VnetDNS traffic).",
+          "additionalProperties": {
+            "$ref": "#/definitions/LocalDNSOverride"
+          }
+        },
+        "kubeDNSOverrides": {
+          "type": "object",
+          "description": "KubeDNS overrides apply to DNS traffic from pods with dnsPolicy:ClusterFirst (referred to as KubeDNS traffic).",
+          "additionalProperties": {
+            "$ref": "#/definitions/LocalDNSOverride"
+          }
+        }
+      }
+    },
+    "LocalDNSState": {
+      "type": "string",
+      "description": "System-generated state of localDNS.",
+      "enum": [
+        "Enabled",
+        "Disabled"
+      ],
+      "x-ms-enum": {
+        "name": "LocalDNSState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Enabled",
+            "value": "Enabled",
+            "description": "localDNS is enabled."
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "localDNS is disabled."
+          }
+        ]
+      }
+    },
+    "Machine": {
+      "type": "object",
+      "description": "A machine. Contains details about the underlying virtual machine. A machine may be visible here but not in kubectl get nodes; if so it may be because the machine has not been registered with the Kubernetes API Server yet.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/MachineProperties",
+          "description": "The properties of the machine"
+        },
+        "zones": {
+          "type": "array",
+          "description": "The Availability zone in which machine is located.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "MachineIpAddress": {
+      "type": "object",
+      "description": "The machine IP address details.",
+      "properties": {
+        "family": {
+          "$ref": "#/definitions/IPFamily",
+          "description": "To determine if address belongs IPv4 or IPv6 family",
+          "readOnly": true
+        },
+        "ip": {
+          "type": "string",
+          "description": "IPv4 or IPv6 address of the machine",
+          "readOnly": true
+        }
+      }
+    },
+    "MachineListResult": {
+      "type": "object",
+      "description": "The response of a Machine list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Machine items on this page",
+          "items": {
+            "$ref": "#/definitions/Machine"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "MachineNetworkProperties": {
+      "type": "object",
+      "description": "network properties of the machine",
+      "properties": {
+        "ipAddresses": {
+          "type": "array",
+          "description": "IPv4, IPv6 addresses of the machine",
+          "items": {
+            "$ref": "#/definitions/MachineIpAddress"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "MachineProperties": {
+      "type": "object",
+      "description": "The properties of the machine",
+      "properties": {
+        "network": {
+          "$ref": "#/definitions/MachineNetworkProperties",
+          "description": "network properties of the machine",
+          "readOnly": true
+        },
+        "resourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Azure resource id of the machine. It can be used to GET underlying VM Instance",
+          "readOnly": true,
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Compute/virtualMachines"
+              },
+              {
+                "type": "Microsoft.Compute/virtualMachineScaleSets/virtualMachines"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "MaintenanceConfiguration": {
+      "type": "object",
+      "description": "Planned maintenance configuration, used to configure when updates can be deployed to a Managed Cluster. See [planned maintenance](https://docs.microsoft.com/azure/aks/planned-maintenance) for more information about planned maintenance.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/MaintenanceConfigurationProperties",
+          "description": "Properties of a default maintenance configuration.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "MaintenanceConfigurationListResult": {
+      "type": "object",
+      "description": "The response of a MaintenanceConfiguration list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The MaintenanceConfiguration items on this page",
+          "items": {
+            "$ref": "#/definitions/MaintenanceConfiguration"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "MaintenanceConfigurationProperties": {
+      "type": "object",
+      "description": "Properties used to configure planned maintenance for a Managed Cluster.",
+      "properties": {
+        "timeInWeek": {
+          "type": "array",
+          "description": "Time slots during the week when planned maintenance is allowed to proceed. If two array entries specify the same day of the week, the applied configuration is the union of times in both entries.",
+          "items": {
+            "$ref": "#/definitions/TimeInWeek"
+          },
+          "x-ms-identifiers": []
+        },
+        "notAllowedTime": {
+          "type": "array",
+          "description": "Time slots on which upgrade is not allowed.",
+          "items": {
+            "$ref": "#/definitions/TimeSpan"
+          },
+          "x-ms-identifiers": []
+        },
+        "maintenanceWindow": {
+          "$ref": "#/definitions/MaintenanceWindow",
+          "description": "Maintenance window for the maintenance configuration."
+        }
+      }
+    },
+    "MaintenanceWindow": {
+      "type": "object",
+      "description": "Maintenance window used to configure scheduled auto-upgrade for a Managed Cluster.",
+      "properties": {
+        "schedule": {
+          "$ref": "#/definitions/Schedule",
+          "description": "Recurrence schedule for the maintenance window."
+        },
+        "durationHours": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Length of maintenance window range from 4 to 24 hours.",
+          "default": 24,
+          "minimum": 4,
+          "maximum": 24
+        },
+        "utcOffset": {
+          "type": "string",
+          "description": "The UTC offset in format +/-HH:mm. For example, '+05:30' for IST and '-07:00' for PST. If not specified, the default is '+00:00'.",
+          "pattern": "^(-|\\+)[0-9]{2}:[0-9]{2}$"
+        },
+        "startDate": {
+          "type": "string",
+          "format": "date",
+          "description": "The date the maintenance window activates. If the current date is before this date, the maintenance window is inactive and will not be used for upgrades. If not specified, the maintenance window will be active right away."
+        },
+        "startTime": {
+          "type": "string",
+          "description": "The start time of the maintenance window. Accepted values are from '00:00' to '23:59'. 'utcOffset' applies to this field. For example: '02:00' with 'utcOffset: +02:00' means UTC time '00:00'.",
+          "pattern": "^\\d{2}:\\d{2}$"
+        },
+        "notAllowedDates": {
+          "type": "array",
+          "description": "Date ranges on which upgrade is not allowed. 'utcOffset' applies to this field. For example, with 'utcOffset: +02:00' and 'dateSpan' being '2022-12-23' to '2023-01-03', maintenance will be blocked from '2022-12-22 22:00' to '2023-01-03 22:00' in UTC time.",
+          "items": {
+            "$ref": "#/definitions/DateSpan"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "required": [
+        "schedule",
+        "durationHours",
+        "startTime"
+      ]
+    },
+    "ManagedCluster": {
+      "type": "object",
+      "description": "Managed cluster.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ManagedClusterProperties",
+          "description": "Properties of a managed cluster.",
+          "x-ms-client-flatten": true
+        },
+        "eTag": {
+          "type": "string",
+          "description": "If eTag is provided in the response body, it may also be provided as a header per the normal etag convention.  Entity tags are used for comparing two or more entities from the same requested resource. HTTP/1.1 uses entity tags in the etag (section 14.19), If-Match (section 14.24), If-None-Match (section 14.26), and If-Range (section 14.27) header fields.",
+          "readOnly": true
+        },
+        "sku": {
+          "$ref": "#/definitions/ManagedClusterSKU",
+          "description": "The managed cluster SKU."
+        },
+        "extendedLocation": {
+          "$ref": "#/definitions/ExtendedLocation",
+          "description": "The extended location of the Virtual Machine."
+        },
+        "identity": {
+          "$ref": "#/definitions/ManagedClusterIdentity",
+          "description": "The identity of the managed cluster, if configured."
+        },
+        "kind": {
+          "type": "string",
+          "description": "This is primarily used to expose different UI experiences in the portal for different kinds"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "ManagedClusterAADProfile": {
+      "type": "object",
+      "description": "AADProfile specifies attributes for Azure Active Directory integration. For more details see [managed AAD on AKS](https://docs.microsoft.com/azure/aks/managed-aad).",
+      "properties": {
+        "managed": {
+          "type": "boolean",
+          "description": "Whether to enable managed AAD."
+        },
+        "enableAzureRBAC": {
+          "type": "boolean",
+          "description": "Whether to enable Azure RBAC for Kubernetes authorization."
+        },
+        "adminGroupObjectIDs": {
+          "type": "array",
+          "description": "The list of AAD group object IDs that will have admin role of the cluster.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "clientAppID": {
+          "type": "string",
+          "description": "(DEPRECATED) The client AAD application ID. Learn more at https://aka.ms/aks/aad-legacy."
+        },
+        "serverAppID": {
+          "type": "string",
+          "description": "(DEPRECATED) The server AAD application ID. Learn more at https://aka.ms/aks/aad-legacy."
+        },
+        "serverAppSecret": {
+          "type": "string",
+          "format": "password",
+          "description": "(DEPRECATED) The server AAD application secret. Learn more at https://aka.ms/aks/aad-legacy.",
+          "x-ms-secret": true
+        },
+        "tenantID": {
+          "type": "string",
+          "description": "The AAD tenant ID to use for authentication. If not specified, will use the tenant of the deployment subscription."
+        }
+      }
+    },
+    "ManagedClusterAIToolchainOperatorProfile": {
+      "type": "object",
+      "description": "When enabling the operator, a set of AKS managed CRDs and controllers will be installed in the cluster. The operator automates the deployment of OSS models for inference and/or training purposes. It provides a set of preset models and enables distributed inference against them.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether to enable AI toolchain operator to the cluster. Indicates if AI toolchain operator  enabled or not."
+        }
+      }
+    },
+    "ManagedClusterAPIServerAccessProfile": {
+      "type": "object",
+      "description": "Access profile for managed cluster API server.",
+      "properties": {
+        "authorizedIPRanges": {
+          "type": "array",
+          "description": "The IP ranges authorized to access the Kubernetes API server. IP ranges are specified in CIDR format, e.g. 137.117.106.88/29. This feature is not compatible with clusters that use Public IP Per Node, or clusters that are using a Basic Load Balancer. For more information see [API server authorized IP ranges](https://docs.microsoft.com/azure/aks/api-server-authorized-ip-ranges).",
+          "items": {
+            "type": "string"
+          }
+        },
+        "enablePrivateCluster": {
+          "type": "boolean",
+          "description": "Whether to create the cluster as a private cluster or not. For more details, see [Creating a private AKS cluster](https://docs.microsoft.com/azure/aks/private-clusters)."
+        },
+        "privateDNSZone": {
+          "type": "string",
+          "description": "The private DNS zone mode for the cluster. The default is System. For more details see [configure private DNS zone](https://docs.microsoft.com/azure/aks/private-clusters#configure-private-dns-zone). Allowed values are 'system' and 'none'."
+        },
+        "enablePrivateClusterPublicFQDN": {
+          "type": "boolean",
+          "description": "Whether to create additional public FQDN for private cluster or not."
+        },
+        "disableRunCommand": {
+          "type": "boolean",
+          "description": "Whether to disable run command for the cluster or not."
+        },
+        "enableVnetIntegration": {
+          "type": "boolean",
+          "description": "Whether to enable apiserver vnet integration for the cluster or not. See aka.ms/AksVnetIntegration for more details."
+        },
+        "subnetId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The subnet to be used when apiserver vnet integration is enabled. It is required when creating a new cluster with BYO Vnet, or when updating an existing cluster to enable apiserver vnet integration.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/virtualNetworks/subnets"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "ManagedClusterAccessProfile": {
+      "type": "object",
+      "description": "Managed cluster Access Profile.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AccessProfile",
+          "description": "AccessProfile of a managed cluster.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "ManagedClusterAddonProfile": {
+      "type": "object",
+      "description": "A Kubernetes add-on profile for a managed cluster.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether the add-on is enabled or not."
+        },
+        "config": {
+          "type": "object",
+          "description": "Key-value pairs for configuring an add-on.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "identity": {
+          "$ref": "#/definitions/ManagedClusterAddonProfileIdentity",
+          "description": "Information of user assigned identity used by this add-on.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "enabled"
+      ]
+    },
+    "ManagedClusterAddonProfileIdentity": {
+      "type": "object",
+      "description": "Information of user assigned identity used by this add-on.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/UserAssignedIdentity"
+        }
+      ]
+    },
+    "ManagedClusterAgentPoolProfile": {
+      "type": "object",
+      "description": "Profile for the container service agent pool.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique name of the agent pool profile in the context of the subscription and resource group. Windows agent pool names must be 6 characters or less.",
+          "pattern": "^[a-z][a-z0-9]{0,11}$"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ManagedClusterAgentPoolProfileProperties"
+        }
+      ]
+    },
+    "ManagedClusterAgentPoolProfileProperties": {
+      "type": "object",
+      "description": "Properties for the container service agent pool profile.",
+      "properties": {
+        "eTag": {
+          "type": "string",
+          "description": "Unique read-only string used to implement optimistic concurrency. The eTag value will change when the resource is updated. Specify an if-match or if-none-match header with the eTag value for a subsequent request to enable optimistic concurrency per the normal eTag convention.",
+          "readOnly": true
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of agents (VMs) to host docker containers. Allowed values must be in the range of 0 to 1000 (inclusive) for user pools and in the range of 1 to 1000 (inclusive) for system pools. The default value is 1."
+        },
+        "vmSize": {
+          "type": "string",
+          "description": "The size of the agent pool VMs. VM size availability varies by region. If a node contains insufficient compute resources (memory, cpu, etc) pods might fail to run correctly. For more details on restricted VM sizes, see: https://docs.microsoft.com/azure/aks/quotas-skus-regions"
+        },
+        "osDiskSizeGB": {
+          "type": "integer",
+          "format": "int32",
+          "description": "OS Disk Size in GB to be used to specify the disk size for every machine in the master/agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified.",
+          "minimum": 0,
+          "maximum": 2048
+        },
+        "osDiskType": {
+          "$ref": "#/definitions/OSDiskType",
+          "description": "The OS disk type to be used for machines in the agent pool. The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested OSDiskSizeGB. Otherwise, defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral OS](https://docs.microsoft.com/azure/aks/cluster-configuration#ephemeral-os)."
+        },
+        "kubeletDiskType": {
+          "$ref": "#/definitions/KubeletDiskType",
+          "description": "Determines the placement of emptyDir volumes, container runtime data root, and Kubelet ephemeral storage."
+        },
+        "workloadRuntime": {
+          "$ref": "#/definitions/WorkloadRuntime",
+          "description": "Determines the type of workload a node can run."
+        },
+        "messageOfTheDay": {
+          "type": "string",
+          "description": "Message of the day for Linux nodes, base64-encoded. A base64-encoded string which will be written to /etc/motd after decoding. This allows customization of the message of the day for Linux nodes. It must not be specified for Windows nodes. It must be a static string (i.e., will be printed raw and not be executed as a script)."
+        },
+        "vnetSubnetID": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The ID of the subnet which agent pool nodes and optionally pods will join on startup. If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/virtualNetworks/subnets"
+              }
+            ]
+          }
+        },
+        "podSubnetID": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The ID of the subnet which pods will join when launched. If omitted, pod IPs are statically assigned on the node subnet (see vnetSubnetID for more details). This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/virtualNetworks/subnets"
+              }
+            ]
+          }
+        },
+        "podIPAllocationMode": {
+          "$ref": "#/definitions/PodIPAllocationMode",
+          "description": "Pod IP Allocation Mode. The IP allocation mode for pods in the agent pool. Must be used with podSubnetId. The default is 'DynamicIndividual'."
+        },
+        "maxPods": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum number of pods that can run on a node."
+        },
+        "osType": {
+          "type": "string",
+          "description": "The operating system type. The default is Linux.",
+          "default": "Linux",
+          "enum": [
+            "Linux",
+            "Windows"
+          ],
+          "x-ms-enum": {
+            "name": "OSType",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Linux",
+                "value": "Linux",
+                "description": "Use Linux."
+              },
+              {
+                "name": "Windows",
+                "value": "Windows",
+                "description": "Use Windows."
+              }
+            ]
+          }
+        },
+        "osSKU": {
+          "$ref": "#/definitions/OSSKU",
+          "description": "Specifies the OS SKU used by the agent pool. The default is Ubuntu if OSType is Linux. The default is Windows2019 when Kubernetes <= 1.24 or Windows2022 when Kubernetes >= 1.25 if OSType is Windows."
+        },
+        "maxCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum number of nodes for auto-scaling"
+        },
+        "minCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The minimum number of nodes for auto-scaling"
+        },
+        "enableAutoScaling": {
+          "type": "boolean",
+          "description": "Whether to enable auto-scaler"
+        },
+        "scaleDownMode": {
+          "$ref": "#/definitions/ScaleDownMode",
+          "description": "The scale down mode to use when scaling the Agent Pool. This also effects the cluster autoscaler behavior. If not specified, it defaults to Delete."
+        },
+        "type": {
+          "$ref": "#/definitions/AgentPoolType",
+          "description": "The type of Agent Pool."
+        },
+        "mode": {
+          "$ref": "#/definitions/AgentPoolMode",
+          "description": "The mode of an agent pool. A cluster must have at least one 'System' Agent Pool at all times. For additional information on agent pool restrictions and best practices, see: https://docs.microsoft.com/azure/aks/use-system-pools"
+        },
+        "orchestratorVersion": {
+          "type": "string",
+          "description": "The version of Kubernetes specified by the user. Both patch version <major.minor.patch> (e.g. 1.20.13) and <major.minor> (e.g. 1.20) are supported. When <major.minor> is specified, the latest supported GA patch version is chosen automatically. Updating the cluster with the same <major.minor> once it has been created (e.g. 1.14.x -> 1.14) will not trigger an upgrade, even if a newer patch version is available. As a best practice, you should upgrade all node pools in an AKS cluster to the same Kubernetes version. The node pool version must have the same major version as the control plane. The node pool minor version must be within two minor versions of the control plane version. The node pool version cannot be greater than the control plane version. For more information see [upgrading a node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#upgrade-a-node-pool)."
+        },
+        "currentOrchestratorVersion": {
+          "type": "string",
+          "description": "The version of Kubernetes the Agent Pool is running. If orchestratorVersion is a fully specified version <major.minor.patch>, this field will be exactly equal to it. If orchestratorVersion is <major.minor>, this field will contain the full <major.minor.patch> version being used.",
+          "readOnly": true
+        },
+        "nodeImageVersion": {
+          "type": "string",
+          "description": "The version of node image"
+        },
+        "upgradeSettings": {
+          "$ref": "#/definitions/AgentPoolUpgradeSettings",
+          "description": "Settings for upgrading the agentpool"
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "The current deployment or provisioning state.",
+          "readOnly": true
+        },
+        "powerState": {
+          "$ref": "#/definitions/PowerState",
+          "description": "Whether the Agent Pool is running or stopped. When an Agent Pool is first created it is initially Running. The Agent Pool can be stopped by setting this field to Stopped. A stopped Agent Pool stops all of its VMs and does not accrue billing charges. An Agent Pool can only be stopped if it is Running and provisioning state is Succeeded"
+        },
+        "availabilityZones": {
+          "type": "array",
+          "description": "The list of Availability zones to use for nodes. This can only be specified if the AgentPoolType property is 'VirtualMachineScaleSets'.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "enableNodePublicIP": {
+          "type": "boolean",
+          "description": "Whether each node is allocated its own public IP. Some scenarios may require nodes in a node pool to receive their own dedicated public IP addresses. A common scenario is for gaming workloads, where a console needs to make a direct connection to a cloud virtual machine to minimize hops. For more information see [assigning a public IP per node](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#assign-a-public-ip-per-node-for-your-node-pools). The default is false."
+        },
+        "nodePublicIPPrefixID": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The public IP prefix ID which VM nodes should use IPs from. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/publicIPPrefixes"
+              }
+            ]
+          }
+        },
+        "scaleSetPriority": {
+          "type": "string",
+          "description": "The Virtual Machine Scale Set priority.",
+          "default": "Regular",
+          "enum": [
+            "Spot",
+            "Regular"
+          ],
+          "x-ms-enum": {
+            "name": "ScaleSetPriority",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Spot",
+                "value": "Spot",
+                "description": "Spot priority VMs will be used. There is no SLA for spot nodes. See [spot on AKS](https://docs.microsoft.com/azure/aks/spot-node-pool) for more information."
+              },
+              {
+                "name": "Regular",
+                "value": "Regular",
+                "description": "Regular VMs will be used."
+              }
+            ]
+          }
+        },
+        "scaleSetEvictionPolicy": {
+          "type": "string",
+          "description": "The Virtual Machine Scale Set eviction policy. The eviction policy specifies what to do with the VM when it is evicted. The default is Delete. For more information about eviction see [spot VMs](https://docs.microsoft.com/azure/virtual-machines/spot-vms)",
+          "default": "Delete",
+          "enum": [
+            "Delete",
+            "Deallocate"
+          ],
+          "x-ms-enum": {
+            "name": "ScaleSetEvictionPolicy",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Delete",
+                "value": "Delete",
+                "description": "Nodes in the underlying Scale Set of the node pool are deleted when they're evicted."
+              },
+              {
+                "name": "Deallocate",
+                "value": "Deallocate",
+                "description": "Nodes in the underlying Scale Set of the node pool are set to the stopped-deallocated state upon eviction. Nodes in the stopped-deallocated state count against your compute quota and can cause issues with cluster scaling or upgrading."
+              }
+            ]
+          }
+        },
+        "spotMaxPrice": {
+          "type": "number",
+          "format": "float",
+          "description": "The max price (in US Dollars) you are willing to pay for spot instances. Possible values are any decimal value greater than zero or -1 which indicates default price to be up-to on-demand. Possible values are any decimal value greater than zero or -1 which indicates the willingness to pay any on-demand price. For more details on spot pricing, see [spot VMs pricing](https://docs.microsoft.com/azure/virtual-machines/spot-vms#pricing)",
+          "default": -1
+        },
+        "tags": {
+          "type": "object",
+          "description": "The tags to be persisted on the agent pool virtual machine scale set.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "nodeLabels": {
+          "type": "object",
+          "description": "The node labels to be persisted across all nodes in agent pool.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "nodeTaints": {
+          "type": "array",
+          "description": "The taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "proximityPlacementGroupID": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The ID for Proximity Placement Group.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Compute/proximityPlacementGroups"
+              }
+            ]
+          }
+        },
+        "kubeletConfig": {
+          "$ref": "#/definitions/KubeletConfig",
+          "description": "The Kubelet configuration on the agent pool nodes."
+        },
+        "linuxOSConfig": {
+          "$ref": "#/definitions/LinuxOSConfig",
+          "description": "The OS configuration of Linux agent nodes."
+        },
+        "enableEncryptionAtHost": {
+          "type": "boolean",
+          "description": "Whether to enable host based OS and data drive encryption. This is only supported on certain VM sizes and in certain Azure regions. For more information, see: https://docs.microsoft.com/azure/aks/enable-host-encryption"
+        },
+        "enableUltraSSD": {
+          "type": "boolean",
+          "description": "Whether to enable UltraSSD"
+        },
+        "enableFIPS": {
+          "type": "boolean",
+          "description": "Whether to use a FIPS-enabled OS. See [Add a FIPS-enabled node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#add-a-fips-enabled-node-pool-preview) for more details."
+        },
+        "gpuInstanceProfile": {
+          "$ref": "#/definitions/GPUInstanceProfile",
+          "description": "GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU."
+        },
+        "creationData": {
+          "$ref": "#/definitions/CreationData",
+          "description": "CreationData to be used to specify the source Snapshot ID if the node pool will be created/upgraded using a snapshot."
+        },
+        "capacityReservationGroupID": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The fully qualified resource ID of the Capacity Reservation Group to provide virtual machines from a reserved group of Virtual Machines. This is of the form: '/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.Compute/capacityreservationgroups/{capacityReservationGroupName}' Customers use it to create an agentpool with a specified CRG. For more information see [Capacity Reservation](https://learn.microsoft.com/en-us/azure/virtual-machines/capacity-reservation-overview)",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Compute/CapacityReservationGroups"
+              }
+            ]
+          }
+        },
+        "hostGroupID": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The fully qualified resource ID of the Dedicated Host Group to provision virtual machines from, used only in creation scenario and not allowed to changed once set. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}. For more information see [Azure dedicated hosts](https://docs.microsoft.com/azure/virtual-machines/dedicated-hosts).",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Compute/hostGroups"
+              }
+            ]
+          }
+        },
+        "networkProfile": {
+          "$ref": "#/definitions/AgentPoolNetworkProfile",
+          "description": "Network-related settings of an agent pool."
+        },
+        "windowsProfile": {
+          "$ref": "#/definitions/AgentPoolWindowsProfile",
+          "description": "The Windows agent pool's specific profile."
+        },
+        "securityProfile": {
+          "$ref": "#/definitions/AgentPoolSecurityProfile",
+          "description": "The security settings of an agent pool."
+        },
+        "gpuProfile": {
+          "$ref": "#/definitions/GPUProfile",
+          "description": "GPU settings for the Agent Pool."
+        },
+        "gatewayProfile": {
+          "$ref": "#/definitions/AgentPoolGatewayProfile",
+          "description": "Profile specific to a managed agent pool in Gateway mode. This field cannot be set if agent pool mode is not Gateway."
+        },
+        "virtualMachinesProfile": {
+          "$ref": "#/definitions/VirtualMachinesProfile",
+          "description": "Specifications on VirtualMachines agent pool."
+        },
+        "virtualMachineNodesStatus": {
+          "type": "array",
+          "description": "The status of nodes in a VirtualMachines agent pool.",
+          "items": {
+            "$ref": "#/definitions/VirtualMachineNodes"
+          },
+          "x-ms-identifiers": []
+        },
+        "status": {
+          "$ref": "#/definitions/AgentPoolStatus",
+          "description": "Contains read-only information about the Agent Pool."
+        },
+        "localDNSProfile": {
+          "$ref": "#/definitions/LocalDNSProfile",
+          "description": "Configures the per-node local DNS, with VnetDNS and KubeDNS overrides. LocalDNS helps improve performance and reliability of DNS resolution in an AKS cluster. For more details see aka.ms/aks/localdns."
+        }
+      }
+    },
+    "ManagedClusterAppRoutingIstio": {
+      "type": "object",
+      "description": "Configuration for using a sidecar-less Istio control plane for managed ingress via the Gateway API with App Routing. See https://aka.ms/gateway-on-istio for information on using Istio for ingress via the Gateway API.",
+      "properties": {
+        "mode": {
+          "$ref": "#/definitions/GatewayAPIIstioEnabled",
+          "description": "Whether to enable Istio as a Gateway API implementation for managed ingress with App Routing."
+        }
+      }
+    },
+    "ManagedClusterAutoUpgradeProfile": {
+      "type": "object",
+      "description": "Auto upgrade profile for a managed cluster.",
+      "properties": {
+        "upgradeChannel": {
+          "$ref": "#/definitions/UpgradeChannel",
+          "description": "The upgrade channel for auto upgrade. The default is 'none'. For more information see [setting the AKS cluster auto-upgrade channel](https://docs.microsoft.com/azure/aks/upgrade-cluster#set-auto-upgrade-channel)."
+        },
+        "nodeOSUpgradeChannel": {
+          "$ref": "#/definitions/NodeOSUpgradeChannel",
+          "description": "Node OS Upgrade Channel. Manner in which the OS on your nodes is updated. The default is NodeImage."
+        }
+      }
+    },
+    "ManagedClusterAzureMonitorProfile": {
+      "type": "object",
+      "description": "Azure Monitor addon profiles for monitoring the managed cluster.",
+      "properties": {
+        "metrics": {
+          "$ref": "#/definitions/ManagedClusterAzureMonitorProfileMetrics",
+          "description": "Metrics profile for the Azure Monitor managed service for Prometheus addon. Collect out-of-the-box Kubernetes infrastructure metrics to send to an Azure Monitor Workspace and configure additional scraping for custom targets. See aka.ms/AzureManagedPrometheus for an overview."
+        },
+        "appMonitoring": {
+          "$ref": "#/definitions/ManagedClusterAzureMonitorProfileAppMonitoring",
+          "description": "Application Monitoring Profile for Kubernetes Application Container. Collects application logs, metrics and traces through auto-instrumentation of the application using Azure Monitor OpenTelemetry based SDKs. See aka.ms/AzureMonitorApplicationMonitoring for an overview."
+        }
+      }
+    },
+    "ManagedClusterAzureMonitorProfileAppMonitoring": {
+      "type": "object",
+      "description": "Application Monitoring profile for AKS.",
+      "properties": {
+        "autoInstrumentation": {
+          "$ref": "#/definitions/ManagedClusterAzureMonitorProfileAppMonitoringAutoInstrumentation",
+          "description": "Application Monitoring auto-instrumentation for AKS. Deploys a webhook that auto-instruments workloads with Microsoft OpenTelemetry Distros to collect OpenTelemetry metrics, logs, and traces. See https://aka.ms/AKSAppMonitoringDocs and https://aka.ms/AzureMonitorApplicationMonitoring for an overview."
+        }
+      }
+    },
+    "ManagedClusterAzureMonitorProfileAppMonitoringAutoInstrumentation": {
+      "type": "object",
+      "description": "Application Monitoring auto-instrumentation for AKS. Deploys a webhook that auto-instruments workloads with Microsoft OpenTelemetry Distros to collect OpenTelemetry metrics, logs, and traces. See https://aka.ms/AKSAppMonitoringDocs and https://aka.ms/AzureMonitorApplicationMonitoring for an overview.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Indicates if Application Monitoring Auto-instrumentation is enabled or not."
+        }
+      }
+    },
+    "ManagedClusterAzureMonitorProfileKubeStateMetrics": {
+      "type": "object",
+      "description": "Kube State Metrics profile for the Azure Managed Prometheus addon. These optional settings are for the kube-state-metrics pod that is deployed with the addon. See aka.ms/AzureManagedPrometheus-optional-parameters for details.",
+      "properties": {
+        "metricLabelsAllowlist": {
+          "type": "string",
+          "description": "Comma-separated list of additional Kubernetes label keys that will be used in the resource's labels metric (Example: 'namespaces=[k8s-label-1,k8s-label-n,...],pods=[app],...'). By default the metric contains only resource name and namespace labels."
+        },
+        "metricAnnotationsAllowList": {
+          "type": "string",
+          "description": "Comma-separated list of Kubernetes annotation keys that will be used in the resource's labels metric (Example: 'namespaces=[kubernetes.io/team,...],pods=[kubernetes.io/team],...'). By default the metric contains only resource name and namespace labels."
+        }
+      }
+    },
+    "ManagedClusterAzureMonitorProfileMetrics": {
+      "type": "object",
+      "description": "Metrics profile for the Azure Monitor managed service for Prometheus addon. Collect out-of-the-box Kubernetes infrastructure metrics to send to an Azure Monitor Workspace and configure additional scraping for custom targets. See aka.ms/AzureManagedPrometheus for an overview.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether to enable or disable the Azure Managed Prometheus addon for Prometheus monitoring. See aka.ms/AzureManagedPrometheus-aks-enable for details on enabling and disabling."
+        },
+        "kubeStateMetrics": {
+          "$ref": "#/definitions/ManagedClusterAzureMonitorProfileKubeStateMetrics",
+          "description": "Kube State Metrics profile for the Azure Managed Prometheus addon. These optional settings are for the kube-state-metrics pod that is deployed with the addon. See aka.ms/AzureManagedPrometheus-optional-parameters for details."
+        },
+        "controlPlane": {
+          "$ref": "#/definitions/ManagedClusterAzureMonitorProfileMetricsControlPlane",
+          "description": "Control plane metrics collection profile for the Azure Managed Prometheus addon. Configures collection of operational runtime metrics from managed control plane components (kube-apiserver, etcd, etc). See aka.ms/aks/controlplane-metrics for an overview."
+        }
+      },
+      "required": [
+        "enabled"
+      ]
+    },
+    "ManagedClusterAzureMonitorProfileMetricsControlPlane": {
+      "type": "object",
+      "description": "Control plane metrics collection profile for the Azure Managed Prometheus addon. Configures collection of operational runtime metrics from managed control plane components (kube-apiserver, etcd, etc). See aka.ms/aks/controlplane-metrics for an overview.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether to enable or disable collection of control plane metrics by the Azure Managed Prometheus addon. Defaults to disabled. See aka.ms/aks/controlplane-metrics for details."
+        }
+      }
+    },
+    "ManagedClusterBootstrapProfile": {
+      "type": "object",
+      "description": "The bootstrap profile.",
+      "properties": {
+        "artifactSource": {
+          "type": "string",
+          "description": "The artifact source. The source where the artifacts are downloaded from.",
+          "default": "Direct",
+          "enum": [
+            "Cache",
+            "Direct"
+          ],
+          "x-ms-enum": {
+            "name": "ArtifactSource",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Cache",
+                "value": "Cache",
+                "description": "pull images from Azure Container Registry with cache"
+              },
+              {
+                "name": "Direct",
+                "value": "Direct",
+                "description": "pull images from Microsoft Artifact Registry"
+              }
+            ]
+          }
+        },
+        "containerRegistryId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The resource Id of Azure Container Registry. The registry must have private network access, premium SKU and zone redundancy.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.ContainerRegistry/registries"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "ManagedClusterCostAnalysis": {
+      "type": "object",
+      "description": "The cost analysis configuration for the cluster",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether to enable cost analysis. The Managed Cluster sku.tier must be set to 'Standard' or 'Premium' to enable this feature. Enabling this will add Kubernetes Namespace and Deployment details to the Cost Analysis views in the Azure portal. If not specified, the default is false. For more information see aka.ms/aks/docs/cost-analysis."
+        }
+      }
+    },
+    "ManagedClusterHTTPProxyConfig": {
+      "type": "object",
+      "description": "Cluster HTTP proxy configuration.",
+      "properties": {
+        "httpProxy": {
+          "type": "string",
+          "description": "The HTTP proxy server endpoint to use."
+        },
+        "httpsProxy": {
+          "type": "string",
+          "description": "The HTTPS proxy server endpoint to use."
+        },
+        "noProxy": {
+          "type": "array",
+          "description": "The endpoints that should not go through proxy.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "trustedCa": {
+          "type": "string",
+          "description": "Alternative CA cert to use for connecting to proxy servers."
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether to enable HTTP proxy. If disabled, the specified proxy configuration will be not be set on pods and nodes. If not specified, the default is true."
+        }
+      }
+    },
+    "ManagedClusterHostedSystemProfile": {
+      "type": "object",
+      "description": "Settings for hosted system addons.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether to enable hosted system addons for the cluster."
+        },
+        "systemNodeSubnetID": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The ID of the subnet that will be joined by system nodes managed and hosted by AKS for running critical system addons. This ID must be provided together with `nodeSubnetID` and `apiserverAccessProfile.subnetId`, and all three subnet IDs must belong to the same VNet. If you don’t specify it, AKS will create a subnet in the managed resource group using a default /26 CIDR.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/virtualNetworks/subnets"
+              }
+            ]
+          }
+        },
+        "nodeSubnetID": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The ID of the subnet that will be joined by worker nodes managed by node auto provisioner for running workload pods in your tenant. This must be provided together with `systemNodeSubnetID` and `apiserverAccessProfile.subnetId`, and all three subnet IDs must be in the same VNet. If you don’t specify it, AKS will create a subnet in the managed resource group using a default /16 CIDR.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/virtualNetworks/subnets"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "ManagedClusterIdentity": {
+      "type": "object",
+      "description": "Identity for the managed cluster.",
+      "properties": {
+        "principalId": {
+          "type": "string",
+          "description": "The principal id of the system assigned identity which is used by master components.",
+          "readOnly": true
+        },
+        "tenantId": {
+          "type": "string",
+          "description": "The tenant id of the system assigned identity which is used by master components.",
+          "readOnly": true
+        },
+        "type": {
+          "$ref": "#/definitions/ResourceIdentityType",
+          "description": "The type of identity used for the managed cluster. For more information see [use managed identities in AKS](https://docs.microsoft.com/azure/aks/use-managed-identity)."
+        },
+        "delegatedResources": {
+          "type": "object",
+          "description": "The delegated identity resources assigned to this managed cluster. This can only be set by another Azure Resource Provider, and managed cluster only accept one delegated identity resource. Internal use only.",
+          "additionalProperties": {
+            "$ref": "../../../../../../common-types/resource-management/v6/managedidentitywithdelegation.json#/definitions/DelegatedResource"
+          }
+        },
+        "userAssignedIdentities": {
+          "type": "object",
+          "description": "The user identity associated with the managed cluster. This identity will be used in control plane. Only one user assigned identity is allowed. The keys must be ARM resource IDs in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'.",
+          "additionalProperties": {
+            "$ref": "#/definitions/ManagedServiceIdentityUserAssignedIdentitiesValue"
+          }
+        }
+      }
+    },
+    "ManagedClusterIngressProfile": {
+      "type": "object",
+      "description": "Ingress profile for the container service cluster.",
+      "properties": {
+        "webAppRouting": {
+          "$ref": "#/definitions/ManagedClusterIngressProfileWebAppRouting",
+          "description": "App Routing settings for the ingress profile. You can find an overview and onboarding guide for this feature at https://learn.microsoft.com/en-us/azure/aks/app-routing?tabs=default%2Cdeploy-app-default."
+        },
+        "gatewayAPI": {
+          "$ref": "#/definitions/ManagedClusterIngressProfileGatewayConfiguration",
+          "description": "Settings for the managed Gateway API installation"
+        }
+      }
+    },
+    "ManagedClusterIngressProfileGatewayConfiguration": {
+      "type": "object",
+      "description": "Configuration for managed Gateway API CRDs. See https://aka.ms/k8s-gateway-api for more details.",
+      "properties": {
+        "installation": {
+          "$ref": "#/definitions/ManagedGatewayType",
+          "description": "Configuration for the managed Gateway API installation. If not specified, the default is 'Disabled'. See https://aka.ms/k8s-gateway-api for more details."
+        }
+      }
+    },
+    "ManagedClusterIngressProfileNginx": {
+      "type": "object",
+      "description": "Nginx ingress controller configuration for the managed cluster ingress profile.",
+      "properties": {
+        "defaultIngressControllerType": {
+          "$ref": "#/definitions/NginxIngressControllerType",
+          "description": "Ingress type for the default NginxIngressController custom resource"
+        }
+      }
+    },
+    "ManagedClusterIngressProfileWebAppRouting": {
+      "type": "object",
+      "description": "Application Routing add-on settings for the ingress profile.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether to enable the Application Routing add-on."
+        },
+        "gatewayAPIImplementations": {
+          "$ref": "#/definitions/ManagedClusterWebAppRoutingGatewayAPIImplementations",
+          "description": "Configurations for Gateway API providers to be used for managed ingress with App Routing. See https://aka.ms/k8s-gateway-api for more information on the Gateway API."
+        },
+        "dnsZoneResourceIds": {
+          "type": "array",
+          "description": "Resource IDs of the DNS zones to be associated with the Application Routing add-on. Used only when Application Routing add-on is enabled. Public and private DNS zones can be in different resource groups, but all public DNS zones must be in the same resource group and all private DNS zones must be in the same resource group.",
+          "maxItems": 5,
+          "items": {
+            "type": "string",
+            "format": "arm-id",
+            "description": "A type definition that refers the id to an Azure Resource Manager resource.",
+            "x-ms-arm-id-details": {
+              "allowedResources": [
+                {
+                  "type": "Microsoft.Network/dnszones"
+                },
+                {
+                  "type": "Microsoft.Network/privateDnsZones"
+                }
+              ]
+            }
+          }
+        },
+        "nginx": {
+          "$ref": "#/definitions/ManagedClusterIngressProfileNginx",
+          "description": "Configuration for the default NginxIngressController. See more at https://learn.microsoft.com/en-us/azure/aks/app-routing-nginx-configuration#the-default-nginx-ingress-controller."
+        },
+        "identity": {
+          "$ref": "#/definitions/UserAssignedIdentity",
+          "description": "Managed identity of the Application Routing add-on. This is the identity that should be granted permissions, for example, to manage the associated Azure DNS resource and get certificates from Azure Key Vault. See [this overview of the add-on](https://learn.microsoft.com/en-us/azure/aks/web-app-routing?tabs=with-osm) for more instructions.",
+          "readOnly": true
+        }
+      }
+    },
+    "ManagedClusterListResult": {
+      "type": "object",
+      "description": "The response of a ManagedCluster list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ManagedCluster items on this page",
+          "items": {
+            "$ref": "#/definitions/ManagedCluster"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ManagedClusterLoadBalancerProfile": {
+      "type": "object",
+      "description": "Profile of the managed cluster load balancer.",
+      "properties": {
+        "managedOutboundIPs": {
+          "$ref": "#/definitions/ManagedClusterLoadBalancerProfileManagedOutboundIPs",
+          "description": "Desired managed outbound IPs for the cluster load balancer."
+        },
+        "outboundIPPrefixes": {
+          "$ref": "#/definitions/ManagedClusterLoadBalancerProfileOutboundIPPrefixes",
+          "description": "Desired outbound IP Prefix resources for the cluster load balancer."
+        },
+        "outboundIPs": {
+          "$ref": "#/definitions/ManagedClusterLoadBalancerProfileOutboundIPs",
+          "description": "Desired outbound IP resources for the cluster load balancer."
+        },
+        "effectiveOutboundIPs": {
+          "type": "array",
+          "description": "The effective outbound IP resources of the cluster load balancer.",
+          "items": {
+            "$ref": "#/definitions/ResourceReference"
+          },
+          "readOnly": true
+        },
+        "allocatedOutboundPorts": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The desired number of allocated SNAT ports per VM. Allowed values are in the range of 0 to 64000 (inclusive). The default value is 0 which results in Azure dynamically allocating ports.",
+          "default": 0,
+          "minimum": 0,
+          "maximum": 64000
+        },
+        "idleTimeoutInMinutes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Desired outbound flow idle timeout in minutes. Allowed values are in the range of 4 to 120 (inclusive). The default value is 30 minutes.",
+          "default": 30,
+          "minimum": 4,
+          "maximum": 120
+        },
+        "enableMultipleStandardLoadBalancers": {
+          "type": "boolean",
+          "description": "Enable multiple standard load balancers per AKS cluster or not."
+        },
+        "backendPoolType": {
+          "type": "string",
+          "description": "The type of the managed inbound Load Balancer BackendPool.",
+          "default": "NodeIPConfiguration",
+          "enum": [
+            "NodeIPConfiguration",
+            "NodeIP"
+          ],
+          "x-ms-enum": {
+            "name": "BackendPoolType",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "NodeIPConfiguration",
+                "value": "NodeIPConfiguration",
+                "description": "The type of the managed inbound Load Balancer BackendPool. https://cloud-provider-azure.sigs.k8s.io/topics/loadbalancer/#configure-load-balancer-backend."
+              },
+              {
+                "name": "NodeIP",
+                "value": "NodeIP",
+                "description": "The type of the managed inbound Load Balancer BackendPool. https://cloud-provider-azure.sigs.k8s.io/topics/loadbalancer/#configure-load-balancer-backend."
+              }
+            ]
+          }
+        }
+      }
+    },
+    "ManagedClusterLoadBalancerProfileManagedOutboundIPs": {
+      "type": "object",
+      "description": "Desired managed outbound IPs for the cluster load balancer.",
+      "properties": {
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The desired number of IPv4 outbound IPs created/managed by Azure for the cluster load balancer. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 1.",
+          "default": 1,
+          "minimum": 1,
+          "maximum": 100
+        },
+        "countIPv6": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The desired number of IPv6 outbound IPs created/managed by Azure for the cluster load balancer. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 0 for single-stack and 1 for dual-stack.",
+          "default": 0,
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
+    },
+    "ManagedClusterLoadBalancerProfileOutboundIPPrefixes": {
+      "type": "object",
+      "description": "Desired outbound IP Prefix resources for the cluster load balancer.",
+      "properties": {
+        "publicIPPrefixes": {
+          "type": "array",
+          "description": "A list of public IP prefix resources.",
+          "items": {
+            "$ref": "#/definitions/ResourceReference"
+          }
+        }
+      }
+    },
+    "ManagedClusterLoadBalancerProfileOutboundIPs": {
+      "type": "object",
+      "description": "Desired outbound IP resources for the cluster load balancer.",
+      "properties": {
+        "publicIPs": {
+          "type": "array",
+          "description": "A list of public IP resources.",
+          "items": {
+            "$ref": "#/definitions/ResourceReference"
+          }
+        }
+      }
+    },
+    "ManagedClusterManagedOutboundIPProfile": {
+      "type": "object",
+      "description": "Profile of the managed outbound IP resources of the managed cluster.",
+      "properties": {
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The desired number of outbound IPs created/managed by Azure. Allowed values must be in the range of 1 to 16 (inclusive). The default value is 1.",
+          "default": 1,
+          "minimum": 1,
+          "maximum": 16
+        }
+      }
+    },
+    "ManagedClusterMetricsProfile": {
+      "type": "object",
+      "description": "The metrics profile for the ManagedCluster.",
+      "properties": {
+        "costAnalysis": {
+          "$ref": "#/definitions/ManagedClusterCostAnalysis",
+          "description": "The configuration for detailed per-Kubernetes resource cost analysis."
+        }
+      }
+    },
+    "ManagedClusterNATGatewayProfile": {
+      "type": "object",
+      "description": "Profile of the managed cluster NAT gateway.",
+      "properties": {
+        "managedOutboundIPProfile": {
+          "$ref": "#/definitions/ManagedClusterManagedOutboundIPProfile",
+          "description": "Profile of the managed outbound IP resources of the cluster NAT gateway."
+        },
+        "effectiveOutboundIPs": {
+          "type": "array",
+          "description": "The effective outbound IP resources of the cluster NAT gateway.",
+          "items": {
+            "$ref": "#/definitions/ResourceReference"
+          },
+          "readOnly": true
+        },
+        "idleTimeoutInMinutes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Desired outbound flow idle timeout in minutes. Allowed values are in the range of 4 to 120 (inclusive). The default value is 4 minutes.",
+          "default": 4,
+          "minimum": 4,
+          "maximum": 120
+        }
+      }
+    },
+    "ManagedClusterNodeProvisioningProfile": {
+      "type": "object",
+      "description": "Node provisioning profile for the managed cluster.",
+      "properties": {
+        "mode": {
+          "$ref": "#/definitions/NodeProvisioningMode",
+          "description": "The node provisioning mode. If not specified, the default is Manual."
+        },
+        "defaultNodePools": {
+          "type": "string",
+          "description": "The set of default Karpenter NodePools (CRDs) configured for node provisioning. This field has no effect unless mode is 'Auto'. Warning: Changing this from Auto to None on an existing cluster will cause the default Karpenter NodePools to be deleted, which will drain and delete the nodes associated with those pools. It is strongly recommended to not do this unless there are idle nodes ready to take the pods evicted by that action. If not specified, the default is Auto. For more information see aka.ms/aks/nap#node-pools.",
+          "default": "Auto",
+          "enum": [
+            "None",
+            "Auto"
+          ],
+          "x-ms-enum": {
+            "name": "NodeProvisioningDefaultNodePools",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "None",
+                "value": "None",
+                "description": "No Karpenter NodePools are provisioned automatically. Automatic scaling will not happen unless the user creates one or more NodePool CRD instances."
+              },
+              {
+                "name": "Auto",
+                "value": "Auto",
+                "description": "A standard set of Karpenter NodePools are provisioned"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "ManagedClusterNodeResourceGroupProfile": {
+      "type": "object",
+      "description": "Node resource group lockdown profile for a managed cluster.",
+      "properties": {
+        "restrictionLevel": {
+          "$ref": "#/definitions/RestrictionLevel",
+          "description": "The restriction level applied to the cluster's node resource group. If not specified, the default is 'Unrestricted'"
+        }
+      }
+    },
+    "ManagedClusterOIDCIssuerProfile": {
+      "type": "object",
+      "description": "The OIDC issuer profile of the Managed Cluster.",
+      "properties": {
+        "issuerURL": {
+          "type": "string",
+          "description": "The OIDC issuer url of the Managed Cluster.",
+          "readOnly": true
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether the OIDC issuer is enabled."
+        }
+      }
+    },
+    "ManagedClusterPodIdentity": {
+      "type": "object",
+      "description": "Details about the pod identity assigned to the Managed Cluster.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the pod identity."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "The namespace of the pod identity."
+        },
+        "bindingSelector": {
+          "type": "string",
+          "description": "The binding selector to use for the AzureIdentityBinding resource."
+        },
+        "identity": {
+          "$ref": "#/definitions/UserAssignedIdentity",
+          "description": "The user assigned identity details."
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ManagedClusterPodIdentityProvisioningState",
+          "description": "The current provisioning state of the pod identity.",
+          "readOnly": true
+        },
+        "provisioningInfo": {
+          "$ref": "#/definitions/ManagedClusterPodIdentityProvisioningInfo",
+          "description": "The provisioning information for the pod identity.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "name",
+        "namespace",
+        "identity"
+      ]
+    },
+    "ManagedClusterPodIdentityException": {
+      "type": "object",
+      "description": "A pod identity exception, which allows pods with certain labels to access the Azure Instance Metadata Service (IMDS) endpoint without being intercepted by the node-managed identity (NMI) server. See [disable AAD Pod Identity for a specific Pod/Application](https://azure.github.io/aad-pod-identity/docs/configure/application_exception/) for more details.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the pod identity exception."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "The namespace of the pod identity exception."
+        },
+        "podLabels": {
+          "type": "object",
+          "description": "The pod labels to match.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "name",
+        "namespace",
+        "podLabels"
+      ]
+    },
+    "ManagedClusterPodIdentityProfile": {
+      "type": "object",
+      "description": "The pod identity profile of the Managed Cluster. See [use AAD pod identity](https://docs.microsoft.com/azure/aks/use-azure-ad-pod-identity) for more details on pod identity integration.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether the pod identity addon is enabled."
+        },
+        "allowNetworkPluginKubenet": {
+          "type": "boolean",
+          "description": "Whether pod identity is allowed to run on clusters with Kubenet networking. Running in Kubenet is disabled by default due to the security related nature of AAD Pod Identity and the risks of IP spoofing. See [using Kubenet network plugin with AAD Pod Identity](https://docs.microsoft.com/azure/aks/use-azure-ad-pod-identity#using-kubenet-network-plugin-with-azure-active-directory-pod-managed-identities) for more information."
+        },
+        "userAssignedIdentities": {
+          "type": "array",
+          "description": "The pod identities to use in the cluster.",
+          "items": {
+            "$ref": "#/definitions/ManagedClusterPodIdentity"
+          },
+          "x-ms-identifiers": []
+        },
+        "userAssignedIdentityExceptions": {
+          "type": "array",
+          "description": "The pod identity exceptions to allow.",
+          "items": {
+            "$ref": "#/definitions/ManagedClusterPodIdentityException"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "ManagedClusterPodIdentityProvisioningError": {
+      "type": "object",
+      "description": "An error response from the pod identity provisioning.",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/ManagedClusterPodIdentityProvisioningErrorBody",
+          "description": "Details about the error."
+        }
+      }
+    },
+    "ManagedClusterPodIdentityProvisioningErrorBody": {
+      "type": "object",
+      "description": "An error response from the pod identity provisioning.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "An identifier for the error. Codes are invariant and are intended to be consumed programmatically."
+        },
+        "message": {
+          "type": "string",
+          "description": "A message describing the error, intended to be suitable for display in a user interface."
+        },
+        "target": {
+          "type": "string",
+          "description": "The target of the particular error. For example, the name of the property in error."
+        },
+        "details": {
+          "type": "array",
+          "description": "A list of additional details about the error.",
+          "items": {
+            "$ref": "#/definitions/ManagedClusterPodIdentityProvisioningErrorBody"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "ManagedClusterPodIdentityProvisioningInfo": {
+      "type": "object",
+      "description": "Pod identity provisioning information.",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/ManagedClusterPodIdentityProvisioningError",
+          "description": "Pod identity assignment error (if any)."
+        }
+      }
+    },
+    "ManagedClusterPodIdentityProvisioningState": {
+      "type": "string",
+      "description": "The current provisioning state of the pod identity.",
+      "enum": [
+        "Assigned",
+        "Canceled",
+        "Deleting",
+        "Failed",
+        "Succeeded",
+        "Updating"
+      ],
+      "x-ms-enum": {
+        "name": "ManagedClusterPodIdentityProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Assigned",
+            "value": "Assigned",
+            "description": "Pod identity is assigned."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Pod identity assignment was canceled."
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Pod identity is being deleted."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Pod identity assignment failed."
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Pod identity assignment succeeded."
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Pod identity is being updated."
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "ManagedClusterPoolUpgradeProfile": {
+      "type": "object",
+      "description": "The list of available upgrade versions.",
+      "properties": {
+        "kubernetesVersion": {
+          "type": "string",
+          "description": "The Kubernetes version (major.minor.patch)."
+        },
+        "name": {
+          "type": "string",
+          "description": "The Agent Pool name."
+        },
+        "osType": {
+          "type": "string",
+          "description": "The operating system type. The default is Linux.",
+          "default": "Linux",
+          "enum": [
+            "Linux",
+            "Windows"
+          ],
+          "x-ms-enum": {
+            "name": "OSType",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Linux",
+                "value": "Linux",
+                "description": "Use Linux."
+              },
+              {
+                "name": "Windows",
+                "value": "Windows",
+                "description": "Use Windows."
+              }
+            ]
+          }
+        },
+        "upgrades": {
+          "type": "array",
+          "description": "List of orchestrator types and versions available for upgrade.",
+          "items": {
+            "$ref": "#/definitions/ManagedClusterPoolUpgradeProfileUpgradesItem"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "required": [
+        "kubernetesVersion",
+        "osType"
+      ]
+    },
+    "ManagedClusterPoolUpgradeProfileUpgradesItem": {
+      "type": "object",
+      "description": "Available upgrades for an AgentPool.",
+      "properties": {
+        "kubernetesVersion": {
+          "type": "string",
+          "description": "The Kubernetes version (major.minor.patch)."
+        },
+        "isPreview": {
+          "type": "boolean",
+          "description": "Whether the Kubernetes version is currently in preview."
+        }
+      }
+    },
+    "ManagedClusterProperties": {
+      "type": "object",
+      "description": "Properties of the managed cluster.",
+      "properties": {
+        "provisioningState": {
+          "type": "string",
+          "description": "The current provisioning state.",
+          "readOnly": true
+        },
+        "powerState": {
+          "$ref": "#/definitions/PowerState",
+          "description": "The Power State of the cluster.",
+          "readOnly": true
+        },
+        "maxAgentPools": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The max number of agent pools for the managed cluster.",
+          "readOnly": true
+        },
+        "kubernetesVersion": {
+          "type": "string",
+          "description": "The version of Kubernetes specified by the user. Both patch version <major.minor.patch> (e.g. 1.20.13) and <major.minor> (e.g. 1.20) are supported. When <major.minor> is specified, the latest supported GA patch version is chosen automatically. Updating the cluster with the same <major.minor> once it has been created (e.g. 1.14.x -> 1.14) will not trigger an upgrade, even if a newer patch version is available. When you upgrade a supported AKS cluster, Kubernetes minor versions cannot be skipped. All upgrades must be performed sequentially by major version number. For example, upgrades between 1.14.x -> 1.15.x or 1.15.x -> 1.16.x are allowed, however 1.14.x -> 1.16.x is not allowed. See [upgrading an AKS cluster](https://docs.microsoft.com/azure/aks/upgrade-cluster) for more details."
+        },
+        "currentKubernetesVersion": {
+          "type": "string",
+          "description": "The version of Kubernetes the Managed Cluster is running. If kubernetesVersion was a fully specified version <major.minor.patch>, this field will be exactly equal to it. If kubernetesVersion was <major.minor>, this field will contain the full <major.minor.patch> version being used.",
+          "readOnly": true
+        },
+        "dnsPrefix": {
+          "type": "string",
+          "description": "The DNS prefix of the Managed Cluster. This cannot be updated once the Managed Cluster has been created."
+        },
+        "fqdnSubdomain": {
+          "type": "string",
+          "description": "The FQDN subdomain of the private cluster with custom private dns zone. This cannot be updated once the Managed Cluster has been created."
+        },
+        "fqdn": {
+          "type": "string",
+          "description": "The FQDN of the master pool.",
+          "readOnly": true
+        },
+        "privateFQDN": {
+          "type": "string",
+          "description": "The FQDN of private cluster.",
+          "readOnly": true
+        },
+        "azurePortalFQDN": {
+          "type": "string",
+          "description": "The special FQDN used by the Azure Portal to access the Managed Cluster. This FQDN is for use only by the Azure Portal and should not be used by other clients. The Azure Portal requires certain Cross-Origin Resource Sharing (CORS) headers to be sent in some responses, which Kubernetes APIServer doesn't handle by default. This special FQDN supports CORS, allowing the Azure Portal to function properly.",
+          "readOnly": true
+        },
+        "agentPoolProfiles": {
+          "type": "array",
+          "description": "The agent pool properties.",
+          "items": {
+            "$ref": "#/definitions/ManagedClusterAgentPoolProfile"
+          },
+          "x-ms-identifiers": []
+        },
+        "linuxProfile": {
+          "$ref": "#/definitions/ContainerServiceLinuxProfile",
+          "description": "The profile for Linux VMs in the Managed Cluster."
+        },
+        "windowsProfile": {
+          "$ref": "#/definitions/ManagedClusterWindowsProfile",
+          "description": "The profile for Windows VMs in the Managed Cluster."
+        },
+        "servicePrincipalProfile": {
+          "$ref": "#/definitions/ManagedClusterServicePrincipalProfile",
+          "description": "Information about a service principal identity for the cluster to use for manipulating Azure APIs."
+        },
+        "addonProfiles": {
+          "type": "object",
+          "description": "The profile of managed cluster add-on.",
+          "additionalProperties": {
+            "$ref": "#/definitions/ManagedClusterAddonProfile"
+          }
+        },
+        "podIdentityProfile": {
+          "$ref": "#/definitions/ManagedClusterPodIdentityProfile",
+          "description": "The pod identity profile of the Managed Cluster. See [use AAD pod identity](https://docs.microsoft.com/azure/aks/use-azure-ad-pod-identity) for more details on AAD pod identity integration."
+        },
+        "oidcIssuerProfile": {
+          "$ref": "#/definitions/ManagedClusterOIDCIssuerProfile",
+          "description": "The OIDC issuer profile of the Managed Cluster."
+        },
+        "nodeResourceGroup": {
+          "type": "string",
+          "description": "The name of the resource group containing agent pool nodes."
+        },
+        "nodeResourceGroupProfile": {
+          "$ref": "#/definitions/ManagedClusterNodeResourceGroupProfile",
+          "description": "Profile of the node resource group configuration."
+        },
+        "enableRBAC": {
+          "type": "boolean",
+          "description": "Whether to enable Kubernetes Role-Based Access Control."
+        },
+        "supportPlan": {
+          "$ref": "#/definitions/KubernetesSupportPlan",
+          "description": "The support plan for the Managed Cluster. If unspecified, the default is 'KubernetesOfficial'."
+        },
+        "networkProfile": {
+          "$ref": "#/definitions/ContainerServiceNetworkProfile",
+          "description": "The network configuration profile."
+        },
+        "aadProfile": {
+          "$ref": "#/definitions/ManagedClusterAADProfile",
+          "description": "The Azure Active Directory configuration."
+        },
+        "autoUpgradeProfile": {
+          "$ref": "#/definitions/ManagedClusterAutoUpgradeProfile",
+          "description": "The auto upgrade configuration."
+        },
+        "upgradeSettings": {
+          "$ref": "#/definitions/ClusterUpgradeSettings",
+          "description": "Settings for upgrading a cluster."
+        },
+        "autoScalerProfile": {
+          "$ref": "#/definitions/ManagedClusterPropertiesAutoScalerProfile",
+          "description": "Parameters to be applied to the cluster-autoscaler when enabled"
+        },
+        "apiServerAccessProfile": {
+          "$ref": "#/definitions/ManagedClusterAPIServerAccessProfile",
+          "description": "The access profile for managed cluster API server."
+        },
+        "diskEncryptionSetID": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The Resource ID of the disk encryption set to use for enabling encryption at rest. This is of the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/diskEncryptionSets/{encryptionSetName}'",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Compute/diskEncryptionSets"
+              }
+            ]
+          }
+        },
+        "identityProfile": {
+          "type": "object",
+          "description": "The user identity associated with the managed cluster. This identity will be used by the kubelet. Only one user assigned identity is allowed. The only accepted key is \"kubeletidentity\", with value of \"resourceId\": \"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}\".",
+          "additionalProperties": {
+            "$ref": "#/definitions/UserAssignedIdentity"
+          }
+        },
+        "privateLinkResources": {
+          "type": "array",
+          "description": "Private link resources associated with the cluster.",
+          "items": {
+            "$ref": "#/definitions/PrivateLinkResource"
+          }
+        },
+        "disableLocalAccounts": {
+          "type": "boolean",
+          "description": "If local accounts should be disabled on the Managed Cluster. If set to true, getting static credentials will be disabled for this cluster. This must only be used on Managed Clusters that are AAD enabled. For more details see [disable local accounts](https://docs.microsoft.com/azure/aks/managed-aad#disable-local-accounts-preview)."
+        },
+        "httpProxyConfig": {
+          "$ref": "#/definitions/ManagedClusterHTTPProxyConfig",
+          "description": "Configurations for provisioning the cluster with HTTP proxy servers."
+        },
+        "securityProfile": {
+          "$ref": "#/definitions/ManagedClusterSecurityProfile",
+          "description": "Security profile for the managed cluster."
+        },
+        "storageProfile": {
+          "$ref": "#/definitions/ManagedClusterStorageProfile",
+          "description": "Storage profile for the managed cluster."
+        },
+        "ingressProfile": {
+          "$ref": "#/definitions/ManagedClusterIngressProfile",
+          "description": "Ingress profile for the managed cluster."
+        },
+        "publicNetworkAccess": {
+          "$ref": "#/definitions/PublicNetworkAccess",
+          "description": "PublicNetworkAccess of the managedCluster. Allow or deny public network access for AKS"
+        },
+        "workloadAutoScalerProfile": {
+          "$ref": "#/definitions/ManagedClusterWorkloadAutoScalerProfile",
+          "description": "Workload Auto-scaler profile for the managed cluster."
+        },
+        "azureMonitorProfile": {
+          "$ref": "#/definitions/ManagedClusterAzureMonitorProfile",
+          "description": "Azure Monitor addon profiles for monitoring the managed cluster."
+        },
+        "serviceMeshProfile": {
+          "$ref": "#/definitions/ServiceMeshProfile",
+          "description": "Service mesh profile for a managed cluster."
+        },
+        "resourceUID": {
+          "type": "string",
+          "description": "The resourceUID uniquely identifies ManagedClusters that reuse ARM ResourceIds (i.e: create, delete, create sequence)",
+          "readOnly": true
+        },
+        "metricsProfile": {
+          "$ref": "#/definitions/ManagedClusterMetricsProfile",
+          "description": "Optional cluster metrics configuration."
+        },
+        "nodeProvisioningProfile": {
+          "$ref": "#/definitions/ManagedClusterNodeProvisioningProfile",
+          "description": "Node provisioning settings that apply to the whole cluster."
+        },
+        "bootstrapProfile": {
+          "$ref": "#/definitions/ManagedClusterBootstrapProfile",
+          "description": "Profile of the cluster bootstrap configuration."
+        },
+        "aiToolchainOperatorProfile": {
+          "$ref": "#/definitions/ManagedClusterAIToolchainOperatorProfile",
+          "description": "AI toolchain operator settings that apply to the whole cluster."
+        },
+        "hostedSystemProfile": {
+          "$ref": "#/definitions/ManagedClusterHostedSystemProfile",
+          "description": "Settings for hosted system addons. For more information, see https://aka.ms/aks/automatic/systemcomponents."
+        },
+        "status": {
+          "$ref": "#/definitions/ManagedClusterStatus",
+          "description": "Contains read-only information about the Managed Cluster."
+        }
+      }
+    },
+    "ManagedClusterPropertiesAutoScalerProfile": {
+      "type": "object",
+      "description": "Parameters to be applied to the cluster-autoscaler when enabled",
+      "properties": {
+        "balance-similar-node-groups": {
+          "type": "string",
+          "description": "Detects similar node pools and balances the number of nodes between them. Valid values are 'true' and 'false'",
+          "x-ms-client-name": "balanceSimilarNodeGroups"
+        },
+        "daemonset-eviction-for-empty-nodes": {
+          "type": "boolean",
+          "description": "DaemonSet pods will be gracefully terminated from empty nodes. If set to true, all daemonset pods on empty nodes will be evicted before deletion of the node. If the daemonset pod cannot be evicted another node will be chosen for scaling. If set to false, the node will be deleted without ensuring that daemonset pods are deleted or evicted.",
+          "x-ms-client-name": "daemonsetEvictionForEmptyNodes"
+        },
+        "daemonset-eviction-for-occupied-nodes": {
+          "type": "boolean",
+          "description": "DaemonSet pods will be gracefully terminated from non-empty nodes. If set to true, all daemonset pods on occupied nodes will be evicted before deletion of the node. If the daemonset pod cannot be evicted another node will be chosen for scaling. If set to false, the node will be deleted without ensuring that daemonset pods are deleted or evicted.",
+          "x-ms-client-name": "daemonsetEvictionForOccupiedNodes"
+        },
+        "ignore-daemonsets-utilization": {
+          "type": "boolean",
+          "description": "Should CA ignore DaemonSet pods when calculating resource utilization for scaling down. If set to true, the resources used by daemonset will be taken into account when making scaling down decisions.",
+          "x-ms-client-name": "ignoreDaemonsetsUtilization"
+        },
+        "expander": {
+          "$ref": "#/definitions/Expander",
+          "description": "The expander to use when scaling up. If not specified, the default is 'random'. See [expanders](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-expanders) for more information."
+        },
+        "max-empty-bulk-delete": {
+          "type": "string",
+          "description": "The maximum number of empty nodes that can be deleted at the same time. This must be a positive integer. The default is 10.",
+          "x-ms-client-name": "maxEmptyBulkDelete"
+        },
+        "max-graceful-termination-sec": {
+          "type": "string",
+          "description": "The maximum number of seconds the cluster autoscaler waits for pod termination when trying to scale down a node. The default is 600.",
+          "x-ms-client-name": "maxGracefulTerminationSec"
+        },
+        "max-node-provision-time": {
+          "type": "string",
+          "description": "The maximum time the autoscaler waits for a node to be provisioned. The default is '15m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported.",
+          "x-ms-client-name": "maxNodeProvisionTime"
+        },
+        "max-total-unready-percentage": {
+          "type": "string",
+          "description": "The maximum percentage of unready nodes in the cluster. After this percentage is exceeded, cluster autoscaler halts operations. The default is 45. The maximum is 100 and the minimum is 0.",
+          "x-ms-client-name": "maxTotalUnreadyPercentage"
+        },
+        "new-pod-scale-up-delay": {
+          "type": "string",
+          "description": "Ignore unscheduled pods before they're a certain age. For scenarios like burst/batch scale where you don't want CA to act before the kubernetes scheduler could schedule all the pods, you can tell CA to ignore unscheduled pods before they're a certain age. The default is '0s'. Values must be an integer followed by a unit ('s' for seconds, 'm' for minutes, 'h' for hours, etc).",
+          "x-ms-client-name": "newPodScaleUpDelay"
+        },
+        "ok-total-unready-count": {
+          "type": "string",
+          "description": "The number of allowed unready nodes, irrespective of max-total-unready-percentage. This must be an integer. The default is 3.",
+          "x-ms-client-name": "okTotalUnreadyCount"
+        },
+        "scan-interval": {
+          "type": "string",
+          "description": "How often cluster is reevaluated for scale up or down. The default is '10'. Values must be an integer number of seconds.",
+          "x-ms-client-name": "scanInterval"
+        },
+        "scale-down-delay-after-add": {
+          "type": "string",
+          "description": "How long after scale up that scale down evaluation resumes. The default is '10m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported.",
+          "x-ms-client-name": "scaleDownDelayAfterAdd"
+        },
+        "scale-down-delay-after-delete": {
+          "type": "string",
+          "description": "How long after node deletion that scale down evaluation resumes. The default is the scan-interval. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported.",
+          "x-ms-client-name": "scaleDownDelayAfterDelete"
+        },
+        "scale-down-delay-after-failure": {
+          "type": "string",
+          "description": "How long after scale down failure that scale down evaluation resumes. The default is '3m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported.",
+          "x-ms-client-name": "scaleDownDelayAfterFailure"
+        },
+        "scale-down-unneeded-time": {
+          "type": "string",
+          "description": "How long a node should be unneeded before it is eligible for scale down. The default is '10m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported.",
+          "x-ms-client-name": "scaleDownUnneededTime"
+        },
+        "scale-down-unready-time": {
+          "type": "string",
+          "description": "How long an unready node should be unneeded before it is eligible for scale down. The default is '20m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported.",
+          "x-ms-client-name": "scaleDownUnreadyTime"
+        },
+        "scale-down-utilization-threshold": {
+          "type": "string",
+          "description": "Node utilization level, defined as sum of requested resources divided by capacity, below which a node can be considered for scale down. The default is '0.5'.",
+          "x-ms-client-name": "scaleDownUtilizationThreshold"
+        },
+        "skip-nodes-with-local-storage": {
+          "type": "string",
+          "description": "If cluster autoscaler will skip deleting nodes with pods with local storage, for example, EmptyDir or HostPath. The default is true.",
+          "x-ms-client-name": "skipNodesWithLocalStorage"
+        },
+        "skip-nodes-with-system-pods": {
+          "type": "string",
+          "description": "If cluster autoscaler will skip deleting nodes with pods from kube-system (except for DaemonSet or mirror pods). The default is true.",
+          "x-ms-client-name": "skipNodesWithSystemPods"
+        }
+      }
+    },
+    "ManagedClusterSKU": {
+      "type": "object",
+      "description": "The SKU of a Managed Cluster.",
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/ManagedClusterSKUName",
+          "description": "The name of a managed cluster SKU."
+        },
+        "tier": {
+          "$ref": "#/definitions/ManagedClusterSKUTier",
+          "description": "The tier of a managed cluster SKU. If not specified, the default is 'Free'. See [AKS Pricing Tier](https://learn.microsoft.com/azure/aks/free-standard-pricing-tiers) for more details."
+        }
+      }
+    },
+    "ManagedClusterSKUName": {
+      "type": "string",
+      "description": "The name of a managed cluster SKU.",
+      "enum": [
+        "Base",
+        "Automatic"
+      ],
+      "x-ms-enum": {
+        "name": "ManagedClusterSKUName",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Base",
+            "value": "Base",
+            "description": "Base option for the AKS control plane."
+          },
+          {
+            "name": "Automatic",
+            "value": "Automatic",
+            "description": "Automatic clusters are optimized to run most production workloads with configuration that follows AKS best practices and recommendations for cluster and workload setup, scalability, and security. For more details about Automatic clusters see aka.ms/aks/automatic."
+          }
+        ]
+      }
+    },
+    "ManagedClusterSKUTier": {
+      "type": "string",
+      "description": "The tier of a managed cluster SKU. If not specified, the default is 'Free'. See [AKS Pricing Tier](https://learn.microsoft.com/azure/aks/free-standard-pricing-tiers) for more details.",
+      "enum": [
+        "Premium",
+        "Standard",
+        "Free"
+      ],
+      "x-ms-enum": {
+        "name": "ManagedClusterSKUTier",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Premium",
+            "value": "Premium",
+            "description": "Cluster has premium capabilities in addition to all of the capabilities included in 'Standard'. Premium enables selection of LongTermSupport (aka.ms/aks/lts) for certain Kubernetes versions."
+          },
+          {
+            "name": "Standard",
+            "value": "Standard",
+            "description": "Recommended for mission-critical and production workloads. Includes Kubernetes control plane autoscaling, workload-intensive testing, and up to 5,000 nodes per cluster. Guarantees 99.95% availability of the Kubernetes API server endpoint for clusters that use Availability Zones and 99.9% of availability for clusters that don't use Availability Zones."
+          },
+          {
+            "name": "Free",
+            "value": "Free",
+            "description": "The cluster management is free, but charged for VM, storage, and networking usage. Best for experimenting, learning, simple testing, or workloads with fewer than 10 nodes. Not recommended for production use cases."
+          }
+        ]
+      }
+    },
+    "ManagedClusterSecurityProfile": {
+      "type": "object",
+      "description": "Security profile for the container service cluster.",
+      "properties": {
+        "defender": {
+          "$ref": "#/definitions/ManagedClusterSecurityProfileDefender",
+          "description": "Microsoft Defender settings for the security profile."
+        },
+        "azureKeyVaultKms": {
+          "$ref": "#/definitions/AzureKeyVaultKms",
+          "description": "Azure Key Vault [key management service](https://kubernetes.io/docs/tasks/administer-cluster/kms-provider/) settings for the security profile."
+        },
+        "workloadIdentity": {
+          "$ref": "#/definitions/ManagedClusterSecurityProfileWorkloadIdentity",
+          "description": "Workload identity settings for the security profile. Workload identity enables Kubernetes applications to access Azure cloud resources securely with Azure AD. See https://aka.ms/aks/wi for more details."
+        },
+        "imageCleaner": {
+          "$ref": "#/definitions/ManagedClusterSecurityProfileImageCleaner",
+          "description": "Image Cleaner settings for the security profile."
+        },
+        "customCATrustCertificates": {
+          "type": "array",
+          "description": "A list of up to 10 base64 encoded CAs that will be added to the trust store on all nodes in the cluster. For more information see [Custom CA Trust Certificates](https://learn.microsoft.com/en-us/azure/aks/custom-certificate-authority).",
+          "minItems": 0,
+          "maxItems": 10,
+          "items": {
+            "type": "string",
+            "format": "byte"
+          }
+        }
+      }
+    },
+    "ManagedClusterSecurityProfileDefender": {
+      "type": "object",
+      "description": "Microsoft Defender settings for the security profile.",
+      "properties": {
+        "logAnalyticsWorkspaceResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Resource ID of the Log Analytics workspace to be associated with Microsoft Defender. When Microsoft Defender is enabled, this field is required and must be a valid workspace resource ID. When Microsoft Defender is disabled, leave the field empty.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.OperationalInsights/workspaces"
+              }
+            ]
+          }
+        },
+        "securityMonitoring": {
+          "$ref": "#/definitions/ManagedClusterSecurityProfileDefenderSecurityMonitoring",
+          "description": "Microsoft Defender threat detection for Cloud settings for the security profile."
+        }
+      }
+    },
+    "ManagedClusterSecurityProfileDefenderSecurityMonitoring": {
+      "type": "object",
+      "description": "Microsoft Defender settings for the security profile threat detection.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether to enable Defender threat detection"
+        }
+      }
+    },
+    "ManagedClusterSecurityProfileImageCleaner": {
+      "type": "object",
+      "description": "Image Cleaner removes unused images from nodes, freeing up disk space and helping to reduce attack surface area. Here are settings for the security profile.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether to enable Image Cleaner on AKS cluster."
+        },
+        "intervalHours": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Image Cleaner scanning interval in hours."
+        }
+      }
+    },
+    "ManagedClusterSecurityProfileWorkloadIdentity": {
+      "type": "object",
+      "description": "Workload identity settings for the security profile.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether to enable workload identity."
+        }
+      }
+    },
+    "ManagedClusterServicePrincipalProfile": {
+      "type": "object",
+      "description": "Information about a service principal identity for the cluster to use for manipulating Azure APIs.",
+      "properties": {
+        "clientId": {
+          "type": "string",
+          "description": "The ID for the service principal."
+        },
+        "secret": {
+          "type": "string",
+          "format": "password",
+          "description": "The secret password associated with the service principal in plain text.",
+          "x-ms-secret": true
+        }
+      },
+      "required": [
+        "clientId"
+      ]
+    },
+    "ManagedClusterStaticEgressGatewayProfile": {
+      "type": "object",
+      "description": "The Static Egress Gateway addon configuration for the cluster.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable Static Egress Gateway addon. Indicates if Static Egress Gateway addon is enabled or not."
+        }
+      }
+    },
+    "ManagedClusterStatus": {
+      "type": "object",
+      "description": "Contains read-only information about the Managed Cluster.",
+      "properties": {
+        "provisioningError": {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorDetail",
+          "description": "The error details information of the managed cluster. Preserves the detailed info of failure. If there was no error, this field is omitted.",
+          "readOnly": true
+        }
+      }
+    },
+    "ManagedClusterStorageProfile": {
+      "type": "object",
+      "description": "Storage profile for the container service cluster.",
+      "properties": {
+        "diskCSIDriver": {
+          "$ref": "#/definitions/ManagedClusterStorageProfileDiskCSIDriver",
+          "description": "AzureDisk CSI Driver settings for the storage profile."
+        },
+        "fileCSIDriver": {
+          "$ref": "#/definitions/ManagedClusterStorageProfileFileCSIDriver",
+          "description": "AzureFile CSI Driver settings for the storage profile."
+        },
+        "snapshotController": {
+          "$ref": "#/definitions/ManagedClusterStorageProfileSnapshotController",
+          "description": "Snapshot Controller settings for the storage profile."
+        },
+        "blobCSIDriver": {
+          "$ref": "#/definitions/ManagedClusterStorageProfileBlobCSIDriver",
+          "description": "AzureBlob CSI Driver settings for the storage profile."
+        }
+      }
+    },
+    "ManagedClusterStorageProfileBlobCSIDriver": {
+      "type": "object",
+      "description": "AzureBlob CSI Driver settings for the storage profile.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether to enable AzureBlob CSI Driver. The default value is false."
+        }
+      }
+    },
+    "ManagedClusterStorageProfileDiskCSIDriver": {
+      "type": "object",
+      "description": "AzureDisk CSI Driver settings for the storage profile.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether to enable AzureDisk CSI Driver. The default value is true."
+        }
+      }
+    },
+    "ManagedClusterStorageProfileFileCSIDriver": {
+      "type": "object",
+      "description": "AzureFile CSI Driver settings for the storage profile.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether to enable AzureFile CSI Driver. The default value is true."
+        }
+      }
+    },
+    "ManagedClusterStorageProfileSnapshotController": {
+      "type": "object",
+      "description": "Snapshot Controller settings for the storage profile.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether to enable Snapshot Controller. The default value is true."
+        }
+      }
+    },
+    "ManagedClusterUpgradeProfile": {
+      "type": "object",
+      "description": "The list of available upgrades for compute pools.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ManagedClusterUpgradeProfileProperties",
+          "description": "The properties of the upgrade profile.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ManagedClusterUpgradeProfileProperties": {
+      "type": "object",
+      "description": "Control plane and agent pool upgrade profiles.",
+      "properties": {
+        "controlPlaneProfile": {
+          "$ref": "#/definitions/ManagedClusterPoolUpgradeProfile",
+          "description": "The list of available upgrade versions for the control plane."
+        },
+        "agentPoolProfiles": {
+          "type": "array",
+          "description": "The list of available upgrade versions for agent pools.",
+          "items": {
+            "$ref": "#/definitions/ManagedClusterPoolUpgradeProfile"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "required": [
+        "controlPlaneProfile",
+        "agentPoolProfiles"
+      ]
+    },
+    "ManagedClusterWebAppRoutingGatewayAPIImplementations": {
+      "type": "object",
+      "description": "Configurations for Gateway API providers to be used for managed ingress with App Routing.",
+      "properties": {
+        "appRoutingIstio": {
+          "$ref": "#/definitions/ManagedClusterAppRoutingIstio",
+          "description": "Configuration for using a sidecar-less Istio control plane for managed ingress via the Gateway API with App Routing. See https://aka.ms/gateway-on-istio for information on using Istio for ingress via the Gateway API."
+        }
+      }
+    },
+    "ManagedClusterWindowsProfile": {
+      "type": "object",
+      "description": "Profile for Windows VMs in the managed cluster.",
+      "properties": {
+        "adminUsername": {
+          "type": "string",
+          "description": "Specifies the name of the administrator account. <br><br> **Restriction:** Cannot end in \".\" <br><br> **Disallowed values:** \"administrator\", \"admin\", \"user\", \"user1\", \"test\", \"user2\", \"test1\", \"user3\", \"admin1\", \"1\", \"123\", \"a\", \"actuser\", \"adm\", \"admin2\", \"aspnet\", \"backup\", \"console\", \"david\", \"guest\", \"john\", \"owner\", \"root\", \"server\", \"sql\", \"support\", \"support_388945a0\", \"sys\", \"test2\", \"test3\", \"user4\", \"user5\". <br><br> **Minimum-length:** 1 character <br><br> **Max-length:** 20 characters"
+        },
+        "adminPassword": {
+          "type": "string",
+          "format": "password",
+          "description": "Specifies the password of the administrator account. <br><br> **Minimum-length:** 8 characters <br><br> **Max-length:** 123 characters <br><br> **Complexity requirements:** 3 out of 4 conditions below need to be fulfilled <br> Has lower characters <br>Has upper characters <br> Has a digit <br> Has a special character (Regex match [\\W_]) <br><br> **Disallowed values:** \"abc@123\", \"P@$$w0rd\", \"P@ssw0rd\", \"P@ssword123\", \"Pa$$word\", \"pass@word1\", \"Password!\", \"Password1\", \"Password22\", \"iloveyou!\"",
+          "x-ms-secret": true
+        },
+        "licenseType": {
+          "$ref": "#/definitions/LicenseType",
+          "description": "The license type to use for Windows VMs. See [Azure Hybrid User Benefits](https://azure.microsoft.com/pricing/hybrid-benefit/faq/) for more details."
+        },
+        "enableCSIProxy": {
+          "type": "boolean",
+          "description": "Whether to enable CSI proxy. For more details on CSI proxy, see the [CSI proxy GitHub repo](https://github.com/kubernetes-csi/csi-proxy)."
+        },
+        "gmsaProfile": {
+          "$ref": "#/definitions/WindowsGmsaProfile",
+          "description": "The Windows gMSA Profile in the Managed Cluster."
+        }
+      },
+      "required": [
+        "adminUsername"
+      ]
+    },
+    "ManagedClusterWorkloadAutoScalerProfile": {
+      "type": "object",
+      "description": "Workload Auto-scaler profile for the managed cluster.",
+      "properties": {
+        "keda": {
+          "$ref": "#/definitions/ManagedClusterWorkloadAutoScalerProfileKeda",
+          "description": "KEDA (Kubernetes Event-driven Autoscaling) settings for the workload auto-scaler profile."
+        },
+        "verticalPodAutoscaler": {
+          "$ref": "#/definitions/ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler",
+          "description": "VPA (Vertical Pod Autoscaler) settings for the workload auto-scaler profile."
+        }
+      }
+    },
+    "ManagedClusterWorkloadAutoScalerProfileKeda": {
+      "type": "object",
+      "description": "KEDA (Kubernetes Event-driven Autoscaling) settings for the workload auto-scaler profile.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether to enable KEDA."
+        }
+      },
+      "required": [
+        "enabled"
+      ]
+    },
+    "ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler": {
+      "type": "object",
+      "description": "VPA (Vertical Pod Autoscaler) settings for the workload auto-scaler profile.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether to enable VPA. Default value is false.",
+          "default": false
+        }
+      },
+      "required": [
+        "enabled"
+      ]
+    },
+    "ManagedGatewayType": {
+      "type": "string",
+      "description": "Configuration for the managed Gateway API installation. If not specified, the default is 'Disabled'. See https://aka.ms/k8s-gateway-api for more details.",
+      "enum": [
+        "Disabled",
+        "Standard"
+      ],
+      "x-ms-enum": {
+        "name": "ManagedGatewayType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Gateway API CRDs will not be reconciled on your cluster."
+          },
+          {
+            "name": "Standard",
+            "value": "Standard",
+            "description": "Gateway API CRDs from the standard release channel will be reconciled onto your cluster. See https://aka.ms/gateway-api-versions to see which bundle will be installed for your Kubernetes version."
+          }
+        ]
+      }
+    },
+    "ManagedNamespace": {
+      "type": "object",
+      "description": "Namespace managed by ARM.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NamespaceProperties",
+          "description": "Properties of a namespace."
+        },
+        "eTag": {
+          "type": "string",
+          "description": "If eTag is provided in the response body, it may also be provided as a header per the normal etag convention.  Entity tags are used for comparing two or more entities from the same requested resource. HTTP/1.1 uses entity tags in the etag (section 14.19), If-Match (section 14.24), If-None-Match (section 14.26), and If-Range (section 14.27) header fields.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "ManagedNamespaceListResult": {
+      "type": "object",
+      "description": "The response of a ManagedNamespace list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ManagedNamespace items on this page",
+          "items": {
+            "$ref": "#/definitions/ManagedNamespace"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ManagedServiceIdentityUserAssignedIdentitiesValue": {
+      "type": "object",
+      "description": "User assigned identity properties.",
+      "properties": {
+        "principalId": {
+          "type": "string",
+          "description": "The principal id of user assigned identity.",
+          "readOnly": true
+        },
+        "clientId": {
+          "type": "string",
+          "description": "The client id of user assigned identity.",
+          "readOnly": true
+        }
+      }
+    },
+    "ManualScaleProfile": {
+      "type": "object",
+      "description": "Specifications on number of machines.",
+      "properties": {
+        "size": {
+          "type": "string",
+          "description": "VM size that AKS will use when creating and scaling e.g. 'Standard_E4s_v3', 'Standard_E16s_v3' or 'Standard_D16s_v5'."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of nodes."
+        }
+      }
+    },
+    "MeshRevision": {
+      "type": "object",
+      "description": "Holds information on upgrades and compatibility for given major.minor mesh release.",
+      "properties": {
+        "revision": {
+          "type": "string",
+          "description": "The revision of the mesh release."
+        },
+        "upgrades": {
+          "type": "array",
+          "description": "List of revisions available for upgrade of a specific mesh revision",
+          "items": {
+            "$ref": "#/definitions/MeshRevisionUpgradesType"
+          }
+        },
+        "compatibleWith": {
+          "type": "array",
+          "description": "List of items this revision of service mesh is compatible with, and their associated versions.",
+          "items": {
+            "$ref": "#/definitions/CompatibleVersions"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "MeshRevisionProfile": {
+      "type": "object",
+      "description": "Mesh revision profile for a mesh.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/MeshRevisionProfileProperties",
+          "description": "Mesh revision profile properties for a mesh"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "MeshRevisionProfileList": {
+      "type": "object",
+      "description": "Holds an array of MeshRevisionsProfiles",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The MeshRevisionProfile items on this page",
+          "items": {
+            "$ref": "#/definitions/MeshRevisionProfile"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "MeshRevisionProfileProperties": {
+      "type": "object",
+      "description": "Mesh revision profile properties for a mesh",
+      "properties": {
+        "meshRevisions": {
+          "type": "array",
+          "description": "Available mesh revisions.",
+          "items": {
+            "$ref": "#/definitions/MeshRevision"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "MeshRevisionUpgradesType": {
+      "type": "string",
+      "description": "An upgradeable mesh revision"
+    },
+    "MeshUpgradeProfile": {
+      "type": "object",
+      "description": "Upgrade profile for given mesh.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/MeshUpgradeProfileProperties",
+          "description": "Mesh upgrade profile properties for a major.minor release."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "MeshUpgradeProfileList": {
+      "type": "object",
+      "description": "Holds an array of MeshUpgradeProfiles",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The MeshUpgradeProfile items on this page",
+          "items": {
+            "$ref": "#/definitions/MeshUpgradeProfile"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "MeshUpgradeProfileProperties": {
+      "type": "object",
+      "description": "Mesh upgrade profile properties for a major.minor release.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/MeshRevision"
+        }
+      ]
+    },
+    "NamespaceProperties": {
+      "type": "object",
+      "description": "Properties of a namespace managed by ARM",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/NamespaceProvisioningState",
+          "description": "The current provisioning state of the namespace.",
+          "readOnly": true
+        },
+        "labels": {
+          "type": "object",
+          "description": "The labels of managed namespace.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "annotations": {
+          "type": "object",
+          "description": "The annotations of managed namespace.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "portalFqdn": {
+          "type": "string",
+          "description": "The special FQDN used by the Azure Portal to access the Managed Cluster. This FQDN is for use only by the Azure Portal and should not be used by other clients. The Azure Portal requires certain Cross-Origin Resource Sharing (CORS) headers to be sent in some responses, which Kubernetes APIServer doesn't handle by default. This special FQDN supports CORS, allowing the Azure Portal to function properly.",
+          "readOnly": true
+        },
+        "defaultResourceQuota": {
+          "$ref": "#/definitions/ResourceQuota",
+          "description": "The default resource quota enforced upon the namespace. Customers can have other Kubernetes resource quota objects under the namespace. Resource quotas are additive; if multiple resource quotas are applied to a given namespace, then the effective limit will be one such that all quotas on the namespace can be satisfied."
+        },
+        "defaultNetworkPolicy": {
+          "$ref": "#/definitions/NetworkPolicies",
+          "description": "The default network policy enforced upon the namespace. Customers can have other Kubernetes network policy objects under the namespace. Network policies are additive; if a policy or policies apply to a given pod for a given direction, the connections allowed in that direction for the pod is the union of what all applicable policies allow."
+        },
+        "adoptionPolicy": {
+          "$ref": "#/definitions/AdoptionPolicy",
+          "description": "Action if Kubernetes namespace with same name already exists."
+        },
+        "deletePolicy": {
+          "$ref": "#/definitions/DeletePolicy",
+          "description": "Delete options of a namespace."
+        }
+      }
+    },
+    "NamespaceProvisioningState": {
+      "type": "string",
+      "description": "The current provisioning state of the namespace.",
+      "enum": [
+        "Updating",
+        "Deleting",
+        "Creating",
+        "Succeeded",
+        "Failed",
+        "Canceled"
+      ],
+      "x-ms-enum": {
+        "name": "NamespaceProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "The namespace is being updated."
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "The namespace is being deleted."
+          },
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "The namespace is being created."
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "The namespace provisioning succeeded."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "The namespace provisioning failed."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "The namespace provisioning was canceled."
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "NetworkDataplane": {
+      "type": "string",
+      "description": "Network dataplane used in the Kubernetes cluster.",
+      "enum": [
+        "azure",
+        "cilium"
+      ],
+      "x-ms-enum": {
+        "name": "NetworkDataplane",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "azure",
+            "value": "azure",
+            "description": "Use Azure network dataplane."
+          },
+          {
+            "name": "cilium",
+            "value": "cilium",
+            "description": "Use Cilium network dataplane. See [Azure CNI Powered by Cilium](https://learn.microsoft.com/azure/aks/azure-cni-powered-by-cilium) for more information."
+          }
+        ]
+      }
+    },
+    "NetworkMode": {
+      "type": "string",
+      "description": "The network mode Azure CNI is configured with. This cannot be specified if networkPlugin is anything other than 'azure'.",
+      "enum": [
+        "transparent",
+        "bridge"
+      ],
+      "x-ms-enum": {
+        "name": "NetworkMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "transparent",
+            "value": "transparent",
+            "description": "No bridge is created. Intra-VM Pod to Pod communication is through IP routes created by Azure CNI. See [Transparent Mode](https://docs.microsoft.com/azure/aks/faq#transparent-mode) for more information."
+          },
+          {
+            "name": "bridge",
+            "value": "bridge",
+            "description": "This is no longer supported"
+          }
+        ]
+      }
+    },
+    "NetworkPlugin": {
+      "type": "string",
+      "description": "Network plugin used for building the Kubernetes network.",
+      "enum": [
+        "azure",
+        "kubenet",
+        "none"
+      ],
+      "x-ms-enum": {
+        "name": "NetworkPlugin",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "azure",
+            "value": "azure",
+            "description": "Use the Azure CNI network plugin. See [Azure CNI (advanced) networking](https://docs.microsoft.com/azure/aks/concepts-network#azure-cni-advanced-networking) for more information."
+          },
+          {
+            "name": "kubenet",
+            "value": "kubenet",
+            "description": "Use the Kubenet network plugin. See [Kubenet (basic) networking](https://docs.microsoft.com/azure/aks/concepts-network#kubenet-basic-networking) for more information."
+          },
+          {
+            "name": "none",
+            "value": "none",
+            "description": "No CNI plugin is pre-installed. See [BYO CNI](https://docs.microsoft.com/en-us/azure/aks/use-byo-cni) for more information."
+          }
+        ]
+      }
+    },
+    "NetworkPluginMode": {
+      "type": "string",
+      "description": "The mode the network plugin should use.",
+      "enum": [
+        "overlay"
+      ],
+      "x-ms-enum": {
+        "name": "NetworkPluginMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "overlay",
+            "value": "overlay",
+            "description": "Used with networkPlugin=azure, pods are given IPs from the PodCIDR address space but use Azure Routing Domains rather than Kubenet's method of route tables. For more information visit https://aka.ms/aks/azure-cni-overlay."
+          }
+        ]
+      }
+    },
+    "NetworkPolicies": {
+      "type": "object",
+      "description": "Default network policy of the namespace, specifying ingress and egress rules.",
+      "properties": {
+        "ingress": {
+          "type": "string",
+          "description": "Enum representing different network policy rules.",
+          "default": "AllowSameNamespace",
+          "enum": [
+            "DenyAll",
+            "AllowAll",
+            "AllowSameNamespace"
+          ],
+          "x-ms-enum": {
+            "name": "PolicyRule",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "DenyAll",
+                "value": "DenyAll",
+                "description": "Deny all network traffic."
+              },
+              {
+                "name": "AllowAll",
+                "value": "AllowAll",
+                "description": "Allow all network traffic."
+              },
+              {
+                "name": "AllowSameNamespace",
+                "value": "AllowSameNamespace",
+                "description": "Allow traffic within the same namespace."
+              }
+            ]
+          }
+        },
+        "egress": {
+          "type": "string",
+          "description": "Enum representing different network policy rules.",
+          "default": "AllowAll",
+          "enum": [
+            "DenyAll",
+            "AllowAll",
+            "AllowSameNamespace"
+          ],
+          "x-ms-enum": {
+            "name": "PolicyRule",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "DenyAll",
+                "value": "DenyAll",
+                "description": "Deny all network traffic."
+              },
+              {
+                "name": "AllowAll",
+                "value": "AllowAll",
+                "description": "Allow all network traffic."
+              },
+              {
+                "name": "AllowSameNamespace",
+                "value": "AllowSameNamespace",
+                "description": "Allow traffic within the same namespace."
+              }
+            ]
+          }
+        }
+      }
+    },
+    "NetworkPolicy": {
+      "type": "string",
+      "description": "Network policy used for building the Kubernetes network.",
+      "enum": [
+        "none",
+        "calico",
+        "azure",
+        "cilium"
+      ],
+      "x-ms-enum": {
+        "name": "NetworkPolicy",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "none",
+            "value": "none",
+            "description": "Network policies will not be enforced. This is the default value when NetworkPolicy is not specified."
+          },
+          {
+            "name": "calico",
+            "value": "calico",
+            "description": "Use Calico network policies. See [differences between Azure and Calico policies](https://docs.microsoft.com/azure/aks/use-network-policies#differences-between-azure-and-calico-policies-and-their-capabilities) for more information."
+          },
+          {
+            "name": "azure",
+            "value": "azure",
+            "description": "Use Azure network policies. See [differences between Azure and Calico policies](https://docs.microsoft.com/azure/aks/use-network-policies#differences-between-azure-and-calico-policies-and-their-capabilities) for more information."
+          },
+          {
+            "name": "cilium",
+            "value": "cilium",
+            "description": "Use Cilium to enforce network policies. This requires networkDataplane to be 'cilium'."
+          }
+        ]
+      }
+    },
+    "NginxIngressControllerType": {
+      "type": "string",
+      "description": "Ingress type for the default NginxIngressController custom resource",
+      "enum": [
+        "AnnotationControlled",
+        "External",
+        "Internal",
+        "None"
+      ],
+      "x-ms-enum": {
+        "name": "NginxIngressControllerType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "AnnotationControlled",
+            "value": "AnnotationControlled",
+            "description": "The default NginxIngressController will be created. Users can edit the default NginxIngressController Custom Resource to configure load balancer annotations."
+          },
+          {
+            "name": "External",
+            "value": "External",
+            "description": "The default NginxIngressController will be created and the operator will provision an external loadbalancer with it. Any annotation to make the default loadbalancer internal will be overwritten."
+          },
+          {
+            "name": "Internal",
+            "value": "Internal",
+            "description": "The default NginxIngressController will be created and the operator will provision an internal loadbalancer with it. Any annotation to make the default loadbalancer external will be overwritten."
+          },
+          {
+            "name": "None",
+            "value": "None",
+            "description": "The default Ingress Controller will not be created. It will not be deleted by the system if it exists. Users should delete the default NginxIngressController Custom Resource manually if desired."
+          }
+        ]
+      }
+    },
+    "NodeOSUpgradeChannel": {
+      "type": "string",
+      "description": "Node OS Upgrade Channel. Manner in which the OS on your nodes is updated. The default is NodeImage.",
+      "enum": [
+        "None",
+        "Unmanaged",
+        "NodeImage",
+        "SecurityPatch"
+      ],
+      "x-ms-enum": {
+        "name": "NodeOSUpgradeChannel",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None",
+            "description": "No attempt to update your machines OS will be made either by OS or by rolling VHDs. This means you are responsible for your security updates"
+          },
+          {
+            "name": "Unmanaged",
+            "value": "Unmanaged",
+            "description": "OS updates will be applied automatically through the OS built-in patching infrastructure. Newly scaled in machines will be unpatched initially and will be patched at some point by the OS's infrastructure. Behavior of this option depends on the OS in question. Ubuntu and Mariner apply security patches through unattended upgrade roughly once a day around 06:00 UTC. Windows does not apply security patches automatically and so for them this option is equivalent to None till further notice"
+          },
+          {
+            "name": "NodeImage",
+            "value": "NodeImage",
+            "description": "AKS will update the nodes with a newly patched VHD containing security fixes and bugfixes on a weekly cadence. With the VHD update machines will be rolling reimaged to that VHD following maintenance windows and surge settings. No extra VHD cost is incurred when choosing this option as AKS hosts the images."
+          },
+          {
+            "name": "SecurityPatch",
+            "value": "SecurityPatch",
+            "description": "AKS downloads and updates the nodes with tested security updates. These updates honor the maintenance window settings and produce a new VHD that is used on new nodes. On some occasions it's not possible to apply the updates in place, in such cases the existing nodes will also be re-imaged to the newly produced VHD in order to apply the changes. This option incurs an extra cost of hosting the new Security Patch VHDs in your resource group for just in time consumption."
+          }
+        ]
+      }
+    },
+    "NodeProvisioningMode": {
+      "type": "string",
+      "description": "The node provisioning mode. If not specified, the default is Manual.",
+      "enum": [
+        "Manual",
+        "Auto"
+      ],
+      "x-ms-enum": {
+        "name": "NodeProvisioningMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Manual",
+            "value": "Manual",
+            "description": "Nodes are provisioned manually by the user"
+          },
+          {
+            "name": "Auto",
+            "value": "Auto",
+            "description": "Nodes are provisioned automatically by AKS using Karpenter (See aka.ms/aks/nap for more details). Fixed size Node Pools can still be created, but autoscaling Node Pools cannot be. (See aka.ms/aks/nap for more details)."
+          }
+        ]
+      }
+    },
+    "OSDiskType": {
+      "type": "string",
+      "description": "The OS disk type to be used for machines in the agent pool. The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested OSDiskSizeGB. Otherwise, defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral OS](https://docs.microsoft.com/azure/aks/cluster-configuration#ephemeral-os).",
+      "enum": [
+        "Managed",
+        "Ephemeral"
+      ],
+      "x-ms-enum": {
+        "name": "OSDiskType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Managed",
+            "value": "Managed",
+            "description": "Azure replicates the operating system disk for a virtual machine to Azure storage to avoid data loss should the VM need to be relocated to another host. Since containers aren't designed to have local state persisted, this behavior offers limited value while providing some drawbacks, including slower node provisioning and higher read/write latency."
+          },
+          {
+            "name": "Ephemeral",
+            "value": "Ephemeral",
+            "description": "Ephemeral OS disks are stored only on the host machine, just like a temporary disk. This provides lower read/write latency, along with faster node scaling and cluster upgrades."
+          }
+        ]
+      }
+    },
+    "OSSKU": {
+      "type": "string",
+      "description": "Specifies the OS SKU used by the agent pool. The default is Ubuntu if OSType is Linux. The default is Windows2019 when Kubernetes <= 1.24 or Windows2022 when Kubernetes >= 1.25 if OSType is Windows.",
+      "enum": [
+        "Ubuntu",
+        "AzureLinux",
+        "AzureLinux3",
+        "CBLMariner",
+        "Windows2019",
+        "Windows2022",
+        "Ubuntu2204",
+        "Windows2025",
+        "Ubuntu2404"
+      ],
+      "x-ms-enum": {
+        "name": "OSSKU",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Ubuntu",
+            "value": "Ubuntu",
+            "description": "Use Ubuntu as the OS for node images."
+          },
+          {
+            "name": "AzureLinux",
+            "value": "AzureLinux",
+            "description": "Use AzureLinux as the OS for node images. Azure Linux is a container-optimized Linux distro built by Microsoft, visit https://aka.ms/azurelinux for more information."
+          },
+          {
+            "name": "AzureLinux3",
+            "value": "AzureLinux3",
+            "description": "Use AzureLinux3 as the OS for node images. Azure Linux is a container-optimized Linux distro built by Microsoft, visit https://aka.ms/azurelinux for more information. For limitations, visit https://aka.ms/aks/node-images. For OS migration guidance, see https://aka.ms/aks/upgrade-os-version."
+          },
+          {
+            "name": "CBLMariner",
+            "value": "CBLMariner",
+            "description": "Deprecated OSSKU. Microsoft recommends that new deployments choose 'AzureLinux' instead."
+          },
+          {
+            "name": "Windows2019",
+            "value": "Windows2019",
+            "description": "Use Windows2019 as the OS for node images. Unsupported for system node pools. Windows2019 only supports Windows2019 containers; it cannot run Windows2022 containers and vice versa."
+          },
+          {
+            "name": "Windows2022",
+            "value": "Windows2022",
+            "description": "Use Windows2022 as the OS for node images. Unsupported for system node pools. Windows2022 only supports Windows2022 containers; it cannot run Windows2019 containers and vice versa."
+          },
+          {
+            "name": "Ubuntu2204",
+            "value": "Ubuntu2204",
+            "description": "Use Ubuntu2204 as the OS for node images, however, Ubuntu 22.04 may not be supported for all nodepools. For limitations and supported kubernetes versions, see https://aka.ms/aks/supported-ubuntu-versions"
+          },
+          {
+            "name": "Windows2025",
+            "value": "Windows2025",
+            "description": "Use Windows2025 as the OS for node images. Unsupported for system node pools. Windows2025 supports Windows2022 and Windows 2025 containers; it cannot run Windows2019 containers and vice versa."
+          },
+          {
+            "name": "Ubuntu2404",
+            "value": "Ubuntu2404",
+            "description": "Use Ubuntu2404 as the OS for node images, however, Ubuntu 24.04 may not be supported for all nodepools. For limitations and supported kubernetes versions, see see https://aka.ms/aks/supported-ubuntu-versions"
+          }
+        ]
+      }
+    },
+    "OperationListResult": {
+      "type": "object",
+      "description": "The List Operation response.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The list of operations",
+          "items": {
+            "$ref": "#/definitions/OperationValue"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "OperationValue": {
+      "type": "object",
+      "description": "Describes the properties of a Operation value.",
+      "properties": {
+        "origin": {
+          "type": "string",
+          "description": "The origin of the operation.",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the operation.",
+          "readOnly": true
+        },
+        "display": {
+          "$ref": "#/definitions/OperationValueDisplay",
+          "description": "Describes the properties of a Operation Value Display.",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "OperationValueDisplay": {
+      "type": "object",
+      "description": "Describes the properties of a Operation Value Display.",
+      "properties": {
+        "operation": {
+          "type": "string",
+          "description": "The display name of the operation.",
+          "readOnly": true
+        },
+        "resource": {
+          "type": "string",
+          "description": "The display name of the resource the operation applies to.",
+          "readOnly": true
+        },
+        "description": {
+          "type": "string",
+          "description": "The description of the operation.",
+          "readOnly": true
+        },
+        "provider": {
+          "type": "string",
+          "description": "The resource provider for the operation.",
+          "readOnly": true
+        }
+      }
+    },
+    "OutboundEnvironmentEndpoint": {
+      "type": "object",
+      "description": "Egress endpoints which AKS agent nodes connect to for common purpose.",
+      "properties": {
+        "category": {
+          "type": "string",
+          "description": "The category of endpoints accessed by the AKS agent node, e.g. azure-resource-management, apiserver, etc."
+        },
+        "endpoints": {
+          "type": "array",
+          "description": "The endpoints that AKS agent nodes connect to",
+          "items": {
+            "$ref": "#/definitions/EndpointDependency"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "OutboundEnvironmentEndpointCollection": {
+      "type": "object",
+      "description": "Collection of OutboundEnvironmentEndpoint",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The OutboundEnvironmentEndpoint items on this page",
+          "items": {
+            "$ref": "#/definitions/OutboundEnvironmentEndpoint"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PodIPAllocationMode": {
+      "type": "string",
+      "description": "Pod IP Allocation Mode. The IP allocation mode for pods in the agent pool. Must be used with podSubnetId. The default is 'DynamicIndividual'.",
+      "enum": [
+        "DynamicIndividual",
+        "StaticBlock"
+      ],
+      "x-ms-enum": {
+        "name": "PodIPAllocationMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "DynamicIndividual",
+            "value": "DynamicIndividual",
+            "description": "Each node gets allocated with a non-contiguous list of IP addresses assignable to pods. This is better for maximizing a small to medium subnet of size /16 or smaller. The Azure CNI cluster with dynamic IP allocation defaults to this mode if the customer does not explicitly specify a podIPAllocationMode"
+          },
+          {
+            "name": "StaticBlock",
+            "value": "StaticBlock",
+            "description": "Each node is statically allocated CIDR block(s) of size /28 = 16 IPs per block to satisfy the maxPods per node. Number of CIDR blocks >= (maxPods / 16). The block, rather than a single IP, counts against the Azure Vnet Private IP limit of 65K. Therefore block mode is suitable for running larger workloads with more than the current limit of 65K pods in a cluster. This mode is better suited to scale with larger subnets of /15 or bigger"
+          }
+        ]
+      }
+    },
+    "PortRange": {
+      "type": "object",
+      "description": "The port range.",
+      "properties": {
+        "portStart": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The minimum port that is included in the range. It should be ranged from 1 to 65535, and be less than or equal to portEnd.",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "portEnd": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum port that is included in the range. It should be ranged from 1 to 65535, and be greater than or equal to portStart.",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "protocol": {
+          "$ref": "#/definitions/Protocol",
+          "description": "The network protocol of the port."
+        }
+      }
+    },
+    "PowerState": {
+      "type": "object",
+      "description": "Describes the Power State of the cluster",
+      "properties": {
+        "code": {
+          "$ref": "#/definitions/Code",
+          "description": "Tells whether the cluster is Running or Stopped"
+        }
+      }
+    },
+    "PrivateEndpoint": {
+      "type": "object",
+      "description": "Private endpoint which a connection belongs to.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The resource ID of the private endpoint"
+        }
+      }
+    },
+    "PrivateEndpointConnection": {
+      "type": "object",
+      "description": "A private endpoint connection",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PrivateEndpointConnectionProperties",
+          "description": "The properties of a private endpoint connection.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "PrivateEndpointConnectionListResult": {
+      "type": "object",
+      "description": "A list of private endpoint connections",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The collection value.",
+          "items": {
+            "$ref": "#/definitions/PrivateEndpointConnection"
+          }
+        }
+      }
+    },
+    "PrivateEndpointConnectionProperties": {
+      "type": "object",
+      "description": "Properties of a private endpoint connection.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/PrivateEndpointConnectionProvisioningState",
+          "description": "The current provisioning state.",
+          "readOnly": true
+        },
+        "privateEndpoint": {
+          "$ref": "#/definitions/PrivateEndpoint",
+          "description": "The resource of private endpoint."
+        },
+        "privateLinkServiceConnectionState": {
+          "$ref": "#/definitions/PrivateLinkServiceConnectionState",
+          "description": "A collection of information about the state of the connection between service consumer and provider."
+        }
+      },
+      "required": [
+        "privateLinkServiceConnectionState"
+      ]
+    },
+    "PrivateEndpointConnectionProvisioningState": {
+      "type": "string",
+      "description": "The current provisioning state.",
+      "enum": [
+        "Canceled",
+        "Creating",
+        "Deleting",
+        "Failed",
+        "Succeeded"
+      ],
+      "x-ms-enum": {
+        "name": "PrivateEndpointConnectionProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Private endpoint connection provisioning was canceled."
+          },
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "Private endpoint connection is being created."
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Private endpoint connection is being deleted."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Private endpoint connection provisioning failed."
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Private endpoint connection provisioning succeeded."
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "PrivateLinkResource": {
+      "type": "object",
+      "description": "A private link resource",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The ID of the private link resource."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the private link resource. See [naming rules](https://aka.ms/search-naming-rules) for more details."
+        },
+        "type": {
+          "type": "string",
+          "description": "The resource type."
+        },
+        "groupId": {
+          "type": "string",
+          "description": "The group ID of the resource."
+        },
+        "requiredMembers": {
+          "type": "array",
+          "description": "The RequiredMembers of the resource",
+          "items": {
+            "type": "string"
+          }
+        },
+        "privateLinkServiceID": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The private link service ID of the resource, this field is exposed only to NRP internally.",
+          "readOnly": true
+        }
+      }
+    },
+    "PrivateLinkResourcesListResult": {
+      "type": "object",
+      "description": "A list of private link resources",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The collection value.",
+          "items": {
+            "$ref": "#/definitions/PrivateLinkResource"
+          }
+        }
+      }
+    },
+    "PrivateLinkServiceConnectionState": {
+      "type": "object",
+      "description": "The state of a private link service connection.",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/ConnectionStatus",
+          "description": "The private link service connection status."
+        },
+        "description": {
+          "type": "string",
+          "description": "The private link service connection description."
+        }
+      }
+    },
+    "Protocol": {
+      "type": "string",
+      "description": "The network protocol of the port.",
+      "enum": [
+        "TCP",
+        "UDP"
+      ],
+      "x-ms-enum": {
+        "name": "Protocol",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "TCP",
+            "value": "TCP",
+            "description": "TCP protocol."
+          },
+          {
+            "name": "UDP",
+            "value": "UDP",
+            "description": "UDP protocol."
+          }
+        ]
+      }
+    },
+    "ProxyRedirectionMechanism": {
+      "type": "string",
+      "description": "Mode of traffic redirection.",
+      "enum": [
+        "InitContainers",
+        "CNIChaining"
+      ],
+      "x-ms-enum": {
+        "name": "ProxyRedirectionMechanism",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "InitContainers",
+            "value": "InitContainers",
+            "description": "Istio will inject an init container into each pod to redirect traffic (requires NET_ADMIN and NET_RAW)."
+          },
+          {
+            "name": "CNIChaining",
+            "value": "CNIChaining",
+            "description": "Istio will install a chained CNI plugin to redirect traffic (recommended)."
+          }
+        ]
+      }
+    },
+    "PublicNetworkAccess": {
+      "type": "string",
+      "description": "PublicNetworkAccess of the managedCluster. Allow or deny public network access for AKS",
+      "enum": [
+        "Enabled",
+        "Disabled"
+      ],
+      "x-ms-enum": {
+        "name": "PublicNetworkAccess",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Enabled",
+            "value": "Enabled",
+            "description": "Inbound/Outbound to the managedCluster is allowed."
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Inbound traffic to managedCluster is disabled, traffic from managedCluster is allowed."
+          }
+        ]
+      }
+    },
+    "RelativeMonthlySchedule": {
+      "type": "object",
+      "description": "For schedules like: 'recur every month on the first Monday' or 'recur every 3 months on last Friday'.",
+      "properties": {
+        "intervalMonths": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Specifies the number of months between each set of occurrences.",
+          "minimum": 1,
+          "maximum": 6
+        },
+        "weekIndex": {
+          "$ref": "#/definitions/Type",
+          "description": "The week index. Specifies on which week of the month the dayOfWeek applies."
+        },
+        "dayOfWeek": {
+          "$ref": "#/definitions/WeekDay",
+          "description": "Specifies on which day of the week the maintenance occurs."
+        }
+      },
+      "required": [
+        "intervalMonths",
+        "weekIndex",
+        "dayOfWeek"
+      ]
+    },
+    "ResourceIdentityType": {
+      "type": "string",
+      "description": "The type of identity used for the managed cluster. For more information see [use managed identities in AKS](https://docs.microsoft.com/azure/aks/use-managed-identity).",
+      "enum": [
+        "SystemAssigned",
+        "UserAssigned",
+        "None"
+      ],
+      "x-ms-enum": {
+        "name": "ResourceIdentityType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "SystemAssigned",
+            "value": "SystemAssigned",
+            "description": "Use an implicitly created system assigned managed identity to manage cluster resources. Master components in the control plane such as kube-controller-manager will use the system assigned managed identity to manipulate Azure resources."
+          },
+          {
+            "name": "UserAssigned",
+            "value": "UserAssigned",
+            "description": "Use a user-specified identity to manage cluster resources. Master components in the control plane such as kube-controller-manager will use the specified user assigned managed identity to manipulate Azure resources."
+          },
+          {
+            "name": "None",
+            "value": "None",
+            "description": "Do not use a managed identity for the Managed Cluster, service principal will be used instead."
+          }
+        ]
+      }
+    },
+    "ResourceQuota": {
+      "type": "object",
+      "description": "Resource quota for the namespace.",
+      "properties": {
+        "cpuRequest": {
+          "type": "string",
+          "description": "CPU request of the namespace in one-thousandth CPU form. See [CPU resource units](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu) for more details."
+        },
+        "cpuLimit": {
+          "type": "string",
+          "description": "CPU limit of the namespace in one-thousandth CPU form. See [CPU resource units](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu) for more details."
+        },
+        "memoryRequest": {
+          "type": "string",
+          "description": "Memory request of the namespace in the power-of-two equivalents form: Ei, Pi, Ti, Gi, Mi, Ki. See [Memory resource units](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory) for more details."
+        },
+        "memoryLimit": {
+          "type": "string",
+          "description": "Memory limit of the namespace in the power-of-two equivalents form: Ei, Pi, Ti, Gi, Mi, Ki. See [Memory resource units](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory) for more details."
+        }
+      }
+    },
+    "ResourceReference": {
+      "type": "object",
+      "description": "A reference to an Azure resource.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The fully qualified Azure resource id."
+        }
+      }
+    },
+    "RestrictionLevel": {
+      "type": "string",
+      "description": "The restriction level applied to the cluster's node resource group. If not specified, the default is 'Unrestricted'",
+      "enum": [
+        "Unrestricted",
+        "ReadOnly"
+      ],
+      "x-ms-enum": {
+        "name": "RestrictionLevel",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Unrestricted",
+            "value": "Unrestricted",
+            "description": "All RBAC permissions are allowed on the managed node resource group"
+          },
+          {
+            "name": "ReadOnly",
+            "value": "ReadOnly",
+            "description": "Only \\*\\/read RBAC permissions allowed on the managed node resource group"
+          }
+        ]
+      }
+    },
+    "RunCommandRequest": {
+      "type": "object",
+      "description": "A run command request",
+      "properties": {
+        "command": {
+          "type": "string",
+          "description": "The command to run."
+        },
+        "context": {
+          "type": "string",
+          "description": "A base64 encoded zip file containing the files required by the command."
+        },
+        "clusterToken": {
+          "type": "string",
+          "description": "AuthToken issued for AKS AAD Server App."
+        }
+      },
+      "required": [
+        "command"
+      ]
+    },
+    "RunCommandResult": {
+      "type": "object",
+      "description": "run command result.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The command id.",
+          "readOnly": true
+        },
+        "properties": {
+          "$ref": "#/definitions/CommandResultProperties",
+          "description": "Properties of command result.",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "ScaleDownMode": {
+      "type": "string",
+      "description": "Describes how VMs are added to or removed from Agent Pools. See [billing states](https://docs.microsoft.com/azure/virtual-machines/states-billing).",
+      "enum": [
+        "Delete",
+        "Deallocate"
+      ],
+      "x-ms-enum": {
+        "name": "ScaleDownMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Delete",
+            "value": "Delete",
+            "description": "Create new instances during scale up and remove instances during scale down."
+          },
+          {
+            "name": "Deallocate",
+            "value": "Deallocate",
+            "description": "Attempt to start deallocated instances (if they exist) during scale up and deallocate instances during scale down."
+          }
+        ]
+      }
+    },
+    "ScaleProfile": {
+      "type": "object",
+      "description": "Specifications on how to scale a VirtualMachines agent pool.",
+      "properties": {
+        "manual": {
+          "type": "array",
+          "description": "Specifications on how to scale the VirtualMachines agent pool to a fixed size.",
+          "items": {
+            "$ref": "#/definitions/ManualScaleProfile"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "Schedule": {
+      "type": "object",
+      "description": "One and only one of the schedule types should be specified. Choose either 'daily', 'weekly', 'absoluteMonthly' or 'relativeMonthly' for your maintenance schedule.",
+      "properties": {
+        "daily": {
+          "$ref": "#/definitions/DailySchedule",
+          "description": "For schedules like: 'recur every day' or 'recur every 3 days'."
+        },
+        "weekly": {
+          "$ref": "#/definitions/WeeklySchedule",
+          "description": "For schedules like: 'recur every Monday' or 'recur every 3 weeks on Wednesday'."
+        },
+        "absoluteMonthly": {
+          "$ref": "#/definitions/AbsoluteMonthlySchedule",
+          "description": "For schedules like: 'recur every month on the 15th' or 'recur every 3 months on the 20th'."
+        },
+        "relativeMonthly": {
+          "$ref": "#/definitions/RelativeMonthlySchedule",
+          "description": "For schedules like: 'recur every month on the first Monday' or 'recur every 3 months on last Friday'."
+        }
+      }
+    },
+    "ServiceMeshMode": {
+      "type": "string",
+      "description": "Mode of the service mesh.",
+      "enum": [
+        "Istio",
+        "Disabled"
+      ],
+      "x-ms-enum": {
+        "name": "ServiceMeshMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Istio",
+            "value": "Istio",
+            "description": "Istio deployed as an AKS addon."
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Mesh is disabled."
+          }
+        ]
+      }
+    },
+    "ServiceMeshProfile": {
+      "type": "object",
+      "description": "Service mesh profile for a managed cluster.",
+      "properties": {
+        "mode": {
+          "$ref": "#/definitions/ServiceMeshMode",
+          "description": "Mode of the service mesh."
+        },
+        "istio": {
+          "$ref": "#/definitions/IstioServiceMesh",
+          "description": "Istio service mesh configuration."
+        }
+      },
+      "required": [
+        "mode"
+      ]
+    },
+    "Snapshot": {
+      "type": "object",
+      "description": "A node pool snapshot resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/SnapshotProperties",
+          "description": "Properties of a snapshot.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "SnapshotListResult": {
+      "type": "object",
+      "description": "The response of a Snapshot list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Snapshot items on this page",
+          "items": {
+            "$ref": "#/definitions/Snapshot"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "SnapshotProperties": {
+      "type": "object",
+      "description": "Properties used to configure a node pool snapshot.",
+      "properties": {
+        "creationData": {
+          "$ref": "#/definitions/CreationData",
+          "description": "CreationData to be used to specify the source agent pool resource ID to create this snapshot."
+        },
+        "snapshotType": {
+          "type": "string",
+          "description": "The type of a snapshot. The default is NodePool.",
+          "default": "NodePool",
+          "enum": [
+            "NodePool"
+          ],
+          "x-ms-enum": {
+            "name": "SnapshotType",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "NodePool",
+                "value": "NodePool",
+                "description": "The snapshot is a snapshot of a node pool."
+              }
+            ]
+          }
+        },
+        "kubernetesVersion": {
+          "type": "string",
+          "description": "The version of Kubernetes.",
+          "readOnly": true
+        },
+        "nodeImageVersion": {
+          "type": "string",
+          "description": "The version of node image.",
+          "readOnly": true
+        },
+        "osType": {
+          "type": "string",
+          "description": "The operating system type. The default is Linux.",
+          "default": "Linux",
+          "enum": [
+            "Linux",
+            "Windows"
+          ],
+          "x-ms-enum": {
+            "name": "OSType",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Linux",
+                "value": "Linux",
+                "description": "Use Linux."
+              },
+              {
+                "name": "Windows",
+                "value": "Windows",
+                "description": "Use Windows."
+              }
+            ]
+          },
+          "readOnly": true
+        },
+        "osSku": {
+          "$ref": "#/definitions/OSSKU",
+          "description": "Specifies the OS SKU used by the agent pool. The default is Ubuntu if OSType is Linux. The default is Windows2019 when Kubernetes <= 1.24 or Windows2022 when Kubernetes >= 1.25 if OSType is Windows.",
+          "readOnly": true
+        },
+        "vmSize": {
+          "type": "string",
+          "description": "The size of the VM.",
+          "readOnly": true
+        },
+        "enableFIPS": {
+          "type": "boolean",
+          "description": "Whether to use a FIPS-enabled OS.",
+          "readOnly": true
+        }
+      }
+    },
+    "SysctlConfig": {
+      "type": "object",
+      "description": "Sysctl settings for Linux agent nodes.",
+      "properties": {
+        "netCoreSomaxconn": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Sysctl setting net.core.somaxconn."
+        },
+        "netCoreNetdevMaxBacklog": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Sysctl setting net.core.netdev_max_backlog."
+        },
+        "netCoreRmemDefault": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Sysctl setting net.core.rmem_default."
+        },
+        "netCoreRmemMax": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Sysctl setting net.core.rmem_max."
+        },
+        "netCoreWmemDefault": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Sysctl setting net.core.wmem_default."
+        },
+        "netCoreWmemMax": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Sysctl setting net.core.wmem_max."
+        },
+        "netCoreOptmemMax": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Sysctl setting net.core.optmem_max."
+        },
+        "netIpv4TcpMaxSynBacklog": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Sysctl setting net.ipv4.tcp_max_syn_backlog."
+        },
+        "netIpv4TcpMaxTwBuckets": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Sysctl setting net.ipv4.tcp_max_tw_buckets."
+        },
+        "netIpv4TcpFinTimeout": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Sysctl setting net.ipv4.tcp_fin_timeout."
+        },
+        "netIpv4TcpKeepaliveTime": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Sysctl setting net.ipv4.tcp_keepalive_time."
+        },
+        "netIpv4TcpKeepaliveProbes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Sysctl setting net.ipv4.tcp_keepalive_probes."
+        },
+        "netIpv4TcpkeepaliveIntvl": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Sysctl setting net.ipv4.tcp_keepalive_intvl.",
+          "minimum": 10,
+          "maximum": 90
+        },
+        "netIpv4TcpTwReuse": {
+          "type": "boolean",
+          "description": "Sysctl setting net.ipv4.tcp_tw_reuse."
+        },
+        "netIpv4IpLocalPortRange": {
+          "type": "string",
+          "description": "Sysctl setting net.ipv4.ip_local_port_range."
+        },
+        "netIpv4NeighDefaultGcThresh1": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Sysctl setting net.ipv4.neigh.default.gc_thresh1."
+        },
+        "netIpv4NeighDefaultGcThresh2": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Sysctl setting net.ipv4.neigh.default.gc_thresh2."
+        },
+        "netIpv4NeighDefaultGcThresh3": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Sysctl setting net.ipv4.neigh.default.gc_thresh3."
+        },
+        "netNetfilterNfConntrackMax": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Sysctl setting net.netfilter.nf_conntrack_max.",
+          "minimum": 131072,
+          "maximum": 2097152
+        },
+        "netNetfilterNfConntrackBuckets": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Sysctl setting net.netfilter.nf_conntrack_buckets.",
+          "minimum": 65536,
+          "maximum": 524288
+        },
+        "fsInotifyMaxUserWatches": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Sysctl setting fs.inotify.max_user_watches."
+        },
+        "fsFileMax": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Sysctl setting fs.file-max."
+        },
+        "fsAioMaxNr": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Sysctl setting fs.aio-max-nr."
+        },
+        "fsNrOpen": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Sysctl setting fs.nr_open."
+        },
+        "kernelThreadsMax": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Sysctl setting kernel.threads-max."
+        },
+        "vmMaxMapCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Sysctl setting vm.max_map_count."
+        },
+        "vmSwappiness": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Sysctl setting vm.swappiness."
+        },
+        "vmVfsCachePressure": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Sysctl setting vm.vfs_cache_pressure."
+        }
+      }
+    },
+    "TagsObject": {
+      "type": "object",
+      "description": "Tags object for patch operations.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "TimeInWeek": {
+      "type": "object",
+      "description": "Time in a week.",
+      "properties": {
+        "day": {
+          "$ref": "#/definitions/WeekDay",
+          "description": "The day of the week."
+        },
+        "hourSlots": {
+          "type": "array",
+          "description": "A list of hours in the day used to identify a time range. Each integer hour represents a time range beginning at 0m after the hour ending at the next hour (non-inclusive). 0 corresponds to 00:00 UTC, 23 corresponds to 23:00 UTC. Specifying [0, 1] means the 00:00 - 02:00 UTC time range.",
+          "items": {
+            "$ref": "#/definitions/HourInDay"
+          }
+        }
+      }
+    },
+    "TimeSpan": {
+      "type": "object",
+      "description": "A time range. For example, between 2021-05-25T13:00:00Z and 2021-05-25T14:00:00Z.",
+      "properties": {
+        "start": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The start of a time span"
+        },
+        "end": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The end of a time span"
+        }
+      }
+    },
+    "TransitEncryptionType": {
+      "type": "string",
+      "description": "Configures pod-to-pod encryption. This can be enabled only on Cilium-based clusters. If not specified, the default value is None.",
+      "enum": [
+        "WireGuard",
+        "None"
+      ],
+      "x-ms-enum": {
+        "name": "TransitEncryptionType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "WireGuard",
+            "value": "WireGuard",
+            "description": "Enable WireGuard encryption. Refer to https://docs.cilium.io/en/latest/security/network/encryption-wireguard/ on use cases and implementation details"
+          },
+          {
+            "name": "None",
+            "value": "None",
+            "description": "Disable Transit encryption"
+          }
+        ]
+      }
+    },
+    "TrustedAccessRole": {
+      "type": "object",
+      "description": "Trusted access role definition.",
+      "properties": {
+        "sourceResourceType": {
+          "type": "string",
+          "description": "Resource type of Azure resource",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of role, name is unique under a source resource type",
+          "readOnly": true
+        },
+        "rules": {
+          "type": "array",
+          "description": "List of rules for the role. This maps to 'rules' property of [Kubernetes Cluster Role](https://kubernetes.io/docs/reference/kubernetes-api/authorization-resources/cluster-role-v1/#ClusterRole).",
+          "items": {
+            "$ref": "#/definitions/TrustedAccessRoleRule"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "TrustedAccessRoleBinding": {
+      "type": "object",
+      "description": "Defines binding between a resource and role",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/TrustedAccessRoleBindingProperties",
+          "description": "Properties for trusted access role binding",
+          "x-ms-client-flatten": true
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "TrustedAccessRoleBindingListResult": {
+      "type": "object",
+      "description": "The response of a TrustedAccessRoleBinding list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The TrustedAccessRoleBinding items on this page",
+          "items": {
+            "$ref": "#/definitions/TrustedAccessRoleBinding"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "TrustedAccessRoleBindingProperties": {
+      "type": "object",
+      "description": "Properties for trusted access role binding",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/TrustedAccessRoleBindingProvisioningState",
+          "description": "The current provisioning state of trusted access role binding.",
+          "readOnly": true
+        },
+        "sourceResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The ARM resource ID of source resource that trusted access is configured for."
+        },
+        "roles": {
+          "type": "array",
+          "description": "A list of roles to bind, each item is a resource type qualified role name. For example: 'Microsoft.MachineLearningServices/workspaces/reader'.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "sourceResourceId",
+        "roles"
+      ]
+    },
+    "TrustedAccessRoleBindingProvisioningState": {
+      "type": "string",
+      "description": "The current provisioning state of trusted access role binding.",
+      "enum": [
+        "Canceled",
+        "Deleting",
+        "Failed",
+        "Succeeded",
+        "Updating"
+      ],
+      "x-ms-enum": {
+        "name": "TrustedAccessRoleBindingProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Trusted access role binding provisioning was canceled."
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Trusted access role binding is being deleted."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Trusted access role binding provisioning failed."
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Trusted access role binding provisioning succeeded."
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Trusted access role binding is being updated."
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "TrustedAccessRoleListResult": {
+      "type": "object",
+      "description": "List of trusted access roles",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The TrustedAccessRole items on this page",
+          "items": {
+            "$ref": "#/definitions/TrustedAccessRole"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "TrustedAccessRoleRule": {
+      "type": "object",
+      "description": "Rule for trusted access role",
+      "properties": {
+        "verbs": {
+          "type": "array",
+          "description": "List of allowed verbs",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "apiGroups": {
+          "type": "array",
+          "description": "List of allowed apiGroups",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "resources": {
+          "type": "array",
+          "description": "List of allowed resources",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "resourceNames": {
+          "type": "array",
+          "description": "List of allowed names",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "nonResourceURLs": {
+          "type": "array",
+          "description": "List of allowed nonResourceURLs",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "Type": {
+      "type": "string",
+      "description": "The week index. Specifies on which week of the month the dayOfWeek applies.",
+      "enum": [
+        "First",
+        "Second",
+        "Third",
+        "Fourth",
+        "Last"
+      ],
+      "x-ms-enum": {
+        "name": "Type",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "First",
+            "value": "First",
+            "description": "First week of the month."
+          },
+          {
+            "name": "Second",
+            "value": "Second",
+            "description": "Second week of the month."
+          },
+          {
+            "name": "Third",
+            "value": "Third",
+            "description": "Third week of the month."
+          },
+          {
+            "name": "Fourth",
+            "value": "Fourth",
+            "description": "Fourth week of the month."
+          },
+          {
+            "name": "Last",
+            "value": "Last",
+            "description": "Last week of the month."
+          }
+        ]
+      }
+    },
+    "UndrainableNodeBehavior": {
+      "type": "string",
+      "description": "Defines the behavior for undrainable nodes during upgrade. The most common cause of undrainable nodes is Pod Disruption Budgets (PDBs), but other issues, such as pod termination grace period is exceeding the remaining per-node drain timeout or pod is still being in a running state, can also cause undrainable nodes.",
+      "enum": [
+        "Cordon",
+        "Schedule"
+      ],
+      "x-ms-enum": {
+        "name": "UndrainableNodeBehavior",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Cordon",
+            "value": "Cordon",
+            "description": "AKS will cordon the blocked nodes and replace them with surge nodes during upgrade. The blocked nodes will be cordoned and replaced by surge nodes. The blocked nodes will have label 'kubernetes.azure.com/upgrade-status:Quarantined'. A surge node will be retained for each blocked node. A best-effort attempt will be made to delete all other surge nodes. If there are enough surge nodes to replace blocked nodes, then the upgrade operation and the managed cluster will be in failed state. Otherwise, the upgrade operation and the managed cluster will be in canceled state."
+          },
+          {
+            "name": "Schedule",
+            "value": "Schedule",
+            "description": "AKS will mark the blocked nodes schedulable, but the blocked nodes are not upgraded. A best-effort attempt will be made to delete all surge nodes. The upgrade operation and the managed cluster will be in failed state if there are any blocked nodes."
+          }
+        ]
+      }
+    },
+    "UpgradeChannel": {
+      "type": "string",
+      "description": "The upgrade channel for auto upgrade. The default is 'none'. For more information see [setting the AKS cluster auto-upgrade channel](https://docs.microsoft.com/azure/aks/upgrade-cluster#set-auto-upgrade-channel).",
+      "enum": [
+        "rapid",
+        "stable",
+        "patch",
+        "node-image",
+        "none"
+      ],
+      "x-ms-enum": {
+        "name": "UpgradeChannel",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "rapid",
+            "value": "rapid",
+            "description": "Automatically upgrade the cluster to the latest supported patch release on the latest supported minor version. In cases where the cluster is at a version of Kubernetes that is at an N-2 minor version where N is the latest supported minor version, the cluster first upgrades to the latest supported patch version on N-1 minor version. For example, if a cluster is running version 1.17.7 and versions 1.17.9, 1.18.4, 1.18.6, and 1.19.1 are available, your cluster first is upgraded to 1.18.6, then is upgraded to 1.19.1."
+          },
+          {
+            "name": "stable",
+            "value": "stable",
+            "description": "Automatically upgrade the cluster to the latest supported patch release on minor version N-1, where N is the latest supported minor version. For example, if a cluster is running version 1.17.7 and versions 1.17.9, 1.18.4, 1.18.6, and 1.19.1 are available, your cluster is upgraded to 1.18.6."
+          },
+          {
+            "name": "patch",
+            "value": "patch",
+            "description": "Automatically upgrade the cluster to the latest supported patch version when it becomes available while keeping the minor version the same. For example, if a cluster is running version 1.17.7 and versions 1.17.9, 1.18.4, 1.18.6, and 1.19.1 are available, your cluster is upgraded to 1.17.9."
+          },
+          {
+            "name": "node-image",
+            "value": "node-image",
+            "description": "Automatically upgrade the node image to the latest version available. Consider using nodeOSUpgradeChannel instead as that allows you to configure node OS patching separate from Kubernetes version patching"
+          },
+          {
+            "name": "none",
+            "value": "none",
+            "description": "Disables auto-upgrades and keeps the cluster at its current version of Kubernetes."
+          }
+        ]
+      }
+    },
+    "UpgradeOverrideSettings": {
+      "type": "object",
+      "description": "Settings for overrides when upgrading a cluster.",
+      "properties": {
+        "forceUpgrade": {
+          "type": "boolean",
+          "description": "Whether to force upgrade the cluster. Note that this option instructs upgrade operation to bypass upgrade protections such as checking for deprecated API usage. Enable this option only with caution."
+        },
+        "until": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Until when the overrides are effective. Note that this only matches the start time of an upgrade, and the effectiveness won't change once an upgrade starts even if the `until` expires as upgrade proceeds. This field is not set by default. It must be set for the overrides to take effect."
+        }
+      }
+    },
+    "UserAssignedIdentity": {
+      "type": "object",
+      "description": "Details about a user assigned identity.",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The resource ID of the user assigned identity.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.ManagedIdentity/userAssignedIdentities"
+              }
+            ]
+          }
+        },
+        "clientId": {
+          "type": "string",
+          "description": "The client ID of the user assigned identity."
+        },
+        "objectId": {
+          "type": "string",
+          "description": "The object ID of the user assigned identity."
+        }
+      }
+    },
+    "VirtualMachineNodes": {
+      "type": "object",
+      "description": "Current status on a group of nodes of the same vm size.",
+      "properties": {
+        "size": {
+          "type": "string",
+          "description": "The VM size of the agents used to host this group of nodes."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of nodes."
+        }
+      }
+    },
+    "VirtualMachinesProfile": {
+      "type": "object",
+      "description": "Specifications on VirtualMachines agent pool.",
+      "properties": {
+        "scale": {
+          "$ref": "#/definitions/ScaleProfile",
+          "description": "Specifications on how to scale a VirtualMachines agent pool."
+        }
+      }
+    },
+    "WeekDay": {
+      "type": "string",
+      "description": "The weekday enum.",
+      "enum": [
+        "Sunday",
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday"
+      ],
+      "x-ms-enum": {
+        "name": "WeekDay",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Sunday",
+            "value": "Sunday",
+            "description": "Represents Sunday."
+          },
+          {
+            "name": "Monday",
+            "value": "Monday",
+            "description": "Represents Monday."
+          },
+          {
+            "name": "Tuesday",
+            "value": "Tuesday",
+            "description": "Represents Tuesday."
+          },
+          {
+            "name": "Wednesday",
+            "value": "Wednesday",
+            "description": "Represents Wednesday."
+          },
+          {
+            "name": "Thursday",
+            "value": "Thursday",
+            "description": "Represents Thursday."
+          },
+          {
+            "name": "Friday",
+            "value": "Friday",
+            "description": "Represents Friday."
+          },
+          {
+            "name": "Saturday",
+            "value": "Saturday",
+            "description": "Represents Saturday."
+          }
+        ]
+      }
+    },
+    "WeeklySchedule": {
+      "type": "object",
+      "description": "For schedules like: 'recur every Monday' or 'recur every 3 weeks on Wednesday'.",
+      "properties": {
+        "intervalWeeks": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Specifies the number of weeks between each set of occurrences.",
+          "minimum": 1,
+          "maximum": 4
+        },
+        "dayOfWeek": {
+          "$ref": "#/definitions/WeekDay",
+          "description": "Specifies on which day of the week the maintenance occurs."
+        }
+      },
+      "required": [
+        "intervalWeeks",
+        "dayOfWeek"
+      ]
+    },
+    "WindowsGmsaProfile": {
+      "type": "object",
+      "description": "Windows gMSA Profile in the managed cluster.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether to enable Windows gMSA. Specifies whether to enable Windows gMSA in the managed cluster."
+        },
+        "dnsServer": {
+          "type": "string",
+          "description": "Specifies the DNS server for Windows gMSA. <br><br> Set it to empty if you have configured the DNS server in the vnet which is used to create the managed cluster."
+        },
+        "rootDomainName": {
+          "type": "string",
+          "description": "Specifies the root domain name for Windows gMSA. <br><br> Set it to empty if you have configured the DNS server in the vnet which is used to create the managed cluster."
+        }
+      }
+    },
+    "WorkloadRuntime": {
+      "type": "string",
+      "description": "Determines the type of workload a node can run.",
+      "enum": [
+        "OCIContainer",
+        "WasmWasi",
+        "KataVmIsolation"
+      ],
+      "x-ms-enum": {
+        "name": "WorkloadRuntime",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "OCIContainer",
+            "value": "OCIContainer",
+            "description": "Nodes will use Kubelet to run standard OCI container workloads."
+          },
+          {
+            "name": "WasmWasi",
+            "value": "WasmWasi",
+            "description": "Nodes will use Krustlet to run WASM workloads using the WASI provider (Preview)."
+          },
+          {
+            "name": "KataVmIsolation",
+            "value": "KataVmIsolation",
+            "description": "Nodes can use (Kata + Cloud Hypervisor + Hyper-V) to enable Nested VM-based pods. Due to the use Hyper-V, AKS node OS itself is a nested VM (the root OS) of Hyper-V. Thus it can only be used with VM series that support Nested Virtualization such as Dv3 series."
+          }
+        ]
+      }
+    }
+  },
+  "parameters": {}
+}


### PR DESCRIPTION
## Summary
- Promotes `controlPlane.enabled` property from `2026-02-02-preview` to the `2026-03-01` stable API version for AKS managed clusters
- Enables GA support for AKS control plane Prometheus metrics collection via Azure Monitor

## Changes
- **main.tsp**: Added `v2026_03_01` stable version to the Versions enum
- **CommonModels.tsp**: Changed `@added` decorators on `controlPlane` property and `ManagedClusterAzureMonitorProfileMetricsControlPlane` model from `v2026_02_02_preview` to `v2026_03_01`
- **stable/2026-03-01/managedClusters.json**: New generated OpenAPI spec with `controlPlane` property added to `ManagedClusterAzureMonitorProfileMetrics`
- **readme.md**: Added `package-2026-03` tag as new default

## Test plan
- [ ] TypeSpec compiles without errors
- [ ] Generated JSON spec includes `controlPlane` property in the correct location
- [ ] API version references in examples updated to `2026-03-01`
- [ ] CI validation passes