### PR TITLE
Add .NET management emitter to Authorization tspconfig.yaml

### DIFF
--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/tspconfig.yaml
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/tspconfig.yaml
@@ -40,6 +40,9 @@ options:
     generate-fakes: true
     head-as-boolean: true
     inject-spans: true
+  "@azure-typespec/http-client-csharp-mgmt":
+    namespace: "Azure.ResourceManager.Authorization"
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/resource-manager"


### PR DESCRIPTION
## Summary

Add the `@azure-typespec/http-client-csharp-mgmt` emitter configuration to the Authorization `tspconfig.yaml`. This is the only missing language emitter - Python, Java, TypeScript, and Go are already configured.

## Motivation

The .NET SDK generation pipeline (7412) ran successfully after the TypeSpec PR (#41617) merged, but produced **no changes** because the tspconfig.yaml was missing the .NET emitter. This blocked auto-generation of the `Azure.ResourceManager.Authorization` NuGet package with deny assignment CRUD support.

All four other SDKs have been successfully generated:
- Python: [azure-sdk-for-python#46223](https://github.com/Azure/azure-sdk-for-python/pull/46223)
- Go: [azure-sdk-for-go#26544](https://github.com/Azure/azure-sdk-for-go/pull/26544)
- JavaScript: [azure-sdk-for-js#38079](https://github.com/Azure/azure-sdk-for-js/pull/38079)
- Java: [azure-sdk-for-java#48751](https://github.com/Azure/azure-sdk-for-java/pull/48751)

## Changes

- Added `@azure-typespec/http-client-csharp-mgmt` emitter with:
  - `namespace: "Azure.ResourceManager.Authorization"`
  - `emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"`

This matches the pattern used by other management plane services (e.g., Microsoft.Advisor, Microsoft.Batch, Microsoft.AppConfiguration).

## Checklist

- [x] I have reviewed the [REST API Spec PR review workflow](https://aka.ms/azsdk/specreview)
- [x] I understand the change is limited to adding a missing SDK emitter config (no spec/API changes)
