### PR TITLE
privatedns: update tspconfig.yaml and client.tsp for Java SDK migration to TypeSpec

### DIFF
--- a/specification/privatedns/resource-manager/Microsoft.Network/PrivateDns/client.tsp
+++ b/specification/privatedns/resource-manager/Microsoft.Network/PrivateDns/client.tsp
@@ -3,3 +3,4 @@ import "./main.tsp";
 using Azure.ClientGenerator.Core;
 
 @@clientName(Microsoft.Network, "PrivateDnsManagementClient", "javascript");
+@@clientName(Microsoft.Network, "PrivateDnsManagementClient", "java");

--- a/specification/privatedns/resource-manager/Microsoft.Network/PrivateDns/client.tsp
+++ b/specification/privatedns/resource-manager/Microsoft.Network/PrivateDns/client.tsp
@@ -4,3 +4,9 @@ using Azure.ClientGenerator.Core;
 
 @@clientName(Microsoft.Network, "PrivateDnsManagementClient", "javascript");
 @@clientName(Microsoft.Network, "PrivateDnsManagementClient", "java");
+
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "backward compatibility"
+@@Azure.ClientGenerator.Core.Legacy.hierarchyBuilding(Microsoft.Network.PrivateZone,
+  Azure.ResourceManager.CommonTypes.TrackedResource,
+  "java"
+);

--- a/specification/privatedns/resource-manager/Microsoft.Network/PrivateDns/tspconfig.yaml
+++ b/specification/privatedns/resource-manager/Microsoft.Network/PrivateDns/tspconfig.yaml
@@ -19,10 +19,15 @@ options:
     generate-sample: true
     flavor: "azure"
   "@azure-tools/typespec-java":
-    emitter-output-dir: "{output-dir}/{service-dir}/azure-resourcemanager-privatednslibrary"
-    namespace: "com.azure.resourcemanager.privatednslibrary"
-    service-name: "PrivateDns" # human-readable service name, whitespace allowed
+    emitter-output-dir: "{output-dir}/{service-dir}/azure-resourcemanager-privatedns"
+    namespace: "com.azure.resourcemanager.privatedns"
+    service-name: "PrivateDnsZone" # human-readable service name, whitespace allowed
     flavor: azure
+    premium: true
+    generate-tests: false
+    client-side-validations: true
+    enable-sync-stack: false
+    customization-class: customization/src/main/java/PrivateDnsCustomization.java
   "@azure-tools/typespec-ts":
     emitter-output-dir: "{output-dir}/{service-dir}/arm-privatedns"
     flavor: azure

--- a/specification/privatedns/resource-manager/Microsoft.Network/PrivateDns/tspconfig.yaml
+++ b/specification/privatedns/resource-manager/Microsoft.Network/PrivateDns/tspconfig.yaml
@@ -27,7 +27,6 @@ options:
     generate-tests: false
     client-side-validations: true
     enable-sync-stack: false
-    customization-class: customization/src/main/java/PrivateDnsCustomization.java
   "@azure-tools/typespec-ts":
     emitter-output-dir: "{output-dir}/{service-dir}/arm-privatedns"
     flavor: azure


### PR DESCRIPTION
Update TypeSpec configuration for privatedns Java SDK migration from Swagger to TypeSpec.

## Changes
- Updated 	spconfig.yaml with Java emitter options (namespace, service-name, premium, generate-tests, customization-class, etc.)
- Updated client.tsp with @@clientName to preserve the PrivateDnsManagementClient class name