### PR TITLE
dns: migrate DNS TypeSpec project for Java SDK

### DIFF
--- a/specification/dns/resource-manager/Microsoft.Network/Dns/client.tsp
+++ b/specification/dns/resource-manager/Microsoft.Network/Dns/client.tsp
@@ -3,3 +3,6 @@ import "./main.tsp";
 using Azure.ClientGenerator.Core;
 
 @@clientName(Microsoft.Network, "DnsManagementClient", "javascript");
+@@clientName(Microsoft.Network, "DnsManagementClient", "java");
+
+@@clientName(Microsoft.Network.RecordSetProperties.TTL, "ttl", "java");

--- a/specification/dns/resource-manager/Microsoft.Network/Dns/tspconfig.yaml
+++ b/specification/dns/resource-manager/Microsoft.Network/Dns/tspconfig.yaml
@@ -18,10 +18,14 @@ options:
     generate-sample: true
     flavor: "azure"
   "@azure-tools/typespec-java":
-    emitter-output-dir: "{output-dir}/{service-dir}/azure-resourcemanager-dnslibrary"
-    namespace: "com.azure.resourcemanager.dnslibrary"
-    service-name: "Dns" # human-readable service name, whitespace allowed
+    emitter-output-dir: "{output-dir}/{service-dir}/azure-resourcemanager-dns"
+    namespace: "com.azure.resourcemanager.dns"
+    service-name: "DnsZone" # human-readable service name, whitespace allowed
     flavor: azure
+    premium: true
+    generate-tests: false
+    client-side-validations: true
+    enable-sync-stack: false
   "@azure-tools/typespec-ts":
     emitter-output-dir: "{output-dir}/{service-dir}/arm-dns"
     flavor: "azure"

--- a/specification/dns/resource-manager/Microsoft.Network/Dns/tspconfig.yaml
+++ b/specification/dns/resource-manager/Microsoft.Network/Dns/tspconfig.yaml
@@ -20,7 +20,7 @@ options:
   "@azure-tools/typespec-java":
     emitter-output-dir: "{output-dir}/{service-dir}/azure-resourcemanager-dns"
     namespace: "com.azure.resourcemanager.dns"
-    service-name: "DnsZone" # human-readable service name, whitespace allowed
+    service-name: "DnsZone"
     flavor: azure
     premium: true
     generate-tests: false


### PR DESCRIPTION
Migrate DNS TypeSpec project configuration for Java SDK generation.

- Fix mitter-output-dir and 
amespace in 	spconfig.yaml
- Set service-name: DnsZone to match existing DnsZoneManager class
- Add premium emitter options
- Add client.tsp with Java-specific customizations (TTL casing fix, namespace client name)