### PR TITLE
[Python] Mitigate breaking changes for azure-mgmt-resource

### DIFF
--- a/specification/resources/resource-manager/Microsoft.Resources/resources/client.tsp
+++ b/specification/resources/resource-manager/Microsoft.Resources/resources/client.tsp
@@ -7,3 +7,8 @@ using Azure.ClientGenerator.Core;
   "ResourceManagementClient",
   "javascript,python,java"
 );
+
+@@clientName(Microsoft.Resources.ErrorResponse,
+  "ResourcesErrorResponse",
+  "python"
+);


### PR DESCRIPTION
# [Python] Mitigate breaking changes for azure-mgmt-resource

## Mitigation

Added `@@clientName` decorator to resolve `ErrorResponse` duplicate name conflict during Python SDK generation:

- `Microsoft.Resources.ErrorResponse` → `ResourcesErrorResponse` (Python scope only)

This is required because the local `ErrorResponse` model conflicts with `Azure.ResourceManager.CommonTypes.ErrorResponse` in the Python client name scope.
