### PR TITLE
[python] Add client name for HorizonDb

### DIFF
--- a/specification/horizondb/resource-manager/Microsoft.HorizonDb/HorizonDb/client.tsp
+++ b/specification/horizondb/resource-manager/Microsoft.HorizonDb/HorizonDb/client.tsp
@@ -1,0 +1,6 @@
+import "@azure-tools/typespec-client-generator-core";
+import "./main.tsp";
+
+using Azure.ClientGenerator.Core;
+
+@@clientName(Microsoft.HorizonDb, "HorizonDBMgmtClient", "python");

--- a/specification/horizondb/resource-manager/Microsoft.HorizonDb/HorizonDb/import "@azure-tools/typespec-client-generator-core"; import "./client.tsp
+++ b/specification/horizondb/resource-manager/Microsoft.HorizonDb/HorizonDb/import "@azure-tools/typespec-client-generator-core"; import "./client.tsp
@@ -1,6 +1,0 @@
-import "@azure-tools/typespec-client-generator-core";
-import "./main.tsp";
-
-using Azure.ClientGenerator.Core;
-
-@@clientName(Microsoft.HorizonDb, "HorizonDBMgmtClient", "python");

--- a/specification/horizondb/resource-manager/Microsoft.HorizonDb/HorizonDb/import "@azure-tools/typespec-client-generator-core"; import "./client.tsp
+++ b/specification/horizondb/resource-manager/Microsoft.HorizonDb/HorizonDb/import "@azure-tools/typespec-client-generator-core"; import "./client.tsp
@@ -1,0 +1,6 @@
+import "@azure-tools/typespec-client-generator-core";
+import "./main.tsp";
+
+using Azure.ClientGenerator.Core;
+
+@@clientName(Microsoft.HorizonDb, "HorizonDBMgmtClient", "python");


### PR DESCRIPTION
Update tsp config for python to add client name for HorizonDb to release: https://github.com/Azure/azure-sdk-for-python/pull/45991