### PR TITLE
Add definitions for multi-NIC support to v2026_03_02_preview

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
@@ -757,6 +757,47 @@ model AgentPoolNetworkProfile {
       type: "Microsoft.Network/applicationSecurityGroups";
     }
   ]>[];
+
+  /**
+   * The list of secondary network interface configurations for the agent pool.
+   */
+  @added(Versions.v2026_03_02_preview)
+  @identifiers(#[])
+  secondaryNetworkInterfaces?: AgentPoolNetworkInterface[];
+}
+
+/**
+ * The type of a secondary network interface.
+ */
+@added(Versions.v2026_03_02_preview)
+union AgentPoolNetworkInterfaceType {
+  string,
+
+  /** Standard NIC attached to a customer-specified subnet with platform-allocated IPs. */
+  Standard: "Standard",
+
+  /** NIC with delegated IP allocation from a third-party orchestrator. */
+  Dynamic: "Dynamic",
+}
+
+/**
+ * A secondary network interface configuration for an agent pool.
+ */
+@added(Versions.v2026_03_02_preview)
+model AgentPoolNetworkInterface {
+  /** The type of the network interface. */
+  type?: AgentPoolNetworkInterfaceType;
+
+  /** The ID of the subnet which the secondary NIC will join. */
+  #suppress "@azure-tools/typespec-azure-core/casing-style" "Property name maintained for backward compatibility with existing API versions"
+  vnetSubnetID?: Azure.Core.armResourceIdentifier<[
+    {
+      type: "Microsoft.Network/virtualNetworks/subnets";
+    }
+  ]>;
+
+  /** Whether to enable accelerated networking on the secondary NIC. */
+  enableAcceleratedNetworking?: boolean;
 }
 
 /**

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
@@ -759,7 +759,16 @@ model AgentPoolNetworkProfile {
   ]>[];
 
   /**
-   * The list of secondary network interface configurations for the agent pool.
+   * Secondary network interface configurations for each VM in the agent pool.
+   * Each entry is a template: one physical NIC per entry is provisioned on every
+   * VM instance. These interfaces are created at agent pool creation time and
+   * are immutable.
+   * The length of the list must be less than the NIC capacity minus 1 for the
+   * VM size of the agent pool (AKS manages the primary NIC). For example, a
+   * Standard_D8a_v4 VM supports up to 4 NICs, so the maximum number of secondary
+   * interfaces allowed is 3. For mixed-SKU VM pools the effective capacity is the
+   * minimum across all SKUs: count(secondaryNetworkInterfaces) + 1 <= min(maxNICs).
+   * For more information, see https://aka.ms/aks/multi-nic
    */
   @added(Versions.v2026_03_02_preview)
   @identifiers(#[])
@@ -767,36 +776,56 @@ model AgentPoolNetworkProfile {
 }
 
 /**
- * The type of a secondary network interface.
+ * Type of network interface to be provisioned on each virtual machine instance.
+ * For more information, see https://aka.ms/aks/multi-nic
  */
 @added(Versions.v2026_03_02_preview)
 union AgentPoolNetworkInterfaceType {
   string,
 
-  /** Standard NIC attached to a customer-specified subnet with platform-allocated IPs. */
+  /**
+   * A standard network interface programmed with an IP from a specified VNet subnet.
+   * Must be used with `vnetSubnetId` set in the AgentPoolNetworkInterface.
+   * IP address family (IPv4/IPv6/Dual-stack) is determined by the subnet.
+   */
   Standard: "Standard",
 
-  /** NIC with delegated IP allocation from a third-party orchestrator. */
+  /**
+   * A secondary network interface created without IP configuration or subnet
+   * attachment. The interface is provisioned in an uninitialized state and the
+   * subnet is attached during workload creation. `vnetSubnetId` must be set to
+   * an empty string (`""`).
+   */
   Dynamic: "Dynamic",
 }
 
 /**
- * A secondary network interface configuration for an agent pool.
+ * Configuration of a secondary network interface provisioned on each VM
+ * instance in the agent pool.
+ * For more information, see https://aka.ms/aks/multi-nic
  */
 @added(Versions.v2026_03_02_preview)
 model AgentPoolNetworkInterface {
-  /** The type of the network interface. */
+  /**
+   * Type of NIC to be provisioned on the VM.
+   */
   type?: AgentPoolNetworkInterfaceType;
 
-  /** The ID of the subnet which the secondary NIC will join. */
-  #suppress "@azure-tools/typespec-azure-core/casing-style" "Property name maintained for backward compatibility with existing API versions"
-  vnetSubnetID?: Azure.Core.armResourceIdentifier<[
+  /**
+   * The resource ID of the subnet which will be attached to the secondary
+   * network interface. Required when `type` is `Standard`; must be an empty
+   * string (`""`) when `type` is `Dynamic`.
+   */
+  vnetSubnetId?: Azure.Core.armResourceIdentifier<[
     {
       type: "Microsoft.Network/virtualNetworks/subnets";
     }
   ]>;
 
-  /** Whether to enable accelerated networking on the secondary NIC. */
+  /**
+   * Whether accelerated networking is enabled on this secondary NIC.
+   * Default: true.
+   */
   enableAcceleratedNetworking?: boolean;
 }
 

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
@@ -814,7 +814,7 @@ model AgentPoolNetworkInterface {
   /**
    * The resource ID of the subnet which will be attached to the secondary
    * network interface. Required when `type` is `Standard`; must be an empty
-   * string (`""`) when `type` is `Dynamic`.
+   * string (`""`) or omitted when `type` is `Dynamic`.
    */
   vnetSubnetId?: Azure.Core.armResourceIdentifier<[
     {
@@ -824,7 +824,9 @@ model AgentPoolNetworkInterface {
 
   /**
    * Whether accelerated networking is enabled on this secondary NIC.
-   * Default: true.
+   * If omitted, this defaults to true only when the agent pool VM SKU supports
+   * accelerated networking. Validation will fail if it is enabled on an
+   * unsupported SKU or NIC configuration.
    */
   enableAcceleratedNetworking?: boolean;
 }

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
@@ -758,52 +758,25 @@ model AgentPoolNetworkProfile {
     }
   ]>[];
 
-  /**
-   * Secondary network interface configurations for each VM in the agent pool.
-   * Each entry is a template: one physical NIC per entry is provisioned on every
-   * VM instance. These interfaces are created at agent pool creation time and
-   * are immutable.
-   * The length of the list must be less than the NIC capacity minus 1 for the
-   * VM size of the agent pool (AKS manages the primary NIC). For example, a
-   * Standard_D8a_v4 VM supports up to 4 NICs, so the maximum number of secondary
-   * interfaces allowed is 3. For mixed-SKU VM pools the effective capacity is the
-   * minimum across all SKUs: count(secondaryNetworkInterfaces) + 1 <= min(maxNICs).
-   * For more information, see https://aka.ms/aks/multi-nic
-   */
+  /** Secondary network interface configurations for each VM in the agent pool. Each entry is a template: one physical NIC per entry is provisioned on every VM instance. These interfaces are created at agent pool creation time and are immutable. The length of the list must be less than the NIC capacity minus 1 for the VM size of the agent pool (AKS manages the primary NIC). For example, a Standard_D8a_v4 VM supports up to 4 NICs, so the maximum number of secondary interfaces allowed is 3. For mixed-SKU VM pools the effective capacity is the minimum across all SKUs: count(secondaryNetworkInterfaces) + 1 <= min(maxNICs). For more information, see https://aka.ms/aks/multi-nic */
   @added(Versions.v2026_03_02_preview)
   @identifiers(#[])
   secondaryNetworkInterfaces?: AgentPoolNetworkInterface[];
 }
 
-/**
- * Type of network interface to be provisioned on each virtual machine instance.
- * For more information, see https://aka.ms/aks/multi-nic
- */
+/** Type of network interface to be provisioned on each virtual machine instance. For more information, see https://aka.ms/aks/multi-nic */
 @added(Versions.v2026_03_02_preview)
 union AgentPoolNetworkInterfaceType {
   string,
 
-  /**
-   * A standard network interface programmed with an IP from a specified VNet subnet.
-   * Must be used with `vnetSubnetId` set in the AgentPoolNetworkInterface.
-   * IP address family (IPv4/IPv6/Dual-stack) is determined by the subnet.
-   */
+  /** A standard network interface programmed with an IP from a specified VNet subnet. Must be used with `vnetSubnetId` set in the AgentPoolNetworkInterface. IP address family (IPv4/IPv6/Dual-stack) is determined by the subnet. */
   Standard: "Standard",
 
-  /**
-   * A secondary network interface created without IP configuration or subnet
-   * attachment. The interface is provisioned in an uninitialized state and the
-   * subnet is attached during workload creation. `vnetSubnetId` must be set to
-   * an empty string (`""`).
-   */
+  /** A secondary network interface created without IP configuration or subnet attachment. The interface is provisioned in an uninitialized state and the subnet is attached during workload creation. `vnetSubnetId` must be set to an empty string (`""`) or omitted. */
   Dynamic: "Dynamic",
 }
 
-/**
- * Configuration of a secondary network interface provisioned on each VM
- * instance in the agent pool.
- * For more information, see https://aka.ms/aks/multi-nic
- */
+/** Configuration of a secondary network interface provisioned on each VM instance in the agent pool. For more information, see https://aka.ms/aks/multi-nic */
 @added(Versions.v2026_03_02_preview)
 model AgentPoolNetworkInterface {
   /**
@@ -811,23 +784,14 @@ model AgentPoolNetworkInterface {
    */
   type?: AgentPoolNetworkInterfaceType;
 
-  /**
-   * The resource ID of the subnet which will be attached to the secondary
-   * network interface. Required when `type` is `Standard`; must be an empty
-   * string (`""`) or omitted when `type` is `Dynamic`.
-   */
+  /** The resource ID of the subnet which will be attached to the secondary network interface. Required when `type` is `Standard`; must be an empty string (`""`) or omitted when `type` is `Dynamic`. */
   vnetSubnetId?: Azure.Core.armResourceIdentifier<[
     {
       type: "Microsoft.Network/virtualNetworks/subnets";
     }
   ]>;
 
-  /**
-   * Whether accelerated networking is enabled on this secondary NIC.
-   * If omitted, this defaults to true only when the agent pool VM SKU supports
-   * accelerated networking. Validation will fail if it is enabled on an
-   * unsupported SKU or NIC configuration.
-   */
+  /** Whether accelerated networking is enabled on this secondary NIC. If omitted, this defaults to true only when the agent pool VM SKU supports accelerated networking. Validation will fail if it is enabled on an unsupported SKU or NIC configuration. */
   enableAcceleratedNetworking?: boolean;
 }
 

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-03-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-03-02-preview/managedClusters.json
@@ -6820,6 +6820,56 @@
         ]
       }
     },
+    "AgentPoolNetworkInterface": {
+      "type": "object",
+      "description": "A secondary network interface configuration for an agent pool.",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/AgentPoolNetworkInterfaceType",
+          "description": "The type of the network interface."
+        },
+        "vnetSubnetID": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The ID of the subnet which the secondary NIC will join.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/virtualNetworks/subnets"
+              }
+            ]
+          }
+        },
+        "enableAcceleratedNetworking": {
+          "type": "boolean",
+          "description": "Whether to enable accelerated networking on the secondary NIC."
+        }
+      }
+    },
+    "AgentPoolNetworkInterfaceType": {
+      "type": "string",
+      "description": "The type of a secondary network interface.",
+      "enum": [
+        "Standard",
+        "Dynamic"
+      ],
+      "x-ms-enum": {
+        "name": "AgentPoolNetworkInterfaceType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Standard",
+            "value": "Standard",
+            "description": "Standard NIC attached to a customer-specified subnet with platform-allocated IPs."
+          },
+          {
+            "name": "Dynamic",
+            "value": "Dynamic",
+            "description": "NIC with delegated IP allocation from a third-party orchestrator."
+          }
+        ]
+      }
+    },
     "AgentPoolNetworkProfile": {
       "type": "object",
       "description": "Network settings of an agent pool.",
@@ -6855,6 +6905,14 @@
               ]
             }
           }
