### PR TITLE
Add SettingUp status to ScenarioRunState

### DIFF
--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-05-01-preview/openapi.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-05-01-preview/openapi.json
@@ -7097,6 +7097,7 @@
         "Validating",
         "ValidationSucceeded",
         "Starting",
+        "SettingUp",
         "Running",
         "Canceling",
         "Canceled",
@@ -7136,6 +7137,11 @@
             "name": "Starting",
             "value": "Starting",
             "description": "The scenario run is in the process of being started."
+          },
+          {
+            "name": "SettingUp",
+            "value": "SettingUp",
+            "description": "The scenario run is in the process of being setup."
           },
           {
             "name": "Running",

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-05-01-preview/openapi.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-05-01-preview/openapi.json
@@ -7099,6 +7099,7 @@
         "Starting",
         "SettingUp",
         "Running",
+        "CleaningUp",
         "Canceling",
         "Canceled",
         "Succeeded",
@@ -7147,6 +7148,11 @@
             "name": "Running",
             "value": "Running",
             "description": "The scenario run is in the process of running."
+          },
+          {
+            "name": "CleaningUp",
+            "value": "CleaningUp",
+            "description": "The scenario run is in the process of being cleaned up."
           },
           {
             "name": "Canceling",

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/scenarioRun.models.tsp
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/scenarioRun.models.tsp
@@ -344,6 +344,11 @@ union ScenarioRunState {
   Starting: "Starting",
 
   /**
+   * The scenario run is in the process of being setup.
+   */
+  SettingUp: "SettingUp",
+
+  /**
    * The scenario run is in the process of running.
    */
   Running: "Running",

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/scenarioRun.models.tsp
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/scenarioRun.models.tsp
@@ -354,6 +354,11 @@ union ScenarioRunState {
   Running: "Running",
 
   /**
+   * The scenario run is in the process of being cleaned up.
+   */
+  CleaningUp: "CleaningUp",
+
+  /**
    * The scenario run is in the process of being canceled.
    */
   Canceling: "Canceling",


### PR DESCRIPTION
Adds two new enum values to the `ScenarioRunState` union in `scenarioRun.models.tsp` for the Chaos Studio 2026-05-01-preview API:

## New States

- **`SettingUp`** — The scenario run is in the process of being set up. Placed after `Starting` and before `Running`.
- **`CleaningUp`** — The scenario run is in the process of being cleaned up. Placed after `Running` and before `Canceling`.

## Updated Scenario Run Lifecycle

`Queued → Resolving → Generating → Validating → ValidationSucceeded → Starting → SettingUp → Running → CleaningUp → Canceling → Canceled/Succeeded/Failed`

## Context

These are generic lifecycle states that will be used for **Agent Setup** and **Agent Clean Up** in the first V1 release of Agents to customers. The `SettingUp` phase handles agent provisioning before fault injection begins, and the `CleaningUp` phase handles agent teardown after the experiment completes.

## Changes

- `scenarioRun.models.tsp` — Added `SettingUp` and `CleaningUp` members to the `ScenarioRunState` union
- `preview/2026-05-01-preview/openapi.json` — Regenerated to include both new enum values