### PR TITLE
Fix session file operations: rename session_id to agent_session_id, align timestamp encoding

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/src/agents-session-files/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-session-files/models.tsp
@@ -28,8 +28,8 @@ model SessionDirectoryEntry {
   @doc("Whether this entry is a directory.")
   is_directory: boolean;
 
-  @doc("The last modification time in UTC (ISO 8601).")
-  @encode(DateTimeKnownEncoding.rfc3339)
+  /** The Unix timestamp (in seconds) when the file was last modified. */
+  @encode("unixTimestamp", int64)
   modified_time: utcDateTime;
 }
 

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-session-files/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-session-files/routes.tsp
@@ -26,7 +26,7 @@ interface AgentSessionFiles {
    */
   #suppress "@azure-tools/typespec-azure-core/byos" "The file is targeting the per-session files mounted to a foundry agent"
   @put
-  @route("/agents/{agent_name}/endpoint/sessions/{session_id}/files/content")
+  @route("/agents/{agent_name}/endpoint/sessions/{agent_session_id}/files/content")
   @extension(
     "x-ms-foundry-meta",
     #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
@@ -38,7 +38,7 @@ interface AgentSessionFiles {
       @path agent_name: string;
 
       /** The session ID. */
-      @path session_id: string;
+      @path agent_session_id: string;
 
       /** The destination file path within the sandbox, relative to the session home directory. */
       @query path: string;
@@ -55,7 +55,7 @@ interface AgentSessionFiles {
    * Download a file from the session sandbox as a binary stream.
    */
   @get
-  @route("/agents/{agent_name}/endpoint/sessions/{session_id}/files/content")
+  @route("/agents/{agent_name}/endpoint/sessions/{agent_session_id}/files/content")
   @extension(
     "x-ms-foundry-meta",
     #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
@@ -67,7 +67,7 @@ interface AgentSessionFiles {
       @path agent_name: string;
 
       /** The session ID. */
-      @path session_id: string;
+      @path agent_session_id: string;
 
       /** The file path to download from the sandbox, relative to the session home directory. */
       @query path: string;
@@ -80,7 +80,7 @@ interface AgentSessionFiles {
    * Returns only the immediate children of the specified directory (non-recursive).
    */
   @get
-  @route("/agents/{agent_name}/endpoint/sessions/{session_id}/files")
+  @route("/agents/{agent_name}/endpoint/sessions/{agent_session_id}/files")
   @extension(
     "x-ms-foundry-meta",
     #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
@@ -92,7 +92,7 @@ interface AgentSessionFiles {
       @path agent_name: string;
 
       /** The session ID. */
-      @path session_id: string;
+      @path agent_session_id: string;
 
       /** The directory path to list, relative to the session home directory. */
       @query path: string;
@@ -105,7 +105,7 @@ interface AgentSessionFiles {
    * If `recursive` is false (default) and the target is a non-empty directory, the API returns 409 Conflict.
    */
   @delete
-  @route("/agents/{agent_name}/endpoint/sessions/{session_id}/files")
+  @route("/agents/{agent_name}/endpoint/sessions/{agent_session_id}/files")
   @extension(
     "x-ms-foundry-meta",
     #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
@@ -117,7 +117,7 @@ interface AgentSessionFiles {
       @path agent_name: string;
 
       /** The session ID. */
-      @path session_id: string;
+      @path agent_session_id: string;
 
       /** The file or directory path to delete, relative to the session home directory. */
       @query path: string;


### PR DESCRIPTION
## Changes

These changes address gaps identified when comparing merged PRs against the `feature/foundry-release` branch.

### 1. Rename `session_id` → `agent_session_id` in session file operations
**Original PR**: [#41586 — Add session file operations API surface](https://github.com/Azure/azure-rest-api-specs/pull/41586) by @ankitsul

Renames the path parameter in all 4 session file CRUD operations (upload, download, list, delete) from `session_id` to `agent_session_id` for consistency with the rest of the agent session API surface.

### 2. Align `modified_time` encoding to `unixTimestamp`
**Original PR**: [#41586 — Add session file operations API surface](https://github.com/Azure/azure-rest-api-specs/pull/41586) by @ankitsul

Changes `modified_time` in `SessionDirectoryEntry` from `DateTimeKnownEncoding.rfc3339` to `@encode("unixTimestamp", int64)` for consistency with `created_at`, `last_accessed_at`, and `expires_at` in `AgentSessionResource` (from [#41691](https://github.com/Azure/azure-rest-api-specs/pull/41691) by @aryaan-singh).

### Files Changed
- `src/agents-session-files/routes.tsp` — 8 occurrences renamed (4 route paths + 4 `@path` declarations)
- `src/agents-session-files/models.tsp` — encoding + doc comment updated
