### PR TITLE
[MSI] Update tspconfig.yaml and client.tsp for Java SDK migration

### DIFF
--- a/specification/msi/resource-manager/Microsoft.ManagedIdentity/ManagedIdentity/client.tsp
+++ b/specification/msi/resource-manager/Microsoft.ManagedIdentity/ManagedIdentity/client.tsp
@@ -13,3 +13,8 @@ using Microsoft.ManagedIdentity;
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(Identity.properties,
   "java"
 );
+
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(SystemAssignedIdentity.properties,
+  "java"
+);

--- a/specification/msi/resource-manager/Microsoft.ManagedIdentity/ManagedIdentity/tspconfig.yaml
+++ b/specification/msi/resource-manager/Microsoft.ManagedIdentity/ManagedIdentity/tspconfig.yaml
@@ -24,7 +24,10 @@ options:
     service-name: "Msi"
     flavor: azure
     premium: true
+    generate-tests: false
+    client-side-validations: true
     enable-sync-stack: false
+    uuid-as-string: false
     service-dir: "sdk/msi"
   "@azure-tools/typespec-ts":
     emitter-output-dir: "{output-dir}/{service-dir}/arm-msi"


### PR DESCRIPTION
Update tspconfig.yaml with generate-tests, client-side-validations, uuid-as-string options for Java SDK migration.

Add flattenProperty for SystemAssignedIdentity.properties in client.tsp to preserve Java public API.