### PR TITLE
Add nodePublicIPPrefixIDs to AgentPoolNetworkProfile for IPv6 ILPIP Support

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
@@ -744,6 +744,24 @@ model AgentPoolNetworkProfile {
   nodePublicIPTags?: IPTag[];
 
   /**
+   * The resource IDs of public IP prefixes for node public IPs.
+   * At most one IPv4 and one IPv6 prefix may be specified. Order does not matter;
+   * the RP determines IP version from the referenced resource's publicIPAddressVersion.
+   * Requires enableNodePublicIP to be true on the agent pool.
+   * Mutually exclusive with the top-level nodePublicIPPrefixID property.
+   * Immutable after node pool creation. To change prefixes, delete and recreate the node pool.
+   * For more information, see https://aka.ms/aks/ipv6-ilpip
+   */
+  #suppress "@azure-tools/typespec-azure-core/casing-style" "Property name maintained for backward compatibility with existing API versions"
+  @added(Versions.v2026_03_02_preview)
+  @maxItems(2)
+  nodePublicIPPrefixIDs?: Azure.Core.armResourceIdentifier<[
+    {
+      type: "Microsoft.Network/publicIPPrefixes";
+    }
+  ]>[];
+
+  /**
    * The port ranges that are allowed to access. The specified ranges are allowed to overlap.
    */
   @identifiers(#[])

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
@@ -744,13 +744,7 @@ model AgentPoolNetworkProfile {
   nodePublicIPTags?: IPTag[];
 
   /**
-   * The resource IDs of public IP prefixes for node public IPs.
-   * At most one IPv4 and one IPv6 prefix may be specified. Order does not matter;
-   * the RP determines IP version from the referenced resource's publicIPAddressVersion.
-   * Requires enableNodePublicIP to be true on the agent pool.
-   * Mutually exclusive with the top-level nodePublicIPPrefixID property.
-   * Immutable after node pool creation. To change prefixes, delete and recreate the node pool.
-   * For more information, see https://aka.ms/aks/ipv6-ilpip
+   * The resource IDs of public IP prefixes for node public IPs. At most one IPv4 and one IPv6 prefix may be specified. Order does not matter; the RP determines IP version from the referenced resource's publicIPAddressVersion. Requires enableNodePublicIP to be true on the agent pool. Mutually exclusive with the top-level nodePublicIPPrefixID property. Immutable after node pool creation. To change prefixes, delete and recreate the node pool. For more information, see https://aka.ms/aks/ipv6-ilpip
    */
   #suppress "@azure-tools/typespec-azure-core/casing-style" "Property name maintained for backward compatibility with existing API versions"
   @added(Versions.v2026_03_02_preview)

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-03-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-03-02-preview/managedClusters.json
@@ -6832,6 +6832,23 @@
           },
           "x-ms-identifiers": []
         },
+        "nodePublicIPPrefixIDs": {
+          "type": "array",
+          "description": "The resource IDs of public IP prefixes for node public IPs.\nAt most one IPv4 and one IPv6 prefix may be specified. Order does not matter;\nthe RP determines IP version from the referenced resource's publicIPAddressVersion.\nRequires enableNodePublicIP to be true on the agent pool.\nMutually exclusive with the top-level nodePublicIPPrefixID property.\nImmutable after node pool creation. To change prefixes, delete and recreate the node pool.\nFor more information, see https://aka.ms/aks/ipv6-ilpip",
+          "maxItems": 2,
+          "items": {
+            "type": "string",
+            "format": "arm-id",
+            "description": "A type definition that refers the id to an Azure Resource Manager resource.",
+            "x-ms-arm-id-details": {
+              "allowedResources": [
+                {
+                  "type": "Microsoft.Network/publicIPPrefixes"
+                }
+              ]
+            }
+          }
+        },
         "allowedHostPorts": {
           "type": "array",
           "description": "The port ranges that are allowed to access. The specified ranges are allowed to overlap.",

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-03-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-03-02-preview/managedClusters.json
@@ -6834,7 +6834,7 @@
         },
         "nodePublicIPPrefixIDs": {
           "type": "array",
-          "description": "The resource IDs of public IP prefixes for node public IPs.\nAt most one IPv4 and one IPv6 prefix may be specified. Order does not matter;\nthe RP determines IP version from the referenced resource's publicIPAddressVersion.\nRequires enableNodePublicIP to be true on the agent pool.\nMutually exclusive with the top-level nodePublicIPPrefixID property.\nImmutable after node pool creation. To change prefixes, delete and recreate the node pool.\nFor more information, see https://aka.ms/aks/ipv6-ilpip",
+          "description": "The resource IDs of public IP prefixes for node public IPs. At most one IPv4 and one IPv6 prefix may be specified. Order does not matter; the RP determines IP version from the referenced resource's publicIPAddressVersion. Requires enableNodePublicIP to be true on the agent pool. Mutually exclusive with the top-level nodePublicIPPrefixID property. Immutable after node pool creation. To change prefixes, delete and recreate the node pool. For more information, see https://aka.ms/aks/ipv6-ilpip",
           "maxItems": 2,
           "items": {
             "type": "string",


### PR DESCRIPTION
Add a new nodePublicIPPrefixIDs array property to AgentPoolNetworkProfile in the 2026-03-02-preview API version. This enables dual-stack (IPv4+IPv6) node public IP assignment via public IP prefixes.

- Array of armResourceIdentifier scoped to Microsoft.Network/publicIPPrefixes
- @maxItems(2): at most one IPv4 and one IPv6 prefix
- @added(Versions.v2026_03_02_preview): version-gated to new preview
- Mutually exclusive with top-level nodePublicIPPrefixID property