### PR TITLE
Add Queued to WorkspaceEvaluationStatus enum

### DIFF
--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-05-01-preview/openapi.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-05-01-preview/openapi.json
@@ -7783,6 +7783,7 @@
       "description": "Enum of the workspace evaluation status.",
       "enum": [
         "Pending",
+        "Queued",
         "InProgress",
         "Succeeded",
         "Failed",
@@ -7796,6 +7797,11 @@
             "name": "Pending",
             "value": "Pending",
             "description": "The evaluation is pending and has not started."
+          },
+          {
+            "name": "Queued",
+            "value": "Queued",
+            "description": "The evaluation has been accepted and is queued for execution."
           },
           {
             "name": "InProgress",

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/workspaceEvaluation.models.tsp
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/workspaceEvaluation.models.tsp
@@ -127,6 +127,11 @@ union WorkspaceEvaluationStatus {
   Pending: "Pending",
 
   /**
+   * The evaluation has been accepted and is queued for execution.
+   */
+  Queued: "Queued",
+
+  /**
    * The evaluation is in progress.
    */
   InProgress: "InProgress",


### PR DESCRIPTION
## Summary

Adds `Queued` to the `WorkspaceEvaluationStatus` union in the TypeSpec definition for `2026-05-01-preview`.

## Problem

The BE returns `"Queued"` as a valid evaluation status when a RefreshRecommendations job has been accepted but hasn't started running yet. The TypeSpec `WorkspaceEvaluationStatus` union only defined `Pending, InProgress, Succeeded, Failed, Canceled` — missing `Queued`.

In `2026-02-01-preview`, `Status` was a plain `string` so `"Queued"` passed through correctly. In `2026-05-01-preview`, `Status` became an enum (`WorkspaceEvaluationStatus`), so the GW's `MapEnumValue<WorkspaceEvaluationStatus>("Queued")` silently fell back to `Pending` (enum default 0).

**2026-02-01-preview (correct):** `"status": "Queued"`
**2026-05-01-preview (broken):** `"status": "Pending"`

## Fix

Added `Queued: "Queued"` to the `WorkspaceEvaluationStatus` union, placed between `Pending` and `InProgress` to match the BE lifecycle order:

```
Pending → Queued → InProgress → Succeeded / Failed / Canceled
```

Recompiled TypeSpec to regenerate `openapi.json`.

**Companion GW PR:** https://dev.azure.com/msazure/Squall/_git/Chaos/pullrequest/15380469