### PR TITLE
fix: add missing enum values and restore errors property for 2026-05-01-preview

### DIFF
--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-05-01-preview/openapi.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-05-01-preview/openapi.json
@@ -7057,9 +7057,11 @@
       "type": "string",
       "description": "Enum of the scenario run state.",
       "enum": [
+        "Queued",
         "Resolving",
         "Generating",
         "Validating",
+        "ValidationSucceeded",
         "Starting",
         "Running",
         "Canceling",
@@ -7071,6 +7073,11 @@
         "name": "ScenarioRunState",
         "modelAsString": true,
         "values": [
+          {
+            "name": "Queued",
+            "value": "Queued",
+            "description": "The scenario run has been queued and is waiting to start."
+          },
           {
             "name": "Resolving",
             "value": "Resolving",
@@ -7085,6 +7092,11 @@
             "name": "Validating",
             "value": "Validating",
             "description": "The scenario run is in the process of being validated."
+          },
+          {
+            "name": "ValidationSucceeded",
+            "value": "ValidationSucceeded",
+            "description": "The scenario run validation has completed successfully."
           },
           {
             "name": "Starting",
@@ -7644,6 +7656,7 @@
       "description": "Enum of the workspace discovery status.",
       "enum": [
         "Pending",
+        "Queued",
         "InProgress",
         "Succeeded",
         "Failed",
@@ -7657,6 +7670,11 @@
             "name": "Pending",
             "value": "Pending",
             "description": "The discovery is pending and has not started."
+          },
+          {
+            "name": "Queued",
+            "value": "Queued",
+            "description": "The discovery has been accepted and is queued for execution."
           },
           {
             "name": "InProgress",
@@ -7786,6 +7804,7 @@
         "Queued",
         "InProgress",
         "Succeeded",
+        "PartiallySucceeded",
         "Failed",
         "Canceled"
       ],
@@ -7812,6 +7831,11 @@
             "name": "Succeeded",
             "value": "Succeeded",
             "description": "The evaluation completed successfully."
+          },
+          {
+            "name": "PartiallySucceeded",
+            "value": "PartiallySucceeded",
+            "description": "The evaluation partially succeeded — some scenarios succeeded while others failed."
           },
           {
             "name": "Failed",

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-05-01-preview/openapi.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-05-01-preview/openapi.json
@@ -6990,9 +6990,18 @@
             "id"
           ]
         },
+        "errors": {
+          "type": "array",
+          "description": "System or infrastructure errors encountered during the scenario run.",
+          "items": {
+            "$ref": "#/definitions/OperationError"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": []
+        },
         "executionErrors": {
           "$ref": "#/definitions/ScenarioErrors",
-          "description": "The scenario run errors.",
+          "description": "Business errors from fault injection — permission and resource state issues.",
           "readOnly": true
         },
         "scenarioRunJson": {
@@ -7561,6 +7570,15 @@
           "format": "date-time",
           "description": "The scenario validation UTC end time.",
           "readOnly": true
+        },
+        "errors": {
+          "type": "array",
+          "description": "System or infrastructure errors encountered during validation.",
+          "items": {
+            "$ref": "#/definitions/OperationError"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": []
         },
         "validationErrors": {
           "$ref": "#/definitions/ScenarioErrors",

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/scenarioConfiguration.models.tsp
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/scenarioConfiguration.models.tsp
@@ -158,6 +158,13 @@ model ValidationProperties {
   endTime?: utcDateTime;
 
   /**
+   * System or infrastructure errors encountered during validation.
+   */
+  @visibility(Lifecycle.Read)
+  @identifiers(#[])
+  errors?: OperationError[];
+
+  /**
    * Business errors from validation — permission and resource state issues.
    */
   validationErrors?: ScenarioErrors;

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/scenarioRun.models.tsp
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/scenarioRun.models.tsp
@@ -289,6 +289,11 @@ union ScenarioRunState {
   string,
 
   /**
+   * The scenario run has been queued and is waiting to start.
+   */
+  Queued: "Queued",
+
+  /**
    * The scenario run is in the process of being resolved.
    */
   Resolving: "Resolving",
@@ -302,6 +307,11 @@ union ScenarioRunState {
    * The scenario run is in the process of being validated.
    */
   Validating: "Validating",
+
+  /**
+   * The scenario run validation has completed successfully.
+   */
+  ValidationSucceeded: "ValidationSucceeded",
 
   /**
    * The scenario run is in the process of being started.

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/scenarioRun.models.tsp
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/scenarioRun.models.tsp
@@ -69,7 +69,14 @@ model ScenarioRunProperties {
   resources: ScenarioRunResource[];
 
   /**
-   * The scenario run errors.
+   * System or infrastructure errors encountered during the scenario run.
+   */
+  @visibility(Lifecycle.Read)
+  @identifiers(#[])
+  errors?: OperationError[];
+
+  /**
+   * Business errors from fault injection — permission and resource state issues.
    */
   @visibility(Lifecycle.Read)
   executionErrors?: ScenarioErrors;

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/workspaceDiscovery.models.tsp
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/workspaceDiscovery.models.tsp
@@ -75,6 +75,11 @@ union WorkspaceDiscoveryStatus {
   Pending: "Pending",
 
   /**
+   * The discovery has been accepted and is queued for execution.
+   */
+  Queued: "Queued",
+
+  /**
    * The discovery is in progress.
    */
   InProgress: "InProgress",

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/workspaceEvaluation.models.tsp
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/workspaceEvaluation.models.tsp
@@ -142,6 +142,11 @@ union WorkspaceEvaluationStatus {
   Succeeded: "Succeeded",
 
   /**
+   * The evaluation partially succeeded — some scenarios succeeded while others failed.
+   */
+  PartiallySucceeded: "PartiallySucceeded",
+
+  /**
    * The evaluation failed.
    */
   Failed: "Failed",


### PR DESCRIPTION
## Summary

Fixes multiple gaps in the `2026-05-01-preview` TypeSpec definitions that were accidentally dropped during the copy from `2026-02-01-preview`.

### Missing enum values (commit 1)

Several enums are missing values that the Backend (BE) sends at runtime, causing `null` responses in the ARM Gateway:

| Enum | Missing Values |
|------|---------------|
| `ScenarioRunState` | `Queued`, `ValidationSucceeded` |
| `WorkspaceDiscoveryStatus` | `Queued` |
| `WorkspaceEvaluationStatus` | `PartiallySucceeded` |

### Missing `errors` property (commit 2)

`ValidationProperties` and `ScenarioRunProperties` are both missing the `errors?: OperationError[]` property that exists in `2026-02-01-preview`. This property carries system/infrastructure errors (e.g., `ScenarioExecutionRbacValidationError`) separate from the business errors in `validationErrors`/`executionErrors` (`ScenarioErrors`).

**V2026_02_01_preview has both:**
- `errors?: OperationError[]` — system/infra errors
- `validationErrors?: ScenarioErrors` / `executionErrors?: ScenarioErrors` — business errors

**V2026_05_01_preview was missing `errors`** — customers could not see system-level error codes.

### Root cause

All gaps trace to PR #15177112 (Add 2026-05-01-preview to GW) where properties/values were missed during the bulk copy.

### ADO Bugs

- #37535393 — Multiple enums missing BE values (umbrella)
- #37536683 — errors (OperationError[]) missing from ValidationProperties and ScenarioRunProperties