### PR TITLE
hero-scenarios: switch to hero-scenarios.md and support fork PRs

### DIFF
--- a/.github/aw/actions-lock.json
+++ b/.github/aw/actions-lock.json
@@ -15,6 +15,11 @@
       "version": "v8",
       "sha": "ed597411d8f924073f98dfc5c65a23a2325f34cd"
     },
+    "actions/github-script@v9": {
+      "repo": "actions/github-script",
+      "version": "v9",
+      "sha": "373c709c69115d41ff229c7e5df9f8788daa9553"
+    },
     "actions/github-script@v9.0.0": {
       "repo": "actions/github-script",
       "version": "v9.0.0",

--- a/.github/aw/actions-lock.json
+++ b/.github/aw/actions-lock.json
@@ -10,6 +10,11 @@
       "version": "v7",
       "sha": "f28e40c7f34bde8b3046d885e986cb6290c5673b"
     },
+    "actions/github-script@v8": {
+      "repo": "actions/github-script",
+      "version": "v8",
+      "sha": "ed597411d8f924073f98dfc5c65a23a2325f34cd"
+    },
     "actions/github-script@v9.0.0": {
       "repo": "actions/github-script",
       "version": "v9.0.0",

--- a/.github/prompts/hero-scenarios-guidelines.md
+++ b/.github/prompts/hero-scenarios-guidelines.md
@@ -14,21 +14,19 @@
 4. If no specification surface was changed, post a single message saying
    no hero scenarios are applicable and stop.
 
-## Step 1 — Check for Existing README
+## Step 1 — Check for Existing Hero Scenarios
 
-Check whether the service already has a `README.md` with hero scenarios.
+Check whether the service already has a `hero-scenarios.md` file.
 Look in the top-level service directory (e.g.,
-`specification/loadtestservice/README.md`) and in each spec subdirectory
-(e.g., `resource-manager/Microsoft.LoadTestService/loadtesting/readme.md`,
-`data-plane/loadtesting/readme.md`).
+`specification/loadtestservice/hero-scenarios.md`) and in each spec subdirectory
+(e.g., `resource-manager/Microsoft.LoadTestService/loadtesting/hero-scenarios.md`,
+`data-plane/loadtesting/hero-scenarios.md`).
 
-- **If no README with hero scenarios exists** (or all READMEs only
-  contain AutoRest configuration), you will generate a full suggested
-  `README.md` in Step 3.
-- **If a README already exists** with substantive service documentation,
-  read it and note the existing hero scenarios. In Step 3, you will only
-  suggest new scenarios that cover API surface introduced by this PR and
-  not already covered.
+- **If no `hero-scenarios.md` exists**, you will generate a full suggested
+  `hero-scenarios.md` in Step 3.
+- **If a `hero-scenarios.md` already exists**, read it and note the existing
+  hero scenarios. In Step 3, you will only suggest new scenarios that cover
+  API surface introduced by this PR and not already covered.
 
 ## Step 2 — Analyze the API Surface
 
@@ -250,27 +248,27 @@ For each scenario, include:
 
 ## Step 4 — Post the Suggestion
 
-**If no README exists**, use `add-comment` to post a PR comment with a
-full suggested README:
+**If no `hero-scenarios.md` exists**, use `add-comment` to post a PR comment
+with a full suggested file:
 
 ```
-## 📖 Suggested README.md
+## 📖 Suggested hero-scenarios.md
 
-> **Path:** `specification/{service}/{specDir}/README.md`
+> **Path:** `specification/{service}/{specDir}/hero-scenarios.md`
 >
-> This service directory has no README documenting the service and its
-> hero scenarios. Consider adding one:
+> This service directory has no `hero-scenarios.md` documenting hero
+> scenarios. Consider adding one:
 
-<the README content as raw markdown — do NOT wrap it in a code fence>
+<the hero-scenarios.md content as raw markdown — do NOT wrap it in a code fence>
 ```
 
-The README should include:
+The file should include:
 1. **Service name and one-paragraph description** — what the service
    does, who it is for, and what problem it solves.
 2. **Hero scenarios** — the scenarios generated in Step 3.
 
-**If a README already exists**, post an inline code suggestion on the
-README file using `create-pull-request-review-comment`. Place the
+**If a `hero-scenarios.md` already exists**, post an inline code suggestion on
+the file using `create-pull-request-review-comment`. Place the
 comment at the end of the file and use a GitHub suggestion block so the
 author can apply it with one click:
 
@@ -283,6 +281,6 @@ author can apply it with one click:
 Then submit the review using `submit-pull-request-review` with event
 `COMMENT` and a one-sentence body summarizing what was suggested.
 
-If the existing README already covers all the API surface in this PR,
-submit a `COMMENT` review with a one-sentence body confirming no new
-scenarios are needed.
+If the existing `hero-scenarios.md` already covers all the API surface in
+this PR, submit a `COMMENT` review with a one-sentence body confirming no
+new scenarios are needed.

