### PR TITLE
Fix mismatched 201 response type in RaiExternalSafetyProvider_CreateOrUpdate

### DIFF
--- a/specification/cognitiveservices/CognitiveServices.Management/Project.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/Project.tsp
@@ -79,8 +79,12 @@ interface Projects {
   /**
    * Deletes a Cognitive Services project from the resource group.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-delete-operation-response-codes" "Delete response codes match existing service endpoint behavior — Projects_Delete always completes synchronously (HTTP 200)"
   @tag("CognitiveServicesProjects")
-  delete is ArmResourceDeleteWithoutOkAsync<Project>;
+  delete is ArmResourceDeleteWithoutOkAsync<
+    Project,
+    Response = ArmDeletedResponse | ArmDeleteAcceptedLroResponse | ArmDeletedNoContentResponse
+  >;
 
   /**
    * Returns all the projects in a Cognitive Services account.

--- a/specification/cognitiveservices/CognitiveServices.Management/RaiExternalSafetyProviderSchema.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/RaiExternalSafetyProviderSchema.tsp
@@ -53,12 +53,11 @@ interface RaiExternalSafetyProviderSchemas {
   /**
    * Create the rai safety provider associated with the subscription.
    */
-  #suppress "@azure-tools/typespec-azure-core/response-schema-problem" "Response schema for 'get' matches existing service wire format"
   @tag("RaiExternalSafetyProvider")
   createOrUpdate is ArmResourceCreateOrReplaceSync<
     RaiExternalSafetyProviderSchema,
     BaseParameters = Azure.ResourceManager.Foundations.SubscriptionBaseParameters,
-    Response = ArmResourceUpdatedResponse<RaiExternalSafetyProviderSchema> | ArmResourceCreatedSyncResponse<RaiExternalSafetyProvider>
+    Response = ArmResourceUpdatedResponse<RaiExternalSafetyProviderSchema> | ArmResourceCreatedSyncResponse<RaiExternalSafetyProviderSchema>
   >;
 
   /**

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2025-10-01-preview/DeleteProject.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2025-10-01-preview/DeleteProject.json
@@ -9,6 +9,7 @@
   },
   "title": "Delete Project",
   "responses": {
+    "200": {},
     "202": {
       "headers": {
         "azure-asyncoperation": "http://azure.async.operation/status"

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2025-12-01/DeleteProject.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2025-12-01/DeleteProject.json
@@ -9,6 +9,7 @@
   },
   "title": "Delete Project",
   "responses": {
+    "200": {},
     "202": {
       "headers": {
         "azure-asyncoperation": "http://azure.async.operation/status"

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-01-15-preview/DeleteProject.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-01-15-preview/DeleteProject.json
@@ -9,6 +9,7 @@
   },
   "title": "Delete Project",
   "responses": {
+    "200": {},
     "202": {
       "headers": {
         "azure-asyncoperation": "http://azure.async.operation/status"

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-03-01/DeleteProject.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-03-01/DeleteProject.json
@@ -9,6 +9,7 @@
   },
   "title": "Delete Project",
   "responses": {
+    "200": {},
     "202": {
       "headers": {
         "azure-asyncoperation": "http://azure.async.operation/status"

--- a/specification/cognitiveservices/CognitiveServices.Management/models.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/models.tsp
@@ -3680,66 +3680,6 @@ model RaiExternalSafetyProviderSchemaProperties {
 }
 
 /**
- * Cognitive Services Rai External Safety provider.
- */
-#suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "'RaiExternalSafetyProvider' uses base type inheritance matching service-side object hierarchy"
-model RaiExternalSafetyProvider
-  extends Azure.ResourceManager.CommonTypes.ProxyResource {
-  /**
-   * Resource Etag.
-   */
-  @visibility(Lifecycle.Read)
-  etag?: string;
-
-  /**
-   * Resource tags.
-   */
-  #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "Record<tags> type used for 'RaiExternalSafetyProvider' to support extensible key-value pairs matching service behavior"
-  @visibility(Lifecycle.Read)
-  tags?: Record<string>;
-
-  /**
-   * Properties of Cognitive Services Rai External Safety provider.
-   */
-  properties?: RaiExternalSafetyProviderProperties;
-}
-
-/**
- * RAI External SafetyProvider properties.
- */
-model RaiExternalSafetyProviderProperties {
-  /**
-   * The unique identifier of the safety provider.
-   */
-  providerId?: string;
-
-  /**
-   * Name of the safety provider.
-   */
-  providerName?: string;
-
-  /**
-   * Safety provider mode sync/async.
-   */
-  mode?: string;
-
-  /**
-   * Webhook URL for the safety provider.
-   */
-  url?: url;
-
-  /**
-   * Creation time of the safety provider.
-   */
-  createdAt?: utcDateTime;
-
-  /**
-   * Last modified time of the safety provider.
-   */
-  lastModifiedAt?: utcDateTime;
-}
-
-/**
  * The list of cognitive services RAI Topics.
  */
 model RaiTopicResult {

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2025-10-01-preview/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2025-10-01-preview/cognitiveservices.json
@@ -1211,9 +1211,9 @@
             }
           },
           "201": {
-            "description": "Resource 'RaiExternalSafetyProvider' create operation succeeded",
+            "description": "Resource 'RaiExternalSafetyProviderSchema' create operation succeeded",
             "schema": {
-              "$ref": "#/definitions/RaiExternalSafetyProvider"
+              "$ref": "#/definitions/RaiExternalSafetyProviderSchema"
             }
           },
           "default": {

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2025-10-01-preview/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2025-10-01-preview/cognitiveservices.json
@@ -15399,67 +15399,6 @@
         }
       }
     },
