### PR TITLE
[Python] Mitigate breaking changes for azure-mgmt-resourcehealth

### DIFF
--- a/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/ResourceHealth/client.tsp
+++ b/specification/resourcehealth/resource-manager/Microsoft.ResourceHealth/ResourceHealth/client.tsp
@@ -1,0 +1,11 @@
+import "@azure-tools/typespec-client-generator-core";
+import "./main.tsp";
+
+using Azure.ClientGenerator.Core;
+
+@@clientName(Azure.ResourceManager.CommonTypes.ProxyResource,
+  "ArmProxyResource",
+  "python"
+);
+
+@@clientName(Microsoft.ResourceHealth, "ResourceHealthMgmtClient", "python");


### PR DESCRIPTION
# [Python] Mitigate breaking changes for azure-mgmt-resourcehealth

## Mitigations

| Breaking Change | Classification | Mitigation |
|---|---|---|
| `ProxyResource` name collision (common-types vs local) | Compilation error | `@@clientName(Azure.ResourceManager.CommonTypes.ProxyResource, "ArmProxyResource", "python")` |
| Client renamed from `ResourceHealthMgmtClient` | Guide #4: Client Naming | `@@clientName(Microsoft.ResourceHealth, "ResourceHealthMgmtClient", "python")` |

## Accepted Breaking Changes (no mitigation needed)

- Guide #11: `EmergingIssuesGetResult` flattened props moved into `properties` object
- Guide #8: `Events` pageable model removed
- Guide #7: `ImpactedResourceStatus`, `ReasonTypeValues` unreferenced models removed
- Guide #9: Multiple params changed to keyword-only (`expand`, `query_start_time`)
- `Operations.list` changed from async to sync
- `EventPropertiesRecommendedActionsItem` renamed to `EventPropertiesRecommendedActionsActionsItem`
- `ProxyResource` lost `system_data` (model restructure)