--- a/.github/workflows/hero-scenarios.lock.yml
+++ b/.github/workflows/hero-scenarios.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"0bed4df14f8b8e4b0bbc8c6c77ffe9cae175a94b786c10a72ac5bd7b1b8b766f","compiler_version":"v0.68.0","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"248633c554b97ea65bed8f98758ec9184a8b66a0e33a25c1aca8141a5bd7381a","compiler_version":"v0.68.0","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"668228422ae6a00e4ad889ee87cd7109ec5666a7","version":"v5.0.4"},{"repo":"actions/cache/save","sha":"668228422ae6a00e4ad889ee87cd7109ec5666a7","version":"v5.0.4"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"ed597411d8f924073f98dfc5c65a23a2325f34cd","version":"v8"},{"repo":"actions/upload-artifact","sha":"bbbca2ddaa5d8feaa63e36b76fdaad77386f024f","version":"v7"},{"repo":"github/gh-aw-actions/setup","sha":"0acfb4a691fe207cd8bc982ea5cb9d750d57a702","version":"v0.68.0"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -45,9 +45,29 @@
 
 name: "Hero Scenario Suggestion"
 "on":
-  pull_request:
+  # permissions: # Permissions applied to pre-activation job
+    # pull-requests: write
+  pull_request_target:
+    forks:
+    - "*"
     types:
     - labeled
+  # steps: # Steps injected into pre-activation job
+  # - id: remove_label
+    # if: github.event_name == 'pull_request_target' && github.event.label.name == 'hero-scenarios-needed'
+    # name: Remove trigger label
+    # uses: actions/github-script@v8
+    # with:
+      # script: |
+        # try {
+          # await github.rest.issues.removeLabel({
+            # ...context.repo,
+            # issue_number: context.payload.pull_request.number,
+            # name: 'hero-scenarios-needed'
+          # });
+        # } catch (e) {
+          # core.warning(`Could not remove label: ${e.message}`);
+        # }
   workflow_dispatch:
     inputs:
       aw_context:
@@ -56,39 +76,36 @@ name: "Hero Scenario Suggestion"
         required: false
         type: string
       item_number:
-        default: ""
-        description: The number of the issue, pull request, or discussion
-        required: false
+        description: PR number to generate hero scenarios for
+        required: true
         type: string
 
 permissions: {}
 
 concurrency:
-  group: "gh-aw-${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}-${{ github.event.label.name || github.run_id }}"
+  group: "gh-aw-${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number || inputs.item_number || github.run_id }}-${{ github.event.label.name || github.run_id }}"
+  cancel-in-progress: true
 
 run-name: "Hero Scenario Suggestion"
 
 jobs:
   activation:
     needs: pre_activation
-    if: >
-      needs.pre_activation.outputs.activated == 'true' && (github.event_name == 'pull_request' && github.event.label.name == 'hero-scenarios-needed')
+    if: needs.pre_activation.outputs.activated == 'true' && (github.event.label.name == 'hero-scenarios-needed')
     runs-on: ubuntu-slim
     permissions:
       actions: read
       contents: read
-      discussions: write
-      issues: write
-      pull-requests: write
     outputs:
-      comment_id: ${{ steps.add-comment.outputs.comment-id }}
-      comment_repo: ${{ steps.add-comment.outputs.comment-repo }}
-      comment_url: ${{ steps.add-comment.outputs.comment-url }}
-      label_command: ${{ steps.remove_trigger_label.outputs.label_name }}
+      body: ${{ steps.sanitized.outputs.body }}
+      comment_id: ""
+      comment_repo: ""
       lockdown_check_failed: ${{ steps.generate_aw_info.outputs.lockdown_check_failed == 'true' }}
       model: ${{ steps.generate_aw_info.outputs.model }}
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
       setup-trace-id: ${{ steps.setup.outputs.trace-id }}
+      text: ${{ steps.sanitized.outputs.text }}
+      title: ${{ steps.sanitized.outputs.title }}
     steps:
       - name: Setup Scripts
         id: setup
@@ -123,19 +140,6 @@ jobs:
             setupGlobals(core, github, context, exec, io);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/generate_aw_info.cjs');
             await main(core, context);
-      - name: Add eyes reaction for immediate feedback
-        id: react
-        if: github.event_name == 'issues' || github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment' || github.event_name == 'discussion' || github.event_name == 'discussion_comment' || github.event_name == 'pull_request' && github.event.pull_request.head.repo.id == github.repository_id
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        env:
-          GH_AW_REACTION: "eyes"
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/add_reaction.cjs');
-            await main();
       - name: Validate COPILOT_GITHUB_TOKEN secret
         id: validate-secret
         run: bash "${RUNNER_TEMP}/gh-aw/actions/validate_multi_secret.sh" COPILOT_GITHUB_TOKEN 'GitHub Copilot CLI' https://github.github.com/gh-aw/reference/engines/#github-copilot-default
@@ -171,29 +175,14 @@ jobs:
             setupGlobals(core, github, context, exec, io);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/check_version_updates.cjs');
             await main();
-      - name: Add comment with workflow run link
-        id: add-comment
-        if: github.event_name == 'issues' || github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment' || github.event_name == 'discussion' || github.event_name == 'discussion_comment' || github.event_name == 'pull_request' && github.event.pull_request.head.repo.id == github.repository_id
+      - name: Compute current body text
+        id: sanitized
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        env:
-          GH_AW_WORKFLOW_NAME: "Hero Scenario Suggestion"
-          GH_AW_SAFE_OUTPUT_MESSAGES: "{\"footer\":\"\\u003e 📖 *Suggested by [{workflow_name}]({run_url})*\",\"runStarted\":\"📖 [{workflow_name}]({run_url}) is generating hero scenarios for this PR…\",\"runSuccess\":\"📖 [{workflow_name}]({run_url}) posted hero scenarios. ✅\",\"runFailure\":\"📖 [{workflow_name}]({run_url}) {status}. ❌\"}"
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
             setupGlobals(core, github, context, exec, io);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/add_workflow_run_comment.cjs');
-            await main();
-      - name: Remove trigger label
-        id: remove_trigger_label
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        env:
-          GH_AW_LABEL_NAMES: "[\"hero-scenarios-needed\"]"
-        with:
-          script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/remove_trigger_label.cjs');
+            const { main } = require('${{ runner.temp }}/gh-aw/actions/compute_text.cjs');
             await main();
       - name: Create prompt with built-in context
         env:
@@ -212,16 +201,16 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_b3f2406ac53a98c3_EOF'
+          cat << 'GH_AW_PROMPT_c20116d3dbb7e676_EOF'
           <system>
-          GH_AW_PROMPT_b3f2406ac53a98c3_EOF
+          GH_AW_PROMPT_c20116d3dbb7e676_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/repo_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_b3f2406ac53a98c3_EOF'
+          cat << 'GH_AW_PROMPT_c20116d3dbb7e676_EOF'
           <safe-output-tools>
           Tools: add_comment, create_pull_request_review_comment(max:5), submit_pull_request_review, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -253,13 +242,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_b3f2406ac53a98c3_EOF
+          GH_AW_PROMPT_c20116d3dbb7e676_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_b3f2406ac53a98c3_EOF'
+          cat << 'GH_AW_PROMPT_c20116d3dbb7e676_EOF'
           </system>
           {{#runtime-import .github/prompts/hero-scenarios-guidelines.md}}
           {{#runtime-import .github/workflows/hero-scenarios.md}}
-          GH_AW_PROMPT_b3f2406ac53a98c3_EOF
+          GH_AW_PROMPT_c20116d3dbb7e676_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -465,9 +454,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_4b43e279b5ba51c3_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_00f178a41d580fa1_EOF'
           {"add_comment":{"max":1,"target":"${{ github.event.pull_request.number }}"},"create_pull_request_review_comment":{"max":5,"side":"RIGHT","target":"${{ github.event.pull_request.number }}"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_repo_memory":{"memories":[{"dir":"/tmp/gh-aw/repo-memory/default","id":"default","max_file_count":100,"max_file_size":10240,"max_patch_size":10240}]},"report_incomplete":{},"submit_pull_request_review":{"footer":"if-body","max":1,"target":"${{ github.event.pull_request.number }}"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_4b43e279b5ba51c3_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_00f178a41d580fa1_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -702,7 +691,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.17'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_5699350bfebbb07e_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_5fce56d6d820e385_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -746,7 +735,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_5699350bfebbb07e_EOF
+          GH_AW_MCP_CONFIG_5fce56d6d820e385_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1098,25 +1087,6 @@ jobs:
             setupGlobals(core, github, context, exec, io);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/handle_agent_failure.cjs');
             await main();
-      - name: Update reaction comment with completion status
-        id: conclusion
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        env:
-          GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
-          GH_AW_COMMENT_ID: ${{ needs.activation.outputs.comment_id }}
-          GH_AW_COMMENT_REPO: ${{ needs.activation.outputs.comment_repo }}
-          GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          GH_AW_WORKFLOW_NAME: "Hero Scenario Suggestion"
-          GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
-          GH_AW_DETECTION_CONCLUSION: ${{ needs.detection.outputs.detection_conclusion }}
-          GH_AW_SAFE_OUTPUT_MESSAGES: "{\"footer\":\"\\u003e 📖 *Suggested by [{workflow_name}]({run_url})*\",\"runStarted\":\"📖 [{workflow_name}]({run_url}) is generating hero scenarios for this PR…\",\"runSuccess\":\"📖 [{workflow_name}]({run_url}) posted hero scenarios. ✅\",\"runFailure\":\"📖 [{workflow_name}]({run_url}) {status}. ❌\"}"
-        with:
-          github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
-          script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/notify_comment_error.cjs');
-            await main();
 
   detection:
     needs:
@@ -1269,11 +1239,14 @@ jobs:
             await main();
 
   pre_activation:
-    if: github.event_name == 'pull_request' && github.event.label.name == 'hero-scenarios-needed'
+    if: github.event.label.name == 'hero-scenarios-needed'
     runs-on: ubuntu-slim
+    permissions:
+      pull-requests: write
     outputs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
       matched_command: ''
+      remove_label_result: ${{ steps.remove_label.outcome }}
       setup-trace-id: ${{ steps.setup.outputs.trace-id }}
     steps:
       - name: Setup Scripts
@@ -1294,6 +1267,21 @@ jobs:
             setupGlobals(core, github, context, exec, io);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/check_membership.cjs');
             await main();
+      - name: Remove trigger label
+        id: remove_label
+        if: github.event_name == 'pull_request_target' && github.event.label.name == 'hero-scenarios-needed'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                ...context.repo,
+                issue_number: context.payload.pull_request.number,
+                name: 'hero-scenarios-needed'
+              });
+            } catch (e) {
+              core.warning(`Could not remove label: ${e.message}`);
+            }
 
   push_repo_memory:
     needs:

--- a/.github/workflows/hero-scenarios.lock.yml
+++ b/.github/workflows/hero-scenarios.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"248633c554b97ea65bed8f98758ec9184a8b66a0e33a25c1aca8141a5bd7381a","compiler_version":"v0.68.0","strict":true,"agent_id":"copilot"}
-# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"668228422ae6a00e4ad889ee87cd7109ec5666a7","version":"v5.0.4"},{"repo":"actions/cache/save","sha":"668228422ae6a00e4ad889ee87cd7109ec5666a7","version":"v5.0.4"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"ed597411d8f924073f98dfc5c65a23a2325f34cd","version":"v8"},{"repo":"actions/upload-artifact","sha":"bbbca2ddaa5d8feaa63e36b76fdaad77386f024f","version":"v7"},{"repo":"github/gh-aw-actions/setup","sha":"0acfb4a691fe207cd8bc982ea5cb9d750d57a702","version":"v0.68.0"}]}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"af318cd3d8b2e7a782de174faf77201db41fc0feaf5cddd5006edf2b1808eac1","compiler_version":"v0.68.0","strict":true,"agent_id":"copilot"}
+# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"668228422ae6a00e4ad889ee87cd7109ec5666a7","version":"v5.0.4"},{"repo":"actions/cache/save","sha":"668228422ae6a00e4ad889ee87cd7109ec5666a7","version":"v5.0.4"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"ed597411d8f924073f98dfc5c65a23a2325f34cd","version":"v8"},{"repo":"actions/upload-artifact","sha":"bbbca2ddaa5d8feaa63e36b76fdaad77386f024f","version":"v7"},{"repo":"github/gh-aw-actions/setup","sha":"0acfb4a691fe207cd8bc982ea5cb9d750d57a702","version":"v0.68.0"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -39,6 +39,7 @@
 #   - actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
 #   - actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 #   - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+#   - actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
 #   - actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
 #   - actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
 #   - github/gh-aw-actions/setup@0acfb4a691fe207cd8bc982ea5cb9d750d57a702 # v0.68.0
@@ -56,7 +57,7 @@ name: "Hero Scenario Suggestion"
   # - id: remove_label
     # if: github.event_name == 'pull_request_target' && github.event.label.name == 'hero-scenarios-needed'
     # name: Remove trigger label
-    # uses: actions/github-script@v8
+    # uses: actions/github-script@v9
     # with:
       # script: |
         # try {
@@ -201,16 +202,16 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_c20116d3dbb7e676_EOF'
+          cat << 'GH_AW_PROMPT_d83ec22b2ad83d8c_EOF'
           <system>
-          GH_AW_PROMPT_c20116d3dbb7e676_EOF
+          GH_AW_PROMPT_d83ec22b2ad83d8c_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/repo_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_c20116d3dbb7e676_EOF'
+          cat << 'GH_AW_PROMPT_d83ec22b2ad83d8c_EOF'
           <safe-output-tools>
           Tools: add_comment, create_pull_request_review_comment(max:5), submit_pull_request_review, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -242,13 +243,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_c20116d3dbb7e676_EOF
+          GH_AW_PROMPT_d83ec22b2ad83d8c_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_c20116d3dbb7e676_EOF'
+          cat << 'GH_AW_PROMPT_d83ec22b2ad83d8c_EOF'
           </system>
           {{#runtime-import .github/prompts/hero-scenarios-guidelines.md}}
           {{#runtime-import .github/workflows/hero-scenarios.md}}
-          GH_AW_PROMPT_c20116d3dbb7e676_EOF
+          GH_AW_PROMPT_d83ec22b2ad83d8c_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -454,9 +455,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_00f178a41d580fa1_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_c8953fd454257f02_EOF'
           {"add_comment":{"max":1,"target":"${{ github.event.pull_request.number }}"},"create_pull_request_review_comment":{"max":5,"side":"RIGHT","target":"${{ github.event.pull_request.number }}"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_repo_memory":{"memories":[{"dir":"/tmp/gh-aw/repo-memory/default","id":"default","max_file_count":100,"max_file_size":10240,"max_patch_size":10240}]},"report_incomplete":{},"submit_pull_request_review":{"footer":"if-body","max":1,"target":"${{ github.event.pull_request.number }}"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_00f178a41d580fa1_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_c8953fd454257f02_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -691,7 +692,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.17'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_5fce56d6d820e385_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_651bd1368a7b5952_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -735,7 +736,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_5fce56d6d820e385_EOF
+          GH_AW_MCP_CONFIG_651bd1368a7b5952_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1270,7 +1271,7 @@ jobs:
       - name: Remove trigger label
         id: remove_label
         if: github.event_name == 'pull_request_target' && github.event.label.name == 'hero-scenarios-needed'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         with:
           script: |
             try {

--- a/.github/workflows/hero-scenarios.lock.yml
+++ b/.github/workflows/hero-scenarios.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"f090e4ad5898889b1fcccf5f9aa6476ef4e0b827debf4054d5185bc8eb1438dc","compiler_version":"v0.68.0","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"0bed4df14f8b8e4b0bbc8c6c77ffe9cae175a94b786c10a72ac5bd7b1b8b766f","compiler_version":"v0.68.0","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"668228422ae6a00e4ad889ee87cd7109ec5666a7","version":"v5.0.4"},{"repo":"actions/cache/save","sha":"668228422ae6a00e4ad889ee87cd7109ec5666a7","version":"v5.0.4"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"ed597411d8f924073f98dfc5c65a23a2325f34cd","version":"v8"},{"repo":"actions/upload-artifact","sha":"bbbca2ddaa5d8feaa63e36b76fdaad77386f024f","version":"v7"},{"repo":"github/gh-aw-actions/setup","sha":"0acfb4a691fe207cd8bc982ea5cb9d750d57a702","version":"v0.68.0"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -48,12 +48,23 @@ name: "Hero Scenario Suggestion"
   pull_request:
     types:
     - labeled
+  workflow_dispatch:
+    inputs:
+      aw_context:
+        default: ""
+        description: Agent caller context (used internally by Agentic Workflows).
+        required: false
+        type: string
+      item_number:
+        default: ""
+        description: The number of the issue, pull request, or discussion
+        required: false
+        type: string
 
 permissions: {}
 
 concurrency:
-  group: "gh-aw-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}"
-  cancel-in-progress: true
+  group: "gh-aw-${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}-${{ github.event.label.name || github.run_id }}"
 
 run-name: "Hero Scenario Suggestion"
 
@@ -61,22 +72,23 @@ jobs:
   activation:
     needs: pre_activation
     if: >
-      needs.pre_activation.outputs.activated == 'true' && ((github.event.label.name == 'hero-scenarios-needed') &&
-      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.repository_id))
+      needs.pre_activation.outputs.activated == 'true' && (github.event_name == 'pull_request' && github.event.label.name == 'hero-scenarios-needed')
     runs-on: ubuntu-slim
     permissions:
       actions: read
       contents: read
+      discussions: write
+      issues: write
+      pull-requests: write
     outputs:
-      body: ${{ steps.sanitized.outputs.body }}
-      comment_id: ""
-      comment_repo: ""
+      comment_id: ${{ steps.add-comment.outputs.comment-id }}
+      comment_repo: ${{ steps.add-comment.outputs.comment-repo }}
+      comment_url: ${{ steps.add-comment.outputs.comment-url }}
+      label_command: ${{ steps.remove_trigger_label.outputs.label_name }}
       lockdown_check_failed: ${{ steps.generate_aw_info.outputs.lockdown_check_failed == 'true' }}
       model: ${{ steps.generate_aw_info.outputs.model }}
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
       setup-trace-id: ${{ steps.setup.outputs.trace-id }}
-      text: ${{ steps.sanitized.outputs.text }}
-      title: ${{ steps.sanitized.outputs.title }}
     steps:
       - name: Setup Scripts
         id: setup
@@ -111,6 +123,19 @@ jobs:
             setupGlobals(core, github, context, exec, io);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/generate_aw_info.cjs');
             await main(core, context);
+      - name: Add eyes reaction for immediate feedback
+        id: react
+        if: github.event_name == 'issues' || github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment' || github.event_name == 'discussion' || github.event_name == 'discussion_comment' || github.event_name == 'pull_request' && github.event.pull_request.head.repo.id == github.repository_id
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          GH_AW_REACTION: "eyes"
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
+            setupGlobals(core, github, context, exec, io);
+            const { main } = require('${{ runner.temp }}/gh-aw/actions/add_reaction.cjs');
+            await main();
       - name: Validate COPILOT_GITHUB_TOKEN secret
         id: validate-secret
         run: bash "${RUNNER_TEMP}/gh-aw/actions/validate_multi_secret.sh" COPILOT_GITHUB_TOKEN 'GitHub Copilot CLI' https://github.github.com/gh-aw/reference/engines/#github-copilot-default
@@ -146,14 +171,29 @@ jobs:
             setupGlobals(core, github, context, exec, io);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/check_version_updates.cjs');
             await main();
-      - name: Compute current body text
-        id: sanitized
+      - name: Add comment with workflow run link
+        id: add-comment
+        if: github.event_name == 'issues' || github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment' || github.event_name == 'discussion' || github.event_name == 'discussion_comment' || github.event_name == 'pull_request' && github.event.pull_request.head.repo.id == github.repository_id
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          GH_AW_WORKFLOW_NAME: "Hero Scenario Suggestion"
+          GH_AW_SAFE_OUTPUT_MESSAGES: "{\"footer\":\"\\u003e 📖 *Suggested by [{workflow_name}]({run_url})*\",\"runStarted\":\"📖 [{workflow_name}]({run_url}) is generating hero scenarios for this PR…\",\"runSuccess\":\"📖 [{workflow_name}]({run_url}) posted hero scenarios. ✅\",\"runFailure\":\"📖 [{workflow_name}]({run_url}) {status}. ❌\"}"
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
             setupGlobals(core, github, context, exec, io);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/compute_text.cjs');
+            const { main } = require('${{ runner.temp }}/gh-aw/actions/add_workflow_run_comment.cjs');
+            await main();
+      - name: Remove trigger label
+        id: remove_trigger_label
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          GH_AW_LABEL_NAMES: "[\"hero-scenarios-needed\"]"
+        with:
+          script: |
+            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
+            setupGlobals(core, github, context, exec, io);
+            const { main } = require('${{ runner.temp }}/gh-aw/actions/remove_trigger_label.cjs');
             await main();
       - name: Create prompt with built-in context
         env:
@@ -163,7 +203,7 @@ jobs:
           GH_AW_GITHUB_EVENT_COMMENT_ID: ${{ github.event.comment.id }}
           GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
           GH_AW_GITHUB_EVENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
-          GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+          GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || inputs.item_number }}
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
@@ -172,16 +212,16 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_280ef80093716470_EOF'
+          cat << 'GH_AW_PROMPT_b3f2406ac53a98c3_EOF'
           <system>
-          GH_AW_PROMPT_280ef80093716470_EOF
+          GH_AW_PROMPT_b3f2406ac53a98c3_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/repo_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_280ef80093716470_EOF'
+          cat << 'GH_AW_PROMPT_b3f2406ac53a98c3_EOF'
           <safe-output-tools>
           Tools: add_comment, create_pull_request_review_comment(max:5), submit_pull_request_review, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -213,19 +253,19 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_280ef80093716470_EOF
+          GH_AW_PROMPT_b3f2406ac53a98c3_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_280ef80093716470_EOF'
+          cat << 'GH_AW_PROMPT_b3f2406ac53a98c3_EOF'
           </system>
           {{#runtime-import .github/prompts/hero-scenarios-guidelines.md}}
           {{#runtime-import .github/workflows/hero-scenarios.md}}
-          GH_AW_PROMPT_280ef80093716470_EOF
+          GH_AW_PROMPT_b3f2406ac53a98c3_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
-          GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+          GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || inputs.item_number }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -243,7 +283,7 @@ jobs:
           GH_AW_GITHUB_EVENT_COMMENT_ID: ${{ github.event.comment.id }}
           GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
           GH_AW_GITHUB_EVENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
-          GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+          GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || inputs.item_number }}
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
@@ -425,9 +465,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_c16705f3bacf1c7e_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_4b43e279b5ba51c3_EOF'
           {"add_comment":{"max":1,"target":"${{ github.event.pull_request.number }}"},"create_pull_request_review_comment":{"max":5,"side":"RIGHT","target":"${{ github.event.pull_request.number }}"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_repo_memory":{"memories":[{"dir":"/tmp/gh-aw/repo-memory/default","id":"default","max_file_count":100,"max_file_size":10240,"max_patch_size":10240}]},"report_incomplete":{},"submit_pull_request_review":{"footer":"if-body","max":1,"target":"${{ github.event.pull_request.number }}"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_c16705f3bacf1c7e_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_4b43e279b5ba51c3_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -662,7 +702,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.17'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_1f9b8572a68510b6_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_5699350bfebbb07e_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -706,7 +746,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_1f9b8572a68510b6_EOF
+          GH_AW_MCP_CONFIG_5699350bfebbb07e_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1058,6 +1098,25 @@ jobs:
             setupGlobals(core, github, context, exec, io);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/handle_agent_failure.cjs');
             await main();
+      - name: Update reaction comment with completion status
+        id: conclusion
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
+          GH_AW_COMMENT_ID: ${{ needs.activation.outputs.comment_id }}
+          GH_AW_COMMENT_REPO: ${{ needs.activation.outputs.comment_repo }}
+          GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GH_AW_WORKFLOW_NAME: "Hero Scenario Suggestion"
+          GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
+          GH_AW_DETECTION_CONCLUSION: ${{ needs.detection.outputs.detection_conclusion }}
+          GH_AW_SAFE_OUTPUT_MESSAGES: "{\"footer\":\"\\u003e 📖 *Suggested by [{workflow_name}]({run_url})*\",\"runStarted\":\"📖 [{workflow_name}]({run_url}) is generating hero scenarios for this PR…\",\"runSuccess\":\"📖 [{workflow_name}]({run_url}) posted hero scenarios. ✅\",\"runFailure\":\"📖 [{workflow_name}]({run_url}) {status}. ❌\"}"
+        with:
+          github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          script: |
+            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
+            setupGlobals(core, github, context, exec, io);
+            const { main } = require('${{ runner.temp }}/gh-aw/actions/notify_comment_error.cjs');
+            await main();
 
   detection:
     needs:
@@ -1210,8 +1269,7 @@ jobs:
             await main();
 
   pre_activation:
-    if: >
-      (github.event.label.name == 'hero-scenarios-needed') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.repository_id)
+    if: github.event_name == 'pull_request' && github.event.label.name == 'hero-scenarios-needed'
     runs-on: ubuntu-slim
     outputs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}

--- a/.github/workflows/hero-scenarios.lock.yml
+++ b/.github/workflows/hero-scenarios.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"b8c984fe69570e8538cfc539310f7b6f08bc5c0d2b7036629ee7c0f2ef8ddae4","compiler_version":"v0.68.0","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"f090e4ad5898889b1fcccf5f9aa6476ef4e0b827debf4054d5185bc8eb1438dc","compiler_version":"v0.68.0","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"668228422ae6a00e4ad889ee87cd7109ec5666a7","version":"v5.0.4"},{"repo":"actions/cache/save","sha":"668228422ae6a00e4ad889ee87cd7109ec5666a7","version":"v5.0.4"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"ed597411d8f924073f98dfc5c65a23a2325f34cd","version":"v8"},{"repo":"actions/upload-artifact","sha":"bbbca2ddaa5d8feaa63e36b76fdaad77386f024f","version":"v7"},{"repo":"github/gh-aw-actions/setup","sha":"0acfb4a691fe207cd8bc982ea5cb9d750d57a702","version":"v0.68.0"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -22,7 +22,7 @@
 #
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
-# Hero Scenarios: Suggest a service README with hero scenarios for API specifications
+# Hero Scenarios: Suggest hero scenarios for API specifications
 #
 # Resolved workflow manifest:
 #   Imports:
@@ -172,16 +172,16 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_ce4e70927d7760db_EOF'
+          cat << 'GH_AW_PROMPT_280ef80093716470_EOF'
           <system>
-          GH_AW_PROMPT_ce4e70927d7760db_EOF
+          GH_AW_PROMPT_280ef80093716470_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/repo_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_ce4e70927d7760db_EOF'
+          cat << 'GH_AW_PROMPT_280ef80093716470_EOF'
           <safe-output-tools>
           Tools: add_comment, create_pull_request_review_comment(max:5), submit_pull_request_review, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -213,13 +213,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_ce4e70927d7760db_EOF
+          GH_AW_PROMPT_280ef80093716470_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_ce4e70927d7760db_EOF'
+          cat << 'GH_AW_PROMPT_280ef80093716470_EOF'
           </system>
           {{#runtime-import .github/prompts/hero-scenarios-guidelines.md}}
           {{#runtime-import .github/workflows/hero-scenarios.md}}
-          GH_AW_PROMPT_ce4e70927d7760db_EOF
+          GH_AW_PROMPT_280ef80093716470_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -425,9 +425,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_253170e3a0c0097d_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_c16705f3bacf1c7e_EOF'
           {"add_comment":{"max":1,"target":"${{ github.event.pull_request.number }}"},"create_pull_request_review_comment":{"max":5,"side":"RIGHT","target":"${{ github.event.pull_request.number }}"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_repo_memory":{"memories":[{"dir":"/tmp/gh-aw/repo-memory/default","id":"default","max_file_count":100,"max_file_size":10240,"max_patch_size":10240}]},"report_incomplete":{},"submit_pull_request_review":{"footer":"if-body","max":1,"target":"${{ github.event.pull_request.number }}"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_253170e3a0c0097d_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_c16705f3bacf1c7e_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -662,7 +662,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.17'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_60fbec613accb8c9_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_1f9b8572a68510b6_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -706,7 +706,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_60fbec613accb8c9_EOF
+          GH_AW_MCP_CONFIG_1f9b8572a68510b6_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1043,7 +1043,7 @@ jobs:
           GH_AW_CHECKOUT_PR_SUCCESS: ${{ needs.agent.outputs.checkout_pr_success }}
           GH_AW_INFERENCE_ACCESS_ERROR: ${{ needs.agent.outputs.inference_access_error }}
           GH_AW_LOCKDOWN_CHECK_FAILED: ${{ needs.activation.outputs.lockdown_check_failed }}
-          GH_AW_SAFE_OUTPUT_MESSAGES: "{\"footer\":\"\\u003e 📖 *Suggested by [{workflow_name}]({run_url})*\",\"runStarted\":\"📖 [{workflow_name}]({run_url}) is generating hero scenarios for this PR…\",\"runSuccess\":\"📖 [{workflow_name}]({run_url}) posted a README suggestion. ✅\",\"runFailure\":\"📖 [{workflow_name}]({run_url}) {status}. ❌\"}"
+          GH_AW_SAFE_OUTPUT_MESSAGES: "{\"footer\":\"\\u003e 📖 *Suggested by [{workflow_name}]({run_url})*\",\"runStarted\":\"📖 [{workflow_name}]({run_url}) is generating hero scenarios for this PR…\",\"runSuccess\":\"📖 [{workflow_name}]({run_url}) posted hero scenarios. ✅\",\"runFailure\":\"📖 [{workflow_name}]({run_url}) {status}. ❌\"}"
           GH_AW_PUSH_REPO_MEMORY_RESULT: ${{ needs.push_repo_memory.result }}
           GH_AW_REPO_MEMORY_VALIDATION_FAILED_default: ${{ needs.push_repo_memory.outputs.validation_failed_default }}
           GH_AW_REPO_MEMORY_VALIDATION_ERROR_default: ${{ needs.push_repo_memory.outputs.validation_error_default }}
@@ -1140,7 +1140,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           WORKFLOW_NAME: "Hero Scenario Suggestion"
-          WORKFLOW_DESCRIPTION: "Hero Scenarios: Suggest a service README with hero scenarios for API specifications"
+          WORKFLOW_DESCRIPTION: "Hero Scenarios: Suggest hero scenarios for API specifications"
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
           script: |
@@ -1328,7 +1328,7 @@ jobs:
       GH_AW_EFFECTIVE_TOKENS: ${{ needs.agent.outputs.effective_tokens }}
       GH_AW_ENGINE_ID: "copilot"
       GH_AW_ENGINE_MODEL: ${{ needs.agent.outputs.model }}
-      GH_AW_SAFE_OUTPUT_MESSAGES: "{\"footer\":\"\\u003e 📖 *Suggested by [{workflow_name}]({run_url})*\",\"runStarted\":\"📖 [{workflow_name}]({run_url}) is generating hero scenarios for this PR…\",\"runSuccess\":\"📖 [{workflow_name}]({run_url}) posted a README suggestion. ✅\",\"runFailure\":\"📖 [{workflow_name}]({run_url}) {status}. ❌\"}"
+      GH_AW_SAFE_OUTPUT_MESSAGES: "{\"footer\":\"\\u003e 📖 *Suggested by [{workflow_name}]({run_url})*\",\"runStarted\":\"📖 [{workflow_name}]({run_url}) is generating hero scenarios for this PR…\",\"runSuccess\":\"📖 [{workflow_name}]({run_url}) posted hero scenarios. ✅\",\"runFailure\":\"📖 [{workflow_name}]({run_url}) {status}. ❌\"}"
       GH_AW_WORKFLOW_ID: "hero-scenarios"
       GH_AW_WORKFLOW_NAME: "Hero Scenario Suggestion"
     outputs:

--- a/.github/workflows/hero-scenarios.md
+++ b/.github/workflows/hero-scenarios.md
@@ -15,7 +15,7 @@ on:
     - name: Remove trigger label
       id: remove_label
       if: github.event_name == 'pull_request_target' && github.event.label.name == 'hero-scenarios-needed'
-      uses: actions/github-script@v8
+      uses: actions/github-script@v9
       with:
         script: |
           try {

--- a/.github/workflows/hero-scenarios.md
+++ b/.github/workflows/hero-scenarios.md
@@ -1,8 +1,33 @@
 ---
 on:
-  label_command:
-    name: hero-scenarios-needed
-    events: [pull_request]
+  pull_request_target:
+    types: [labeled]
+    forks: ["*"]
+  workflow_dispatch:
+    inputs:
+      item_number:
+        description: PR number to generate hero scenarios for
+        required: true
+        type: string
+  permissions:
+    pull-requests: write
+  steps:
+    - name: Remove trigger label
+      id: remove_label
+      if: github.event_name == 'pull_request_target' && github.event.label.name == 'hero-scenarios-needed'
+      uses: actions/github-script@v8
+      with:
+        script: |
+          try {
+            await github.rest.issues.removeLabel({
+              ...context.repo,
+              issue_number: context.payload.pull_request.number,
+              name: 'hero-scenarios-needed'
+            });
+          } catch (e) {
+            core.warning(`Could not remove label: ${e.message}`);
+          }
+if: github.event.label.name == 'hero-scenarios-needed'
 description: "Hero Scenarios: Suggest hero scenarios for API specifications"
 permissions:
   contents: read

--- a/.github/workflows/hero-scenarios.md
+++ b/.github/workflows/hero-scenarios.md
@@ -1,9 +1,8 @@
 ---
 on:
-  pull_request:
-    types: [labeled]
-labels: [hero-scenarios-needed]
-if: github.event.label.name == 'hero-scenarios-needed'
+  label_command:
+    name: hero-scenarios-needed
+    events: [pull_request]
 description: "Hero Scenarios: Suggest hero scenarios for API specifications"
 permissions:
   contents: read

--- a/.github/workflows/hero-scenarios.md
+++ b/.github/workflows/hero-scenarios.md
@@ -4,7 +4,7 @@ on:
     types: [labeled]
 labels: [hero-scenarios-needed]
 if: github.event.label.name == 'hero-scenarios-needed'
-description: "Hero Scenarios: Suggest a service README with hero scenarios for API specifications"
+description: "Hero Scenarios: Suggest hero scenarios for API specifications"
 permissions:
   contents: read
   pull-requests: read
@@ -32,7 +32,7 @@ safe-outputs:
   messages:
     footer: "> 📖 *Suggested by [{workflow_name}]({run_url})*"
     run-started: "📖 [{workflow_name}]({run_url}) is generating hero scenarios for this PR…"
-    run-success: "📖 [{workflow_name}]({run_url}) posted a README suggestion. ✅"
+    run-success: "📖 [{workflow_name}]({run_url}) posted hero scenarios. ✅"
     run-failure: "📖 [{workflow_name}]({run_url}) {status}. ❌"
 timeout-minutes: 10
 ---
@@ -40,6 +40,6 @@ timeout-minutes: 10
 # Hero Scenario Suggestion
 
 Review pull request #${{ github.event.pull_request.number }} and suggest
-a service README with hero scenarios based on the API surface changed.
+a `hero-scenarios.md` file with hero scenarios based on the API surface changed.
 
 Follow the hero-scenarios guidelines imported above.


### PR DESCRIPTION
## Summary

This PR makes two changes to the hero-scenarios agentic workflow:

### 1. Output to `hero-scenarios.md` instead of `README.md`
- Agent now suggests content for `hero-scenarios.md` in each service directory
- Updated guidelines prompt to check for and generate `hero-scenarios.md`

### 2. Support PRs from forks
- Replaced `label_command` trigger with `pull_request_target: types: [labeled]` + `forks: ["*"]`
- `label_command` injects a `repo.id == repository_id` check that blocks fork PRs; `pull_request_target` runs from the base branch with full write token and secrets access
- Reimplemented label_command features manually:
  - **Label removal** via `on.steps` in pre_activation job
  - **Label filtering** via `if: github.event.label.name == 'hero-scenarios-needed'`
  - **Manual trigger** via explicit `workflow_dispatch` with `item_number` input
  - **Role check** via compiler-generated `check_membership` step
- Security model: label gate (only collaborators can trigger) + base repo context (write token) + API-only code reading (no checkout of fork code)

### Testing

Verified on a cross-fork PR: [deyaaeldeen/azure-rest-api-specs#2](https://github.com/deyaaeldeen/azure-rest-api-specs/pull/2) (PR from `deyaaeldeen-org` fork into `deyaaeldeen` fork). Workflow triggered, agent ran, and hero scenarios were posted as a comment successfully.