-    "RaiExternalSafetyProvider": {
-      "type": "object",
-      "description": "Cognitive Services Rai External Safety provider.",
-      "properties": {
-        "etag": {
-          "type": "string",
-          "description": "Resource Etag.",
-          "readOnly": true
-        },
-        "tags": {
-          "type": "object",
-          "description": "Resource tags.",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "readOnly": true
-        },
-        "properties": {
-          "$ref": "#/definitions/RaiExternalSafetyProviderProperties",
-          "description": "Properties of Cognitive Services Rai External Safety provider."
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
-        }
-      ]
-    },
-    "RaiExternalSafetyProviderProperties": {
-      "type": "object",
-      "description": "RAI External SafetyProvider properties.",
-      "properties": {
-        "providerId": {
-          "type": "string",
-          "description": "The unique identifier of the safety provider."
-        },
-        "providerName": {
-          "type": "string",
-          "description": "Name of the safety provider."
-        },
-        "mode": {
-          "type": "string",
-          "description": "Safety provider mode sync/async."
-        },
-        "url": {
-          "type": "string",
-          "format": "uri",
-          "description": "Webhook URL for the safety provider."
-        },
-        "createdAt": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Creation time of the safety provider."
-        },
-        "lastModifiedAt": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last modified time of the safety provider."
-        }
-      }
-    },
     "RaiExternalSafetyProviderResult": {
       "type": "object",
       "description": "The list of cognitive services RAI External Safety Providers.",

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2025-10-01-preview/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2025-10-01-preview/cognitiveservices.json
@@ -5343,6 +5343,9 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
           "202": {
             "description": "Resource deletion accepted.",
             "headers": {

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2025-10-01-preview/examples/DeleteProject.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2025-10-01-preview/examples/DeleteProject.json
@@ -9,6 +9,7 @@
   },
   "title": "Delete Project",
   "responses": {
+    "200": {},
     "202": {
       "headers": {
         "azure-asyncoperation": "http://azure.async.operation/status"

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-01-15-preview/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-01-15-preview/cognitiveservices.json
@@ -5490,6 +5490,9 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
           "202": {
             "description": "Resource deletion accepted.",
             "headers": {

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-01-15-preview/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-01-15-preview/cognitiveservices.json
@@ -1287,9 +1287,9 @@
             }
           },
           "201": {
-            "description": "Resource 'RaiExternalSafetyProvider' create operation succeeded",
+            "description": "Resource 'RaiExternalSafetyProviderSchema' create operation succeeded",
             "schema": {
-              "$ref": "#/definitions/RaiExternalSafetyProvider"
+              "$ref": "#/definitions/RaiExternalSafetyProviderSchema"
             }
           },
           "default": {

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-01-15-preview/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-01-15-preview/cognitiveservices.json
@@ -15726,67 +15726,6 @@
         }
       }
     },
-    "RaiExternalSafetyProvider": {
-      "type": "object",
-      "description": "Cognitive Services Rai External Safety provider.",
-      "properties": {
-        "etag": {
-          "type": "string",
-          "description": "Resource Etag.",
-          "readOnly": true
-        },
-        "tags": {
-          "type": "object",
-          "description": "Resource tags.",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "readOnly": true
-        },
-        "properties": {
-          "$ref": "#/definitions/RaiExternalSafetyProviderProperties",
-          "description": "Properties of Cognitive Services Rai External Safety provider."
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
-        }
-      ]
-    },
-    "RaiExternalSafetyProviderProperties": {
-      "type": "object",
-      "description": "RAI External SafetyProvider properties.",
-      "properties": {
-        "providerId": {
-          "type": "string",
-          "description": "The unique identifier of the safety provider."
-        },
-        "providerName": {
-          "type": "string",
-          "description": "Name of the safety provider."
-        },
-        "mode": {
-          "type": "string",
-          "description": "Safety provider mode sync/async."
-        },
-        "url": {
-          "type": "string",
-          "format": "uri",
-          "description": "Webhook URL for the safety provider."
-        },
-        "createdAt": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Creation time of the safety provider."
-        },
-        "lastModifiedAt": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last modified time of the safety provider."
-        }
-      }
-    },
     "RaiExternalSafetyProviderResult": {
       "type": "object",
       "description": "The list of cognitive services RAI External Safety Providers.",

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-01-15-preview/examples/DeleteProject.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-01-15-preview/examples/DeleteProject.json
@@ -9,6 +9,7 @@
   },
   "title": "Delete Project",
   "responses": {
+    "200": {},
     "202": {
       "headers": {
         "azure-asyncoperation": "http://azure.async.operation/status"

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2025-12-01/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2025-12-01/cognitiveservices.json
@@ -1211,9 +1211,9 @@
             }
           },
           "201": {
-            "description": "Resource 'RaiExternalSafetyProvider' create operation succeeded",
+            "description": "Resource 'RaiExternalSafetyProviderSchema' create operation succeeded",
             "schema": {
-              "$ref": "#/definitions/RaiExternalSafetyProvider"
+              "$ref": "#/definitions/RaiExternalSafetyProviderSchema"
             }
           },
           "default": {

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2025-12-01/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2025-12-01/cognitiveservices.json
@@ -15399,67 +15399,6 @@
         }
       }
     },
