### PR TITLE
Add common useDependency 2025-07-01 in VMSS

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/Network/Common/main.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Common/main.tsp
@@ -47,11 +47,6 @@ namespace Common;
  */
 enum Versions {
   /**
-   * The 2018-10-01 API version.
-   */
-  v2018_10_01: "2018-10-01",
-
-  /**
    * The 2025-05-01 API version.
    */
   v2025_05_01: "2025-05-01",

--- a/specification/network/resource-manager/Microsoft.Network/Network/Vmss/back-compatible.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Vmss/back-compatible.tsp
@@ -75,10 +75,6 @@ using TypeSpec.Versioning;
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @@Legacy.flattenProperty(FrontendIPConfiguration.properties);
 
-@@removed(DdosSettings.ddosCustomPolicy,
-  Microsoft.Compute.Versions.v2018_10_01
-);
-
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @@Legacy.flattenProperty(ApplicationGatewayBackendAddressPool.properties);
 

--- a/specification/network/resource-manager/Microsoft.Network/Network/Vmss/main.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Vmss/main.tsp
@@ -42,6 +42,6 @@ enum Versions {
   /**
    * The 2018-10-01 API version.
    */
-  @useDependency(Common.Versions.v2018_10_01)
+  @useDependency(Common.Versions.v2025_07_01)
   v2018_10_01: "2018-10-01",
 }

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2018-10-01/vmssNetwork.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2018-10-01/vmssNetwork.json
@@ -881,6 +881,16 @@
         }
       }
     },
+    "Common.DdosFrontendIpConfigurationSettings": {
+      "type": "object",
+      "description": "DDoS protection settings for a frontend IP configuration.",
+      "properties": {
+        "ddosCustomPolicy": {
+          "$ref": "#/definitions/Common.SubResource",
+          "description": "The reference to the DDoS Custom Policy resource."
+        }
+      }
+    },
     "Common.DdosSettings": {
       "type": "object",
       "description": "Contains the DDoS protection settings of the public IP.",
@@ -1229,6 +1239,10 @@
           "$ref": "#/definitions/Common.ProvisioningState",
           "description": "The provisioning state of the frontend IP configuration resource.",
           "readOnly": true
+        },
+        "ddosSettings": {
+          "$ref": "#/definitions/Common.DdosFrontendIpConfigurationSettings",
+          "description": "The DDoS protection settings associated with the frontend IP configuration."
         }
       }
     },

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2018-10-01/vmssNetwork.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2018-10-01/vmssNetwork.json
@@ -899,6 +899,10 @@
           "$ref": "#/definitions/Common.DdosSettingsProtectionMode",
           "description": "The DDoS protection mode of the public IP"
         },
+        "ddosCustomPolicy": {
+          "$ref": "#/definitions/Common.SubResource",
+          "description": "The DDoS custom policy associated with the public IP."
+        },
         "ddosProtectionPlan": {
           "$ref": "#/definitions/Common.SubResource",
           "description": "The DDoS protection plan associated with the public IP. Can only be set if ProtectionMode is Enabled"


### PR DESCRIPTION
Expectation for versioning in the same service
---
**In 2025-05-01**

Network
enum Versions {
  @useDependency(Common.Versions.v2025_05_01)
  v2025_05_01: "2025-05-01" => swagger with 2025-05-01 common model
}

VMSS
enum Versions {
  @useDependency(Common.Versions.v2025_05_01)
  v2018_10_01: "2018-10-01", => swagger with 2025-05-01 common model
}

Common 
enum Versions {
  v2025_05_01: "2025-05-01",
}


**In 2025-07-01**

Network
enum Versions {
  @useDependency(Common.Versions.v2025_05_01)
  v2025_05_01: "2025-05-01" => swagger with 2025-05-01 common model

@useDependency(Common.Versions.v2025_07_01)
  v2025_07_01: "2025-07-01", => swagger with 2025-07-01 common model
}

VMSS
enum Versions {
  @useDependency(Common.Versions.v2025_07_01)
  v2018_10_01: "2018-10-01", => swagger with 2025-07-01 common model
}

Common 
enum Versions {
  v2025_05_01: "2025-05-01",
  v2025_07_01: "2025-07-01",
}

