### PR TITLE
Add schedule profile and instance view fields [minimumCommitmentDays] for future reservation

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/examples/2025-04-01/capacityReservationExamples/CapacityReservation_CreateOrUpdate.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/examples/2025-04-01/capacityReservationExamples/CapacityReservation_CreateOrUpdate.json
@@ -14,7 +14,13 @@
       },
       "zones": [
         "1"
-      ]
+      ],
+      "properties": {
+        "scheduleProfile": {
+          "start": "2026-04-20",
+          "minimumCommitmentDays": 14
+        }
+      }
     },
     "capacityReservationGroupName": "myCapacityReservationGroup",
     "capacityReservationName": "myCapacityReservation"

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/examples/2025-04-01/capacityReservationExamples/CapacityReservation_Get.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/examples/2025-04-01/capacityReservationExamples/CapacityReservation_Get.json
@@ -39,6 +39,10 @@
                 }
               ]
             },
+            "reservationStateInfo": {
+              "reservationState": "Pending"
+            },
+            "minimumCommitmentEndDate": "2026-05-04T00:00:00+00:00",
             "statuses": [
               {
                 "code": "ProvisioningState/succeeded",

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2024-07-01/capacityReservation.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2024-07-01/capacityReservation.json
@@ -870,6 +870,17 @@
           "$ref": "#/definitions/CapacityReservationUtilization",
           "description": "Unutilized capacity of the capacity reservation."
         },
+        "reservationStateInfo": {
+          "$ref": "#/definitions/ReservationStateInfo",
+          "readOnly": true,
+          "description": "The reservation state information of the capacity reservation."
+        },
+        "minimumCommitmentEndDate": {
+          "readOnly": true,
+          "type": "string",
+          "format": "date-time",
+          "description": "The date time at which the minimum commitment period of the capacity reservation ends."
+        },
         "statuses": {
           "type": "array",
           "items": {
@@ -880,6 +891,17 @@
         }
       },
       "description": "The instance view of a capacity reservation that provides as snapshot of the runtime properties of the capacity reservation that is managed by the platform and can change outside of control plane operations."
+    },
+    "ReservationStateInfo": {
+      "type": "object",
+      "properties": {
+        "reservationState": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The reservation state of the capacity reservation."
+        }
+      },
+      "description": "The reservation state information of the capacity reservation."
     },
     "CapacityReservationUtilization": {
       "type": "object",
@@ -960,9 +982,29 @@
           "type": "string",
           "format": "date-time",
           "description": "Specifies the time at which the Capacity Reservation resource was created. Minimum api-version: 2021-11-01."
+        },
+        "scheduleProfile": {
+          "$ref": "#/definitions/ScheduleProfile",
+          "description": "The schedule profile for the capacity reservation."
         }
       },
       "description": "Properties of the Capacity reservation."
+    },
+    "ScheduleProfile": {
+      "type": "object",
+      "properties": {
+        "start": {
+          "type": "string",
+          "format": "date",
+          "description": "The start date of the schedule."
+        },
+        "minimumCommitmentDays": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The minimum number of days the capacity reservation must be committed."
+        }
+      },
+      "description": "Profile for scheduled capacity reservation."
     },
     "CapacityReservation": {
       "type": "object",


### PR DESCRIPTION
This PR adds support for Future Capacity Reservation by introducing the following fields to the capacity reservation API:

- `scheduleProfile` - Configuration for scheduling future capacity reservations
- `reservationState` - Current state of the capacity reservation
- `minimumCommitmentDays` - Optional minimum commitment period that users must provide when creating future capacity reservations in Azure Compute platform

**Changes:**
- Updated capacity reservation schema to include new fields
- Updated examples to reflect the new schema

**Migration Notes:**
The new fields are optional and backward-compatible with existing capacity reservation operations.