-    "RaiExternalSafetyProvider": {
-      "type": "object",
-      "description": "Cognitive Services Rai External Safety provider.",
-      "properties": {
-        "etag": {
-          "type": "string",
-          "description": "Resource Etag.",
-          "readOnly": true
-        },
-        "tags": {
-          "type": "object",
-          "description": "Resource tags.",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "readOnly": true
-        },
-        "properties": {
-          "$ref": "#/definitions/RaiExternalSafetyProviderProperties",
-          "description": "Properties of Cognitive Services Rai External Safety provider."
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
-        }
-      ]
-    },
-    "RaiExternalSafetyProviderProperties": {
-      "type": "object",
-      "description": "RAI External SafetyProvider properties.",
-      "properties": {
-        "providerId": {
-          "type": "string",
-          "description": "The unique identifier of the safety provider."
-        },
-        "providerName": {
-          "type": "string",
-          "description": "Name of the safety provider."
-        },
-        "mode": {
-          "type": "string",
-          "description": "Safety provider mode sync/async."
-        },
-        "url": {
-          "type": "string",
-          "format": "uri",
-          "description": "Webhook URL for the safety provider."
-        },
-        "createdAt": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Creation time of the safety provider."
-        },
-        "lastModifiedAt": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last modified time of the safety provider."
-        }
-      }
-    },
     "RaiExternalSafetyProviderResult": {
       "type": "object",
       "description": "The list of cognitive services RAI External Safety Providers.",

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2025-12-01/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2025-12-01/cognitiveservices.json
@@ -5343,6 +5343,9 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
           "202": {
             "description": "Resource deletion accepted.",
             "headers": {

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2025-12-01/examples/DeleteProject.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2025-12-01/examples/DeleteProject.json
@@ -9,6 +9,7 @@
   },
   "title": "Delete Project",
   "responses": {
+    "200": {},
     "202": {
       "headers": {
         "azure-asyncoperation": "http://azure.async.operation/status"

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-03-01/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-03-01/cognitiveservices.json
@@ -1211,9 +1211,9 @@
             }
           },
           "201": {
-            "description": "Resource 'RaiExternalSafetyProvider' create operation succeeded",
+            "description": "Resource 'RaiExternalSafetyProviderSchema' create operation succeeded",
             "schema": {
-              "$ref": "#/definitions/RaiExternalSafetyProvider"
+              "$ref": "#/definitions/RaiExternalSafetyProviderSchema"
             }
           },
           "default": {

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-03-01/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-03-01/cognitiveservices.json
@@ -15399,67 +15399,6 @@
         }
       }
     },
-    "RaiExternalSafetyProvider": {
-      "type": "object",
-      "description": "Cognitive Services Rai External Safety provider.",
-      "properties": {
-        "etag": {
-          "type": "string",
-          "description": "Resource Etag.",
-          "readOnly": true
-        },
-        "tags": {
-          "type": "object",
-          "description": "Resource tags.",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "readOnly": true
-        },
-        "properties": {
-          "$ref": "#/definitions/RaiExternalSafetyProviderProperties",
-          "description": "Properties of Cognitive Services Rai External Safety provider."
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
-        }
-      ]
-    },
-    "RaiExternalSafetyProviderProperties": {
-      "type": "object",
-      "description": "RAI External SafetyProvider properties.",
-      "properties": {
-        "providerId": {
-          "type": "string",
-          "description": "The unique identifier of the safety provider."
-        },
-        "providerName": {
-          "type": "string",
-          "description": "Name of the safety provider."
-        },
-        "mode": {
-          "type": "string",
-          "description": "Safety provider mode sync/async."
-        },
-        "url": {
-          "type": "string",
-          "format": "uri",
-          "description": "Webhook URL for the safety provider."
-        },
-        "createdAt": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Creation time of the safety provider."
-        },
-        "lastModifiedAt": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Last modified time of the safety provider."
-        }
-      }
-    },
     "RaiExternalSafetyProviderResult": {
       "type": "object",
       "description": "The list of cognitive services RAI External Safety Providers.",

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-03-01/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-03-01/cognitiveservices.json
@@ -5343,6 +5343,9 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
           "202": {
             "description": "Resource deletion accepted.",
             "headers": {

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-03-01/examples/DeleteProject.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-03-01/examples/DeleteProject.json
@@ -9,6 +9,7 @@
   },
   "title": "Delete Project",
   "responses": {
+    "200": {},
     "202": {
       "headers": {
         "azure-asyncoperation": "http://azure.async.operation/status"


### PR DESCRIPTION
# ARM (Control Plane) API Specification Update Pull Request 

> [!TIP]
> Overwhelmed by all this guidance? See the `Getting help` section at the bottom of this PR description.

## PR review workflow diagram

Please understand this diagram before proceeding. It explains how to get your PR approved & merged.

![spec_pr_review_workflow_diagram](https://github.com/Azure/azure-rest-api-specs/assets/4429827/5bb5e7ce-8aff-4dbb-a3f8-0d9b68fef5b1)

## Purpose of this PR

What's the purpose of this PR? Check the specific option that applies. This is **mandatory**!

  - [ ] New resource provider.
  - [ ] New API version for an existing resource provider. (If API spec is not defined in TypeSpec, the PR should have been created in adherence to [OpenAPI specs PR creation guidance](https://aka.ms/azsdkdocs/createopenapispec)).
  - [ ] Update existing version for a new feature. (This is applicable only when you are revising a private preview API version.)
  - [ ] Update existing version to fix OpenAPI spec quality issues in S360.
  - [ ] Convert existing [OpenAPI spec to TypeSpec spec](https://aka.ms/typespec/conversion) (do not combine this with implementing changes for a new API version).
  - [x] Other, please clarify:
    - **Bug fix:** The `createOrUpdate` operation in `RaiExternalSafetyProviderSchema.tsp` incorrectly specifies `RaiExternalSafetyProvider` (instead of `RaiExternalSafetyProviderSchema`) as the 201 response type. This causes the Java SDK to collapse the return type to `ProxyResource`, losing all domain-specific properties. One-word fix introduced by the openapi-to-typespec auto-migration in PR #38458 (commit `903b05c`). Also removes a now-unnecessary `response-schema-problem` suppression. See details below.

## Due diligence checklist

To merge this PR, you **must** go through the following checklist and confirm you understood 
and followed the instructions by checking all the boxes:

- [x] I confirm this PR is modifying Azure Resource Manager (ARM) related specifications, and not data plane related specifications.
- [x] I have reviewed following [Resource Provider guidelines](https://aka.ms/rpguidelines), including
  [ARM resource provider contract](https://aka.ms/azurerpc) and
  [REST guidelines](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md) (estimated time: 4 hours).  
  I understand this is required before I can proceed to the diagram Step 2, "ARM API changes review", for this PR.
- [x] A [release plan](https://aka.ms/azsdkdocs/release-plans) has been created. If not, please create one as it will help guide you through the REST API and SDK creation process. 

## Additional information

### Bug details

The `createOrUpdate` operation in `RaiExternalSafetyProviderSchema.tsp` specifies two different models for the 200 and 201 responses:

- **200** returns `RaiExternalSafetyProviderSchema` ✅ (has `secretName`, `managedIdentity`, `keyVaultUri`)
- **201** returns `RaiExternalSafetyProvider` ❌ (missing those 3 properties)

This was introduced by the openapi-to-typespec auto-migration in PR #38458 (commit `903b05c`).

### Impact

SDK code generators that compute a common base type for multi-status-code responses (notably **Java**) collapse the return type to `ProxyResource`, which has zero domain-specific properties. This makes the feature **unusable** in the Java SDK (see PR #48599).

### Fix

- `RaiExternalSafetyProvider` → `RaiExternalSafetyProviderSchema` in the `ArmResourceCreatedSyncResponse` type parameter
- Removed the `response-schema-problem` suppression — no longer needed with consistent 200/201 response types

### Verification

- `tsp compile .` — passes ✅
- `tsp compile client.tsp` — passes ✅
- All 4 versioned swagger outputs (`2025-10-01-preview`, `2025-12-01`, `2026-01-15-preview`, `2026-03-01`) now have matching 200/201 `$ref` targets

<details>
<summary> Viewing API changes</summary>

For convenient view of the API changes made by this PR, refer to the URLs provided in the table 
in the `Generated ApiView` comment added to this PR. You can use ApiView to show API versions diff. 

</details>
<details>
<summary>Suppressing failures</summary>

If one or multiple validation error/warning suppression(s) is detected in your PR, please follow the 
[suppressions guide](https://aka.ms/azsdk/pr-suppressions) to get approval.

</details>

## Getting help

- First, please carefully read through this PR description, from top to bottom. Please fill out the `Purpose of this PR` and `Due diligence checklist`.
- If you don't have permissions to remove or add labels to the PR, request `write access` per [aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories](https://aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories)
- To understand what you must do next to merge this PR, see the `Next Steps to Merge` comment. It will appear within few minutes of submitting this PR and will continue to be up-to-date with current PR state.
- For guidance on fixing this PR CI check failures, see the hyperlinks provided in given failure 
  and https://aka.ms/ci-fix.
- For help with ARM review (PR workflow diagram Step 2), see https://aka.ms/azsdk/pr-arm-review.
- If the PR CI checks appear to be stuck in `queued` state, please add a comment with contents `/azp run`.
  This should result in a new comment denoting a `PR validation pipeline` has started and the checks should be updated after few minutes.
- If the help provided by the previous points is not enough, post to https://aka.ms/azsdk/support/specreview-channel and link to this PR.
- For guidance on SDK breaking change review, refer to https://aka.ms/ci-fix.