### PR TITLE
Fix LRO response types for GalleryScript and GalleryScriptVersion operations

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeGallery/GalleryScript.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeGallery/GalleryScript.tsp
@@ -52,7 +52,8 @@ interface GalleryScripts {
     GalleryScript,
     Response = ArmResourceUpdatedResponse<GalleryScript> | ArmResourceCreatedResponse<
       GalleryScript,
-      ArmLroLocationHeader & Azure.Core.Foundations.RetryAfterHeader
+      ArmLroLocationHeader<FinalResult = GalleryScript> &
+        Azure.Core.Foundations.RetryAfterHeader
     >
   >;
 
@@ -64,7 +65,8 @@ interface GalleryScripts {
   update is ComputeCustomPatchAsync<
     GalleryScript,
     PatchModel = GalleryScriptUpdate,
-    Response = ArmResponse<GalleryScript> | ArmAcceptedLroResponse
+    Response = ArmResponse<GalleryScript> | ArmAcceptedLroResponse<LroHeaders = ArmLroLocationHeader<FinalResult = GalleryScript> &
+      Azure.Core.Foundations.RetryAfterHeader>
   >;
 
   /**

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeGallery/GalleryScriptVersion.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeGallery/GalleryScriptVersion.tsp
@@ -33,7 +33,7 @@ namespace ComputeGallery {
   /**
    * Common LRO headers (Azure-AsyncOperation required Jan 2025). Keep Location + Retry-After for backward compatibility.
    */
-  alias GalleryScriptVersionLroHeaders = ArmAsyncOperationHeader<FinalResult = GalleryScriptVersion> &
+  alias GalleryScriptVersionLroHeaders<FinalResult = GalleryScriptVersion> = ArmAsyncOperationHeader<FinalResult = FinalResult> &
     ArmLroLocationHeader &
     Azure.Core.Foundations.RetryAfterHeader;
 
@@ -89,7 +89,7 @@ namespace ComputeGallery {
       Azure.ResourceManager.Foundations.DefaultBaseParameters<GalleryScriptVersion>,
       GalleryScriptVersionLroHeaders,
       {},
-      ArmDeleteAcceptedLroResponse<GalleryScriptVersionLroHeaders> | ArmDeletedNoContentResponse
+      ArmDeleteAcceptedLroResponse<GalleryScriptVersionLroHeaders<void>> | ArmDeletedNoContentResponse
     >;
 
     /**


### PR DESCRIPTION
## Fix

Add `FinalResult` parameter to LRO headers for GalleryScripts and GalleryScriptVersions `createOrUpdate` and `update` operations so the generated Go SDK correctly includes the resource in response types. Also fix the `delete` operation's LRO header to use `FinalResult = void`.

### Changes
- **GalleryScript.tsp**: Added `FinalResult = GalleryScript` to `ArmLroLocationHeader` in `createOrUpdate`; expanded `ArmAcceptedLroResponse` with explicit LRO headers in `update`
- **GalleryScriptVersion.tsp**: Made `GalleryScriptVersionLroHeaders` alias generic with a `FinalResult` parameter (defaults to `GalleryScriptVersion`); updated `delete` operation to pass `FinalResult = void` since delete should not return a resource body

### Context
During TypeSpec migration validation for the Go SDK (`armcompute`), the changelog showed:
- Field `GalleryScript` of struct `GalleryScriptsClientCreateOrUpdateResponse` has been removed
- Field `GalleryScript` of struct `GalleryScriptsClientUpdateResponse` has been removed
- Field `GalleryScriptVersion` of struct `GalleryScriptVersionsClientDeleteResponse` incorrectly included

This matches the [breaking changes guide pattern #5](https://github.com/Azure/azure-sdk-for-go/blob/main/documentation/development/breaking-changes/sdk-breaking-changes-guide-migration.md) (Missing Fields in Response Types).
