### PR TITLE
Add 2026-05-01-preview API version - custom access strings

### DIFF
--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/OperationsList.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/OperationsList.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.Cache/redisEnterprise/read",
+            "display": {
+              "description": "View the Redis Enterprise cache's settings and configuration in the management portal",
+              "operation": "Manage Redis Enterprise cache (read)",
+              "provider": "Microsoft Cache",
+              "resource": "Redis Enterprise cache"
+            }
+          },
+          {
+            "name": "Microsoft.Cache/redisEnterprise/write",
+            "display": {
+              "description": "Modify the Redis Enterprise cache's settings and configuration in the management portal",
+              "operation": "Manage Redis Enterprise cache (write)",
+              "provider": "Microsoft Cache",
+              "resource": "Redis Enterprise cache"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Operations_List",
+  "title": "OperationsList"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/OperationsStatusGet.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/OperationsStatusGet.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "operationId": "testoperationid",
+    "api-version": "2026-05-01-preview",
+    "location": "West US",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testoperationid",
+        "endTime": "2017-01-01T16:13:13.933Z",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/locations/westus/operationsStatus/testoperationid",
+        "startTime": "2017-01-01T13:13:13.933Z",
+        "status": "Succeeded"
+      }
+    }
+  },
+  "operationId": "OperationsStatus_Get",
+  "title": "OperationsStatusGet"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseAccessPolicyAssignmentCreateUpdate.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseAccessPolicyAssignmentCreateUpdate.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "accessPolicyAssignmentName": "defaultTestEntraApp1",
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "parameters": {
+      "properties": {
+        "user": {
+          "objectId": "6497c918-11ad-41e7-1b0f-7c518a87d0b0"
+        }
+      }
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "defaultTestEntraApp1",
+        "type": "Microsoft.Cache/redisEnterprise/databases/accessPolicyAssignments",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default/accessPolicyAssignments/default-TestEntraApp1",
+        "properties": {
+          "accessString": "+@all ~*",
+          "provisioningState": "Succeeded",
+          "user": {
+            "objectId": "6497c918-11ad-41e7-1b0f-7c518a87d0b0"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "defaultTestEntraApp1",
+        "type": "Microsoft.Cache/redisEnterprise/databases/accessPolicyAssignments",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default/accessPolicyAssignments/default-TestEntraApp1",
+        "properties": {
+          "accessString": "+@all ~*",
+          "provisioningState": "Succeeded",
+          "user": {
+            "objectId": "6497c918-11ad-41e7-1b0f-7c518a87d0b0"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "AccessPolicyAssignment_CreateUpdate",
+  "title": "RedisEnterpriseAccessPolicyAssignmentCreateUpdate"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseAccessPolicyAssignmentCreateUpdateWithCustomAccessString.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseAccessPolicyAssignmentCreateUpdateWithCustomAccessString.json
@@ -1,0 +1,50 @@
+{
+  "parameters": {
+    "accessPolicyAssignmentName": "defaultTestEntraApp1",
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "parameters": {
+      "properties": {
+        "accessString": "+@read ~cache:*",
+        "user": {
+          "objectId": "6497c918-11ad-41e7-1b0f-7c518a87d0b0"
+        }
+      }
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "defaultTestEntraApp1",
+        "type": "Microsoft.Cache/redisEnterprise/databases/accessPolicyAssignments",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default/accessPolicyAssignments/default-TestEntraApp1",
+        "properties": {
+          "accessString": "+@read ~cache:*",
+          "provisioningState": "Succeeded",
+          "user": {
+            "objectId": "6497c918-11ad-41e7-1b0f-7c518a87d0b0"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "defaultTestEntraApp1",
+        "type": "Microsoft.Cache/redisEnterprise/databases/accessPolicyAssignments",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default/accessPolicyAssignments/default-TestEntraApp1",
+        "properties": {
+          "accessString": "+@read ~cache:*",
+          "provisioningState": "Succeeded",
+          "user": {
+            "objectId": "6497c918-11ad-41e7-1b0f-7c518a87d0b0"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "AccessPolicyAssignment_CreateUpdate",
+  "title": "RedisEnterpriseAccessPolicyAssignmentCreateUpdateWithCustomAccessString"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseAccessPolicyAssignmentDelete.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseAccessPolicyAssignmentDelete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "accessPolicyAssignmentName": "defaultTestEntraApp1",
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationStatus...",
+        "Location": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationResult..."
+      }
+    },
+    "204": {}
+  },
+  "operationId": "AccessPolicyAssignment_Delete",
+  "title": "RedisEnterpriseAccessPolicyAssignmentDelete"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseAccessPolicyAssignmentGet.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseAccessPolicyAssignmentGet.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "accessPolicyAssignmentName": "accessPolicyAssignmentName1",
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "accessPolicyAssignmentName1",
+        "type": "Microsoft.Cache/redisEnterprise/databases/accessPolicyAssignments",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default/accessPolicyAssignments/accessPolicyAssignmentName1",
+        "properties": {
+          "accessString": "+@all ~*",
+          "provisioningState": "Succeeded",
+          "user": {
+            "objectId": "6497c918-11ad-41e7-1b0f-7c518a87d0b0"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "AccessPolicyAssignment_Get",
+  "title": "RedisEnterpriseAccessPolicyAssignmentGet"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseAccessPolicyAssignmentGetWithFailedProvisioningState.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseAccessPolicyAssignmentGetWithFailedProvisioningState.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "accessPolicyAssignmentName": "accessPolicyAssignmentName1",
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "accessPolicyAssignmentName1",
+        "type": "Microsoft.Cache/redisEnterprise/databases/accessPolicyAssignments",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default/accessPolicyAssignments/accessPolicyAssignmentName1",
+        "properties": {
+          "accessString": "+@invalid-syntax",
+          "provisioningError": {
+            "code": "InvalidAccessString",
+            "message": "ERR Error in ACL SETUSER modifier '+@invalid-syntax': Adding a subcommand of a command already fully added is not allowed. A full command can only be added to a rule",
+            "target": "properties.accessString"
+          },
+          "provisioningState": "Failed",
+          "user": {
+            "objectId": "6497c918-11ad-41e7-1b0f-7c518a87d0b0"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "AccessPolicyAssignment_Get",
+  "title": "RedisEnterpriseAccessPolicyAssignmentGetWithFailedProvisioningState"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseAccessPolicyAssignmentsList.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseAccessPolicyAssignmentsList.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "accessPolicyAssignmentName1",
+            "type": "Microsoft.Cache/redisEnterprise/databases/accessPolicyAssignments",
+            "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default/accessPolicyAssignments/accessPolicyAssignmentName1",
+            "properties": {
+              "accessString": "+@all ~*",
+              "provisioningState": "Succeeded",
+              "user": {
+                "objectId": "6497c918-11ad-41e7-1b0f-7c518a87d0b0"
+              }
+            }
+          },
+          {
+            "name": "accessPolicyAssignmentName2",
+            "type": "Microsoft.Cache/redisEnterprise/databases/accessPolicyAssignments",
+            "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default/accessPolicyAssignments/accessPolicyAssignmentName2",
+            "properties": {
+              "accessString": "+@all ~*",
+              "provisioningState": "Succeeded",
+              "user": {
+                "objectId": "7497c918-11ad-41e7-1b0f-7c518a87d0b0"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "AccessPolicyAssignment_List",
+  "title": "RedisEnterpriseAccessPolicyAssignmentList"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseCreate.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseCreate.json
@@ -1,0 +1,215 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "parameters": {
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/your-subscription/resourceGroups/your-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/your-identity": {}
+        }
+      },
+      "location": "West US",
+      "properties": {
+        "encryption": {
+          "customerManagedKeyEncryption": {
+            "keyEncryptionKeyIdentity": {
+              "identityType": "userAssignedIdentity",
+              "userAssignedIdentityResourceId": "/subscriptions/your-subscription/resourceGroups/your-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/your-identity"
+            },
+            "keyEncryptionKeyUrl": "https://your-kv.vault.azure.net/keys/your-key/your-key-version"
+          }
+        },
+        "minimumTlsVersion": "1.2",
+        "publicNetworkAccess": "Disabled",
+        "maintenanceConfiguration": {
+          "maintenanceWindows": [
+            {
+              "type": "Weekly",
+              "duration": "PT6H",
+              "startHourUtc": 3,
+              "schedule": {
+                "dayOfWeek": "Monday"
+              }
+            },
+            {
+              "type": "Weekly",
+              "duration": "PT6H",
+              "startHourUtc": 3,
+              "schedule": {
+                "dayOfWeek": "Tuesday"
+              }
+            },
+            {
+              "type": "Weekly",
+              "duration": "PT6H",
+              "startHourUtc": 3,
+              "schedule": {
+                "dayOfWeek": "Wednesday"
+              }
+            }
+          ]
+        }
+      },
+      "sku": {
+        "name": "EnterpriseFlash_F300",
+        "capacity": 3
+      },
+      "tags": {
+        "tag1": "value1"
+      },
+      "zones": [
+        "1",
+        "2",
+        "3"
+      ]
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "cache1",
+        "type": "Microsoft.Cache/redisEnterprise",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/your-subscription/resourceGroups/your-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/your-identity": {
+              "clientId": "00000000-0000-0000-0000-000000000000",
+              "principalId": "00000000-0000-0000-0000-000000000000"
+            }
+          }
+        },
+        "kind": "v1",
+        "location": "West US",
+        "properties": {
+          "hostName": "cache1.westus.something.azure.net",
+          "minimumTlsVersion": "1.2",
+          "provisioningState": "Succeeded",
+          "publicNetworkAccess": "Disabled",
+          "maintenanceConfiguration": {
+            "maintenanceWindows": [
+              {
+                "type": "Weekly",
+                "duration": "PT6H",
+                "startHourUtc": 3,
+                "schedule": {
+                  "dayOfWeek": "Monday"
+                }
+              },
+              {
+                "type": "Weekly",
+                "duration": "PT6H",
+                "startHourUtc": 3,
+                "schedule": {
+                  "dayOfWeek": "Tuesday"
+                }
+              },
+              {
+                "type": "Weekly",
+                "duration": "PT6H",
+                "startHourUtc": 3,
+                "schedule": {
+                  "dayOfWeek": "Wednesday"
+                }
+              }
+            ]
+          },
+          "redisVersion": "5",
+          "resourceState": "Running"
+        },
+        "sku": {
+          "name": "EnterpriseFlash_F300",
+          "capacity": 3
+        },
+        "tags": {
+          "tag1": "value1"
+        },
+        "zones": [
+          "1",
+          "2",
+          "3"
+        ]
+      }
+    },
+    "201": {
+      "body": {
+        "name": "cache1",
+        "type": "Microsoft.Cache/redisEnterprise",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/your-subscription/resourceGroups/your-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/your-identity": {
+              "clientId": "00000000-0000-0000-0000-000000000000",
+              "principalId": "00000000-0000-0000-0000-000000000000"
+            }
+          }
+        },
+        "kind": "v1",
+        "location": "West US",
+        "properties": {
+          "encryption": {
+            "customerManagedKeyEncryption": {
+              "keyEncryptionKeyIdentity": {
+                "identityType": "userAssignedIdentity",
+                "userAssignedIdentityResourceId": "/subscriptions/your-subscription/resourceGroups/your-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/your-identity"
+              },
+              "keyEncryptionKeyUrl": "https://your-kv.vault.azure.net/keys/your-key/your-key-version"
+            }
+          },
+          "hostName": "cache1.westus.something.azure.net",
+          "minimumTlsVersion": "1.2",
+          "provisioningState": "Creating",
+          "publicNetworkAccess": "Disabled",
+          "maintenanceConfiguration": {
+            "maintenanceWindows": [
+              {
+                "type": "Weekly",
+                "duration": "PT6H",
+                "startHourUtc": 3,
+                "schedule": {
+                  "dayOfWeek": "Monday"
+                }
+              },
+              {
+                "type": "Weekly",
+                "duration": "PT6H",
+                "startHourUtc": 3,
+                "schedule": {
+                  "dayOfWeek": "Tuesday"
+                }
+              },
+              {
+                "type": "Weekly",
+                "duration": "PT6H",
+                "startHourUtc": 3,
+                "schedule": {
+                  "dayOfWeek": "Wednesday"
+                }
+              }
+            ]
+          },
+          "redisVersion": "5",
+          "resourceState": "Creating"
+        },
+        "sku": {
+          "name": "EnterpriseFlash_F300",
+          "capacity": 3
+        },
+        "tags": {
+          "tag1": "value1"
+        },
+        "zones": [
+          "1",
+          "2",
+          "3"
+        ]
+      }
+    }
+  },
+  "operationId": "RedisEnterprise_Create",
+  "title": "RedisEnterpriseCreate"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseDatabasesCreate.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseDatabasesCreate.json
@@ -1,0 +1,119 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "parameters": {
+      "properties": {
+        "accessKeysAuthentication": "Enabled",
+        "clientProtocol": "Encrypted",
+        "clusteringPolicy": "EnterpriseCluster",
+        "deferUpgrade": "NotDeferred",
+        "evictionPolicy": "AllKeysLRU",
+        "notifyKeyspaceEvents": "KEA",
+        "modules": [
+          {
+            "name": "RedisBloom",
+            "args": "ERROR_RATE 0.00 INITIAL_SIZE 400"
+          },
+          {
+            "name": "RedisTimeSeries",
+            "args": "RETENTION_POLICY 20"
+          },
+          {
+            "name": "RediSearch"
+          }
+        ],
+        "persistence": {
+          "aofEnabled": true,
+          "aofFrequency": "1s"
+        },
+        "port": 10000
+      }
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "cache1/default",
+        "type": "Microsoft.Cache/redisEnterprise/databases",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default",
+        "properties": {
+          "accessKeysAuthentication": "Enabled",
+          "clientProtocol": "Encrypted",
+          "clusteringPolicy": "EnterpriseCluster",
+          "deferUpgrade": "NotDeferred",
+          "evictionPolicy": "AllKeysLRU",
+          "notifyKeyspaceEvents": "KEA",
+          "modules": [
+            {
+              "name": "RedisBloom",
+              "args": "ERROR_RATE 0.00 INITIAL_SIZE 400",
+              "version": "1.0.0"
+            },
+            {
+              "name": "RedisTimeSeries",
+              "args": "RETENTION_POLICY 20",
+              "version": "1.0.0"
+            },
+            {
+              "name": "RediSearch",
+              "args": "",
+              "version": "1.0.0"
+            }
+          ],
+          "persistence": {
+            "aofEnabled": true,
+            "aofFrequency": "1s"
+          },
+          "port": 10000,
+          "provisioningState": "Updating",
+          "redisVersion": "6.0",
+          "resourceState": "Updating"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "cache1/db1",
+        "type": "Microsoft.Cache/redisEnterprise/databases",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/db1",
+        "properties": {
+          "accessKeysAuthentication": "Enabled",
+          "clientProtocol": "Encrypted",
+          "clusteringPolicy": "EnterpriseCluster",
+          "evictionPolicy": "AllKeysLRU",
+          "notifyKeyspaceEvents": "KEA",
+          "modules": [
+            {
+              "name": "RedisBloom",
+              "args": "ERROR_RATE 0.00 INITIAL_SIZE 400",
+              "version": "1.0.0"
+            },
+            {
+              "name": "RedisTimeSeries",
+              "args": "RETENTION_POLICY 20",
+              "version": "1.0.0"
+            },
+            {
+              "name": "RediSearch",
+              "args": "",
+              "version": "1.0.0"
+            }
+          ],
+          "persistence": {
+            "aofEnabled": true,
+            "aofFrequency": "1s"
+          },
+          "port": 10000,
+          "provisioningState": "Creating",
+          "resourceState": "Creating"
+        }
+      }
+    }
+  },
+  "operationId": "Databases_Create",
+  "title": "RedisEnterpriseDatabasesCreate"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseDatabasesCreateWithGeoReplication.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseDatabasesCreateWithGeoReplication.json
@@ -1,0 +1,98 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "parameters": {
+      "properties": {
+        "accessKeysAuthentication": "Enabled",
+        "clientProtocol": "Encrypted",
+        "clusteringPolicy": "EnterpriseCluster",
+        "evictionPolicy": "NoEviction",
+        "geoReplication": {
+          "groupNickname": "groupName",
+          "linkedDatabases": [
+            {
+              "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default"
+            },
+            {
+              "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8e/resourceGroups/rg2/providers/Microsoft.Cache/redisEnterprise/cache2/databases/default"
+            }
+          ]
+        },
+        "notifyKeyspaceEvents": "KEA",
+        "port": 10000
+      }
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "cache1/default",
+        "type": "Microsoft.Cache/redisEnterprise/databases",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default",
+        "properties": {
+          "accessKeysAuthentication": "Enabled",
+          "clientProtocol": "Encrypted",
+          "clusteringPolicy": "EnterpriseCluster",
+          "deferUpgrade": "NotDeferred",
+          "evictionPolicy": "NoEviction",
+          "geoReplication": {
+            "groupNickname": "groupName",
+            "linkedDatabases": [
+              {
+                "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8e/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default",
+                "state": "Linking"
+              },
+              {
+                "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f2/resourceGroups/rg2/providers/Microsoft.Cache/redisEnterprise/cache2/databases/default",
+                "state": "Linking"
+              }
+            ]
+          },
+          "notifyKeyspaceEvents": "KEA",
+          "port": 10000,
+          "provisioningState": "Updating",
+          "redisVersion": "6.0",
+          "resourceState": "Updating"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "cache1/db1",
+        "type": "Microsoft.Cache/redisEnterprise/databases",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/db1",
+        "properties": {
+          "accessKeysAuthentication": "Enabled",
+          "clientProtocol": "Plaintext",
+          "clusteringPolicy": "EnterpriseCluster",
+          "deferUpgrade": "NotDeferred",
+          "evictionPolicy": "NoEviction",
+          "geoReplication": {
+            "groupNickname": "groupName",
+            "linkedDatabases": [
+              {
+                "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8e/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default",
+                "state": "Linking"
+              },
+              {
+                "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f2/resourceGroups/rg2/providers/Microsoft.Cache/redisEnterprise/cache2/databases/default",
+                "state": "Linking"
+              }
+            ]
+          },
+          "notifyKeyspaceEvents": "KEA",
+          "port": 10000,
+          "provisioningState": "Creating",
+          "redisVersion": "6.0",
+          "resourceState": "Creating"
+        }
+      }
+    }
+  },
+  "operationId": "Databases_Create",
+  "title": "RedisEnterpriseDatabasesCreate With Active Geo Replication"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseDatabasesDelete.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseDatabasesDelete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "db1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationStatus...",
+        "Location": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationResult..."
+      }
+    },
+    "204": {}
+  },
+  "operationId": "Databases_Delete",
+  "title": "RedisEnterpriseDatabasesDelete"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseDatabasesExport.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseDatabasesExport.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "parameters": {
+      "sasUri": "https://contosostorage.blob.core.window.net/urlToBlobContainer?sasKeyParameters"
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationStatus...",
+        "Location": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationResult..."
+      }
+    }
+  },
+  "operationId": "Databases_Export",
+  "title": "RedisEnterpriseDatabasesExport"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseDatabasesFlush.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseDatabasesFlush.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "parameters": {
+      "ids": [
+        "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f2/resourceGroups/rg2/providers/Microsoft.Cache/redisEnterprise/cache2/databases/default"
+      ]
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationStatus..."
+      }
+    }
+  },
+  "operationId": "Databases_Flush",
+  "title": "How to flush all the keys in the database"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseDatabasesForceLink.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseDatabasesForceLink.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "parameters": {
+      "geoReplication": {
+        "groupNickname": "groupName",
+        "linkedDatabases": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default"
+          },
+          {
+            "id": "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg2/providers/Microsoft.Cache/redisEnterprise/cache2/databases/default"
+          }
+        ]
+      }
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/...pathToOperationStatus..."
+      }
+    }
+  },
+  "operationId": "Databases_ForceLinkToReplicationGroup",
+  "title": "How to relink a database after a regional outage"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseDatabasesForceUnlink.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseDatabasesForceUnlink.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "parameters": {
+      "ids": [
+        "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f2/resourceGroups/rg2/providers/Microsoft.Cache/redisEnterprise/cache2/databases/default"
+      ]
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationStatus..."
+      }
+    }
+  },
+  "operationId": "Databases_ForceUnlink",
+  "title": "How to unlink a database during a regional outage"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseDatabasesGet.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseDatabasesGet.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "cache1/default",
+        "type": "Microsoft.Cache/redisEnterprise/databases",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default",
+        "properties": {
+          "accessKeysAuthentication": "Enabled",
+          "clientProtocol": "Encrypted",
+          "clusteringPolicy": "OSSCluster",
+          "deferUpgrade": "NotDeferred",
+          "evictionPolicy": "AllKeysLRU",
+          "notifyKeyspaceEvents": "",
+          "modules": [
+            {
+              "name": "RediSearch",
+              "args": "",
+              "version": "1.0.0"
+            }
+          ],
+          "persistence": {
+            "rdbEnabled": true,
+            "rdbFrequency": "12h"
+          },
+          "port": 10000,
+          "provisioningState": "Succeeded",
+          "redisVersion": "6.0",
+          "resourceState": "Running"
+        }
+      }
+    }
+  },
+  "operationId": "Databases_Get",
+  "title": "RedisEnterpriseDatabasesGet"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseDatabasesImport.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseDatabasesImport.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "parameters": {
+      "sasUris": [
+        "https://contosostorage.blob.core.window.net/urltoBlobFile1?sasKeyParameters",
+        "https://contosostorage.blob.core.window.net/urltoBlobFile2?sasKeyParameters"
+      ]
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationStatus...",
+        "Location": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationResult..."
+      }
+    }
+  },
+  "operationId": "Databases_Import",
+  "title": "RedisEnterpriseDatabasesImport"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseDatabasesListByCluster.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseDatabasesListByCluster.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "cache1/default",
+            "type": "Microsoft.Cache/redisEnterprise/databases",
+            "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default",
+            "properties": {
+              "accessKeysAuthentication": "Disabled",
+              "clientProtocol": "Encrypted",
+              "clusteringPolicy": "OSSCluster",
+              "deferUpgrade": "NotDeferred",
+              "evictionPolicy": "AllKeysLRU",
+              "notifyKeyspaceEvents": "",
+              "modules": [
+                {
+                  "name": "RediSearch",
+                  "args": "",
+                  "version": "1.0.0"
+                }
+              ],
+              "persistence": {
+                "rdbEnabled": true,
+                "rdbFrequency": "12h"
+              },
+              "port": 10000,
+              "provisioningState": "Succeeded",
+              "redisVersion": "6.0",
+              "resourceState": "Running"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Databases_ListByCluster",
+  "title": "RedisEnterpriseDatabasesListByCluster"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseDatabasesListKeys.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseDatabasesListKeys.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "primaryKey": "<primaryKey>",
+        "secondaryKey": "<secondaryKey>"
+      }
+    }
+  },
+  "operationId": "Databases_ListKeys",
+  "title": "RedisEnterpriseDatabasesListKeys"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseDatabasesNoClusterCacheCreate.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseDatabasesNoClusterCacheCreate.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "parameters": {
+      "properties": {
+        "clientProtocol": "Encrypted",
+        "clusteringPolicy": "NoCluster",
+        "evictionPolicy": "NoEviction",
+        "notifyKeyspaceEvents": "",
+        "port": 10000
+      }
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "cache1/default",
+        "type": "Microsoft.Cache/redisEnterprise/databases",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default",
+        "properties": {
+          "accessKeysAuthentication": "Enabled",
+          "clientProtocol": "Encrypted",
+          "clusteringPolicy": "NoCluster",
+          "deferUpgrade": "NotDeferred",
+          "evictionPolicy": "NoEviction",
+          "notifyKeyspaceEvents": "",
+          "port": 10000,
+          "provisioningState": "Updating",
+          "redisVersion": "7.2",
+          "resourceState": "Updating"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "cache1/default",
+        "type": "Microsoft.Cache/redisEnterprise/databases",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default",
+        "properties": {
+          "accessKeysAuthentication": "Enabled",
+          "clientProtocol": "Encrypted",
+          "clusteringPolicy": "NoCluster",
+          "deferUpgrade": "NotDeferred",
+          "evictionPolicy": "NoEviction",
+          "notifyKeyspaceEvents": "",
+          "port": 10000,
+          "provisioningState": "Creating",
+          "redisVersion": "7.2",
+          "resourceState": "Creating"
+        }
+      }
+    }
+  },
+  "operationId": "Databases_Create",
+  "title": "RedisEnterpriseDatabasesCreate No Cluster Cache"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseDatabasesNoClusterCacheUpdateClustering.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseDatabasesNoClusterCacheUpdateClustering.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "parameters": {
+      "properties": {
+        "clientProtocol": "Encrypted",
+        "clusteringPolicy": "EnterpriseCluster",
+        "evictionPolicy": "NoEviction",
+        "notifyKeyspaceEvents": "",
+        "port": 10000
+      }
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "cache1/default",
+        "type": "Microsoft.Cache/redisEnterprise/databases",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default",
+        "properties": {
+          "accessKeysAuthentication": "Enabled",
+          "clientProtocol": "Encrypted",
+          "clusteringPolicy": "EnterpriseCluster",
+          "deferUpgrade": "NotDeferred",
+          "evictionPolicy": "NoEviction",
+          "notifyKeyspaceEvents": "",
+          "port": 10000,
+          "provisioningState": "Updating",
+          "redisVersion": "7.2",
+          "resourceState": "Updating"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationStatus...",
+        "Location": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationResult..."
+      }
+    }
+  },
+  "operationId": "Databases_Update",
+  "title": "RedisEnterpriseDatabasesUpdate Clustering on No Cluster Cache"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseDatabasesRegenerateKey.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseDatabasesRegenerateKey.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "parameters": {
+      "keyType": "Primary"
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "primaryKey": "<primaryKey>",
+        "secondaryKey": "<secondaryKey>"
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationStatus...",
+        "Location": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationResult..."
+      }
+    }
+  },
+  "operationId": "Databases_RegenerateKey",
+  "title": "RedisEnterpriseDatabasesRegenerateKey"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseDatabasesUpdate.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseDatabasesUpdate.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "parameters": {
+      "properties": {
+        "accessKeysAuthentication": "Enabled",
+        "clientProtocol": "Encrypted",
+        "evictionPolicy": "AllKeysLRU",
+        "notifyKeyspaceEvents": "KEA",
+        "persistence": {
+          "rdbEnabled": true,
+          "rdbFrequency": "12h"
+        }
+      }
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "cache1/default",
+        "type": "Microsoft.Cache/redisEnterprise/databases",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default",
+        "properties": {
+          "accessKeysAuthentication": "Enabled",
+          "clientProtocol": "Encrypted",
+          "clusteringPolicy": "OSSCluster",
+          "deferUpgrade": "NotDeferred",
+          "evictionPolicy": "AllKeysLRU",
+          "notifyKeyspaceEvents": "KEA",
+          "modules": [
+            {
+              "name": "RediSearch",
+              "args": "",
+              "version": "1.0.0"
+            }
+          ],
+          "persistence": {
+            "rdbEnabled": true,
+            "rdbFrequency": "12h"
+          },
+          "port": 10000,
+          "provisioningState": "Updating",
+          "redisVersion": "6.0",
+          "resourceState": "Updating"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationStatus...",
+        "Location": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationResult..."
+      }
+    }
+  },
+  "operationId": "Databases_Update",
+  "title": "RedisEnterpriseDatabasesUpdate"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseDatabasesUpgradeDBRedisVersion.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseDatabasesUpgradeDBRedisVersion.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationStatus..."
+      }
+    }
+  },
+  "operationId": "Databases_UpgradeDBRedisVersion",
+  "title": "How to upgrade your database Redis version"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseDelete.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseDelete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationStatus...",
+        "Location": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationResult..."
+      }
+    },
+    "204": {}
+  },
+  "operationId": "RedisEnterprise_Delete",
+  "title": "RedisEnterpriseDelete"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseDeletePrivateEndpointConnection.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseDeletePrivateEndpointConnection.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "privateEndpointConnectionName": "pectest01",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationStatus...",
+        "Location": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationResult..."
+      }
+    },
+    "204": {}
+  },
+  "operationId": "PrivateEndpointConnections_Delete",
+  "title": "RedisEnterpriseDeletePrivateEndpointConnection"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseGet.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseGet.json
@@ -1,0 +1,82 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "cache1",
+        "type": "Microsoft.Cache/redisEnterprise",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1",
+        "kind": "v1",
+        "location": "West US",
+        "properties": {
+          "hostName": "cache1.westus.something.azure.com",
+          "minimumTlsVersion": "1.2",
+          "privateEndpointConnections": [
+            {
+              "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/privateEndpointConnections/cachePec",
+              "properties": {
+                "privateEndpoint": {
+                  "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Network/privateEndpoints/cachePe"
+                },
+                "privateLinkServiceConnectionState": {
+                  "description": "Please approve my connection",
+                  "actionsRequired": "None",
+                  "status": "Approved"
+                }
+              }
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "publicNetworkAccess": "Disabled",
+          "maintenanceConfiguration": {
+            "maintenanceWindows": [
+              {
+                "type": "Weekly",
+                "duration": "PT6H",
+                "startHourUtc": 3,
+                "schedule": {
+                  "dayOfWeek": "Monday"
+                }
+              },
+              {
+                "type": "Weekly",
+                "duration": "PT6H",
+                "startHourUtc": 3,
+                "schedule": {
+                  "dayOfWeek": "Tuesday"
+                }
+              },
+              {
+                "type": "Weekly",
+                "duration": "PT6H",
+                "startHourUtc": 3,
+                "schedule": {
+                  "dayOfWeek": "Wednesday"
+                }
+              }
+            ]
+          },
+          "redisVersion": "6",
+          "resourceState": "Running"
+        },
+        "sku": {
+          "name": "EnterpriseFlash_F300",
+          "capacity": 3
+        },
+        "tags": {},
+        "zones": [
+          "1",
+          "2",
+          "3"
+        ]
+      }
+    }
+  },
+  "operationId": "RedisEnterprise_Get",
+  "title": "RedisEnterpriseGet"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseGetPrivateEndpointConnection.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseGetPrivateEndpointConnection.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "privateEndpointConnectionName": "pectest01",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "pectest01",
+        "type": "Microsoft.Cache/redisEnterprise/privateEndpointConnections",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/privateEndpointConnections/pectest01",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Network/privateEndpoints/petest01"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Auto-Approved",
+            "actionsRequired": "None",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_Get",
+  "title": "RedisEnterpriseGetPrivateEndpointConnection"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseList.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseList.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "cache1",
+            "type": "Microsoft.Cache/redisEnterprise",
+            "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1",
+            "kind": "v1",
+            "location": "West US",
+            "properties": {
+              "hostName": "cache1.westus.something.azure.com",
+              "minimumTlsVersion": "1.2",
+              "provisioningState": "Succeeded",
+              "publicNetworkAccess": "Disabled",
+              "redisVersion": "6",
+              "resourceState": "Running"
+            },
+            "sku": {
+              "name": "EnterpriseFlash_F300",
+              "capacity": 3
+            },
+            "tags": {}
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "RedisEnterprise_List",
+  "title": "RedisEnterpriseList"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseListByResourceGroup.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseListByResourceGroup.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "cache1",
+            "type": "Microsoft.Cache/redisEnterprise",
+            "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1",
+            "kind": "v1",
+            "location": "West US",
+            "properties": {
+              "hostName": "cache1.westus.something.azure.com",
+              "minimumTlsVersion": "1.2",
+              "provisioningState": "Succeeded",
+              "publicNetworkAccess": "Disabled",
+              "redisVersion": "5",
+              "resourceState": "Running"
+            },
+            "sku": {
+              "name": "EnterpriseFlash_F300",
+              "capacity": 3
+            },
+            "tags": {},
+            "zones": [
+              "1",
+              "2",
+              "3"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "RedisEnterprise_ListByResourceGroup",
+  "title": "RedisEnterpriseListByResourceGroup"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseListPrivateEndpointConnections.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseListPrivateEndpointConnections.json
@@ -1,0 +1,51 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "privateEndpointConnectionName": "pectest01",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "pectest01",
+            "type": "Microsoft.Cache/redisEnterprise/privateEndpointConnections",
+            "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/privateEndpointConnections/pectest01",
+            "properties": {
+              "privateEndpoint": {
+                "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Network/privateEndpoints/petest01"
+              },
+              "privateLinkServiceConnectionState": {
+                "description": "Auto-Approved",
+                "actionsRequired": "None",
+                "status": "Approved"
+              },
+              "provisioningState": "Succeeded"
+            }
+          },
+          {
+            "name": "pectest01",
+            "type": "Microsoft.Cache/redisEnterprise/privateEndpointConnections",
+            "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/privateEndpointConnections/pectest01",
+            "properties": {
+              "privateEndpoint": {
+                "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Network/privateEndpoints/petest01"
+              },
+              "privateLinkServiceConnectionState": {
+                "description": "Auto-Approved",
+                "actionsRequired": "None",
+                "status": "Approved"
+              },
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_List",
+  "title": "RedisEnterpriseListPrivateEndpointConnections"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseListPrivateLinkResources.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseListPrivateLinkResources.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "redisEnterpriseCache",
+            "type": "Microsoft.Cache/redisEnterprise/privateLinkResources",
+            "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/privateLinkResources/redisEnterpriseCache",
+            "properties": {
+              "groupId": "redisEnterpriseCache",
+              "requiredMembers": [
+                "redisEnterpriseCache"
+              ],
+              "requiredZoneNames": [
+                "privatelink.redisenterprise.cache.windows.net"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PrivateLinkResources_ListByCluster",
+  "title": "RedisEnterpriseListPrivateLinkResources"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseListSkusForScaling.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseListSkusForScaling.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "skus": [
+          {
+            "name": "MemoryOptimized_M100",
+            "sizeInGB": 120
+          },
+          {
+            "name": "ComputeOptimized_X700",
+            "sizeInGB": 720
+          },
+          {
+            "name": "Balanced_B5",
+            "sizeInGB": 6
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "RedisEnterprise_ListSkusForScaling",
+  "title": "RedisEnterpriseListSkusForScaling"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseMigrationCancel.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseMigrationCancel.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationStatus..."
+      }
+    }
+  },
+  "operationId": "Migration_Cancel",
+  "title": "RedisEnterpriseMigrationCancel"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseMigrationGet.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseMigrationGet.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "cache1/default",
+        "type": "Microsoft.Cache/redisEnterprise/migrations",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/migrations/default",
+        "properties": {
+          "creationTime": "2024-10-01T12:00:00Z",
+          "lastModifiedTime": "2024-10-01T12:00:00Z",
+          "provisioningState": "InProgress",
+          "skipDataMigration": true,
+          "sourceResourceId": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redis/cache1",
+          "sourceType": "AzureCacheForRedis",
+          "statusDetails": "",
+          "switchDns": true,
+          "targetResourceId": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1"
+        }
+      }
+    }
+  },
+  "operationId": "Migration_Get",
+  "title": "RedisEnterpriseMigrationGet"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseMigrationList.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseMigrationList.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "cache1/default",
+            "type": "Microsoft.Cache/redisEnterprise/migrations",
+            "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/migrations/default",
+            "properties": {
+              "creationTime": "2024-10-01T12:00:00Z",
+              "lastModifiedTime": "2024-10-01T12:00:00Z",
+              "provisioningState": "InProgress",
+              "skipDataMigration": true,
+              "sourceResourceId": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redis/cache1",
+              "sourceType": "AzureCacheForRedis",
+              "statusDetails": "",
+              "switchDns": true,
+              "targetResourceId": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Migration_List",
+  "title": "RedisEnterpriseMigrationList"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseMigrationStart.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseMigrationStart.json
@@ -1,0 +1,62 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "parameters": {
+      "properties": {
+        "skipDataMigration": true,
+        "sourceResourceId": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redis/cache1",
+        "sourceType": "AzureCacheForRedis",
+        "switchDns": true
+      }
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Cache/redisEnterprise/migrations",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/migrations/default",
+        "properties": {
+          "creationTime": "2024-10-01T12:00:00Z",
+          "lastModifiedTime": "2024-10-01T12:00:00Z",
+          "provisioningState": "Completed",
+          "skipDataMigration": true,
+          "sourceResourceId": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redis/cache1",
+          "sourceType": "AzureCacheForRedis",
+          "statusDetails": "",
+          "switchDns": true,
+          "targetResourceId": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationStatus..."
+      }
+    },
+    "201": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Cache/redisEnterprise/migrations",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/migrations/default",
+        "properties": {
+          "creationTime": "2024-10-01T12:00:00Z",
+          "lastModifiedTime": "2024-10-01T12:00:00Z",
+          "provisioningState": "Completed",
+          "skipDataMigration": true,
+          "sourceResourceId": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redis/cache1",
+          "sourceType": "AzureCacheForRedis",
+          "statusDetails": "",
+          "switchDns": true,
+          "targetResourceId": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationStatus..."
+      }
+    }
+  },
+  "operationId": "Migration_Start",
+  "title": "RedisEnterpriseMigrationStart"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseMigrationValidate.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseMigrationValidate.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "body": {
+      "sourceResourceId": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redis/cache1",
+      "skipDataMigration": true,
+      "forceMigrate": false
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "isValid": false,
+        "errors": [
+          {
+            "disparities": [
+              {
+                "category": "TLS",
+                "message": "The source resource only accepts TLS connections, but the target resource only accepts non-TLS connections."
+              }
+            ]
+          }
+        ],
+        "warnings": [
+          {
+            "disparities": [
+              {
+                "category": "Managed Identity",
+                "message": "The source resource has a system-assigned managed identity. Managed identities are not copied as part of migration."
+              },
+              {
+                "category": "Persistence",
+                "message": "The source resource has RDB persistence enabled. Persistence settings are not copied as part of migration."
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Migrations_Validate",
+  "title": "RedisEnterpriseMigrationValidate"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterprisePutPrivateEndpointConnection.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterprisePutPrivateEndpointConnection.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "privateEndpointConnectionName": "pectest01",
+    "properties": {
+      "properties": {
+        "privateLinkServiceConnectionState": {
+          "description": "Auto-Approved",
+          "status": "Approved"
+        }
+      }
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "pectest01",
+        "type": "Microsoft.Cache/redisEnterprise/privateEndpointConnections",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/privateEndpointConnections/pectest01",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Network/privateEndpoints/petest01"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Auto-Approved",
+            "actionsRequired": "None",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_Put",
+  "title": "RedisEnterprisePutPrivateEndpointConnection"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseUpdate.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/examples/2026-05-01-preview/RedisEnterpriseUpdate.json
@@ -1,0 +1,119 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "parameters": {
+      "properties": {
+        "minimumTlsVersion": "1.2",
+        "publicNetworkAccess": "Enabled",
+        "maintenanceConfiguration": {
+          "maintenanceWindows": [
+            {
+              "type": "Weekly",
+              "duration": "PT6H",
+              "startHourUtc": 3,
+              "schedule": {
+                "dayOfWeek": "Monday"
+              }
+            },
+            {
+              "type": "Weekly",
+              "duration": "PT6H",
+              "startHourUtc": 3,
+              "schedule": {
+                "dayOfWeek": "Tuesday"
+              }
+            },
+            {
+              "type": "Weekly",
+              "duration": "PT6H",
+              "startHourUtc": 3,
+              "schedule": {
+                "dayOfWeek": "Wednesday"
+              }
+            }
+          ]
+        }
+      },
+      "sku": {
+        "name": "EnterpriseFlash_F300",
+        "capacity": 9
+      },
+      "tags": {
+        "tag1": "value1"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "cache1",
+        "type": "Microsoft.Cache/redisEnterprise",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1",
+        "identity": {
+          "type": "None"
+        },
+        "kind": "v1",
+        "location": "West US",
+        "properties": {
+          "hostName": "cache1.westus.something.azure.com",
+          "minimumTlsVersion": "1.2",
+          "provisioningState": "Updating",
+          "publicNetworkAccess": "Enabled",
+          "maintenanceConfiguration": {
+            "maintenanceWindows": [
+              {
+                "type": "Weekly",
+                "duration": "PT6H",
+                "startHourUtc": 3,
+                "schedule": {
+                  "dayOfWeek": "Monday"
+                }
+              },
+              {
+                "type": "Weekly",
+                "duration": "PT6H",
+                "startHourUtc": 3,
+                "schedule": {
+                  "dayOfWeek": "Tuesday"
+                }
+              },
+              {
+                "type": "Weekly",
+                "duration": "PT6H",
+                "startHourUtc": 3,
+                "schedule": {
+                  "dayOfWeek": "Wednesday"
+                }
+              }
+            ]
+          },
+          "redisVersion": "5",
+          "resourceState": "Updating"
+        },
+        "sku": {
+          "name": "EnterpriseFlash_F300",
+          "capacity": 9
+        },
+        "tags": {
+          "tag1": "value1"
+        },
+        "zones": [
+          "1",
+          "2",
+          "3"
+        ]
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationStatus...",
+        "Location": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationResult..."
+      }
+    }
+  },
+  "operationId": "RedisEnterprise_Update",
+  "title": "RedisEnterpriseUpdate"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/main.tsp
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/main.tsp
@@ -48,6 +48,11 @@ enum Versions {
    * The 2026-02-01-preview API version.
    */
   v2026_02_01_preview: "2026-02-01-preview",
+
+  /**
+   * The 2026-05-01-preview API version.
+   */
+  v2026_05_01_preview: "2026-05-01-preview",
 }
 
 interface Operations extends Azure.ResourceManager.Operations {}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/models.tsp
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/models.tsp
@@ -1455,7 +1455,21 @@ model AccessPolicyAssignmentProperties {
    * Name of access policy under specific access policy assignment. Only "default" policy is supported for now.
    */
   @pattern("^([a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]|[a-zA-Z0-9])$")
+  @removed(Versions.v2026_05_01_preview)
   accessPolicyName: string;
+
+  /**
+   * The Redis ACL permissions string applied to this assignment, for example `+@read ~cache:*`. Defaults to `+@all ~*` if not specified.
+   */
+  @added(Versions.v2026_05_01_preview)
+  accessString?: string;
+
+  /**
+   * Provisioning error details when the access string failed to apply (e.g., invalid ACL syntax). Null when provisioning succeeded.
+   */
+  @visibility(Lifecycle.Read)
+  @added(Versions.v2026_05_01_preview)
+  provisioningError?: AccessPolicyAssignmentProvisioningError;
 
   /**
    * The user associated with the access policy.
@@ -1471,6 +1485,27 @@ model AccessPolicyAssignmentPropertiesUser {
    * The object ID of the user.
    */
   objectId?: string;
+}
+
+/**
+ * Error details for access policy assignment provisioning failures.
+ */
+@added(Versions.v2026_05_01_preview)
+model AccessPolicyAssignmentProvisioningError {
+  /**
+   * Machine-readable error code (e.g., "InvalidAccessString").
+   */
+  code: string;
+
+  /**
+   * Human-readable error message describing the failure.
+   */
+  message: string;
+
+  /**
+   * The property that caused the error (e.g., "properties.accessString").
+   */
+  target?: string;
 }
 
 /**

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/OperationsList.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/OperationsList.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.Cache/redisEnterprise/read",
+            "display": {
+              "description": "View the Redis Enterprise cache's settings and configuration in the management portal",
+              "operation": "Manage Redis Enterprise cache (read)",
+              "provider": "Microsoft Cache",
+              "resource": "Redis Enterprise cache"
+            }
+          },
+          {
+            "name": "Microsoft.Cache/redisEnterprise/write",
+            "display": {
+              "description": "Modify the Redis Enterprise cache's settings and configuration in the management portal",
+              "operation": "Manage Redis Enterprise cache (write)",
+              "provider": "Microsoft Cache",
+              "resource": "Redis Enterprise cache"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Operations_List",
+  "title": "OperationsList"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/OperationsStatusGet.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/OperationsStatusGet.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "operationId": "testoperationid",
+    "api-version": "2026-05-01-preview",
+    "location": "West US",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testoperationid",
+        "endTime": "2017-01-01T16:13:13.933Z",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/locations/westus/operationsStatus/testoperationid",
+        "startTime": "2017-01-01T13:13:13.933Z",
+        "status": "Succeeded"
+      }
+    }
+  },
+  "operationId": "OperationsStatus_Get",
+  "title": "OperationsStatusGet"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseAccessPolicyAssignmentCreateUpdate.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseAccessPolicyAssignmentCreateUpdate.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "accessPolicyAssignmentName": "defaultTestEntraApp1",
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "parameters": {
+      "properties": {
+        "user": {
+          "objectId": "6497c918-11ad-41e7-1b0f-7c518a87d0b0"
+        }
+      }
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "defaultTestEntraApp1",
+        "type": "Microsoft.Cache/redisEnterprise/databases/accessPolicyAssignments",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default/accessPolicyAssignments/default-TestEntraApp1",
+        "properties": {
+          "accessString": "+@all ~*",
+          "provisioningState": "Succeeded",
+          "user": {
+            "objectId": "6497c918-11ad-41e7-1b0f-7c518a87d0b0"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "defaultTestEntraApp1",
+        "type": "Microsoft.Cache/redisEnterprise/databases/accessPolicyAssignments",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default/accessPolicyAssignments/default-TestEntraApp1",
+        "properties": {
+          "accessString": "+@all ~*",
+          "provisioningState": "Succeeded",
+          "user": {
+            "objectId": "6497c918-11ad-41e7-1b0f-7c518a87d0b0"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "AccessPolicyAssignment_CreateUpdate",
+  "title": "RedisEnterpriseAccessPolicyAssignmentCreateUpdate"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseAccessPolicyAssignmentCreateUpdateWithCustomAccessString.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseAccessPolicyAssignmentCreateUpdateWithCustomAccessString.json
@@ -1,0 +1,50 @@
+{
+  "parameters": {
+    "accessPolicyAssignmentName": "defaultTestEntraApp1",
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "parameters": {
+      "properties": {
+        "accessString": "+@read ~cache:*",
+        "user": {
+          "objectId": "6497c918-11ad-41e7-1b0f-7c518a87d0b0"
+        }
+      }
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "defaultTestEntraApp1",
+        "type": "Microsoft.Cache/redisEnterprise/databases/accessPolicyAssignments",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default/accessPolicyAssignments/default-TestEntraApp1",
+        "properties": {
+          "accessString": "+@read ~cache:*",
+          "provisioningState": "Succeeded",
+          "user": {
+            "objectId": "6497c918-11ad-41e7-1b0f-7c518a87d0b0"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "defaultTestEntraApp1",
+        "type": "Microsoft.Cache/redisEnterprise/databases/accessPolicyAssignments",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default/accessPolicyAssignments/default-TestEntraApp1",
+        "properties": {
+          "accessString": "+@read ~cache:*",
+          "provisioningState": "Succeeded",
+          "user": {
+            "objectId": "6497c918-11ad-41e7-1b0f-7c518a87d0b0"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "AccessPolicyAssignment_CreateUpdate",
+  "title": "RedisEnterpriseAccessPolicyAssignmentCreateUpdateWithCustomAccessString"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseAccessPolicyAssignmentDelete.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseAccessPolicyAssignmentDelete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "accessPolicyAssignmentName": "defaultTestEntraApp1",
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationStatus...",
+        "Location": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationResult..."
+      }
+    },
+    "204": {}
+  },
+  "operationId": "AccessPolicyAssignment_Delete",
+  "title": "RedisEnterpriseAccessPolicyAssignmentDelete"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseAccessPolicyAssignmentGet.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseAccessPolicyAssignmentGet.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "accessPolicyAssignmentName": "accessPolicyAssignmentName1",
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "accessPolicyAssignmentName1",
+        "type": "Microsoft.Cache/redisEnterprise/databases/accessPolicyAssignments",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default/accessPolicyAssignments/accessPolicyAssignmentName1",
+        "properties": {
+          "accessString": "+@all ~*",
+          "provisioningState": "Succeeded",
+          "user": {
+            "objectId": "6497c918-11ad-41e7-1b0f-7c518a87d0b0"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "AccessPolicyAssignment_Get",
+  "title": "RedisEnterpriseAccessPolicyAssignmentGet"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseAccessPolicyAssignmentGetWithFailedProvisioningState.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseAccessPolicyAssignmentGetWithFailedProvisioningState.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "accessPolicyAssignmentName": "accessPolicyAssignmentName1",
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "accessPolicyAssignmentName1",
+        "type": "Microsoft.Cache/redisEnterprise/databases/accessPolicyAssignments",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default/accessPolicyAssignments/accessPolicyAssignmentName1",
+        "properties": {
+          "accessString": "+@invalid-syntax",
+          "provisioningError": {
+            "code": "InvalidAccessString",
+            "message": "ERR Error in ACL SETUSER modifier '+@invalid-syntax': Adding a subcommand of a command already fully added is not allowed. A full command can only be added to a rule",
+            "target": "properties.accessString"
+          },
+          "provisioningState": "Failed",
+          "user": {
+            "objectId": "6497c918-11ad-41e7-1b0f-7c518a87d0b0"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "AccessPolicyAssignment_Get",
+  "title": "RedisEnterpriseAccessPolicyAssignmentGetWithFailedProvisioningState"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseAccessPolicyAssignmentsList.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseAccessPolicyAssignmentsList.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "accessPolicyAssignmentName1",
+            "type": "Microsoft.Cache/redisEnterprise/databases/accessPolicyAssignments",
+            "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default/accessPolicyAssignments/accessPolicyAssignmentName1",
+            "properties": {
+              "accessString": "+@all ~*",
+              "provisioningState": "Succeeded",
+              "user": {
+                "objectId": "6497c918-11ad-41e7-1b0f-7c518a87d0b0"
+              }
+            }
+          },
+          {
+            "name": "accessPolicyAssignmentName2",
+            "type": "Microsoft.Cache/redisEnterprise/databases/accessPolicyAssignments",
+            "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default/accessPolicyAssignments/accessPolicyAssignmentName2",
+            "properties": {
+              "accessString": "+@all ~*",
+              "provisioningState": "Succeeded",
+              "user": {
+                "objectId": "7497c918-11ad-41e7-1b0f-7c518a87d0b0"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "AccessPolicyAssignment_List",
+  "title": "RedisEnterpriseAccessPolicyAssignmentList"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseCreate.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseCreate.json
@@ -1,0 +1,215 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "parameters": {
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/your-subscription/resourceGroups/your-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/your-identity": {}
+        }
+      },
+      "location": "West US",
+      "properties": {
+        "encryption": {
+          "customerManagedKeyEncryption": {
+            "keyEncryptionKeyIdentity": {
+              "identityType": "userAssignedIdentity",
+              "userAssignedIdentityResourceId": "/subscriptions/your-subscription/resourceGroups/your-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/your-identity"
+            },
+            "keyEncryptionKeyUrl": "https://your-kv.vault.azure.net/keys/your-key/your-key-version"
+          }
+        },
+        "minimumTlsVersion": "1.2",
+        "publicNetworkAccess": "Disabled",
+        "maintenanceConfiguration": {
+          "maintenanceWindows": [
+            {
+              "type": "Weekly",
+              "duration": "PT6H",
+              "startHourUtc": 3,
+              "schedule": {
+                "dayOfWeek": "Monday"
+              }
+            },
+            {
+              "type": "Weekly",
+              "duration": "PT6H",
+              "startHourUtc": 3,
+              "schedule": {
+                "dayOfWeek": "Tuesday"
+              }
+            },
+            {
+              "type": "Weekly",
+              "duration": "PT6H",
+              "startHourUtc": 3,
+              "schedule": {
+                "dayOfWeek": "Wednesday"
+              }
+            }
+          ]
+        }
+      },
+      "sku": {
+        "name": "EnterpriseFlash_F300",
+        "capacity": 3
+      },
+      "tags": {
+        "tag1": "value1"
+      },
+      "zones": [
+        "1",
+        "2",
+        "3"
+      ]
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "cache1",
+        "type": "Microsoft.Cache/redisEnterprise",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/your-subscription/resourceGroups/your-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/your-identity": {
+              "clientId": "00000000-0000-0000-0000-000000000000",
+              "principalId": "00000000-0000-0000-0000-000000000000"
+            }
+          }
+        },
+        "kind": "v1",
+        "location": "West US",
+        "properties": {
+          "hostName": "cache1.westus.something.azure.net",
+          "minimumTlsVersion": "1.2",
+          "provisioningState": "Succeeded",
+          "publicNetworkAccess": "Disabled",
+          "maintenanceConfiguration": {
+            "maintenanceWindows": [
+              {
+                "type": "Weekly",
+                "duration": "PT6H",
+                "startHourUtc": 3,
+                "schedule": {
+                  "dayOfWeek": "Monday"
+                }
+              },
+              {
+                "type": "Weekly",
+                "duration": "PT6H",
+                "startHourUtc": 3,
+                "schedule": {
+                  "dayOfWeek": "Tuesday"
+                }
+              },
+              {
+                "type": "Weekly",
+                "duration": "PT6H",
+                "startHourUtc": 3,
+                "schedule": {
+                  "dayOfWeek": "Wednesday"
+                }
+              }
+            ]
+          },
+          "redisVersion": "5",
+          "resourceState": "Running"
+        },
+        "sku": {
+          "name": "EnterpriseFlash_F300",
+          "capacity": 3
+        },
+        "tags": {
+          "tag1": "value1"
+        },
+        "zones": [
+          "1",
+          "2",
+          "3"
+        ]
+      }
+    },
+    "201": {
+      "body": {
+        "name": "cache1",
+        "type": "Microsoft.Cache/redisEnterprise",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/your-subscription/resourceGroups/your-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/your-identity": {
+              "clientId": "00000000-0000-0000-0000-000000000000",
+              "principalId": "00000000-0000-0000-0000-000000000000"
+            }
+          }
+        },
+        "kind": "v1",
+        "location": "West US",
+        "properties": {
+          "encryption": {
+            "customerManagedKeyEncryption": {
+              "keyEncryptionKeyIdentity": {
+                "identityType": "userAssignedIdentity",
+                "userAssignedIdentityResourceId": "/subscriptions/your-subscription/resourceGroups/your-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/your-identity"
+              },
+              "keyEncryptionKeyUrl": "https://your-kv.vault.azure.net/keys/your-key/your-key-version"
+            }
+          },
+          "hostName": "cache1.westus.something.azure.net",
+          "minimumTlsVersion": "1.2",
+          "provisioningState": "Creating",
+          "publicNetworkAccess": "Disabled",
+          "maintenanceConfiguration": {
+            "maintenanceWindows": [
+              {
+                "type": "Weekly",
+                "duration": "PT6H",
+                "startHourUtc": 3,
+                "schedule": {
+                  "dayOfWeek": "Monday"
+                }
+              },
+              {
+                "type": "Weekly",
+                "duration": "PT6H",
+                "startHourUtc": 3,
+                "schedule": {
+                  "dayOfWeek": "Tuesday"
+                }
+              },
+              {
+                "type": "Weekly",
+                "duration": "PT6H",
+                "startHourUtc": 3,
+                "schedule": {
+                  "dayOfWeek": "Wednesday"
+                }
+              }
+            ]
+          },
+          "redisVersion": "5",
+          "resourceState": "Creating"
+        },
+        "sku": {
+          "name": "EnterpriseFlash_F300",
+          "capacity": 3
+        },
+        "tags": {
+          "tag1": "value1"
+        },
+        "zones": [
+          "1",
+          "2",
+          "3"
+        ]
+      }
+    }
+  },
+  "operationId": "RedisEnterprise_Create",
+  "title": "RedisEnterpriseCreate"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseDatabasesCreate.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseDatabasesCreate.json
@@ -1,0 +1,119 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "parameters": {
+      "properties": {
+        "accessKeysAuthentication": "Enabled",
+        "clientProtocol": "Encrypted",
+        "clusteringPolicy": "EnterpriseCluster",
+        "deferUpgrade": "NotDeferred",
+        "evictionPolicy": "AllKeysLRU",
+        "notifyKeyspaceEvents": "KEA",
+        "modules": [
+          {
+            "name": "RedisBloom",
+            "args": "ERROR_RATE 0.00 INITIAL_SIZE 400"
+          },
+          {
+            "name": "RedisTimeSeries",
+            "args": "RETENTION_POLICY 20"
+          },
+          {
+            "name": "RediSearch"
+          }
+        ],
+        "persistence": {
+          "aofEnabled": true,
+          "aofFrequency": "1s"
+        },
+        "port": 10000
+      }
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "cache1/default",
+        "type": "Microsoft.Cache/redisEnterprise/databases",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default",
+        "properties": {
+          "accessKeysAuthentication": "Enabled",
+          "clientProtocol": "Encrypted",
+          "clusteringPolicy": "EnterpriseCluster",
+          "deferUpgrade": "NotDeferred",
+          "evictionPolicy": "AllKeysLRU",
+          "notifyKeyspaceEvents": "KEA",
+          "modules": [
+            {
+              "name": "RedisBloom",
+              "args": "ERROR_RATE 0.00 INITIAL_SIZE 400",
+              "version": "1.0.0"
+            },
+            {
+              "name": "RedisTimeSeries",
+              "args": "RETENTION_POLICY 20",
+              "version": "1.0.0"
+            },
+            {
+              "name": "RediSearch",
+              "args": "",
+              "version": "1.0.0"
+            }
+          ],
+          "persistence": {
+            "aofEnabled": true,
+            "aofFrequency": "1s"
+          },
+          "port": 10000,
+          "provisioningState": "Updating",
+          "redisVersion": "6.0",
+          "resourceState": "Updating"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "cache1/db1",
+        "type": "Microsoft.Cache/redisEnterprise/databases",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/db1",
+        "properties": {
+          "accessKeysAuthentication": "Enabled",
+          "clientProtocol": "Encrypted",
+          "clusteringPolicy": "EnterpriseCluster",
+          "evictionPolicy": "AllKeysLRU",
+          "notifyKeyspaceEvents": "KEA",
+          "modules": [
+            {
+              "name": "RedisBloom",
+              "args": "ERROR_RATE 0.00 INITIAL_SIZE 400",
+              "version": "1.0.0"
+            },
+            {
+              "name": "RedisTimeSeries",
+              "args": "RETENTION_POLICY 20",
+              "version": "1.0.0"
+            },
+            {
+              "name": "RediSearch",
+              "args": "",
+              "version": "1.0.0"
+            }
+          ],
+          "persistence": {
+            "aofEnabled": true,
+            "aofFrequency": "1s"
+          },
+          "port": 10000,
+          "provisioningState": "Creating",
+          "resourceState": "Creating"
+        }
+      }
+    }
+  },
+  "operationId": "Databases_Create",
+  "title": "RedisEnterpriseDatabasesCreate"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseDatabasesCreateWithGeoReplication.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseDatabasesCreateWithGeoReplication.json
@@ -1,0 +1,98 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "parameters": {
+      "properties": {
+        "accessKeysAuthentication": "Enabled",
+        "clientProtocol": "Encrypted",
+        "clusteringPolicy": "EnterpriseCluster",
+        "evictionPolicy": "NoEviction",
+        "geoReplication": {
+          "groupNickname": "groupName",
+          "linkedDatabases": [
+            {
+              "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default"
+            },
+            {
+              "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8e/resourceGroups/rg2/providers/Microsoft.Cache/redisEnterprise/cache2/databases/default"
+            }
+          ]
+        },
+        "notifyKeyspaceEvents": "KEA",
+        "port": 10000
+      }
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "cache1/default",
+        "type": "Microsoft.Cache/redisEnterprise/databases",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default",
+        "properties": {
+          "accessKeysAuthentication": "Enabled",
+          "clientProtocol": "Encrypted",
+          "clusteringPolicy": "EnterpriseCluster",
+          "deferUpgrade": "NotDeferred",
+          "evictionPolicy": "NoEviction",
+          "geoReplication": {
+            "groupNickname": "groupName",
+            "linkedDatabases": [
+              {
+                "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8e/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default",
+                "state": "Linking"
+              },
+              {
+                "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f2/resourceGroups/rg2/providers/Microsoft.Cache/redisEnterprise/cache2/databases/default",
+                "state": "Linking"
+              }
+            ]
+          },
+          "notifyKeyspaceEvents": "KEA",
+          "port": 10000,
+          "provisioningState": "Updating",
+          "redisVersion": "6.0",
+          "resourceState": "Updating"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "cache1/db1",
+        "type": "Microsoft.Cache/redisEnterprise/databases",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/db1",
+        "properties": {
+          "accessKeysAuthentication": "Enabled",
+          "clientProtocol": "Plaintext",
+          "clusteringPolicy": "EnterpriseCluster",
+          "deferUpgrade": "NotDeferred",
+          "evictionPolicy": "NoEviction",
+          "geoReplication": {
+            "groupNickname": "groupName",
+            "linkedDatabases": [
+              {
+                "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8e/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default",
+                "state": "Linking"
+              },
+              {
+                "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f2/resourceGroups/rg2/providers/Microsoft.Cache/redisEnterprise/cache2/databases/default",
+                "state": "Linking"
+              }
+            ]
+          },
+          "notifyKeyspaceEvents": "KEA",
+          "port": 10000,
+          "provisioningState": "Creating",
+          "redisVersion": "6.0",
+          "resourceState": "Creating"
+        }
+      }
+    }
+  },
+  "operationId": "Databases_Create",
+  "title": "RedisEnterpriseDatabasesCreate With Active Geo Replication"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseDatabasesDelete.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseDatabasesDelete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "db1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationStatus...",
+        "Location": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationResult..."
+      }
+    },
+    "204": {}
+  },
+  "operationId": "Databases_Delete",
+  "title": "RedisEnterpriseDatabasesDelete"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseDatabasesExport.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseDatabasesExport.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "parameters": {
+      "sasUri": "https://contosostorage.blob.core.window.net/urlToBlobContainer?sasKeyParameters"
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationStatus...",
+        "Location": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationResult..."
+      }
+    }
+  },
+  "operationId": "Databases_Export",
+  "title": "RedisEnterpriseDatabasesExport"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseDatabasesFlush.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseDatabasesFlush.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "parameters": {
+      "ids": [
+        "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f2/resourceGroups/rg2/providers/Microsoft.Cache/redisEnterprise/cache2/databases/default"
+      ]
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationStatus..."
+      }
+    }
+  },
+  "operationId": "Databases_Flush",
+  "title": "How to flush all the keys in the database"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseDatabasesForceLink.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseDatabasesForceLink.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "parameters": {
+      "geoReplication": {
+        "groupNickname": "groupName",
+        "linkedDatabases": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default"
+          },
+          {
+            "id": "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg2/providers/Microsoft.Cache/redisEnterprise/cache2/databases/default"
+          }
+        ]
+      }
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/...pathToOperationStatus..."
+      }
+    }
+  },
+  "operationId": "Databases_ForceLinkToReplicationGroup",
+  "title": "How to relink a database after a regional outage"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseDatabasesForceUnlink.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseDatabasesForceUnlink.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "parameters": {
+      "ids": [
+        "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f2/resourceGroups/rg2/providers/Microsoft.Cache/redisEnterprise/cache2/databases/default"
+      ]
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationStatus..."
+      }
+    }
+  },
+  "operationId": "Databases_ForceUnlink",
+  "title": "How to unlink a database during a regional outage"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseDatabasesGet.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseDatabasesGet.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "cache1/default",
+        "type": "Microsoft.Cache/redisEnterprise/databases",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default",
+        "properties": {
+          "accessKeysAuthentication": "Enabled",
+          "clientProtocol": "Encrypted",
+          "clusteringPolicy": "OSSCluster",
+          "deferUpgrade": "NotDeferred",
+          "evictionPolicy": "AllKeysLRU",
+          "notifyKeyspaceEvents": "",
+          "modules": [
+            {
+              "name": "RediSearch",
+              "args": "",
+              "version": "1.0.0"
+            }
+          ],
+          "persistence": {
+            "rdbEnabled": true,
+            "rdbFrequency": "12h"
+          },
+          "port": 10000,
+          "provisioningState": "Succeeded",
+          "redisVersion": "6.0",
+          "resourceState": "Running"
+        }
+      }
+    }
+  },
+  "operationId": "Databases_Get",
+  "title": "RedisEnterpriseDatabasesGet"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseDatabasesImport.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseDatabasesImport.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "parameters": {
+      "sasUris": [
+        "https://contosostorage.blob.core.window.net/urltoBlobFile1?sasKeyParameters",
+        "https://contosostorage.blob.core.window.net/urltoBlobFile2?sasKeyParameters"
+      ]
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationStatus...",
+        "Location": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationResult..."
+      }
+    }
+  },
+  "operationId": "Databases_Import",
+  "title": "RedisEnterpriseDatabasesImport"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseDatabasesListByCluster.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseDatabasesListByCluster.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "cache1/default",
+            "type": "Microsoft.Cache/redisEnterprise/databases",
+            "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default",
+            "properties": {
+              "accessKeysAuthentication": "Disabled",
+              "clientProtocol": "Encrypted",
+              "clusteringPolicy": "OSSCluster",
+              "deferUpgrade": "NotDeferred",
+              "evictionPolicy": "AllKeysLRU",
+              "notifyKeyspaceEvents": "",
+              "modules": [
+                {
+                  "name": "RediSearch",
+                  "args": "",
+                  "version": "1.0.0"
+                }
+              ],
+              "persistence": {
+                "rdbEnabled": true,
+                "rdbFrequency": "12h"
+              },
+              "port": 10000,
+              "provisioningState": "Succeeded",
+              "redisVersion": "6.0",
+              "resourceState": "Running"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Databases_ListByCluster",
+  "title": "RedisEnterpriseDatabasesListByCluster"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseDatabasesListKeys.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseDatabasesListKeys.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "primaryKey": "<primaryKey>",
+        "secondaryKey": "<secondaryKey>"
+      }
+    }
+  },
+  "operationId": "Databases_ListKeys",
+  "title": "RedisEnterpriseDatabasesListKeys"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseDatabasesNoClusterCacheCreate.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseDatabasesNoClusterCacheCreate.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "parameters": {
+      "properties": {
+        "clientProtocol": "Encrypted",
+        "clusteringPolicy": "NoCluster",
+        "evictionPolicy": "NoEviction",
+        "notifyKeyspaceEvents": "",
+        "port": 10000
+      }
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "cache1/default",
+        "type": "Microsoft.Cache/redisEnterprise/databases",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default",
+        "properties": {
+          "accessKeysAuthentication": "Enabled",
+          "clientProtocol": "Encrypted",
+          "clusteringPolicy": "NoCluster",
+          "deferUpgrade": "NotDeferred",
+          "evictionPolicy": "NoEviction",
+          "notifyKeyspaceEvents": "",
+          "port": 10000,
+          "provisioningState": "Updating",
+          "redisVersion": "7.2",
+          "resourceState": "Updating"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "cache1/default",
+        "type": "Microsoft.Cache/redisEnterprise/databases",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default",
+        "properties": {
+          "accessKeysAuthentication": "Enabled",
+          "clientProtocol": "Encrypted",
+          "clusteringPolicy": "NoCluster",
+          "deferUpgrade": "NotDeferred",
+          "evictionPolicy": "NoEviction",
+          "notifyKeyspaceEvents": "",
+          "port": 10000,
+          "provisioningState": "Creating",
+          "redisVersion": "7.2",
+          "resourceState": "Creating"
+        }
+      }
+    }
+  },
+  "operationId": "Databases_Create",
+  "title": "RedisEnterpriseDatabasesCreate No Cluster Cache"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseDatabasesNoClusterCacheUpdateClustering.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseDatabasesNoClusterCacheUpdateClustering.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "parameters": {
+      "properties": {
+        "clientProtocol": "Encrypted",
+        "clusteringPolicy": "EnterpriseCluster",
+        "evictionPolicy": "NoEviction",
+        "notifyKeyspaceEvents": "",
+        "port": 10000
+      }
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "cache1/default",
+        "type": "Microsoft.Cache/redisEnterprise/databases",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default",
+        "properties": {
+          "accessKeysAuthentication": "Enabled",
+          "clientProtocol": "Encrypted",
+          "clusteringPolicy": "EnterpriseCluster",
+          "deferUpgrade": "NotDeferred",
+          "evictionPolicy": "NoEviction",
+          "notifyKeyspaceEvents": "",
+          "port": 10000,
+          "provisioningState": "Updating",
+          "redisVersion": "7.2",
+          "resourceState": "Updating"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationStatus...",
+        "Location": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationResult..."
+      }
+    }
+  },
+  "operationId": "Databases_Update",
+  "title": "RedisEnterpriseDatabasesUpdate Clustering on No Cluster Cache"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseDatabasesRegenerateKey.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseDatabasesRegenerateKey.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "parameters": {
+      "keyType": "Primary"
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "primaryKey": "<primaryKey>",
+        "secondaryKey": "<secondaryKey>"
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationStatus...",
+        "Location": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationResult..."
+      }
+    }
+  },
+  "operationId": "Databases_RegenerateKey",
+  "title": "RedisEnterpriseDatabasesRegenerateKey"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseDatabasesUpdate.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseDatabasesUpdate.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "parameters": {
+      "properties": {
+        "accessKeysAuthentication": "Enabled",
+        "clientProtocol": "Encrypted",
+        "evictionPolicy": "AllKeysLRU",
+        "notifyKeyspaceEvents": "KEA",
+        "persistence": {
+          "rdbEnabled": true,
+          "rdbFrequency": "12h"
+        }
+      }
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "cache1/default",
+        "type": "Microsoft.Cache/redisEnterprise/databases",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/databases/default",
+        "properties": {
+          "accessKeysAuthentication": "Enabled",
+          "clientProtocol": "Encrypted",
+          "clusteringPolicy": "OSSCluster",
+          "deferUpgrade": "NotDeferred",
+          "evictionPolicy": "AllKeysLRU",
+          "notifyKeyspaceEvents": "KEA",
+          "modules": [
+            {
+              "name": "RediSearch",
+              "args": "",
+              "version": "1.0.0"
+            }
+          ],
+          "persistence": {
+            "rdbEnabled": true,
+            "rdbFrequency": "12h"
+          },
+          "port": 10000,
+          "provisioningState": "Updating",
+          "redisVersion": "6.0",
+          "resourceState": "Updating"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationStatus...",
+        "Location": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationResult..."
+      }
+    }
+  },
+  "operationId": "Databases_Update",
+  "title": "RedisEnterpriseDatabasesUpdate"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseDatabasesUpgradeDBRedisVersion.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseDatabasesUpgradeDBRedisVersion.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationStatus..."
+      }
+    }
+  },
+  "operationId": "Databases_UpgradeDBRedisVersion",
+  "title": "How to upgrade your database Redis version"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseDelete.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseDelete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationStatus...",
+        "Location": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationResult..."
+      }
+    },
+    "204": {}
+  },
+  "operationId": "RedisEnterprise_Delete",
+  "title": "RedisEnterpriseDelete"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseDeletePrivateEndpointConnection.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseDeletePrivateEndpointConnection.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "privateEndpointConnectionName": "pectest01",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationStatus...",
+        "Location": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationResult..."
+      }
+    },
+    "204": {}
+  },
+  "operationId": "PrivateEndpointConnections_Delete",
+  "title": "RedisEnterpriseDeletePrivateEndpointConnection"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseGet.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseGet.json
@@ -1,0 +1,82 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "cache1",
+        "type": "Microsoft.Cache/redisEnterprise",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1",
+        "kind": "v1",
+        "location": "West US",
+        "properties": {
+          "hostName": "cache1.westus.something.azure.com",
+          "minimumTlsVersion": "1.2",
+          "privateEndpointConnections": [
+            {
+              "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/privateEndpointConnections/cachePec",
+              "properties": {
+                "privateEndpoint": {
+                  "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Network/privateEndpoints/cachePe"
+                },
+                "privateLinkServiceConnectionState": {
+                  "description": "Please approve my connection",
+                  "actionsRequired": "None",
+                  "status": "Approved"
+                }
+              }
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "publicNetworkAccess": "Disabled",
+          "maintenanceConfiguration": {
+            "maintenanceWindows": [
+              {
+                "type": "Weekly",
+                "duration": "PT6H",
+                "startHourUtc": 3,
+                "schedule": {
+                  "dayOfWeek": "Monday"
+                }
+              },
+              {
+                "type": "Weekly",
+                "duration": "PT6H",
+                "startHourUtc": 3,
+                "schedule": {
+                  "dayOfWeek": "Tuesday"
+                }
+              },
+              {
+                "type": "Weekly",
+                "duration": "PT6H",
+                "startHourUtc": 3,
+                "schedule": {
+                  "dayOfWeek": "Wednesday"
+                }
+              }
+            ]
+          },
+          "redisVersion": "6",
+          "resourceState": "Running"
+        },
+        "sku": {
+          "name": "EnterpriseFlash_F300",
+          "capacity": 3
+        },
+        "tags": {},
+        "zones": [
+          "1",
+          "2",
+          "3"
+        ]
+      }
+    }
+  },
+  "operationId": "RedisEnterprise_Get",
+  "title": "RedisEnterpriseGet"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseGetPrivateEndpointConnection.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseGetPrivateEndpointConnection.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "privateEndpointConnectionName": "pectest01",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "pectest01",
+        "type": "Microsoft.Cache/redisEnterprise/privateEndpointConnections",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/privateEndpointConnections/pectest01",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Network/privateEndpoints/petest01"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Auto-Approved",
+            "actionsRequired": "None",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_Get",
+  "title": "RedisEnterpriseGetPrivateEndpointConnection"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseList.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseList.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "cache1",
+            "type": "Microsoft.Cache/redisEnterprise",
+            "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1",
+            "kind": "v1",
+            "location": "West US",
+            "properties": {
+              "hostName": "cache1.westus.something.azure.com",
+              "minimumTlsVersion": "1.2",
+              "provisioningState": "Succeeded",
+              "publicNetworkAccess": "Disabled",
+              "redisVersion": "6",
+              "resourceState": "Running"
+            },
+            "sku": {
+              "name": "EnterpriseFlash_F300",
+              "capacity": 3
+            },
+            "tags": {}
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "RedisEnterprise_List",
+  "title": "RedisEnterpriseList"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseListByResourceGroup.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseListByResourceGroup.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "cache1",
+            "type": "Microsoft.Cache/redisEnterprise",
+            "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1",
+            "kind": "v1",
+            "location": "West US",
+            "properties": {
+              "hostName": "cache1.westus.something.azure.com",
+              "minimumTlsVersion": "1.2",
+              "provisioningState": "Succeeded",
+              "publicNetworkAccess": "Disabled",
+              "redisVersion": "5",
+              "resourceState": "Running"
+            },
+            "sku": {
+              "name": "EnterpriseFlash_F300",
+              "capacity": 3
+            },
+            "tags": {},
+            "zones": [
+              "1",
+              "2",
+              "3"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "RedisEnterprise_ListByResourceGroup",
+  "title": "RedisEnterpriseListByResourceGroup"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseListPrivateEndpointConnections.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseListPrivateEndpointConnections.json
@@ -1,0 +1,51 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "privateEndpointConnectionName": "pectest01",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "pectest01",
+            "type": "Microsoft.Cache/redisEnterprise/privateEndpointConnections",
+            "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/privateEndpointConnections/pectest01",
+            "properties": {
+              "privateEndpoint": {
+                "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Network/privateEndpoints/petest01"
+              },
+              "privateLinkServiceConnectionState": {
+                "description": "Auto-Approved",
+                "actionsRequired": "None",
+                "status": "Approved"
+              },
+              "provisioningState": "Succeeded"
+            }
+          },
+          {
+            "name": "pectest01",
+            "type": "Microsoft.Cache/redisEnterprise/privateEndpointConnections",
+            "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/privateEndpointConnections/pectest01",
+            "properties": {
+              "privateEndpoint": {
+                "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Network/privateEndpoints/petest01"
+              },
+              "privateLinkServiceConnectionState": {
+                "description": "Auto-Approved",
+                "actionsRequired": "None",
+                "status": "Approved"
+              },
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_List",
+  "title": "RedisEnterpriseListPrivateEndpointConnections"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseListPrivateLinkResources.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseListPrivateLinkResources.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "redisEnterpriseCache",
+            "type": "Microsoft.Cache/redisEnterprise/privateLinkResources",
+            "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/privateLinkResources/redisEnterpriseCache",
+            "properties": {
+              "groupId": "redisEnterpriseCache",
+              "requiredMembers": [
+                "redisEnterpriseCache"
+              ],
+              "requiredZoneNames": [
+                "privatelink.redisenterprise.cache.windows.net"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PrivateLinkResources_ListByCluster",
+  "title": "RedisEnterpriseListPrivateLinkResources"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseListSkusForScaling.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseListSkusForScaling.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "skus": [
+          {
+            "name": "MemoryOptimized_M100",
+            "sizeInGB": 120
+          },
+          {
+            "name": "ComputeOptimized_X700",
+            "sizeInGB": 720
+          },
+          {
+            "name": "Balanced_B5",
+            "sizeInGB": 6
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "RedisEnterprise_ListSkusForScaling",
+  "title": "RedisEnterpriseListSkusForScaling"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseMigrationCancel.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseMigrationCancel.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "databaseName": "default",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationStatus..."
+      }
+    }
+  },
+  "operationId": "Migration_Cancel",
+  "title": "RedisEnterpriseMigrationCancel"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseMigrationGet.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseMigrationGet.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "cache1/default",
+        "type": "Microsoft.Cache/redisEnterprise/migrations",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/migrations/default",
+        "properties": {
+          "creationTime": "2024-10-01T12:00:00Z",
+          "lastModifiedTime": "2024-10-01T12:00:00Z",
+          "provisioningState": "InProgress",
+          "skipDataMigration": true,
+          "sourceResourceId": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redis/cache1",
+          "sourceType": "AzureCacheForRedis",
+          "statusDetails": "",
+          "switchDns": true,
+          "targetResourceId": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1"
+        }
+      }
+    }
+  },
+  "operationId": "Migration_Get",
+  "title": "RedisEnterpriseMigrationGet"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseMigrationList.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseMigrationList.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "cache1/default",
+            "type": "Microsoft.Cache/redisEnterprise/migrations",
+            "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/migrations/default",
+            "properties": {
+              "creationTime": "2024-10-01T12:00:00Z",
+              "lastModifiedTime": "2024-10-01T12:00:00Z",
+              "provisioningState": "InProgress",
+              "skipDataMigration": true,
+              "sourceResourceId": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redis/cache1",
+              "sourceType": "AzureCacheForRedis",
+              "statusDetails": "",
+              "switchDns": true,
+              "targetResourceId": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Migration_List",
+  "title": "RedisEnterpriseMigrationList"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseMigrationStart.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseMigrationStart.json
@@ -1,0 +1,62 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "parameters": {
+      "properties": {
+        "skipDataMigration": true,
+        "sourceResourceId": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redis/cache1",
+        "sourceType": "AzureCacheForRedis",
+        "switchDns": true
+      }
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Cache/redisEnterprise/migrations",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/migrations/default",
+        "properties": {
+          "creationTime": "2024-10-01T12:00:00Z",
+          "lastModifiedTime": "2024-10-01T12:00:00Z",
+          "provisioningState": "Completed",
+          "skipDataMigration": true,
+          "sourceResourceId": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redis/cache1",
+          "sourceType": "AzureCacheForRedis",
+          "statusDetails": "",
+          "switchDns": true,
+          "targetResourceId": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationStatus..."
+      }
+    },
+    "201": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Cache/redisEnterprise/migrations",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/migrations/default",
+        "properties": {
+          "creationTime": "2024-10-01T12:00:00Z",
+          "lastModifiedTime": "2024-10-01T12:00:00Z",
+          "provisioningState": "Completed",
+          "skipDataMigration": true,
+          "sourceResourceId": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redis/cache1",
+          "sourceType": "AzureCacheForRedis",
+          "statusDetails": "",
+          "switchDns": true,
+          "targetResourceId": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationStatus..."
+      }
+    }
+  },
+  "operationId": "Migration_Start",
+  "title": "RedisEnterpriseMigrationStart"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseMigrationValidate.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseMigrationValidate.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "body": {
+      "sourceResourceId": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redis/cache1",
+      "skipDataMigration": true,
+      "forceMigrate": false
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "isValid": false,
+        "errors": [
+          {
+            "disparities": [
+              {
+                "category": "TLS",
+                "message": "The source resource only accepts TLS connections, but the target resource only accepts non-TLS connections."
+              }
+            ]
+          }
+        ],
+        "warnings": [
+          {
+            "disparities": [
+              {
+                "category": "Managed Identity",
+                "message": "The source resource has a system-assigned managed identity. Managed identities are not copied as part of migration."
+              },
+              {
+                "category": "Persistence",
+                "message": "The source resource has RDB persistence enabled. Persistence settings are not copied as part of migration."
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Migrations_Validate",
+  "title": "RedisEnterpriseMigrationValidate"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterprisePutPrivateEndpointConnection.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterprisePutPrivateEndpointConnection.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "privateEndpointConnectionName": "pectest01",
+    "properties": {
+      "properties": {
+        "privateLinkServiceConnectionState": {
+          "description": "Auto-Approved",
+          "status": "Approved"
+        }
+      }
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "pectest01",
+        "type": "Microsoft.Cache/redisEnterprise/privateEndpointConnections",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1/privateEndpointConnections/pectest01",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Network/privateEndpoints/petest01"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Auto-Approved",
+            "actionsRequired": "None",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_Put",
+  "title": "RedisEnterprisePutPrivateEndpointConnection"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseUpdate.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/examples/RedisEnterpriseUpdate.json
@@ -1,0 +1,119 @@
+{
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "clusterName": "cache1",
+    "parameters": {
+      "properties": {
+        "minimumTlsVersion": "1.2",
+        "publicNetworkAccess": "Enabled",
+        "maintenanceConfiguration": {
+          "maintenanceWindows": [
+            {
+              "type": "Weekly",
+              "duration": "PT6H",
+              "startHourUtc": 3,
+              "schedule": {
+                "dayOfWeek": "Monday"
+              }
+            },
+            {
+              "type": "Weekly",
+              "duration": "PT6H",
+              "startHourUtc": 3,
+              "schedule": {
+                "dayOfWeek": "Tuesday"
+              }
+            },
+            {
+              "type": "Weekly",
+              "duration": "PT6H",
+              "startHourUtc": 3,
+              "schedule": {
+                "dayOfWeek": "Wednesday"
+              }
+            }
+          ]
+        }
+      },
+      "sku": {
+        "name": "EnterpriseFlash_F300",
+        "capacity": 9
+      },
+      "tags": {
+        "tag1": "value1"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "cache1",
+        "type": "Microsoft.Cache/redisEnterprise",
+        "id": "/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/resourceGroups/rg1/providers/Microsoft.Cache/redisEnterprise/cache1",
+        "identity": {
+          "type": "None"
+        },
+        "kind": "v1",
+        "location": "West US",
+        "properties": {
+          "hostName": "cache1.westus.something.azure.com",
+          "minimumTlsVersion": "1.2",
+          "provisioningState": "Updating",
+          "publicNetworkAccess": "Enabled",
+          "maintenanceConfiguration": {
+            "maintenanceWindows": [
+              {
+                "type": "Weekly",
+                "duration": "PT6H",
+                "startHourUtc": 3,
+                "schedule": {
+                  "dayOfWeek": "Monday"
+                }
+              },
+              {
+                "type": "Weekly",
+                "duration": "PT6H",
+                "startHourUtc": 3,
+                "schedule": {
+                  "dayOfWeek": "Tuesday"
+                }
+              },
+              {
+                "type": "Weekly",
+                "duration": "PT6H",
+                "startHourUtc": 3,
+                "schedule": {
+                  "dayOfWeek": "Wednesday"
+                }
+              }
+            ]
+          },
+          "redisVersion": "5",
+          "resourceState": "Updating"
+        },
+        "sku": {
+          "name": "EnterpriseFlash_F300",
+          "capacity": 9
+        },
+        "tags": {
+          "tag1": "value1"
+        },
+        "zones": [
+          "1",
+          "2",
+          "3"
+        ]
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationStatus...",
+        "Location": "https://management.azure.com/subscriptions/e7b5a9d2-6b6a-4d2f-9143-20d9a10f5b8f/providers/Microsoft.Cache/...pathToOperationResult..."
+      }
+    }
+  },
+  "operationId": "RedisEnterprise_Update",
+  "title": "RedisEnterpriseUpdate"
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/redisenterprise.json
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/preview/2026-05-01-preview/redisenterprise.json
@@ -1,0 +1,4650 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "RedisEnterpriseManagementClient",
+    "version": "2026-05-01-preview",
+    "description": "REST API for managing Redis Enterprise resources in Azure.",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Operations"
+    },
+    {
+      "name": "Clusters"
+    },
+    {
+      "name": "Databases"
+    },
+    {
+      "name": "AccessPolicyAssignments"
+    },
+    {
+      "name": "PrivateEndpointConnections"
+    },
+    {
+      "name": "Migrations"
+    }
+  ],
+  "paths": {
+    "/providers/Microsoft.Cache/operations": {
+      "get": {
+        "operationId": "Operations_List",
+        "tags": [
+          "Operations"
+        ],
+        "description": "Lists all of the available REST API operations of the Microsoft.Cache provider.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/OperationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "OperationsList": {
+            "$ref": "./examples/OperationsList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Cache/locations/{location}/operationsStatus/{operationId}": {
+      "get": {
+        "operationId": "OperationsStatus_Get",
+        "description": "Gets the status of operation.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "operationId",
+            "in": "path",
+            "description": "The ID of an ongoing async operation.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/OperationStatus"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "OperationsStatusGet": {
+            "$ref": "./examples/OperationsStatusGet.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Cache/redisEnterprise": {
+      "get": {
+        "operationId": "RedisEnterprise_List",
+        "tags": [
+          "Clusters"
+        ],
+        "description": "Lists all Redis Enterprise clusters in the specified subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ClusterList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RedisEnterpriseList": {
+            "$ref": "./examples/RedisEnterpriseList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise": {
+      "get": {
+        "operationId": "RedisEnterprise_ListByResourceGroup",
+        "tags": [
+          "Clusters"
+        ],
+        "description": "Lists all Redis Enterprise clusters in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ClusterList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RedisEnterpriseListByResourceGroup": {
+            "$ref": "./examples/RedisEnterpriseListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}": {
+      "get": {
+        "operationId": "RedisEnterprise_Get",
+        "tags": [
+          "Clusters"
+        ],
+        "description": "Gets information about a Redis Enterprise cluster",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise cluster. Name must be 1-60 characters long. Allowed characters(A-Z, a-z, 0-9) and hyphen(-). There can be no leading nor trailing nor consecutive hyphens",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Cluster"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RedisEnterpriseGet": {
+            "$ref": "./examples/RedisEnterpriseGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "RedisEnterprise_Create",
+        "tags": [
+          "Clusters"
+        ],
+        "description": "Creates or updates an existing (overwrite/recreate, with potential downtime) cache cluster",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise cluster. Name must be 1-60 characters long. Allowed characters(A-Z, a-z, 0-9) and hyphen(-). There can be no leading nor trailing nor consecutive hyphens",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the Create Redis Enterprise operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Cluster"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Cluster' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Cluster"
+            }
+          },
+          "201": {
+            "description": "Resource 'Cluster' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Cluster"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RedisEnterpriseCreate": {
+            "$ref": "./examples/RedisEnterpriseCreate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "original-uri",
+          "final-state-schema": "#/definitions/Cluster"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "RedisEnterprise_Update",
+        "tags": [
+          "Clusters"
+        ],
+        "description": "Updates an existing Redis Enterprise cluster",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise cluster. Name must be 1-60 characters long. Allowed characters(A-Z, a-z, 0-9) and hyphen(-). There can be no leading nor trailing nor consecutive hyphens",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the Update Redis Enterprise operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ClusterUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Cluster"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RedisEnterpriseUpdate": {
+            "$ref": "./examples/RedisEnterpriseUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/Cluster"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "RedisEnterprise_Delete",
+        "tags": [
+          "Clusters"
+        ],
+        "description": "Deletes a Redis Enterprise cache cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise cluster. Name must be 1-60 characters long. Allowed characters(A-Z, a-z, 0-9) and hyphen(-). There can be no leading nor trailing nor consecutive hyphens",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RedisEnterpriseDelete": {
+            "$ref": "./examples/RedisEnterpriseDelete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}/databases": {
+      "get": {
+        "operationId": "Databases_ListByCluster",
+        "tags": [
+          "Databases"
+        ],
+        "description": "Gets all databases in the specified Redis Enterprise cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise cluster. Name must be 1-60 characters long. Allowed characters(A-Z, a-z, 0-9) and hyphen(-). There can be no leading nor trailing nor consecutive hyphens",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DatabaseList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RedisEnterpriseDatabasesListByCluster": {
+            "$ref": "./examples/RedisEnterpriseDatabasesListByCluster.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}/databases/{databaseName}": {
+      "get": {
+        "operationId": "Databases_Get",
+        "tags": [
+          "Databases"
+        ],
+        "description": "Gets information about a database in a Redis Enterprise cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise cluster. Name must be 1-60 characters long. Allowed characters(A-Z, a-z, 0-9) and hyphen(-). There can be no leading nor trailing nor consecutive hyphens",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise database.",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Database"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RedisEnterpriseDatabasesGet": {
+            "$ref": "./examples/RedisEnterpriseDatabasesGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Databases_Create",
+        "tags": [
+          "Databases"
+        ],
+        "description": "Creates a database",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise cluster. Name must be 1-60 characters long. Allowed characters(A-Z, a-z, 0-9) and hyphen(-). There can be no leading nor trailing nor consecutive hyphens",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise database.",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update database operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Database"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Database' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Database"
+            }
+          },
+          "201": {
+            "description": "Resource 'Database' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Database"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RedisEnterpriseDatabasesCreate": {
+            "$ref": "./examples/RedisEnterpriseDatabasesCreate.json"
+          },
+          "RedisEnterpriseDatabasesCreate No Cluster Cache": {
+            "$ref": "./examples/RedisEnterpriseDatabasesNoClusterCacheCreate.json"
+          },
+          "RedisEnterpriseDatabasesCreate With Active Geo Replication": {
+            "$ref": "./examples/RedisEnterpriseDatabasesCreateWithGeoReplication.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "original-uri",
+          "final-state-schema": "#/definitions/Database"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "Databases_Update",
+        "tags": [
+          "Databases"
+        ],
+        "description": "Updates a database",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise cluster. Name must be 1-60 characters long. Allowed characters(A-Z, a-z, 0-9) and hyphen(-). There can be no leading nor trailing nor consecutive hyphens",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise database.",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update database operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DatabaseUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Database"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RedisEnterpriseDatabasesUpdate": {
+            "$ref": "./examples/RedisEnterpriseDatabasesUpdate.json"
+          },
+          "RedisEnterpriseDatabasesUpdate Clustering on No Cluster Cache": {
+            "$ref": "./examples/RedisEnterpriseDatabasesNoClusterCacheUpdateClustering.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/Database"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "Databases_Delete",
+        "tags": [
+          "Databases"
+        ],
+        "description": "Deletes a single database",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise cluster. Name must be 1-60 characters long. Allowed characters(A-Z, a-z, 0-9) and hyphen(-). There can be no leading nor trailing nor consecutive hyphens",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise database.",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RedisEnterpriseDatabasesDelete": {
+            "$ref": "./examples/RedisEnterpriseDatabasesDelete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}/databases/{databaseName}/accessPolicyAssignments": {
+      "get": {
+        "operationId": "AccessPolicyAssignment_List",
+        "tags": [
+          "AccessPolicyAssignments"
+        ],
+        "description": "Gets all access policy assignments..",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise cluster. Name must be 1-60 characters long. Allowed characters(A-Z, a-z, 0-9) and hyphen(-). There can be no leading nor trailing nor consecutive hyphens",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise database.",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AccessPolicyAssignmentList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RedisEnterpriseAccessPolicyAssignmentList": {
+            "$ref": "./examples/RedisEnterpriseAccessPolicyAssignmentsList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}/databases/{databaseName}/accessPolicyAssignments/{accessPolicyAssignmentName}": {
+      "get": {
+        "operationId": "AccessPolicyAssignment_Get",
+        "tags": [
+          "AccessPolicyAssignments"
+        ],
+        "description": "Gets information about access policy assignment for database.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise cluster. Name must be 1-60 characters long. Allowed characters(A-Z, a-z, 0-9) and hyphen(-). There can be no leading nor trailing nor consecutive hyphens",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise database.",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          },
+          {
+            "name": "accessPolicyAssignmentName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise database access policy assignment.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[A-Za-z0-9]{1,60}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AccessPolicyAssignment"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RedisEnterpriseAccessPolicyAssignmentGet": {
+            "$ref": "./examples/RedisEnterpriseAccessPolicyAssignmentGet.json"
+          },
+          "RedisEnterpriseAccessPolicyAssignmentGetWithFailedProvisioningState": {
+            "$ref": "./examples/RedisEnterpriseAccessPolicyAssignmentGetWithFailedProvisioningState.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "AccessPolicyAssignment_CreateUpdate",
+        "tags": [
+          "AccessPolicyAssignments"
+        ],
+        "description": "Creates/Updates a particular access policy assignment for a database",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise cluster. Name must be 1-60 characters long. Allowed characters(A-Z, a-z, 0-9) and hyphen(-). There can be no leading nor trailing nor consecutive hyphens",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise database.",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          },
+          {
+            "name": "accessPolicyAssignmentName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise database access policy assignment.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[A-Za-z0-9]{1,60}$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create access policy assignment for database.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AccessPolicyAssignment"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'AccessPolicyAssignment' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/AccessPolicyAssignment"
+            }
+          },
+          "201": {
+            "description": "Resource 'AccessPolicyAssignment' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/AccessPolicyAssignment"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RedisEnterpriseAccessPolicyAssignmentCreateUpdate": {
+            "$ref": "./examples/RedisEnterpriseAccessPolicyAssignmentCreateUpdate.json"
+          },
+          "RedisEnterpriseAccessPolicyAssignmentCreateUpdateWithCustomAccessString": {
+            "$ref": "./examples/RedisEnterpriseAccessPolicyAssignmentCreateUpdateWithCustomAccessString.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "original-uri",
+          "final-state-schema": "#/definitions/AccessPolicyAssignment"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "AccessPolicyAssignment_Delete",
+        "tags": [
+          "AccessPolicyAssignments"
+        ],
+        "description": "Deletes a single access policy assignment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise cluster. Name must be 1-60 characters long. Allowed characters(A-Z, a-z, 0-9) and hyphen(-). There can be no leading nor trailing nor consecutive hyphens",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise database.",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          },
+          {
+            "name": "accessPolicyAssignmentName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise database access policy assignment.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[A-Za-z0-9]{1,60}$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RedisEnterpriseAccessPolicyAssignmentDelete": {
+            "$ref": "./examples/RedisEnterpriseAccessPolicyAssignmentDelete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}/databases/{databaseName}/export": {
+      "post": {
+        "operationId": "Databases_Export",
+        "tags": [
+          "Databases"
+        ],
+        "description": "Exports a database file from target database.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise cluster. Name must be 1-60 characters long. Allowed characters(A-Z, a-z, 0-9) and hyphen(-). There can be no leading nor trailing nor consecutive hyphens",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise database.",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Storage information for exporting into the cluster",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ExportClusterParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RedisEnterpriseDatabasesExport": {
+            "$ref": "./examples/RedisEnterpriseDatabasesExport.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}/databases/{databaseName}/flush": {
+      "post": {
+        "operationId": "Databases_Flush",
+        "tags": [
+          "Databases"
+        ],
+        "description": "Flushes all the keys in this database and also from its linked databases.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise cluster. Name must be 1-60 characters long. Allowed characters(A-Z, a-z, 0-9) and hyphen(-). There can be no leading nor trailing nor consecutive hyphens",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise database.",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Information identifying the databases to be flushed",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/FlushParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "How to flush all the keys in the database": {
+            "$ref": "./examples/RedisEnterpriseDatabasesFlush.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}/databases/{databaseName}/forceLinkToReplicationGroup": {
+      "post": {
+        "operationId": "Databases_ForceLinkToReplicationGroup",
+        "tags": [
+          "Databases"
+        ],
+        "description": "Forcibly recreates an existing database on the specified cluster, and rejoins it to an existing replication group. **IMPORTANT NOTE:** All data in this database will be discarded, and the database will temporarily be unavailable while rejoining the replication group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise cluster. Name must be 1-60 characters long. Allowed characters(A-Z, a-z, 0-9) and hyphen(-). There can be no leading nor trailing nor consecutive hyphens",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise database.",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Information identifying the database to be unlinked.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ForceLinkParameters"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "How to relink a database after a regional outage": {
+            "$ref": "./examples/RedisEnterpriseDatabasesForceLink.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}/databases/{databaseName}/forceUnlink": {
+      "post": {
+        "operationId": "Databases_ForceUnlink",
+        "tags": [
+          "Databases"
+        ],
+        "description": "Forcibly removes the link to the specified database resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise cluster. Name must be 1-60 characters long. Allowed characters(A-Z, a-z, 0-9) and hyphen(-). There can be no leading nor trailing nor consecutive hyphens",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise database.",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Information identifying the database to be unlinked.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ForceUnlinkParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "How to unlink a database during a regional outage": {
+            "$ref": "./examples/RedisEnterpriseDatabasesForceUnlink.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}/databases/{databaseName}/import": {
+      "post": {
+        "operationId": "Databases_Import",
+        "tags": [
+          "Databases"
+        ],
+        "description": "Imports database files to target database.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise cluster. Name must be 1-60 characters long. Allowed characters(A-Z, a-z, 0-9) and hyphen(-). There can be no leading nor trailing nor consecutive hyphens",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise database.",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Storage information for importing into the cluster",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ImportClusterParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RedisEnterpriseDatabasesImport": {
+            "$ref": "./examples/RedisEnterpriseDatabasesImport.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}/databases/{databaseName}/listKeys": {
+      "post": {
+        "operationId": "Databases_ListKeys",
+        "tags": [
+          "Databases"
+        ],
+        "description": "Retrieves the access keys for the Redis Enterprise database.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise cluster. Name must be 1-60 characters long. Allowed characters(A-Z, a-z, 0-9) and hyphen(-). There can be no leading nor trailing nor consecutive hyphens",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise database.",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AccessKeys"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RedisEnterpriseDatabasesListKeys": {
+            "$ref": "./examples/RedisEnterpriseDatabasesListKeys.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}/databases/{databaseName}/regenerateKey": {
+      "post": {
+        "operationId": "Databases_RegenerateKey",
+        "tags": [
+          "Databases"
+        ],
+        "description": "Regenerates the Redis Enterprise database's access keys.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise cluster. Name must be 1-60 characters long. Allowed characters(A-Z, a-z, 0-9) and hyphen(-). There can be no leading nor trailing nor consecutive hyphens",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise database.",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Specifies which key to regenerate.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RegenerateKeyParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AccessKeys"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RedisEnterpriseDatabasesRegenerateKey": {
+            "$ref": "./examples/RedisEnterpriseDatabasesRegenerateKey.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/AccessKeys"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}/databases/{databaseName}/upgradeDBRedisVersion": {
+      "post": {
+        "operationId": "Databases_UpgradeDBRedisVersion",
+        "tags": [
+          "Databases"
+        ],
+        "description": "Upgrades the database Redis version to the latest available.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise cluster. Name must be 1-60 characters long. Allowed characters(A-Z, a-z, 0-9) and hyphen(-). There can be no leading nor trailing nor consecutive hyphens",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          },
+          {
+            "name": "databaseName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise database.",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "How to upgrade your database Redis version": {
+            "$ref": "./examples/RedisEnterpriseDatabasesUpgradeDBRedisVersion.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}/listSkusForScaling": {
+      "post": {
+        "operationId": "RedisEnterprise_ListSkusForScaling",
+        "tags": [
+          "Clusters"
+        ],
+        "description": "Lists the available SKUs for scaling the Redis Enterprise cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise cluster. Name must be 1-60 characters long. Allowed characters(A-Z, a-z, 0-9) and hyphen(-). There can be no leading nor trailing nor consecutive hyphens",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SkuDetailsList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RedisEnterpriseListSkusForScaling": {
+            "$ref": "./examples/RedisEnterpriseListSkusForScaling.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}/migrations": {
+      "get": {
+        "operationId": "Migration_List",
+        "tags": [
+          "Migrations"
+        ],
+        "description": "Gets information about all migrations attempts in a Redis Enterprise cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise cluster. Name must be 1-60 characters long. Allowed characters(A-Z, a-z, 0-9) and hyphen(-). There can be no leading nor trailing nor consecutive hyphens",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MigrationList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RedisEnterpriseMigrationList": {
+            "$ref": "./examples/RedisEnterpriseMigrationList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}/migrations/default": {
+      "get": {
+        "operationId": "Migration_Get",
+        "tags": [
+          "Migrations"
+        ],
+        "description": "Gets information about a migration in a Redis Enterprise cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise cluster. Name must be 1-60 characters long. Allowed characters(A-Z, a-z, 0-9) and hyphen(-). There can be no leading nor trailing nor consecutive hyphens",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Migration"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RedisEnterpriseMigrationGet": {
+            "$ref": "./examples/RedisEnterpriseMigrationGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Migration_Start",
+        "tags": [
+          "Migrations"
+        ],
+        "description": "Starts a new migration",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise cluster. Name must be 1-60 characters long. Allowed characters(A-Z, a-z, 0-9) and hyphen(-). There can be no leading nor trailing nor consecutive hyphens",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to start a migration operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Migration"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/Migration"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "201": {
+            "description": "The request has succeeded and a new resource has been created as a result.",
+            "schema": {
+              "$ref": "#/definitions/Migration"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RedisEnterpriseMigrationStart": {
+            "$ref": "./examples/RedisEnterpriseMigrationStart.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "original-uri",
+          "final-state-schema": "#/definitions/Migration"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}/migrations/default/cancel": {
+      "post": {
+        "operationId": "Migration_Cancel",
+        "tags": [
+          "Migrations"
+        ],
+        "description": "Cancel or rollback the migration operation in a Redis Enterprise cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise cluster. Name must be 1-60 characters long. Allowed characters(A-Z, a-z, 0-9) and hyphen(-). There can be no leading nor trailing nor consecutive hyphens",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RedisEnterpriseMigrationCancel": {
+            "$ref": "./examples/RedisEnterpriseMigrationCancel.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}/migrations/default/validate": {
+      "post": {
+        "operationId": "Migrations_Validate",
+        "tags": [
+          "Migrations"
+        ],
+        "description": "Validates if a source Azure Cache for Redis resource can be migrated to a target Azure Managed Redis resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise cluster. Name must be 1-60 characters long. Allowed characters(A-Z, a-z, 0-9) and hyphen(-). There can be no leading nor trailing nor consecutive hyphens",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Parameters supplied to validate a migration operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/MigrationValidationRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MigrationValidationResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RedisEnterpriseMigrationValidate": {
+            "$ref": "./examples/RedisEnterpriseMigrationValidate.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}/privateEndpointConnections": {
+      "get": {
+        "operationId": "PrivateEndpointConnections_List",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "Lists all the private endpoint connections associated with the Redis Enterprise cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise cluster. Name must be 1-60 characters long. Allowed characters(A-Z, a-z, 0-9) and hyphen(-). There can be no leading nor trailing nor consecutive hyphens",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnectionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RedisEnterpriseListPrivateEndpointConnections": {
+            "$ref": "./examples/RedisEnterpriseListPrivateEndpointConnections.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}/privateEndpointConnections/{privateEndpointConnectionName}": {
+      "get": {
+        "operationId": "PrivateEndpointConnections_Get",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "Gets the specified private endpoint connection associated with the Redis Enterprise cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise cluster. Name must be 1-60 characters long. Allowed characters(A-Z, a-z, 0-9) and hyphen(-). There can be no leading nor trailing nor consecutive hyphens",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/privatelinks.json#/parameters/PrivateEndpointConnectionName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/privatelinks.json#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RedisEnterpriseGetPrivateEndpointConnection": {
+            "$ref": "./examples/RedisEnterpriseGetPrivateEndpointConnection.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "PrivateEndpointConnections_Put",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "Updates the state of the specified private endpoint connection associated with the Redis Enterprise cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise cluster. Name must be 1-60 characters long. Allowed characters(A-Z, a-z, 0-9) and hyphen(-). There can be no leading nor trailing nor consecutive hyphens",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/privatelinks.json#/parameters/PrivateEndpointConnectionName"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The private endpoint connection properties.",
+            "required": true,
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/privatelinks.json#/definitions/PrivateEndpointConnection"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Resource 'PrivateEndpointConnection' create operation succeeded",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/privatelinks.json#/definitions/PrivateEndpointConnection"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RedisEnterprisePutPrivateEndpointConnection": {
+            "$ref": "./examples/RedisEnterprisePutPrivateEndpointConnection.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "../../../../../../common-types/resource-management/v6/privatelinks.json#/definitions/PrivateEndpointConnection"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "PrivateEndpointConnections_Delete",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "Deletes the specified private endpoint connection associated with the Redis Enterprise cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise cluster. Name must be 1-60 characters long. Allowed characters(A-Z, a-z, 0-9) and hyphen(-). There can be no leading nor trailing nor consecutive hyphens",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/privatelinks.json#/parameters/PrivateEndpointConnectionName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RedisEnterpriseDeletePrivateEndpointConnection": {
+            "$ref": "./examples/RedisEnterpriseDeletePrivateEndpointConnection.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}/privateLinkResources": {
+      "get": {
+        "operationId": "PrivateLinkResources_ListByCluster",
+        "tags": [
+          "Clusters"
+        ],
+        "description": "Gets the private link resources that need to be created for a Redis Enterprise cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "The name of the Redis Enterprise cluster. Name must be 1-60 characters long. Allowed characters(A-Z, a-z, 0-9) and hyphen(-). There can be no leading nor trailing nor consecutive hyphens",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?=.{1,60}$)[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/privatelinks.json#/definitions/PrivateLinkResourceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RedisEnterpriseListPrivateLinkResources": {
+            "$ref": "./examples/RedisEnterpriseListPrivateLinkResources.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "AccessKeyType": {
+      "type": "string",
+      "description": "Which access key to regenerate.",
+      "enum": [
+        "Primary",
+        "Secondary"
+      ],
+      "x-ms-enum": {
+        "name": "AccessKeyType",
+        "modelAsString": false,
+        "values": [
+          {
+            "name": "Primary",
+            "value": "Primary",
+            "description": "Primary"
+          },
+          {
+            "name": "Secondary",
+            "value": "Secondary",
+            "description": "Secondary"
+          }
+        ]
+      }
+    },
+    "AccessKeys": {
+      "type": "object",
+      "description": "The secret access keys used for authenticating connections to redis",
+      "properties": {
+        "primaryKey": {
+          "type": "string",
+          "description": "The current primary key that clients can use to authenticate",
+          "readOnly": true
+        },
+        "secondaryKey": {
+          "type": "string",
+          "description": "The current secondary key that clients can use to authenticate",
+          "readOnly": true
+        }
+      }
+    },
+    "AccessKeysAuthentication": {
+      "type": "string",
+      "description": "This property can be Enabled/Disabled to allow or deny access with the current access keys. Can be updated even after database is created.",
+      "enum": [
+        "Disabled",
+        "Enabled"
+      ],
+      "x-ms-enum": {
+        "name": "AccessKeysAuthentication",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Disabled"
+          },
+          {
+            "name": "Enabled",
+            "value": "Enabled",
+            "description": "Enabled"
+          }
+        ]
+      }
+    },
+    "AccessPolicyAssignment": {
+      "type": "object",
+      "description": "Describes the access policy assignment of Redis Enterprise database",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AccessPolicyAssignmentProperties",
+          "description": "Properties of the access policy assignment.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "AccessPolicyAssignmentList": {
+      "type": "object",
+      "description": "The response of a list-all operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The AccessPolicyAssignment items on this page",
+          "items": {
+            "$ref": "#/definitions/AccessPolicyAssignment"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "AccessPolicyAssignmentProperties": {
+      "type": "object",
+      "description": "Properties of Redis Enterprise database access policy assignment.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "Current provisioning status of the access policy assignment.",
+          "readOnly": true
+        },
+        "accessString": {
+          "type": "string",
+          "description": "The Redis ACL permissions string applied to this assignment, for example `+@read ~cache:*`. Defaults to `+@all ~*` if not specified."
+        },
+        "provisioningError": {
+          "$ref": "#/definitions/AccessPolicyAssignmentProvisioningError",
+          "description": "Provisioning error details when the access string failed to apply (e.g., invalid ACL syntax). Null when provisioning succeeded.",
+          "readOnly": true
+        },
+        "user": {
+          "$ref": "#/definitions/AccessPolicyAssignmentPropertiesUser",
+          "description": "The user associated with the access policy."
+        }
+      },
+      "required": [
+        "user"
+      ]
+    },
+    "AccessPolicyAssignmentPropertiesUser": {
+      "type": "object",
+      "description": "The user associated with the access policy.",
+      "properties": {
+        "objectId": {
+          "type": "string",
+          "description": "The object ID of the user."
+        }
+      }
+    },
+    "AccessPolicyAssignmentProvisioningError": {
+      "type": "object",
+      "description": "Error details for access policy assignment provisioning failures.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "Machine-readable error code (e.g., \"InvalidAccessString\")."
+        },
+        "message": {
+          "type": "string",
+          "description": "Human-readable error message describing the failure."
+        },
+        "target": {
+          "type": "string",
+          "description": "The property that caused the error (e.g., \"properties.accessString\")."
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ]
+    },
+    "AofFrequency": {
+      "type": "string",
+      "description": "Sets the frequency at which data is written to disk. Defaults to '1s', meaning 'every second'. Note that the 'always' setting is deprecated, because of its performance impact.",
+      "enum": [
+        "1s",
+        "always"
+      ],
+      "x-ms-enum": {
+        "name": "AofFrequency",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "OneS",
+            "value": "1s",
+            "description": "1s"
+          },
+          {
+            "name": "Always",
+            "value": "always",
+            "description": "always"
+          }
+        ]
+      }
+    },
+    "AzureCacheForRedisMigrationProperties": {
+      "type": "object",
+      "description": "Properties for Redis Enterprise migration operation for Azure Cache for Redis.",
+      "properties": {
+        "sourceResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The source resource ID to migrate from. This is the resource ID of the Azure Cache for Redis.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Cache/redis"
+              }
+            ]
+          }
+        },
+        "switchDns": {
+          "type": "boolean",
+          "description": "Sets whether the DNS is switched automatically after the data is transferred from the source cache to the target cache. This property must be true during the preview."
+        },
+        "skipDataMigration": {
+          "type": "boolean",
+          "description": "Sets whether the data is migrated from source to target or not. This property must be true during the preview."
+        },
+        "forceMigrate": {
+          "type": "boolean",
+          "description": "Sets whether to ignore warnings when performing validation of the migration request. If this property is true, warning-level disparities between the source and target resources will be ignored, and the request will only fail validation if there are error-level disparities. The default value is false."
+        }
+      },
+      "required": [
+        "sourceResourceId",
+        "switchDns",
+        "skipDataMigration"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/MigrationProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureCacheForRedis"
+    },
+    "Cluster": {
+      "type": "object",
+      "description": "Describes the Redis Enterprise cluster",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ClusterCreateProperties",
+          "description": "Other properties of the cluster.",
+          "x-ms-client-flatten": true
+        },
+        "kind": {
+          "$ref": "#/definitions/Kind",
+          "description": "Distinguishes the kind of cluster. Read-only.",
+          "readOnly": true
+        },
+        "sku": {
+          "$ref": "#/definitions/Sku",
+          "description": "The SKU to create, which affects price, performance, and features."
+        },
+        "zones": {
+          "type": "array",
+          "description": "The availability zones.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "identity": {
+          "$ref": "../../../../../../common-types/resource-management/v4/managedidentity.json#/definitions/ManagedServiceIdentity",
+          "description": "The managed service identities assigned to this resource."
+        }
+      },
+      "required": [
+        "sku"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "ClusterCreateProperties": {
+      "type": "object",
+      "description": "Properties of Redis Enterprise clusters for create operations",
+      "properties": {
+        "publicNetworkAccess": {
+          "$ref": "#/definitions/PublicNetworkAccess",
+          "description": "Whether or not public network traffic can access the Redis cluster. Only 'Enabled' or 'Disabled' can be set. null is returned only for clusters created using an old API version which do not have this property and cannot be set.",
+          "x-nullable": true
+        }
+      },
+      "required": [
+        "publicNetworkAccess"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ClusterProperties"
+        }
+      ]
+    },
+    "ClusterList": {
+      "type": "object",
+      "description": "The response of a list-all operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Cluster items on this page",
+          "items": {
+            "$ref": "#/definitions/Cluster"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ClusterProperties": {
+      "type": "object",
+      "description": "Properties of Redis Enterprise clusters, as opposed to general resource properties like location, tags",
+      "properties": {
+        "highAvailability": {
+          "$ref": "#/definitions/HighAvailability",
+          "description": "Enabled by default. If highAvailability is disabled, the data set is not replicated. This affects the availability SLA, and increases the risk of data loss."
+        },
+        "minimumTlsVersion": {
+          "$ref": "#/definitions/TlsVersion",
+          "description": "The minimum TLS version for the cluster to support, e.g. '1.2'. Newer versions can be added in the future. Note that TLS 1.0 and TLS 1.1 are now completely obsolete -- you cannot use them. They are mentioned only for the sake of consistency with old API versions."
+        },
+        "encryption": {
+          "$ref": "#/definitions/ClusterPropertiesEncryption",
+          "description": "Encryption-at-rest configuration for the cluster."
+        },
+        "maintenanceConfiguration": {
+          "$ref": "#/definitions/MaintenanceConfiguration",
+          "description": "Cluster-level maintenance configuration.",
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        },
+        "hostName": {
+          "type": "string",
+          "description": "DNS name of the cluster endpoint",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "Current provisioning status of the cluster",
+          "readOnly": true
+        },
+        "redundancyMode": {
+          "$ref": "#/definitions/RedundancyMode",
+          "description": "Explains the current redundancy strategy of the cluster, which affects the expected SLA.",
+          "readOnly": true
+        },
+        "resourceState": {
+          "$ref": "#/definitions/ResourceState",
+          "description": "Current resource status of the cluster",
+          "readOnly": true
+        },
+        "redisVersion": {
+          "type": "string",
+          "description": "Version of redis the cluster supports, e.g. '6'",
+          "readOnly": true
+        },
+        "privateEndpointConnections": {
+          "type": "array",
+          "description": "List of private endpoint connections associated with the specified Redis Enterprise cluster",
+          "items": {
+            "$ref": "../../../../../../common-types/resource-management/v6/privatelinks.json#/definitions/PrivateEndpointConnection"
+          },
+          "readOnly": true
+        },
+        "migratedEndpoint": {
+          "type": "string",
+          "description": "The endpoint of the source resource that is currently pointing to this resource as a result of an ACR/ACRE to AMR migration.",
+          "readOnly": true
+        }
+      }
+    },
+    "ClusterPropertiesEncryption": {
+      "type": "object",
+      "description": "Encryption-at-rest configuration for the cluster.",
+      "properties": {
+        "customerManagedKeyEncryption": {
+          "$ref": "#/definitions/ClusterPropertiesEncryptionCustomerManagedKeyEncryption",
+          "description": "All Customer-managed key encryption properties for the resource. Set this to an empty object to use Microsoft-managed key encryption."
+        }
+      }
+    },
+    "ClusterPropertiesEncryptionCustomerManagedKeyEncryption": {
+      "type": "object",
+      "description": "All Customer-managed key encryption properties for the resource. Set this to an empty object to use Microsoft-managed key encryption.",
+      "properties": {
+        "keyEncryptionKeyIdentity": {
+          "$ref": "#/definitions/ClusterPropertiesEncryptionCustomerManagedKeyEncryptionKeyIdentity",
+          "description": "All identity configuration for Customer-managed key settings defining which identity should be used to auth to Key Vault."
+        },
+        "keyEncryptionKeyUrl": {
+          "type": "string",
+          "description": "Key encryption key Url, versioned only. Ex: https://contosovault.vault.azure.net/keys/contosokek/562a4bb76b524a1493a6afe8e536ee78"
+        }
+      }
+    },
+    "ClusterPropertiesEncryptionCustomerManagedKeyEncryptionKeyIdentity": {
+      "type": "object",
+      "description": "All identity configuration for Customer-managed key settings defining which identity should be used to auth to Key Vault.",
+      "properties": {
+        "userAssignedIdentityResourceId": {
+          "type": "string",
+          "description": "User assigned identity to use for accessing key encryption key Url. Ex: /subscriptions/<sub uuid>/resourceGroups/<resource group>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myId."
+        },
+        "identityType": {
+          "$ref": "#/definitions/CmkIdentityType",
+          "description": "Only userAssignedIdentity is supported in this API version; other types may be supported in the future"
+        }
+      }
+    },
+    "ClusterUpdate": {
+      "type": "object",
+      "description": "A partial update to the Redis Enterprise cluster",
+      "properties": {
+        "sku": {
+          "$ref": "#/definitions/Sku",
+          "description": "The SKU to create, which affects price, performance, and features."
+        },
+        "properties": {
+          "$ref": "#/definitions/ClusterUpdateProperties",
+          "description": "Other properties of the cluster.",
+          "x-ms-client-flatten": true
+        },
+        "identity": {
+          "$ref": "../../../../../../common-types/resource-management/v4/managedidentity.json#/definitions/ManagedServiceIdentity",
+          "description": "The managed service identities assigned to this resource."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        }
+      }
+    },
+    "ClusterUpdateProperties": {
+      "type": "object",
+      "description": "Properties of Redis Enterprise clusters for update operations",
+      "properties": {
+        "publicNetworkAccess": {
+          "$ref": "#/definitions/PublicNetworkAccess",
+          "description": "Whether or not public network traffic can access the Redis cluster. Only 'Enabled' or 'Disabled' can be set. null is returned only for clusters created using an old API version which do not have this property and cannot be set.",
+          "x-nullable": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ClusterProperties"
+        }
+      ]
+    },
+    "ClusteringPolicy": {
+      "type": "string",
+      "description": "Clustering policy - default is OSSCluster. This property can be updated only if the current value is NoCluster. If the value is OSSCluster or EnterpriseCluster, it cannot be updated without deleting the database.",
+      "enum": [
+        "EnterpriseCluster",
+        "OSSCluster",
+        "NoCluster"
+      ],
+      "x-ms-enum": {
+        "name": "ClusteringPolicy",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "EnterpriseCluster",
+            "value": "EnterpriseCluster",
+            "description": "Enterprise clustering policy uses only the classic redis protocol, which does not support redis cluster commands."
+          },
+          {
+            "name": "OSSCluster",
+            "value": "OSSCluster",
+            "description": "OSS clustering policy follows the redis cluster specification, and requires all clients to support redis clustering."
+          },
+          {
+            "name": "NoCluster",
+            "value": "NoCluster",
+            "description": "The NoCluster policy is used for non-clustered Redis instances that do not require clustering features."
+          }
+        ]
+      }
+    },
+    "CmkIdentityType": {
+      "type": "string",
+      "description": "Only userAssignedIdentity is supported in this API version; other types may be supported in the future",
+      "enum": [
+        "systemAssignedIdentity",
+        "userAssignedIdentity"
+      ],
+      "x-ms-enum": {
+        "name": "CmkIdentityType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "SystemAssignedIdentity",
+            "value": "systemAssignedIdentity",
+            "description": "systemAssignedIdentity"
+          },
+          {
+            "name": "UserAssignedIdentity",
+            "value": "userAssignedIdentity",
+            "description": "userAssignedIdentity"
+          }
+        ]
+      }
+    },
+    "Database": {
+      "type": "object",
+      "description": "Describes a database on the Redis Enterprise cluster",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/DatabaseCreateProperties",
+          "description": "Other properties of the database.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "DatabaseCreateProperties": {
+      "type": "object",
+      "description": "Properties for creating Redis Enterprise databases",
+      "properties": {
+        "accessKeysAuthentication": {
+          "type": "string",
+          "description": "This property can be Enabled/Disabled to allow or deny access with the current access keys. Can be updated even after database is created. Default is Disabled.",
+          "default": "Disabled",
+          "enum": [
+            "Disabled",
+            "Enabled"
+          ],
+          "x-ms-enum": {
+            "name": "AccessKeysAuthentication",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Disabled",
+                "value": "Disabled",
+                "description": "Disabled"
+              },
+              {
+                "name": "Enabled",
+                "value": "Enabled",
+                "description": "Enabled"
+              }
+            ]
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/DatabaseProperties"
+        }
+      ]
+    },
+    "DatabaseList": {
+      "type": "object",
+      "description": "The response of a list-all operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Database items on this page",
+          "items": {
+            "$ref": "#/definitions/Database"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "DatabaseProperties": {
+      "type": "object",
+      "description": "Properties of Redis Enterprise databases, as opposed to general resource properties like location, tags",
+      "properties": {
+        "clientProtocol": {
+          "$ref": "#/definitions/Protocol",
+          "description": "Specifies whether redis clients can connect using TLS-encrypted or plaintext redis protocols. Default is TLS-encrypted."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32",
+          "description": "TCP port of the database endpoint. Specified at create time. Defaults to an available port.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "Current provisioning status of the database",
+          "readOnly": true
+        },
+        "resourceState": {
+          "$ref": "#/definitions/ResourceState",
+          "description": "Current resource status of the database",
+          "readOnly": true
+        },
+        "clusteringPolicy": {
+          "$ref": "#/definitions/ClusteringPolicy",
+          "description": "Clustering policy - default is OSSCluster. This property can be updated only if the current value is NoCluster. If the value is OSSCluster or EnterpriseCluster, it cannot be updated without deleting the database.",
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        },
+        "evictionPolicy": {
+          "$ref": "#/definitions/EvictionPolicy",
+          "description": "Redis eviction policy - default is VolatileLRU"
+        },
+        "persistence": {
+          "$ref": "#/definitions/Persistence",
+          "description": "Persistence settings"
+        },
+        "modules": {
+          "type": "array",
+          "description": "Optional set of redis modules to enable in this database - modules can only be added at creation time.",
+          "items": {
+            "$ref": "#/definitions/Module"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ],
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "geoReplication": {
+          "$ref": "#/definitions/DatabasePropertiesGeoReplication",
+          "description": "Optional set of properties to configure geo replication for this database.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "redisVersion": {
+          "type": "string",
+          "description": "Version of Redis the database is running on, e.g. '6.0'",
+          "readOnly": true
+        },
+        "deferUpgrade": {
+          "$ref": "#/definitions/DeferUpgradeSetting",
+          "description": "Option to defer upgrade when newest version is released - default is NotDeferred. Learn more: https://aka.ms/redisversionupgrade"
+        },
+        "accessKeysAuthentication": {
+          "$ref": "#/definitions/AccessKeysAuthentication",
+          "description": "This property can be Enabled/Disabled to allow or deny access with the current access keys. Can be updated even after database is created."
+        },
+        "notifyKeyspaceEvents": {
+          "type": "string",
+          "description": "Specifies which keyspace events should trigger notifications. Default is an empty string, meaning this feature is disabled. When enabled, at least 'K' (keyspace events) or 'E' (keyevent events) must be present. For example, 'AKE' enables all standard events. See https://redis.io/docs/latest/develop/use/keyspace-notifications/ for the complete list of event types."
+        }
+      }
+    },
+    "DatabasePropertiesGeoReplication": {
+      "type": "object",
+      "description": "Optional set of properties to configure geo replication for this database.",
+      "properties": {
+        "groupNickname": {
+          "type": "string",
+          "description": "Name for the group of linked database resources",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "linkedDatabases": {
+          "type": "array",
+          "description": "List of database resources to link with this database",
+          "items": {
+            "$ref": "#/definitions/LinkedDatabase"
+          }
+        }
+      }
+    },
+    "DatabaseUpdate": {
+      "type": "object",
+      "description": "A partial update to the Redis Enterprise database",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/DatabaseUpdateProperties",
+          "description": "Properties of the database.",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "DatabaseUpdateProperties": {
+      "type": "object",
+      "description": "Properties for updating Redis Enterprise databases",
+      "properties": {
+        "accessKeysAuthentication": {
+          "$ref": "#/definitions/AccessKeysAuthentication",
+          "description": "This property can be Enabled/Disabled to allow or deny access with the current access keys. Can be updated even after database is created. Default is Disabled."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/DatabaseProperties"
+        }
+      ]
+    },
+    "DeferUpgradeSetting": {
+      "type": "string",
+      "description": "Option to defer upgrade when newest version is released - default is NotDeferred. Learn more: https://aka.ms/redisversionupgrade",
+      "enum": [
+        "Deferred",
+        "NotDeferred"
+      ],
+      "x-ms-enum": {
+        "name": "DeferUpgradeSetting",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Deferred",
+            "value": "Deferred",
+            "description": "Deferred"
+          },
+          {
+            "name": "NotDeferred",
+            "value": "NotDeferred",
+            "description": "NotDeferred"
+          }
+        ]
+      }
+    },
+    "EvictionPolicy": {
+      "type": "string",
+      "description": "Redis eviction policy - default is VolatileLRU",
+      "enum": [
+        "AllKeysLFU",
+        "AllKeysLRU",
+        "AllKeysRandom",
+        "VolatileLRU",
+        "VolatileLFU",
+        "VolatileTTL",
+        "VolatileRandom",
+        "NoEviction"
+      ],
+      "x-ms-enum": {
+        "name": "EvictionPolicy",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "AllKeysLFU",
+            "value": "AllKeysLFU",
+            "description": "AllKeysLFU"
+          },
+          {
+            "name": "AllKeysLRU",
+            "value": "AllKeysLRU",
+            "description": "AllKeysLRU"
+          },
+          {
+            "name": "AllKeysRandom",
+            "value": "AllKeysRandom",
+            "description": "AllKeysRandom"
+          },
+          {
+            "name": "VolatileLRU",
+            "value": "VolatileLRU",
+            "description": "VolatileLRU"
+          },
+          {
+            "name": "VolatileLFU",
+            "value": "VolatileLFU",
+            "description": "VolatileLFU"
+          },
+          {
+            "name": "VolatileTTL",
+            "value": "VolatileTTL",
+            "description": "VolatileTTL"
+          },
+          {
+            "name": "VolatileRandom",
+            "value": "VolatileRandom",
+            "description": "VolatileRandom"
+          },
+          {
+            "name": "NoEviction",
+            "value": "NoEviction",
+            "description": "NoEviction"
+          }
+        ]
+      }
+    },
+    "ExportClusterParameters": {
+      "type": "object",
+      "description": "Parameters for a Redis Enterprise export operation.",
+      "properties": {
+        "sasUri": {
+          "type": "string",
+          "format": "password",
+          "description": "SAS URI for the target directory to export to",
+          "x-ms-secret": true
+        }
+      },
+      "required": [
+        "sasUri"
+      ]
+    },
+    "FlushParameters": {
+      "type": "object",
+      "description": "Parameters for a Redis Enterprise active geo-replication flush operation",
+      "properties": {
+        "ids": {
+          "type": "array",
+          "description": "The identifiers of all the other database resources in the georeplication group to be flushed.",
+          "items": {
+            "type": "string",
+            "format": "arm-id",
+            "description": "A type definition that refers the id to an Azure Resource Manager resource.",
+            "x-ms-arm-id-details": {
+              "allowedResources": [
+                {
+                  "type": "Microsoft.Cache/redisEnterprise/databases"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "ForceLinkParameters": {
+      "type": "object",
+      "description": "Parameters for reconfiguring active geo-replication, of an existing database that was previously unlinked from a replication group.",
+      "properties": {
+        "geoReplication": {
+          "$ref": "#/definitions/ForceLinkParametersGeoReplication",
+          "description": "Properties to configure geo replication for this database.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        }
+      },
+      "required": [
+        "geoReplication"
+      ]
+    },
+    "ForceLinkParametersGeoReplication": {
+      "type": "object",
+      "description": "Properties to configure geo replication for this database.",
+      "properties": {
+        "groupNickname": {
+          "type": "string",
+          "description": "The name of the group of linked database resources. This should match the existing replication group name.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "linkedDatabases": {
+          "type": "array",
+          "description": "The resource IDs of the databases that are expected to be linked and included in the replication group. This parameter is used to validate that the linking is to the expected (unlinked) part of the replication group, if it is splintered.",
+          "items": {
+            "$ref": "#/definitions/LinkedDatabase"
+          }
+        }
+      }
+    },
+    "ForceUnlinkParameters": {
+      "type": "object",
+      "description": "Parameters for a Redis Enterprise Active Geo Replication Force Unlink operation.",
+      "properties": {
+        "ids": {
+          "type": "array",
+          "description": "The resource IDs of the database resources to be unlinked.",
+          "items": {
+            "type": "string",
+            "format": "arm-id",
+            "description": "A type definition that refers the id to an Azure Resource Manager resource.",
+            "x-ms-arm-id-details": {
+              "allowedResources": [
+                {
+                  "type": "Microsoft.Cache/redisEnterprise/databases"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "required": [
+        "ids"
+      ]
+    },
+    "HighAvailability": {
+      "type": "string",
+      "description": "Enabled by default. If highAvailability is disabled, the data set is not replicated. This affects the availability SLA, and increases the risk of data loss.",
+      "enum": [
+        "Enabled",
+        "Disabled"
+      ],
+      "x-ms-enum": {
+        "name": "HighAvailability",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Enabled",
+            "value": "Enabled",
+            "description": "Enabled"
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Disabled"
+          }
+        ]
+      }
+    },
+    "ImportClusterParameters": {
+      "type": "object",
+      "description": "Parameters for a Redis Enterprise import operation.",
+      "properties": {
+        "sasUris": {
+          "type": "array",
+          "description": "SAS URIs for the target blobs to import from",
+          "items": {
+            "$ref": "#/definitions/SecretUri"
+          }
+        }
+      },
+      "required": [
+        "sasUris"
+      ]
+    },
+    "Kind": {
+      "type": "string",
+      "description": "Distinguishes the kind of cluster. Read-only.",
+      "enum": [
+        "v1",
+        "v2"
+      ],
+      "x-ms-enum": {
+        "name": "Kind",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "V1",
+            "value": "v1",
+            "description": "v1"
+          },
+          {
+            "name": "V2",
+            "value": "v2",
+            "description": "v2"
+          }
+        ]
+      }
+    },
+    "LinkState": {
+      "type": "string",
+      "description": "State of the link between the database resources.",
+      "enum": [
+        "Linked",
+        "Linking",
+        "Unlinking",
+        "LinkFailed",
+        "UnlinkFailed"
+      ],
+      "x-ms-enum": {
+        "name": "LinkState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Linked",
+            "value": "Linked",
+            "description": "Linked"
+          },
+          {
+            "name": "Linking",
+            "value": "Linking",
+            "description": "Linking"
+          },
+          {
+            "name": "Unlinking",
+            "value": "Unlinking",
+            "description": "Unlinking"
+          },
+          {
+            "name": "LinkFailed",
+            "value": "LinkFailed",
+            "description": "LinkFailed"
+          },
+          {
+            "name": "UnlinkFailed",
+            "value": "UnlinkFailed",
+            "description": "UnlinkFailed"
+          }
+        ]
+      }
+    },
+    "LinkedDatabase": {
+      "type": "object",
+      "description": "Specifies details of a linked database resource.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Resource ID of a database resource to link with this database.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ],
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Cache/redisEnterprise/databases"
+              }
+            ]
+          }
+        },
+        "state": {
+          "$ref": "#/definitions/LinkState",
+          "description": "State of the link between the database resources.",
+          "readOnly": true
+        }
+      }
+    },
+    "MaintenanceConfiguration": {
+      "type": "object",
+      "description": "Cluster-level maintenance configuration.",
+      "properties": {
+        "maintenanceWindows": {
+          "type": "array",
+          "description": "Custom maintenance windows that apply to the cluster.",
+          "items": {
+            "$ref": "#/definitions/MaintenanceWindow"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "MaintenanceDayOfWeek": {
+      "type": "string",
+      "description": "Day of week. Required when the maintenance window type is 'Weekly'.",
+      "enum": [
+        "Sunday",
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday"
+      ],
+      "x-ms-enum": {
+        "name": "MaintenanceDayOfWeek",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Sunday",
+            "value": "Sunday"
+          },
+          {
+            "name": "Monday",
+            "value": "Monday"
+          },
+          {
+            "name": "Tuesday",
+            "value": "Tuesday"
+          },
+          {
+            "name": "Wednesday",
+            "value": "Wednesday"
+          },
+          {
+            "name": "Thursday",
+            "value": "Thursday"
+          },
+          {
+            "name": "Friday",
+            "value": "Friday"
+          },
+          {
+            "name": "Saturday",
+            "value": "Saturday"
+          }
+        ]
+      }
+    },
+    "MaintenanceWindow": {
+      "type": "object",
+      "description": "A single custom maintenance window.",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/MaintenanceWindowType",
+          "description": "Maintenance window type."
+        },
+        "duration": {
+          "type": "string",
+          "description": "Duration in ISO-8601 format, for example 'PT5H'."
+        },
+        "startHourUtc": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Start hour (0-23) in UTC when the maintenance window begins.",
+          "minimum": 0,
+          "maximum": 23
+        },
+        "schedule": {
+          "$ref": "#/definitions/MaintenanceWindowSchedule",
+          "description": "Recurring schedule for the maintenance window."
+        }
+      },
+      "required": [
+        "type",
+        "duration",
+        "startHourUtc",
+        "schedule"
+      ]
+    },
+    "MaintenanceWindowSchedule": {
+      "type": "object",
+      "description": "Schedule details for a maintenance window.",
+      "properties": {
+        "dayOfWeek": {
+          "$ref": "#/definitions/MaintenanceDayOfWeek",
+          "description": "Day of week. Required when the maintenance window type is 'Weekly'."
+        }
+      }
+    },
+    "MaintenanceWindowType": {
+      "type": "string",
+      "description": "Maintenance window type.",
+      "enum": [
+        "Weekly"
+      ],
+      "x-ms-enum": {
+        "name": "MaintenanceWindowType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Weekly",
+            "value": "Weekly",
+            "description": "Weekly maintenance window."
+          }
+        ]
+      }
+    },
+    "Migration": {
+      "type": "object",
+      "description": "Describes the current migration operation on a Redis Enterprise cluster.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/MigrationProperties",
+          "description": "Properties of the migration operation."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "MigrationList": {
+      "type": "object",
+      "description": "The response of a list-all migrations.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Migration items on this page",
+          "items": {
+            "$ref": "#/definitions/Migration"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "MigrationProperties": {
+      "type": "object",
+      "description": "Properties for Redis Enterprise migration operation.",
+      "properties": {
+        "sourceType": {
+          "$ref": "#/definitions/SourceType",
+          "description": "Describes the source of the migration operation."
+        },
+        "targetResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The Azure resource ID of the Azure Managed Redis destination cache to migrate.",
+          "readOnly": true,
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Cache/redisEnterprise"
+              }
+            ]
+          }
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/MigrationProvisioningState",
+          "description": "Current provisioning status of the migration",
+          "readOnly": true
+        },
+        "statusDetails": {
+          "type": "string",
+          "description": "Additional details about the migration operation's status in free text format.",
+          "readOnly": true
+        },
+        "creationTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The timestamp when the migration operation was created.",
+          "readOnly": true
+        },
+        "lastModifiedTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The timestamp when the migration operation was last updated.",
+          "readOnly": true
+        }
+      },
+      "discriminator": "sourceType",
+      "required": [
+        "sourceType"
+      ]
+    },
+    "MigrationProvisioningState": {
+      "type": "string",
+      "description": "Current provisioning status",
+      "enum": [
+        "Accepted",
+        "InProgress",
+        "ReadyForDnsSwitch",
+        "Succeeded",
+        "Failed",
+        "Cancelling",
+        "Cancelled",
+        "CancellationFailed"
+      ],
+      "x-ms-enum": {
+        "name": "MigrationProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Accepted",
+            "value": "Accepted",
+            "description": "The request has been accepted and the migration operation is being initialized."
+          },
+          {
+            "name": "InProgress",
+            "value": "InProgress",
+            "description": "The migration operation is in progress."
+          },
+          {
+            "name": "ReadyForDnsSwitch",
+            "value": "ReadyForDnsSwitch",
+            "description": "The migration operation has completed transferring data and is ready for DNS switch."
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "The migration operation has completed successfully."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "The migration operation has failed."
+          },
+          {
+            "name": "Cancelling",
+            "value": "Cancelling",
+            "description": "The migration operation is being cancelled."
+          },
+          {
+            "name": "Cancelled",
+            "value": "Cancelled",
+            "description": "The migration operation has been cancelled."
+          },
+          {
+            "name": "CancellationFailed",
+            "value": "CancellationFailed",
+            "description": "The migration operation cancellation has failed."
+          }
+        ]
+      }
+    },
+    "MigrationValidationDisparity": {
+      "type": "object",
+      "description": "Represents a specific validation issue found during migration validation.",
+      "properties": {
+        "category": {
+          "type": "string",
+          "description": "A localized string denoting the category of the validation issue. Examples are \"Region\", \"Data\", \"Identity\", \"Clustering Mode\", and \"TLS\"."
+        },
+        "message": {
+          "type": "string",
+          "description": "Detailed message describing the validation issue."
+        }
+      },
+      "required": [
+        "category",
+        "message"
+      ]
+    },
+    "MigrationValidationError": {
+      "type": "object",
+      "description": "Represents a validation error that prevents migration.",
+      "properties": {
+        "disparities": {
+          "type": "array",
+          "description": "List of specific disparities that cause this error.",
+          "items": {
+            "$ref": "#/definitions/MigrationValidationDisparity"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "required": [
+        "disparities"
+      ]
+    },
+    "MigrationValidationRequest": {
+      "type": "object",
+      "description": "Properties for validating migration from Azure Cache for Redis to Redis Enterprise.",
+      "properties": {
+        "sourceResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The source resource ID to validate migration from. This is the resource ID of the Azure Cache for Redis.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Cache/redis"
+              }
+            ]
+          }
+        },
+        "skipDataMigration": {
+          "type": "boolean",
+          "description": "Sets whether the data is migrated from source to target or not. The default value is true."
+        },
+        "forceMigrate": {
+          "type": "boolean",
+          "description": "Sets whether to ignore warnings when validating if the source cache can be migrated to the target cache. If this property is true, the isValid property in the response will ignore warning-level disparities between the source and target resource. The default value is false."
+        }
+      },
+      "required": [
+        "sourceResourceId"
+      ]
+    },
+    "MigrationValidationResponse": {
+      "type": "object",
+      "description": "Response for migration validation operation.",
+      "properties": {
+        "isValid": {
+          "type": "boolean",
+          "description": "Indicates whether the migration validation passed."
+        },
+        "errors": {
+          "type": "array",
+          "description": "List of validation errors that prevent migration.",
+          "items": {
+            "$ref": "#/definitions/MigrationValidationError"
+          },
+          "x-ms-identifiers": []
+        },
+        "warnings": {
+          "type": "array",
+          "description": "List of validation warnings that may impact migration.",
+          "items": {
+            "$ref": "#/definitions/MigrationValidationWarning"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "required": [
+        "isValid"
+      ]
+    },
+    "MigrationValidationWarning": {
+      "type": "object",
+      "description": "Represents a validation warning that may impact migration.",
+      "properties": {
+        "disparities": {
+          "type": "array",
+          "description": "List of specific disparities that cause this warning.",
+          "items": {
+            "$ref": "#/definitions/MigrationValidationDisparity"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "required": [
+        "disparities"
+      ]
+    },
+    "Module": {
+      "type": "object",
+      "description": "Specifies configuration of a redis module",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the module, e.g. 'RedisBloom', 'RediSearch', 'RedisTimeSeries'",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "args": {
+          "type": "string",
+          "description": "Configuration options for the module, e.g. 'ERROR_RATE 0.01 INITIAL_SIZE 400'.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "description": "The version of the module, e.g. '1.0'.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "OperationStatus": {
+      "type": "object",
+      "description": "The status of a long-running operation.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The operation's unique id."
+        },
+        "name": {
+          "type": "string",
+          "description": "The operation's name."
+        },
+        "startTime": {
+          "type": "string",
+          "description": "The start time of the operation."
+        },
+        "endTime": {
+          "type": "string",
+          "description": "The end time of the operation."
+        },
+        "status": {
+          "type": "string",
+          "description": "The current status of the operation."
+        },
+        "error": {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse",
+          "description": "Error response describing why the operation failed."
+        }
+      }
+    },
+    "Persistence": {
+      "type": "object",
+      "description": "Persistence-related configuration for the Redis Enterprise database",
+      "properties": {
+        "aofEnabled": {
+          "type": "boolean",
+          "description": "Sets whether AOF is enabled. Note that at most one of AOF or RDB persistence may be enabled."
+        },
+        "rdbEnabled": {
+          "type": "boolean",
+          "description": "Sets whether RDB is enabled. Note that at most one of AOF or RDB persistence may be enabled."
+        },
+        "aofFrequency": {
+          "$ref": "#/definitions/AofFrequency",
+          "description": "Sets the frequency at which data is written to disk. Defaults to '1s', meaning 'every second'. Note that the 'always' setting is deprecated, because of its performance impact."
+        },
+        "rdbFrequency": {
+          "$ref": "#/definitions/RdbFrequency",
+          "description": "Sets the frequency at which a snapshot of the database is created."
+        }
+      }
+    },
+    "PrivateEndpointConnectionListResult": {
+      "type": "object",
+      "description": "The response of a PrivateEndpointConnection list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PrivateEndpointConnection items on this page",
+          "items": {
+            "$ref": "../../../../../../common-types/resource-management/v6/privatelinks.json#/definitions/PrivateEndpointConnection"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "Protocol": {
+      "type": "string",
+      "description": "Specifies whether redis clients can connect using TLS-encrypted or plaintext redis protocols. Default is TLS-encrypted.",
+      "enum": [
+        "Encrypted",
+        "Plaintext"
+      ],
+      "x-ms-enum": {
+        "name": "Protocol",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Encrypted",
+            "value": "Encrypted",
+            "description": "Encrypted"
+          },
+          {
+            "name": "Plaintext",
+            "value": "Plaintext",
+            "description": "Plaintext"
+          }
+        ]
+      }
+    },
+    "ProvisioningState": {
+      "type": "string",
+      "description": "Current provisioning status",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Creating",
+        "Updating",
+        "Deleting"
+      ],
+      "x-ms-enum": {
+        "name": "ProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "Creating"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          }
+        ]
+      }
+    },
+    "PublicNetworkAccess": {
+      "type": "string",
+      "description": "Whether or not public network traffic can access the Redis cluster. Only 'Enabled' or 'Disabled' can be set. null is returned only for clusters created using an old API version which do not have this property and cannot be set.",
+      "enum": [
+        "Enabled",
+        "Disabled"
+      ],
+      "x-ms-enum": {
+        "name": "PublicNetworkAccess",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Enabled",
+            "value": "Enabled",
+            "description": "Enabled"
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Disabled"
+          }
+        ]
+      }
+    },
+    "RdbFrequency": {
+      "type": "string",
+      "description": "Sets the frequency at which a snapshot of the database is created.",
+      "enum": [
+        "1h",
+        "6h",
+        "12h"
+      ],
+      "x-ms-enum": {
+        "name": "RdbFrequency",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "OneH",
+            "value": "1h",
+            "description": "1h"
+          },
+          {
+            "name": "SixH",
+            "value": "6h",
+            "description": "6h"
+          },
+          {
+            "name": "TwelveH",
+            "value": "12h",
+            "description": "12h"
+          }
+        ]
+      }
+    },
+    "RedundancyMode": {
+      "type": "string",
+      "description": "Explains the current redundancy strategy of the cluster, which affects the expected SLA.",
+      "enum": [
+        "None",
+        "LR",
+        "ZR"
+      ],
+      "x-ms-enum": {
+        "name": "RedundancyMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None",
+            "description": "No redundancy. Availability loss will occur."
+          },
+          {
+            "name": "LR",
+            "value": "LR",
+            "description": "Local redundancy with high availability."
+          },
+          {
+            "name": "ZR",
+            "value": "ZR",
+            "description": "Zone redundant. Higher availability."
+          }
+        ]
+      }
+    },
+    "RegenerateKeyParameters": {
+      "type": "object",
+      "description": "Specifies which access keys to reset to a new random value.",
+      "properties": {
+        "keyType": {
+          "$ref": "#/definitions/AccessKeyType",
+          "description": "Which access key to regenerate."
+        }
+      },
+      "required": [
+        "keyType"
+      ]
+    },
+    "ResourceState": {
+      "type": "string",
+      "description": "Current resource status",
+      "enum": [
+        "Running",
+        "Creating",
+        "CreateFailed",
+        "Updating",
+        "UpdateFailed",
+        "Deleting",
+        "DeleteFailed",
+        "Enabling",
+        "EnableFailed",
+        "Disabling",
+        "DisableFailed",
+        "Disabled",
+        "Scaling",
+        "ScalingFailed",
+        "Moving"
+      ],
+      "x-ms-enum": {
+        "name": "ResourceState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Running",
+            "value": "Running",
+            "description": "Running"
+          },
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "Creating"
+          },
+          {
+            "name": "CreateFailed",
+            "value": "CreateFailed",
+            "description": "CreateFailed"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Updating"
+          },
+          {
+            "name": "UpdateFailed",
+            "value": "UpdateFailed",
+            "description": "UpdateFailed"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          },
+          {
+            "name": "DeleteFailed",
+            "value": "DeleteFailed",
+            "description": "DeleteFailed"
+          },
+          {
+            "name": "Enabling",
+            "value": "Enabling",
+            "description": "Enabling"
+          },
+          {
+            "name": "EnableFailed",
+            "value": "EnableFailed",
+            "description": "EnableFailed"
+          },
+          {
+            "name": "Disabling",
+            "value": "Disabling",
+            "description": "Disabling"
+          },
+          {
+            "name": "DisableFailed",
+            "value": "DisableFailed",
+            "description": "DisableFailed"
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Disabled"
+          },
+          {
+            "name": "Scaling",
+            "value": "Scaling",
+            "description": "Scaling"
+          },
+          {
+            "name": "ScalingFailed",
+            "value": "ScalingFailed",
+            "description": "ScalingFailed"
+          },
+          {
+            "name": "Moving",
+            "value": "Moving",
+            "description": "Moving"
+          }
+        ]
+      }
+    },
+    "SecretUri": {
+      "type": "string",
+      "format": "password",
+      "x-ms-secret": true
+    },
+    "Sku": {
+      "type": "object",
+      "description": "SKU parameters supplied to the create Redis Enterprise cluster operation.",
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/SkuName",
+          "description": "The level of Redis Enterprise cluster to deploy. Possible values: ('Balanced_B5', 'MemoryOptimized_M10', 'ComputeOptimized_X5', etc.). For more information on SKUs see the latest pricing documentation. Note that additional SKUs may become supported in the future."
+        },
+        "capacity": {
+          "type": "integer",
+          "format": "int32",
+          "description": "This property is only used with Enterprise and EnterpriseFlash SKUs. Determines the size of the cluster. Valid values are (2, 4, 6, ...) for Enterprise SKUs and (3, 9, 15, ...) for EnterpriseFlash SKUs."
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "SkuDetails": {
+      "type": "object",
+      "description": "Details of a Redis Enterprise cluster SKU.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the SKU.",
+          "readOnly": true
+        },
+        "sizeInGB": {
+          "type": "number",
+          "format": "float",
+          "description": "The cache size in GB.",
+          "readOnly": true
+        }
+      }
+    },
+    "SkuDetailsList": {
+      "type": "object",
+      "description": "The response of a listSkusForScaling operation.",
+      "properties": {
+        "skus": {
+          "type": "array",
+          "description": "List of SKUS available to scale up or scale down.",
+          "items": {
+            "$ref": "#/definitions/SkuDetails"
+          }
+        }
+      }
+    },
+    "SkuName": {
+      "type": "string",
+      "description": "The level of Redis Enterprise cluster to deploy. Possible values: ('Balanced_B5', 'MemoryOptimized_M10', 'ComputeOptimized_X5', etc.). For more information on SKUs see the latest pricing documentation. Note that additional SKUs may become supported in the future.",
+      "enum": [
+        "Enterprise_E1",
+        "Enterprise_E5",
+        "Enterprise_E10",
+        "Enterprise_E20",
+        "Enterprise_E50",
+        "Enterprise_E100",
+        "Enterprise_E200",
+        "Enterprise_E400",
+        "EnterpriseFlash_F300",
+        "EnterpriseFlash_F700",
+        "EnterpriseFlash_F1500",
+        "Balanced_B0",
+        "Balanced_B1",
+        "Balanced_B3",
+        "Balanced_B5",
+        "Balanced_B10",
+        "Balanced_B20",
+        "Balanced_B50",
+        "Balanced_B100",
+        "Balanced_B150",
+        "Balanced_B250",
+        "Balanced_B350",
+        "Balanced_B500",
+        "Balanced_B700",
+        "Balanced_B1000",
+        "MemoryOptimized_M10",
+        "MemoryOptimized_M20",
+        "MemoryOptimized_M50",
+        "MemoryOptimized_M100",
+        "MemoryOptimized_M150",
+        "MemoryOptimized_M250",
+        "MemoryOptimized_M350",
+        "MemoryOptimized_M500",
+        "MemoryOptimized_M700",
+        "MemoryOptimized_M1000",
+        "MemoryOptimized_M1500",
+        "MemoryOptimized_M2000",
+        "ComputeOptimized_X3",
+        "ComputeOptimized_X5",
+        "ComputeOptimized_X10",
+        "ComputeOptimized_X20",
+        "ComputeOptimized_X50",
+        "ComputeOptimized_X100",
+        "ComputeOptimized_X150",
+        "ComputeOptimized_X250",
+        "ComputeOptimized_X350",
+        "ComputeOptimized_X500",
+        "ComputeOptimized_X700",
+        "FlashOptimized_A250",
+        "FlashOptimized_A500",
+        "FlashOptimized_A700",
+        "FlashOptimized_A1000",
+        "FlashOptimized_A1500",
+        "FlashOptimized_A2000",
+        "FlashOptimized_A4500"
+      ],
+      "x-ms-enum": {
+        "name": "SkuName",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "EnterpriseE1",
+            "value": "Enterprise_E1",
+            "description": "Enterprise_E1"
+          },
+          {
+            "name": "EnterpriseE5",
+            "value": "Enterprise_E5",
+            "description": "Enterprise_E5"
+          },
+          {
+            "name": "EnterpriseE10",
+            "value": "Enterprise_E10",
+            "description": "Enterprise_E10"
+          },
+          {
+            "name": "EnterpriseE20",
+            "value": "Enterprise_E20",
+            "description": "Enterprise_E20"
+          },
+          {
+            "name": "EnterpriseE50",
+            "value": "Enterprise_E50",
+            "description": "Enterprise_E50"
+          },
+          {
+            "name": "EnterpriseE100",
+            "value": "Enterprise_E100",
+            "description": "Enterprise_E100"
+          },
+          {
+            "name": "EnterpriseE200",
+            "value": "Enterprise_E200",
+            "description": "Enterprise_E200"
+          },
+          {
+            "name": "EnterpriseE400",
+            "value": "Enterprise_E400",
+            "description": "Enterprise_E400"
+          },
+          {
+            "name": "EnterpriseFlashF300",
+            "value": "EnterpriseFlash_F300",
+            "description": "EnterpriseFlash_F300"
+          },
+          {
+            "name": "EnterpriseFlashF700",
+            "value": "EnterpriseFlash_F700",
+            "description": "EnterpriseFlash_F700"
+          },
+          {
+            "name": "EnterpriseFlashF1500",
+            "value": "EnterpriseFlash_F1500",
+            "description": "EnterpriseFlash_F1500"
+          },
+          {
+            "name": "BalancedB0",
+            "value": "Balanced_B0",
+            "description": "Balanced_B0"
+          },
+          {
+            "name": "BalancedB1",
+            "value": "Balanced_B1",
+            "description": "Balanced_B1"
+          },
+          {
+            "name": "BalancedB3",
+            "value": "Balanced_B3",
+            "description": "Balanced_B3"
+          },
+          {
+            "name": "BalancedB5",
+            "value": "Balanced_B5",
+            "description": "Balanced_B5"
+          },
+          {
+            "name": "BalancedB10",
+            "value": "Balanced_B10",
+            "description": "Balanced_B10"
+          },
+          {
+            "name": "BalancedB20",
+            "value": "Balanced_B20",
+            "description": "Balanced_B20"
+          },
+          {
+            "name": "BalancedB50",
+            "value": "Balanced_B50",
+            "description": "Balanced_B50"
+          },
+          {
+            "name": "BalancedB100",
+            "value": "Balanced_B100",
+            "description": "Balanced_B100"
+          },
+          {
+            "name": "BalancedB150",
+            "value": "Balanced_B150",
+            "description": "Balanced_B150"
+          },
+          {
+            "name": "BalancedB250",
+            "value": "Balanced_B250",
+            "description": "Balanced_B250"
+          },
+          {
+            "name": "BalancedB350",
+            "value": "Balanced_B350",
+            "description": "Balanced_B350"
+          },
+          {
+            "name": "BalancedB500",
+            "value": "Balanced_B500",
+            "description": "Balanced_B500"
+          },
+          {
+            "name": "BalancedB700",
+            "value": "Balanced_B700",
+            "description": "Balanced_B700"
+          },
+          {
+            "name": "BalancedB1000",
+            "value": "Balanced_B1000",
+            "description": "Balanced_B1000"
+          },
+          {
+            "name": "MemoryOptimizedM10",
+            "value": "MemoryOptimized_M10",
+            "description": "MemoryOptimized_M10"
+          },
+          {
+            "name": "MemoryOptimizedM20",
+            "value": "MemoryOptimized_M20",
+            "description": "MemoryOptimized_M20"
+          },
+          {
+            "name": "MemoryOptimizedM50",
+            "value": "MemoryOptimized_M50",
+            "description": "MemoryOptimized_M50"
+          },
+          {
+            "name": "MemoryOptimizedM100",
+            "value": "MemoryOptimized_M100",
+            "description": "MemoryOptimized_M100"
+          },
+          {
+            "name": "MemoryOptimizedM150",
+            "value": "MemoryOptimized_M150",
+            "description": "MemoryOptimized_M150"
+          },
+          {
+            "name": "MemoryOptimizedM250",
+            "value": "MemoryOptimized_M250",
+            "description": "MemoryOptimized_M250"
+          },
+          {
+            "name": "MemoryOptimizedM350",
+            "value": "MemoryOptimized_M350",
+            "description": "MemoryOptimized_M350"
+          },
+          {
+            "name": "MemoryOptimizedM500",
+            "value": "MemoryOptimized_M500",
+            "description": "MemoryOptimized_M500"
+          },
+          {
+            "name": "MemoryOptimizedM700",
+            "value": "MemoryOptimized_M700",
+            "description": "MemoryOptimized_M700"
+          },
+          {
+            "name": "MemoryOptimizedM1000",
+            "value": "MemoryOptimized_M1000",
+            "description": "MemoryOptimized_M1000"
+          },
+          {
+            "name": "MemoryOptimizedM1500",
+            "value": "MemoryOptimized_M1500",
+            "description": "MemoryOptimized_M1500"
+          },
+          {
+            "name": "MemoryOptimizedM2000",
+            "value": "MemoryOptimized_M2000",
+            "description": "MemoryOptimized_M2000"
+          },
+          {
+            "name": "ComputeOptimizedX3",
+            "value": "ComputeOptimized_X3",
+            "description": "ComputeOptimized_X3"
+          },
+          {
+            "name": "ComputeOptimizedX5",
+            "value": "ComputeOptimized_X5",
+            "description": "ComputeOptimized_X5"
+          },
+          {
+            "name": "ComputeOptimizedX10",
+            "value": "ComputeOptimized_X10",
+            "description": "ComputeOptimized_X10"
+          },
+          {
+            "name": "ComputeOptimizedX20",
+            "value": "ComputeOptimized_X20",
+            "description": "ComputeOptimized_X20"
+          },
+          {
+            "name": "ComputeOptimizedX50",
+            "value": "ComputeOptimized_X50",
+            "description": "ComputeOptimized_X50"
+          },
+          {
+            "name": "ComputeOptimizedX100",
+            "value": "ComputeOptimized_X100",
+            "description": "ComputeOptimized_X100"
+          },
+          {
+            "name": "ComputeOptimizedX150",
+            "value": "ComputeOptimized_X150",
+            "description": "ComputeOptimized_X150"
+          },
+          {
+            "name": "ComputeOptimizedX250",
+            "value": "ComputeOptimized_X250",
+            "description": "ComputeOptimized_X250"
+          },
+          {
+            "name": "ComputeOptimizedX350",
+            "value": "ComputeOptimized_X350",
+            "description": "ComputeOptimized_X350"
+          },
+          {
+            "name": "ComputeOptimizedX500",
+            "value": "ComputeOptimized_X500",
+            "description": "ComputeOptimized_X500"
+          },
+          {
+            "name": "ComputeOptimizedX700",
+            "value": "ComputeOptimized_X700",
+            "description": "ComputeOptimized_X700"
+          },
+          {
+            "name": "FlashOptimizedA250",
+            "value": "FlashOptimized_A250",
+            "description": "FlashOptimized_A250"
+          },
+          {
+            "name": "FlashOptimizedA500",
+            "value": "FlashOptimized_A500",
+            "description": "FlashOptimized_A500"
+          },
+          {
+            "name": "FlashOptimizedA700",
+            "value": "FlashOptimized_A700",
+            "description": "FlashOptimized_A700"
+          },
+          {
+            "name": "FlashOptimizedA1000",
+            "value": "FlashOptimized_A1000",
+            "description": "FlashOptimized_A1000"
+          },
+          {
+            "name": "FlashOptimizedA1500",
+            "value": "FlashOptimized_A1500",
+            "description": "FlashOptimized_A1500"
+          },
+          {
+            "name": "FlashOptimizedA2000",
+            "value": "FlashOptimized_A2000",
+            "description": "FlashOptimized_A2000"
+          },
+          {
+            "name": "FlashOptimizedA4500",
+            "value": "FlashOptimized_A4500",
+            "description": "FlashOptimized_A4500"
+          }
+        ]
+      }
+    },
+    "SourceType": {
+      "type": "string",
+      "description": "Describes the source of the migration operation.",
+      "enum": [
+        "AzureCacheForRedis"
+      ],
+      "x-ms-enum": {
+        "name": "SourceType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "AzureCacheForRedis",
+            "value": "AzureCacheForRedis",
+            "description": "Migration from Azure Cache for Redis to Redis Enterprise."
+          }
+        ]
+      }
+    },
+    "TlsVersion": {
+      "type": "string",
+      "description": "The minimum TLS version for the cluster to support, e.g. '1.2'. Newer versions can be added in the future. Note that TLS 1.0 and TLS 1.1 are now completely obsolete -- you cannot use them. They are mentioned only for the sake of consistency with old API versions.",
+      "enum": [
+        "1.0",
+        "1.1",
+        "1.2"
+      ],
+      "x-ms-enum": {
+        "name": "TlsVersion",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "One0",
+            "value": "1.0",
+            "description": "1.0"
+          },
+          {
+            "name": "One1",
+            "value": "1.1",
+            "description": "1.1"
+          },
+          {
+            "name": "One2",
+            "value": "1.2",
+            "description": "1.2"
+          }
+        ]
+      }
+    }
+  },
+  "parameters": {}
+}

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/readme.md
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/readme.md
@@ -26,7 +26,16 @@ These are the global settings for the RedisEnterprise API.
 
 ``` yaml
 openapi-type: arm
-tag: package-preview-2026-02-01
+tag: package-preview-2026-05-01
+```
+
+### Tag: package-preview-2026-05-01
+
+These settings apply only when `--tag=package-preview-2026-05-01` is specified on the command line.
+
+```yaml $(tag) == 'package-preview-2026-05-01'
+input-file:
+  - preview/2026-05-01-preview/redisenterprise.json
 ```
 
 ### Tag: package-preview-2026-02-01


### PR DESCRIPTION
# ARM (Control Plane) API Specification Update Pull Request

## Purpose of this PR

- [x] New API version for an existing resource provider.

### Summary

Add `2026-05-01-preview` API version for Redis Enterprise (`Microsoft.Cache`) with custom access strings for Access Policy Assignments.

**Changes from 2026-02-01-preview:**
- Replace `accessPolicyName` (required) with `accessString` (optional, defaults to `+@all ~*`)
- Add `provisioningError` structured error (code, message, target) for failed ACL provisioning
- Add `AccessPolicyAssignmentProvisioningError` model with required code/message fields
- Add examples for custom access string creation and failed provisioning state
- Fix access policy assignment resource type and ID paths in examples

## Due diligence checklist

- [x] I confirm this PR is modifying Azure Resource Manager (ARM) related specifications, and not data plane related specifications.
- [x] I have reviewed following [Resource Provider guidelines](https://aka.ms/rpguidelines), including [ARM resource provider contract](https://aka.ms/azurerpc) and [REST guidelines](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md).
- [ ] A [release plan](https://aka.ms/azsdkdocs/release-plans) has been created.

## Getting help

- See the `Next Steps to Merge` comment for current PR state.
- For CI fix guidance: https://aka.ms/ci-fix
- For ARM review help: https://aka.ms/azsdk/pr-arm-review