### PR TITLE
Remove isolation key fields from HeaderIsolationKeySource

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -698,12 +698,6 @@ model EntraIsolationKeySource extends IsolationKeySource {
 )
 model HeaderIsolationKeySource extends IsolationKeySource {
   kind: IsolationKeySourceKind.Header;
-
-  @doc("The user isolation key header value")
-  user_isolation_key: string;
-
-  @doc("The chat isolation key header value")
-  chat_isolation_key: string;
 }
 
 @extension(


### PR DESCRIPTION
Removed user and chat isolation key definitions from HeaderIsolationKeySource model.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