+        },
+        "secondaryNetworkInterfaces": {
+          "type": "array",
+          "description": "The list of secondary network interface configurations for the agent pool.",
+          "items": {
+            "$ref": "#/definitions/AgentPoolNetworkInterface"
+          },
+          "x-ms-identifiers": []
         }
       }
     },

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-03-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-03-02-preview/managedClusters.json
@@ -6831,7 +6831,7 @@
         "vnetSubnetId": {
           "type": "string",
           "format": "arm-id",
-          "description": "The resource ID of the subnet which will be attached to the secondary network interface. Required when `type` is `Standard`; must be an empty string (`\"\"`) when `type` is `Dynamic`.",
+          "description": "The resource ID of the subnet which will be attached to the secondary network interface. Required when `type` is `Standard`; must be an empty string (`\"\"`) or omitted when `type` is `Dynamic`.",
           "x-ms-arm-id-details": {
             "allowedResources": [
               {
@@ -6842,7 +6842,7 @@
         },
         "enableAcceleratedNetworking": {
           "type": "boolean",
-          "description": "Whether accelerated networking is enabled on this secondary NIC. Default: true."
+          "description": "Whether accelerated networking is enabled on this secondary NIC. If omitted, this defaults to true only when the agent pool VM SKU supports accelerated networking. Validation will fail if it is enabled on an unsupported SKU or NIC configuration."
         }
       }
     },
@@ -6865,7 +6865,7 @@
           {
             "name": "Dynamic",
             "value": "Dynamic",
-            "description": "A secondary network interface created without IP configuration or subnet attachment. The interface is provisioned in an uninitialized state and the subnet is attached during workload creation. `vnetSubnetId` must be set to an empty string (`\"\"`)."
+            "description": "A secondary network interface created without IP configuration or subnet attachment. The interface is provisioned in an uninitialized state and the subnet is attached during workload creation. `vnetSubnetId` must be set to an empty string (`\"\"`) or omitted."
           }
         ]
       }

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-03-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-03-02-preview/managedClusters.json
@@ -6822,16 +6822,16 @@
     },
     "AgentPoolNetworkInterface": {
       "type": "object",
-      "description": "A secondary network interface configuration for an agent pool.",
+      "description": "Configuration of a secondary network interface provisioned on each VM instance in the agent pool. For more information, see https://aka.ms/aks/multi-nic",
       "properties": {
         "type": {
           "$ref": "#/definitions/AgentPoolNetworkInterfaceType",
-          "description": "The type of the network interface."
+          "description": "Type of NIC to be provisioned on the VM."
         },
-        "vnetSubnetID": {
+        "vnetSubnetId": {
           "type": "string",
           "format": "arm-id",
-          "description": "The ID of the subnet which the secondary NIC will join.",
+          "description": "The resource ID of the subnet which will be attached to the secondary network interface. Required when `type` is `Standard`; must be an empty string (`\"\"`) when `type` is `Dynamic`.",
           "x-ms-arm-id-details": {
             "allowedResources": [
               {
@@ -6842,13 +6842,13 @@
         },
         "enableAcceleratedNetworking": {
           "type": "boolean",
-          "description": "Whether to enable accelerated networking on the secondary NIC."
+          "description": "Whether accelerated networking is enabled on this secondary NIC. Default: true."
         }
       }
     },
     "AgentPoolNetworkInterfaceType": {
       "type": "string",
-      "description": "The type of a secondary network interface.",
+      "description": "Type of network interface to be provisioned on each virtual machine instance. For more information, see https://aka.ms/aks/multi-nic",
       "enum": [
         "Standard",
         "Dynamic"
@@ -6860,12 +6860,12 @@
           {
             "name": "Standard",
             "value": "Standard",
-            "description": "Standard NIC attached to a customer-specified subnet with platform-allocated IPs."
+            "description": "A standard network interface programmed with an IP from a specified VNet subnet. Must be used with `vnetSubnetId` set in the AgentPoolNetworkInterface. IP address family (IPv4/IPv6/Dual-stack) is determined by the subnet."
           },
           {
             "name": "Dynamic",
             "value": "Dynamic",
-            "description": "NIC with delegated IP allocation from a third-party orchestrator."
+            "description": "A secondary network interface created without IP configuration or subnet attachment. The interface is provisioned in an uninitialized state and the subnet is attached during workload creation. `vnetSubnetId` must be set to an empty string (`\"\"`)."
           }
         ]
       }
@@ -6908,7 +6908,7 @@
         },
         "secondaryNetworkInterfaces": {
           "type": "array",
-          "description": "The list of secondary network interface configurations for the agent pool.",
+          "description": "Secondary network interface configurations for each VM in the agent pool. Each entry is a template: one physical NIC per entry is provisioned on every VM instance. These interfaces are created at agent pool creation time and are immutable. The length of the list must be less than the NIC capacity minus 1 for the VM size of the agent pool (AKS manages the primary NIC). For example, a Standard_D8a_v4 VM supports up to 4 NICs, so the maximum number of secondary interfaces allowed is 3. For mixed-SKU VM pools the effective capacity is the minimum across all SKUs: count(secondaryNetworkInterfaces) + 1 <= min(maxNICs). For more information, see https://aka.ms/aks/multi-nic",
           "items": {
             "$ref": "#/definitions/AgentPoolNetworkInterface"
           },

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-03-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-03-02-preview/managedClusters.json
@@ -6822,7 +6822,7 @@
     },
     "AgentPoolNetworkInterface": {
       "type": "object",
-      "description": "Configuration of a secondary network interface provisioned on each VM\ninstance in the agent pool.\nFor more information, see https://aka.ms/aks/multi-nic",
+      "description": "Configuration of a secondary network interface provisioned on each VM instance in the agent pool. For more information, see https://aka.ms/aks/multi-nic",
       "properties": {
         "type": {
           "$ref": "#/definitions/AgentPoolNetworkInterfaceType",
@@ -6831,7 +6831,7 @@
         "vnetSubnetId": {
           "type": "string",
           "format": "arm-id",
-          "description": "The resource ID of the subnet which will be attached to the secondary\nnetwork interface. Required when `type` is `Standard`; must be an empty\nstring (`\"\"`) or omitted when `type` is `Dynamic`.",
+          "description": "The resource ID of the subnet which will be attached to the secondary network interface. Required when `type` is `Standard`; must be an empty string (`\"\"`) or omitted when `type` is `Dynamic`.",
           "x-ms-arm-id-details": {
             "allowedResources": [
               {
@@ -6842,13 +6842,13 @@
         },
         "enableAcceleratedNetworking": {
           "type": "boolean",
-          "description": "Whether accelerated networking is enabled on this secondary NIC.\nIf omitted, this defaults to true only when the agent pool VM SKU supports\naccelerated networking. Validation will fail if it is enabled on an\nunsupported SKU or NIC configuration."
+          "description": "Whether accelerated networking is enabled on this secondary NIC. If omitted, this defaults to true only when the agent pool VM SKU supports accelerated networking. Validation will fail if it is enabled on an unsupported SKU or NIC configuration."
         }
       }
     },
     "AgentPoolNetworkInterfaceType": {
       "type": "string",
-      "description": "Type of network interface to be provisioned on each virtual machine instance.\nFor more information, see https://aka.ms/aks/multi-nic",
+      "description": "Type of network interface to be provisioned on each virtual machine instance. For more information, see https://aka.ms/aks/multi-nic",
       "enum": [
         "Standard",
         "Dynamic"
@@ -6860,12 +6860,12 @@
           {
             "name": "Standard",
             "value": "Standard",
-            "description": "A standard network interface programmed with an IP from a specified VNet subnet.\nMust be used with `vnetSubnetId` set in the AgentPoolNetworkInterface.\nIP address family (IPv4/IPv6/Dual-stack) is determined by the subnet."
+            "description": "A standard network interface programmed with an IP from a specified VNet subnet. Must be used with `vnetSubnetId` set in the AgentPoolNetworkInterface. IP address family (IPv4/IPv6/Dual-stack) is determined by the subnet."
           },
           {
             "name": "Dynamic",
             "value": "Dynamic",
-            "description": "A secondary network interface created without IP configuration or subnet\nattachment. The interface is provisioned in an uninitialized state and the\nsubnet is attached during workload creation. `vnetSubnetId` must be set to\nan empty string (`\"\"`)."
+            "description": "A secondary network interface created without IP configuration or subnet attachment. The interface is provisioned in an uninitialized state and the subnet is attached during workload creation. `vnetSubnetId` must be set to an empty string (`\"\"`) or omitted."
           }
         ]
       }
@@ -6908,7 +6908,7 @@
         },
         "secondaryNetworkInterfaces": {
           "type": "array",
-          "description": "Secondary network interface configurations for each VM in the agent pool.\nEach entry is a template: one physical NIC per entry is provisioned on every\nVM instance. These interfaces are created at agent pool creation time and\nare immutable.\nThe length of the list must be less than the NIC capacity minus 1 for the\nVM size of the agent pool (AKS manages the primary NIC). For example, a\nStandard_D8a_v4 VM supports up to 4 NICs, so the maximum number of secondary\ninterfaces allowed is 3. For mixed-SKU VM pools the effective capacity is the\nminimum across all SKUs: count(secondaryNetworkInterfaces) + 1 <= min(maxNICs).\nFor more information, see https://aka.ms/aks/multi-nic",
+          "description": "Secondary network interface configurations for each VM in the agent pool. Each entry is a template: one physical NIC per entry is provisioned on every VM instance. These interfaces are created at agent pool creation time and are immutable. The length of the list must be less than the NIC capacity minus 1 for the VM size of the agent pool (AKS manages the primary NIC). For example, a Standard_D8a_v4 VM supports up to 4 NICs, so the maximum number of secondary interfaces allowed is 3. For mixed-SKU VM pools the effective capacity is the minimum across all SKUs: count(secondaryNetworkInterfaces) + 1 <= min(maxNICs). For more information, see https://aka.ms/aks/multi-nic",
           "items": {
             "$ref": "#/definitions/AgentPoolNetworkInterface"
           },

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-03-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-03-02-preview/managedClusters.json
@@ -6822,7 +6822,7 @@
     },
     "AgentPoolNetworkInterface": {
       "type": "object",
-      "description": "Configuration of a secondary network interface provisioned on each VM instance in the agent pool. For more information, see https://aka.ms/aks/multi-nic",
+      "description": "Configuration of a secondary network interface provisioned on each VM\ninstance in the agent pool.\nFor more information, see https://aka.ms/aks/multi-nic",
       "properties": {
         "type": {
           "$ref": "#/definitions/AgentPoolNetworkInterfaceType",
@@ -6831,7 +6831,7 @@
         "vnetSubnetId": {
           "type": "string",
           "format": "arm-id",
-          "description": "The resource ID of the subnet which will be attached to the secondary network interface. Required when `type` is `Standard`; must be an empty string (`\"\"`) or omitted when `type` is `Dynamic`.",
+          "description": "The resource ID of the subnet which will be attached to the secondary\nnetwork interface. Required when `type` is `Standard`; must be an empty\nstring (`\"\"`) or omitted when `type` is `Dynamic`.",
           "x-ms-arm-id-details": {
             "allowedResources": [
               {
@@ -6842,13 +6842,13 @@
         },
         "enableAcceleratedNetworking": {
           "type": "boolean",
-          "description": "Whether accelerated networking is enabled on this secondary NIC. If omitted, this defaults to true only when the agent pool VM SKU supports accelerated networking. Validation will fail if it is enabled on an unsupported SKU or NIC configuration."
+          "description": "Whether accelerated networking is enabled on this secondary NIC.\nIf omitted, this defaults to true only when the agent pool VM SKU supports\naccelerated networking. Validation will fail if it is enabled on an\nunsupported SKU or NIC configuration."
         }
       }
     },
     "AgentPoolNetworkInterfaceType": {
       "type": "string",
-      "description": "Type of network interface to be provisioned on each virtual machine instance. For more information, see https://aka.ms/aks/multi-nic",
+      "description": "Type of network interface to be provisioned on each virtual machine instance.\nFor more information, see https://aka.ms/aks/multi-nic",
       "enum": [
         "Standard",
         "Dynamic"
@@ -6860,12 +6860,12 @@
           {
             "name": "Standard",
             "value": "Standard",
-            "description": "A standard network interface programmed with an IP from a specified VNet subnet. Must be used with `vnetSubnetId` set in the AgentPoolNetworkInterface. IP address family (IPv4/IPv6/Dual-stack) is determined by the subnet."
+            "description": "A standard network interface programmed with an IP from a specified VNet subnet.\nMust be used with `vnetSubnetId` set in the AgentPoolNetworkInterface.\nIP address family (IPv4/IPv6/Dual-stack) is determined by the subnet."
           },
           {
             "name": "Dynamic",
             "value": "Dynamic",
-            "description": "A secondary network interface created without IP configuration or subnet attachment. The interface is provisioned in an uninitialized state and the subnet is attached during workload creation. `vnetSubnetId` must be set to an empty string (`\"\"`) or omitted."
+            "description": "A secondary network interface created without IP configuration or subnet\nattachment. The interface is provisioned in an uninitialized state and the\nsubnet is attached during workload creation. `vnetSubnetId` must be set to\nan empty string (`\"\"`)."
           }
         ]
       }
@@ -6908,7 +6908,7 @@
         },
         "secondaryNetworkInterfaces": {
           "type": "array",
-          "description": "Secondary network interface configurations for each VM in the agent pool. Each entry is a template: one physical NIC per entry is provisioned on every VM instance. These interfaces are created at agent pool creation time and are immutable. The length of the list must be less than the NIC capacity minus 1 for the VM size of the agent pool (AKS manages the primary NIC). For example, a Standard_D8a_v4 VM supports up to 4 NICs, so the maximum number of secondary interfaces allowed is 3. For mixed-SKU VM pools the effective capacity is the minimum across all SKUs: count(secondaryNetworkInterfaces) + 1 <= min(maxNICs). For more information, see https://aka.ms/aks/multi-nic",
+          "description": "Secondary network interface configurations for each VM in the agent pool.\nEach entry is a template: one physical NIC per entry is provisioned on every\nVM instance. These interfaces are created at agent pool creation time and\nare immutable.\nThe length of the list must be less than the NIC capacity minus 1 for the\nVM size of the agent pool (AKS manages the primary NIC). For example, a\nStandard_D8a_v4 VM supports up to 4 NICs, so the maximum number of secondary\ninterfaces allowed is 3. For mixed-SKU VM pools the effective capacity is the\nminimum across all SKUs: count(secondaryNetworkInterfaces) + 1 <= min(maxNICs).\nFor more information, see https://aka.ms/aks/multi-nic",
           "items": {
             "$ref": "#/definitions/AgentPoolNetworkInterface"
           },


### PR DESCRIPTION
As part of the 2026-03-02 preview API, add definitions for:
- `AgentPoolNetworkInterface`
- `AgentPoolNetworkInterfaceType`

Add `secondaryNetworkInterfaces` property to `AgentPoolNetworkProfile`.