### PR TITLE
Exclude SloView operations from SDK generation

### DIFF
--- a/specification/monitoringservice/resource-manager/Microsoft.Monitor/Slis/client.tsp
+++ b/specification/monitoringservice/resource-manager/Microsoft.Monitor/Slis/client.tsp
@@ -6,10 +6,7 @@ using Azure.ClientGenerator.Core;
 #suppress "@azure-tools/typespec-azure-resource-manager/missing-operations-endpoint" "Operations API was moved to its own service."
 namespace Microsoft.Monitor;
 
-// Mark SloView preview operations and their exclusively-used models as internal.
-// Shared models (EvaluationType, BaselineProperties, Signal, etc.) remain public
-// because they are also used by the public Slis interface.
-@@access(Access.internal, SloView.sliSignalPreview);
-@@access(Access.internal, SignalPreviewSliProperties);
-@@access(Access.internal, PreviewType);
-@@access(Access.internal, KqlmQueryResult);
+// Hide sliSignalPreview from all SDK generations.
+// @@access targets operations, so we mark the single operation inside SloView
+// as internal. The Slis interface remains public.
+@@access(SloView.sliSignalPreview, Access.internal);

--- a/specification/monitoringservice/resource-manager/Microsoft.Monitor/Slis/client.tsp
+++ b/specification/monitoringservice/resource-manager/Microsoft.Monitor/Slis/client.tsp
@@ -6,9 +6,10 @@ using Azure.ClientGenerator.Core;
 #suppress "@azure-tools/typespec-azure-resource-manager/missing-operations-endpoint" "Operations API was moved to its own service."
 namespace Microsoft.Monitor;
 
-// Hide SloView (sliSignalPreview) operations from public SDK generation.
-// The SloView interface and its exclusively-used models (SignalPreviewSliProperties,
-// PreviewType, KqlmQueryResult, etc.) will be marked as internal.
+// Mark SloView preview operations and their exclusively-used models as internal.
 // Shared models (EvaluationType, BaselineProperties, Signal, etc.) remain public
 // because they are also used by the public Slis interface.
-@@access(SloView.sliSignalPreview, Access.internal);
+@@access(Access.internal, SloView.sliSignalPreview);
+@@access(Access.internal, SignalPreviewSliProperties);
+@@access(Access.internal, PreviewType);
+@@access(Access.internal, KqlmQueryResult);

--- a/specification/monitoringservice/resource-manager/Microsoft.Monitor/Slis/client.tsp
+++ b/specification/monitoringservice/resource-manager/Microsoft.Monitor/Slis/client.tsp
@@ -6,7 +6,9 @@ using Azure.ClientGenerator.Core;
 #suppress "@azure-tools/typespec-azure-resource-manager/missing-operations-endpoint" "Operations API was moved to its own service."
 namespace Microsoft.Monitor;
 
-// Hide sliSignalPreview from all SDK generations.
-// @@access targets operations, so we mark the single operation inside SloView
-// as internal. The Slis interface remains public.
+// Hide SloView (sliSignalPreview) operations from public SDK generation.
+// The SloView interface and its exclusively-used models (SignalPreviewSliProperties,
+// PreviewType, KqlmQueryResult, etc.) will be marked as internal.
+// Shared models (EvaluationType, BaselineProperties, Signal, etc.) remain public
+// because they are also used by the public Slis interface.
 @@access(SloView.sliSignalPreview, Access.internal);

--- a/specification/monitoringservice/resource-manager/Microsoft.Monitor/Slis/client.tsp
+++ b/specification/monitoringservice/resource-manager/Microsoft.Monitor/Slis/client.tsp
@@ -6,9 +6,10 @@ using Azure.ClientGenerator.Core;
 #suppress "@azure-tools/typespec-azure-resource-manager/missing-operations-endpoint" "Operations API was moved to its own service."
 namespace Microsoft.Monitor;
 
-// Hide SloView (sliSignalPreview) operations from public SDK generation.
-// The SloView interface and its exclusively-used models (SignalPreviewSliProperties,
-// PreviewType, KqlmQueryResult, etc.) will be marked as internal.
+// Exclude SloView and its exclusively-used models from public SDK generation.
 // Shared models (EvaluationType, BaselineProperties, Signal, etc.) remain public
 // because they are also used by the public Slis interface.
-@@access(SloView.sliSignalPreview, Access.internal);
+@@exclude(SloView.sliSignalPreview);
+@@exclude(SignalPreviewSliProperties);
+@@exclude(PreviewType);
+@@exclude(KqlmQueryResult);

--- a/specification/monitoringservice/resource-manager/Microsoft.Monitor/Slis/signalPreview.tsp
+++ b/specification/monitoringservice/resource-manager/Microsoft.Monitor/Slis/signalPreview.tsp
@@ -4,11 +4,13 @@ import "@typespec/openapi";
 import "@typespec/versioning";
 import "@azure-tools/typespec-azure-core";
 import "@azure-tools/typespec-azure-resource-manager";
+import "@azure-tools/typespec-client-generator-core";
 
 using TypeSpec.Http;
 using TypeSpec.Rest;
 using TypeSpec.OpenAPI;
 using Azure.ResourceManager;
+using Azure.ClientGenerator.Core;
 
 namespace Microsoft.Monitor;
 
@@ -67,6 +69,7 @@ interface SloView {
   @armResourceCollectionAction
   @action("providers/Microsoft.Monitor/sliSignalPreview")
   @doc("Returns preview data for the signal.")
+  @scope("!(csharp, python, java, javascript, go)")
   sliSignalPreview(
     ...ServiceGroupBaseParameters,
     ...Azure.ResourceManager.ApiVersionParameter,


### PR DESCRIPTION
## Summary
Use @@scope to exclude signalPreview operation from all languages targeted for SDK generation.

### Validation
- TypeSpec compiles cleanly (0 errors, 2 advisory warnings)
- Pattern follows the approach used in loadtestservice data-plane client.tsp

### Work Item
AB#37617083