### PR TITLE
Add model for Tool Search Tool and "defer" to all supported tools

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
@@ -42,6 +42,39 @@ namespace Azure.AI.Projects {
   #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
   @@copyVariants(OpenAI.IncludeEnum, Azure.AI.Projects._AgentIncludable);
 
+  /**
+   * Configuration for tool deferral behavior when tool search is enabled.
+   * Controls whether a tool or its sub-tools are deferred from tools/list and only
+   * discoverable via tool_search queries.
+   */
+  model ToolDeferConfig {
+    /**
+     * Whether deferral is enabled for this tool or its sub-tools.
+     * Default: true when a tool_search tool is present in the toolbox.
+     */
+    enabled?: boolean;
+
+    /**
+     * Optional deferral mode. Reserved for future use.
+     */
+    mode?: string;
+
+    /**
+     * List of tool names that are pinned (always visible in tools/list regardless of deferral).
+     */
+    pinned?: string[];
+  }
+
+  #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
+  @@copyProperties(OpenAI.Tool,
+    {
+      /**
+       * Deferral settings for this tool when tool search is enabled.
+       */
+      defer?: ToolDeferConfig,
+    }
+  );
+
   #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
   @@copyProperties(OpenAI.MCPTool,
     {

--- a/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
@@ -18,6 +18,7 @@ namespace Azure.AI.Projects {
     sharepoint_grounding_preview: "sharepoint_grounding_preview",
     memory_search_preview: "memory_search_preview",
     work_iq_preview: "work_iq_preview",
+    tool_search_preview: "tool_search_preview",
   }
 
   // General availability tools:
@@ -50,14 +51,9 @@ namespace Azure.AI.Projects {
   model ToolDeferConfig {
     /**
      * Whether deferral is enabled for this tool or its sub-tools.
-     * Default: true when a tool_search tool is present in the toolbox.
+     * Default: true when a ToolSearchTool is present in the toolbox.
      */
     enabled?: boolean;
-
-    /**
-     * Optional deferral mode. Reserved for future use.
-     */
-    mode?: string;
 
     /**
      * List of tool names that are pinned (always visible in tools/list regardless of deferral).
@@ -65,6 +61,7 @@ namespace Azure.AI.Projects {
     pinned?: string[];
   }
 
+  // Add defer to the base Tool class so all tools inherit it.
   #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
   @@copyProperties(OpenAI.Tool,
     {
@@ -912,6 +909,25 @@ namespace Azure.AI.Projects {
     update_delay?: int32 = 300;
   }
 
+  /**
+   * A tool for enabling semantic search over the agent's toolbox.
+   * When present, other tools may be deferred and only discoverable via tool_search queries.
+   */
+  model ToolSearchTool extends OpenAI.Tool {
+    /**
+     * The type of the tool. Always `tool_search_preview`.
+     */
+    type: "tool_search_preview";
+
+    ...ToolNameAndDescriptionExtension;
+
+    /**
+     * Default deferral configuration applied to all tools in the toolbox.
+     * Individual tools can override this via their own `defer` property.
+     */
+    default_defer?: ToolDeferConfig;
+  }
+
   alias MemorySearchToolCallItemBase = {
     @doc("The results returned from the memory search.")
     results?: MemorySearchItem[] | null;
@@ -919,6 +935,7 @@ namespace Azure.AI.Projects {
 
   model MemorySearchToolCallItemParam extends OpenAI.Item {
     type: "memory_search_call";
+
     ...MemorySearchToolCallItemBase;
   }
 

--- a/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
@@ -65,17 +65,15 @@ namespace Azure.AI.Projects {
     pinned?: string[];
   }
 
-  /**
-   * Intermediate model for tools that support deferral.
-   * Tools that can be deferred from tools/list should extend this model
-   * instead of OpenAI.Tool directly.
-   */
-  model DeferrableTool extends OpenAI.Tool {
-    /**
-     * Deferral settings for this tool when tool search is enabled.
-     */
-    defer?: ToolDeferConfig;
-  }
+  #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
+  @@copyProperties(OpenAI.Tool,
+    {
+      /**
+       * Deferral settings for this tool when tool search is enabled.
+       */
+      defer?: ToolDeferConfig,
+    }
+  );
 
   #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
   @@copyProperties(OpenAI.MCPTool,
@@ -170,7 +168,7 @@ namespace Azure.AI.Projects {
   /**
    * The input definition information for a bing grounding search tool as used to configure an agent.
    */
-  model BingGroundingTool extends DeferrableTool {
+  model BingGroundingTool extends OpenAI.Tool {
     /**
      * The object type, which is always 'bing_grounding'.
      */
@@ -201,7 +199,7 @@ namespace Azure.AI.Projects {
   /**
    * The input definition information for a Microsoft Fabric tool as used to configure an agent.
    */
-  model MicrosoftFabricPreviewTool extends DeferrableTool {
+  model MicrosoftFabricPreviewTool extends OpenAI.Tool {
     /**
      * The object type, which is always 'fabric_dataagent_preview'.
      */
@@ -232,7 +230,7 @@ namespace Azure.AI.Projects {
   /**
    * The input definition information for a sharepoint tool as used to configure an agent.
    */
-  model SharepointPreviewTool extends DeferrableTool {
+  model SharepointPreviewTool extends OpenAI.Tool {
     /**
      * The object type, which is always 'sharepoint_grounding_preview'.
      */
@@ -249,7 +247,7 @@ namespace Azure.AI.Projects {
   /**
    * The input definition information for an Azure AI search tool as used to configure an agent.
    */
-  model AzureAISearchTool extends DeferrableTool {
+  model AzureAISearchTool extends OpenAI.Tool {
     /**
      * The object type, which is always 'azure_ai_search'.
      */
@@ -343,7 +341,7 @@ namespace Azure.AI.Projects {
   /**
    * The input definition information for an OpenAPI tool as used to configure an agent.
    */
-  model OpenApiTool extends DeferrableTool {
+  model OpenApiTool extends OpenAI.Tool {
     /**
      * The object type, which is always 'openapi'.
      */
@@ -358,7 +356,7 @@ namespace Azure.AI.Projects {
   /**
    * The input definition information for a Bing custom search tool as used to configure an agent.
    */
-  model BingCustomSearchPreviewTool extends DeferrableTool {
+  model BingCustomSearchPreviewTool extends OpenAI.Tool {
     /**
      * The object type, which is always 'bing_custom_search_preview'.
      */
@@ -375,7 +373,7 @@ namespace Azure.AI.Projects {
   /**
    * The input definition information for a Browser Automation Tool, as used to configure an Agent.
    */
-  model BrowserAutomationPreviewTool extends DeferrableTool {
+  model BrowserAutomationPreviewTool extends OpenAI.Tool {
     /**
      * The object type, which is always 'browser_automation_preview'.
      */
@@ -416,7 +414,7 @@ namespace Azure.AI.Projects {
   /**
    * The input definition information for an Azure Function Tool, as used to configure an Agent.
    */
-  model AzureFunctionTool extends DeferrableTool {
+  model AzureFunctionTool extends OpenAI.Tool {
     /**
      * The object type, which is always 'browser_automation'.
      */
@@ -779,7 +777,7 @@ namespace Azure.AI.Projects {
   /**
    * A tool for capturing structured outputs
    */
-  model CaptureStructuredOutputsTool extends DeferrableTool {
+  model CaptureStructuredOutputsTool extends OpenAI.Tool {
     /**
      * The type of the tool. Always `capture_structured_outputs`.
      */
@@ -794,7 +792,7 @@ namespace Azure.AI.Projects {
   /**
    * An agent implementing the A2A protocol.
    */
-  model A2APreviewTool extends DeferrableTool {
+  model A2APreviewTool extends OpenAI.Tool {
     /**
      * The type of the tool. Always `"a2a_preview`.
      */
@@ -833,7 +831,7 @@ namespace Azure.AI.Projects {
   /**
    * A WorkIQ server-side tool.
    */
-  model WorkIQPreviewTool extends DeferrableTool {
+  model WorkIQPreviewTool extends OpenAI.Tool {
     /**
      * The object type, which is always 'work_iq_preview'.
      */
@@ -848,7 +846,7 @@ namespace Azure.AI.Projects {
   /**
    * A tool for integrating memories into the agent.
    */
-  model MemorySearchPreviewTool extends DeferrableTool {
+  model MemorySearchPreviewTool extends OpenAI.Tool {
     /**
      * The type of the tool. Always `memory_search_preview`.
      */
@@ -883,7 +881,7 @@ namespace Azure.AI.Projects {
    * A tool for integrating memories into the agent.
    */
   @removed(Versions.v1)
-  model MemorySearchTool extends DeferrableTool {
+  model MemorySearchTool extends OpenAI.Tool {
     /**
      * The type of the tool. Always `memory_search_preview`.
      */

--- a/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
@@ -65,15 +65,17 @@ namespace Azure.AI.Projects {
     pinned?: string[];
   }
 
-  #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
-  @@copyProperties(OpenAI.Tool,
-    {
-      /**
-       * Deferral settings for this tool when tool search is enabled.
-       */
-      defer?: ToolDeferConfig,
-    }
-  );
+  /**
+   * Intermediate model for tools that support deferral.
+   * Tools that can be deferred from tools/list should extend this model
+   * instead of OpenAI.Tool directly.
+   */
+  model DeferrableTool extends OpenAI.Tool {
+    /**
+     * Deferral settings for this tool when tool search is enabled.
+     */
+    defer?: ToolDeferConfig;
+  }
 
   #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
   @@copyProperties(OpenAI.MCPTool,
@@ -168,7 +170,7 @@ namespace Azure.AI.Projects {
   /**
    * The input definition information for a bing grounding search tool as used to configure an agent.
    */
-  model BingGroundingTool extends OpenAI.Tool {
+  model BingGroundingTool extends DeferrableTool {
     /**
      * The object type, which is always 'bing_grounding'.
      */
@@ -199,7 +201,7 @@ namespace Azure.AI.Projects {
   /**
    * The input definition information for a Microsoft Fabric tool as used to configure an agent.
    */
-  model MicrosoftFabricPreviewTool extends OpenAI.Tool {
+  model MicrosoftFabricPreviewTool extends DeferrableTool {
     /**
      * The object type, which is always 'fabric_dataagent_preview'.
      */
@@ -230,7 +232,7 @@ namespace Azure.AI.Projects {
   /**
    * The input definition information for a sharepoint tool as used to configure an agent.
    */
-  model SharepointPreviewTool extends OpenAI.Tool {
+  model SharepointPreviewTool extends DeferrableTool {
     /**
      * The object type, which is always 'sharepoint_grounding_preview'.
      */
@@ -247,7 +249,7 @@ namespace Azure.AI.Projects {
   /**
    * The input definition information for an Azure AI search tool as used to configure an agent.
    */
-  model AzureAISearchTool extends OpenAI.Tool {
+  model AzureAISearchTool extends DeferrableTool {
     /**
      * The object type, which is always 'azure_ai_search'.
      */
@@ -341,7 +343,7 @@ namespace Azure.AI.Projects {
   /**
    * The input definition information for an OpenAPI tool as used to configure an agent.
    */
-  model OpenApiTool extends OpenAI.Tool {
+  model OpenApiTool extends DeferrableTool {
     /**
      * The object type, which is always 'openapi'.
      */
@@ -356,7 +358,7 @@ namespace Azure.AI.Projects {
   /**
    * The input definition information for a Bing custom search tool as used to configure an agent.
    */
-  model BingCustomSearchPreviewTool extends OpenAI.Tool {
+  model BingCustomSearchPreviewTool extends DeferrableTool {
     /**
      * The object type, which is always 'bing_custom_search_preview'.
      */
@@ -373,7 +375,7 @@ namespace Azure.AI.Projects {
   /**
    * The input definition information for a Browser Automation Tool, as used to configure an Agent.
    */
-  model BrowserAutomationPreviewTool extends OpenAI.Tool {
+  model BrowserAutomationPreviewTool extends DeferrableTool {
     /**
      * The object type, which is always 'browser_automation_preview'.
      */
@@ -414,7 +416,7 @@ namespace Azure.AI.Projects {
   /**
    * The input definition information for an Azure Function Tool, as used to configure an Agent.
    */
-  model AzureFunctionTool extends OpenAI.Tool {
+  model AzureFunctionTool extends DeferrableTool {
     /**
      * The object type, which is always 'browser_automation'.
      */
@@ -777,7 +779,7 @@ namespace Azure.AI.Projects {
   /**
    * A tool for capturing structured outputs
    */
-  model CaptureStructuredOutputsTool extends OpenAI.Tool {
+  model CaptureStructuredOutputsTool extends DeferrableTool {
     /**
      * The type of the tool. Always `capture_structured_outputs`.
      */
@@ -792,7 +794,7 @@ namespace Azure.AI.Projects {
   /**
    * An agent implementing the A2A protocol.
    */
-  model A2APreviewTool extends OpenAI.Tool {
+  model A2APreviewTool extends DeferrableTool {
     /**
      * The type of the tool. Always `"a2a_preview`.
      */
@@ -831,7 +833,7 @@ namespace Azure.AI.Projects {
   /**
    * A WorkIQ server-side tool.
    */
-  model WorkIQPreviewTool extends OpenAI.Tool {
+  model WorkIQPreviewTool extends DeferrableTool {
     /**
      * The object type, which is always 'work_iq_preview'.
      */
@@ -846,7 +848,7 @@ namespace Azure.AI.Projects {
   /**
    * A tool for integrating memories into the agent.
    */
-  model MemorySearchPreviewTool extends OpenAI.Tool {
+  model MemorySearchPreviewTool extends DeferrableTool {
     /**
      * The type of the tool. Always `memory_search_preview`.
      */
@@ -881,7 +883,7 @@ namespace Azure.AI.Projects {
    * A tool for integrating memories into the agent.
    */
   @removed(Versions.v1)
-  model MemorySearchTool extends OpenAI.Tool {
+  model MemorySearchTool extends DeferrableTool {
     /**
      * The type of the tool. Always `memory_search_preview`.
      */


### PR DESCRIPTION
## Add ToolSearch support and per-tool defer to Azure AI Foundry Agents TypeSpec

Adds TypeSpec models for the **Tool Search** built-in tool and introduces **per-tool `defer`** configuration on all supported tools. When a `ToolSearchTool` is present, deferred tools are discoverable via `tool_search` queries instead of being listed in `tools/list`.

### Changes (`specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp`)

**New enum value:**
- `tool_search_preview` added to `ToolType`

**New models:**
- **`ToolDeferConfig`** — Configuration for tool deferral behavior. Properties: `enabled?: boolean`, `pinned?: string[]`
- **`ToolSearchConfig`** — Configuration for the tool_search built-in tool. Properties: `defer_by_default?: boolean`, `mode?: string`
- **`ToolSearchTool`** — Built-in tool definition (`type: "tool_search_preview"`) with optional `name`, `description`, and `config` (ToolSearchConfig). Extends `Tool` directly — does **not** have `defer`.

**Per-tool defer (21 tools):**
`defer?: ToolDeferConfig` is added to each individual tool via `@@copyProperties` (for OpenAI tools) or directly in the model body (for Azure tools). This per-tool approach — rather than putting `defer` on the base `Tool` class — enables `ToolSearchTool` to extend `Tool` without inheriting `defer`.

Tools with `defer`:
- **OpenAI tools (8):** MCPTool, WebSearchTool, CodeInterpreterTool, ImageGenTool, FileSearchTool, FunctionTool, ComputerUsePreviewTool, WebSearchPreviewTool
- **Azure tools (13):** BingGroundingTool, MicrosoftFabricPreviewTool, SharepointPreviewTool, AzureAISearchTool, OpenApiTool, BingCustomSearchPreviewTool, BrowserAutomationPreviewTool, AzureFunctionTool, CaptureStructuredOutputsTool, A2APreviewTool, WorkIQPreviewTool, MemorySearchPreviewTool, MemorySearchTool

Tools **without** `defer`: ToolSearchTool (by design), RemoteTool, UnknownTool, parameter models (*Param)

### Design

When a `ToolSearchTool` is present in an agent's toolbox:
- Tools with `defer.enabled = true` are hidden from `tools/list` and only discoverable via `tool_search` queries
- `ToolSearchConfig.defer_by_default` controls whether deferral is opt-in or opt-out for tools that don't explicitly set `defer`
- `ToolDeferConfig.pinned` lists tool names always visible in `tools/list` regardless of deferral