### PR TITLE
feat(agents): restore x-agent-session-id response header on all proxy endpoints

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -725,6 +725,15 @@
         "responses": {
           "200": {
             "description": "The request has succeeded.",
+            "headers": {
+              "x-agent-session-id": {
+                "required": true,
+                "description": "Session ID for this invocation. Returns the session ID associated with the invocation.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
             "content": {
               "*/*": {
                 "schema": {}
@@ -801,6 +810,15 @@
         "responses": {
           "200": {
             "description": "The request has succeeded.",
+            "headers": {
+              "x-agent-session-id": {
+                "required": true,
+                "description": "Session ID for this invocation. Returns the session ID associated with the invocation.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
             "content": {
               "*/*": {
                 "schema": {}
@@ -7345,6 +7363,15 @@
         "responses": {
           "200": {
             "description": "The request has succeeded.",
+            "headers": {
+              "x-agent-session-id": {
+                "required": false,
+                "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -8016,6 +8043,15 @@
         "responses": {
           "200": {
             "description": "The request has succeeded.",
+            "headers": {
+              "x-agent-session-id": {
+                "required": false,
+                "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -8061,6 +8097,15 @@
         "responses": {
           "200": {
             "description": "The request has succeeded.",
+            "headers": {
+              "x-agent-session-id": {
+                "required": false,
+                "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -8103,6 +8148,15 @@
         "responses": {
           "200": {
             "description": "The request has succeeded.",
+            "headers": {
+              "x-agent-session-id": {
+                "required": false,
+                "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -8186,6 +8240,15 @@
         "responses": {
           "200": {
             "description": "The request has succeeded.",
+            "headers": {
+              "x-agent-session-id": {
+                "required": false,
+                "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -778,6 +778,15 @@
         "responses": {
           "200": {
             "description": "The request has succeeded.",
+            "headers": {
+              "x-agent-session-id": {
+                "required": true,
+                "description": "Session ID for this invocation. Returns the session ID associated with the invocation.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
             "content": {
               "*/*": {
                 "schema": {}
@@ -854,6 +863,15 @@
         "responses": {
           "200": {
             "description": "The request has succeeded.",
+            "headers": {
+              "x-agent-session-id": {
+                "required": true,
+                "description": "Session ID for this invocation. Returns the session ID associated with the invocation.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
             "content": {
               "*/*": {
                 "schema": {}
@@ -9132,6 +9150,15 @@
         "responses": {
           "200": {
             "description": "The request has succeeded.",
+            "headers": {
+              "x-agent-session-id": {
+                "required": false,
+                "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -9827,6 +9854,15 @@
         "responses": {
           "200": {
             "description": "The request has succeeded.",
+            "headers": {
+              "x-agent-session-id": {
+                "required": false,
+                "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -9872,6 +9908,15 @@
         "responses": {
           "200": {
             "description": "The request has succeeded.",
+            "headers": {
+              "x-agent-session-id": {
+                "required": false,
+                "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -9914,6 +9959,15 @@
         "responses": {
           "200": {
             "description": "The request has succeeded.",
+            "headers": {
+              "x-agent-session-id": {
+                "required": false,
+                "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -9997,6 +10051,15 @@
         "responses": {
           "200": {
             "description": "The request has succeeded.",
+            "headers": {
+              "x-agent-session-id": {
+                "required": false,
+                "description": "Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-invocations/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-invocations/routes.tsp
@@ -58,7 +58,7 @@ interface AgentInvocations {
       @header("x-agent-invocation-id") invocationId: string;
 
       /** Session ID for this invocation. Returns the provided session ID or an auto-generated one if not provided in the request. */
-      @header("x-agent-session-id") sessionId: string;
+      @header("x-agent-session-id") agentSessionId: string;
 
       /** The content type of the response body. */
       @header contentType: string;
@@ -84,6 +84,9 @@ interface AgentInvocations {
       @path invocation_id: string;
     } & AgentInvocationPreviewHeader,
     {
+      /** Session ID for this invocation. Returns the session ID associated with the invocation. */
+      @header("x-agent-session-id") agentSessionId: string;
+
       /** The content type of the response body. */
       @header contentType: string;
 
@@ -114,6 +117,9 @@ interface AgentInvocations {
       @body request?: unknown;
     } & AgentInvocationPreviewHeader,
     {
+      /** Session ID for this invocation. Returns the session ID associated with the invocation. */
+      @header("x-agent-session-id") agentSessionId: string;
+
       /** The content type of the response body. */
       @header contentType: string;
 

--- a/specification/ai-foundry/data-plane/Foundry/src/openai-responses/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai-responses/routes.tsp
@@ -6,6 +6,12 @@ using TypeSpec.OpenAPI;
 
 namespace Azure.AI.Projects;
 
+/** Optional response header containing the session ID for hosted agent requests. */
+alias AgentSessionIdResponseHeader = {
+  /** Session ID for this request. Only present for hosted agent responses. Returns the provided session ID or an auto-generated one if not provided in the request. */
+  @header("x-agent-session-id") agentSessionId?: string;
+};
+
 #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "OpenAI-based operations are not conventionally versioned"
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "OpenAI-based operations are definitionally non-standard"
 @route("openai/v1/responses")
@@ -17,7 +23,12 @@ interface Responses {
   @operationId("createResponse")
   @post
   @sharedRoute
-  createResponse is OpenAIOperation<OpenAI.CreateResponse, OpenAI.Response>;
+  createResponse is OpenAIOperation<
+    OpenAI.CreateResponse,
+    AgentSessionIdResponseHeader & {
+      @body body: OpenAI.Response;
+    }
+  >;
 
   /**
    * Creates a model response (streaming response).
@@ -27,7 +38,7 @@ interface Responses {
   @sharedRoute
   createResponseStream is OpenAIOperation<
     OpenAI.CreateResponse,
-    SseResponseOf<OpenAI.CreateResponseStreamingResponse>
+    AgentSessionIdResponseHeader & SseResponseOf<OpenAI.CreateResponseStreamingResponse>
   >;
 
   /**
@@ -54,7 +65,9 @@ interface Responses {
       @query stream?: boolean = false;
       @query starting_after?: int32;
     },
-    OpenAI.Response
+    AgentSessionIdResponseHeader & {
+      @body body: OpenAI.Response;
+    }
   >;
 
   /**
@@ -80,7 +93,7 @@ interface Responses {
       @header accept: "text/event-stream";
       @query starting_after?: int32;
     },
-    SseResponseOf<OpenAI.CreateResponseStreamingResponse>
+    AgentSessionIdResponseHeader & SseResponseOf<OpenAI.CreateResponseStreamingResponse>
   >;
 
   /**
@@ -98,7 +111,9 @@ interface Responses {
       @example("resp_677efb5139a88190b512bc3fef8e535d")
       response_id: string;
     },
-    DeleteResponseResult
+    AgentSessionIdResponseHeader & {
+      @body body: DeleteResponseResult;
+    }
   >;
 
   /**
@@ -116,7 +131,9 @@ interface Responses {
       @example("resp_677efb5139a88190b512bc3fef8e535d")
       response_id: string;
     },
-    OpenAI.Response
+    AgentSessionIdResponseHeader & {
+      @body body: OpenAI.Response;
+    }
   >;
 
   /**
@@ -134,7 +151,9 @@ interface Responses {
 
       ...CommonPageQueryParameters;
     },
-    AgentsPagedResult<OpenAI.ItemResource>
+    AgentSessionIdResponseHeader & {
+      @body body: AgentsPagedResult<OpenAI.ItemResource>;
+    }
   >;
 
   /**


### PR DESCRIPTION
## What
Restore `x-agent-session-id` response header on all container-proxy endpoints for both invocation and responses protocols.

## Changes

### Invocation protocol (`agents-invocations/routes.tsp`)
- **GET** `getAgentInvocation` — added `x-agent-session-id` (required)
- **Cancel** `cancelAgentInvocation` — added `x-agent-session-id` (required)
- **POST** `createAgentInvocation` — renamed `sessionId` → `agentSessionId` for consistency (header already existed)

### Responses protocol (`openai-responses/routes.tsp`)
Added `x-agent-session-id` (optional) to all 6 proxy endpoints:
- `createResponse`, `createResponseStream`
- `getResponse`, `getResponseStream`
- `deleteResponse`, `cancelResponse`

### Not modified (non-proxy endpoints)
- `listInputItems`, `listResponses`, `compactResponseConversation`, `getAgentInvocationOpenApiSpec`

## Design decisions
- **Invocations**: header is **required** — these are hosted-agent-only endpoints
- **Responses**: header is **optional** — these serve both hosted and non-hosted agents
- `x-agent-response-id` is NOT added (not a supported header per team discussion)
