### PR TITLE
Fix ScenarioAction parameters and duration types for 2026-05-01-preview

### DIFF
--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-05-01-preview/Scenarios_CreateOrUpdate.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-05-01-preview/Scenarios_CreateOrUpdate.json
@@ -2,42 +2,85 @@
   "parameters": {
     "api-version": "2026-05-01-preview",
     "workspaceName": "exampleWorkspace",
-    "scenarioName": "myVMShutdownScenario",
+    "scenarioName": "zoneDownScenario",
     "resourceGroupName": "exampleRG",
     "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291",
     "resource": {
       "properties": {
-        "description": "This scenario demonstrates shutting down virtual machines to test application resilience to infrastructure failures.",
+        "description": "Induces an outage of all discovered VM and VMSS instances in the target zone with an option to invoke custom scripted actions using Automation Runbooks. Additionally, it forces failover of discovered Redis instances to simulate backend zonal outage.",
         "parameters": [
           {
             "name": "duration",
             "type": "string",
-            "default": "PT5M",
+            "default": "PT15M",
             "required": false,
-            "description": "Duration of the shutdown in ISO 8601 format"
+            "description": "The duration of the outage scenario."
           },
           {
-            "name": "targetResourceIds",
-            "type": "array",
-            "required": true,
-            "description": "Array of target virtual machine resource IDs"
+            "name": "customRunbook1ResourceId",
+            "type": "string",
+            "required": false,
+            "description": "Optional custom runbook 1 resource ID. If not provided, this action will be skipped."
+          },
+          {
+            "name": "customRunbook1ParametersJson",
+            "type": "string",
+            "required": false,
+            "default": "{}",
+            "description": "Optional custom runbook 1 parameters in JSON format."
           }
         ],
         "actions": [
           {
-            "name": "shutdownAction",
-            "actionId": "microsoft-compute-shutdown/1.0",
-            "description": "Shutdown virtual machines to test resilience",
+            "name": "vmssZoneDown",
+            "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+            "description": "Force shutdown VMSS instances in target zone",
+            "duration": "%%{parameters.duration}%%",
+            "parameters": [
+              {
+                "key": "zones",
+                "value": "%%{filters.zones}%%"
+              }
+            ]
+          },
+          {
+            "name": "vmZoneDown",
+            "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+            "description": "Force shutdown VM instances in target zone",
+            "duration": "%%{parameters.duration}%%",
+            "parameters": [
+              {
+                "key": "zones",
+                "value": "%%{filters.zones}%%"
+              }
+            ]
+          },
+          {
+            "name": "redisFailover",
+            "actionId": "urn:csci:microsoft:azureClusteredCacheForRedis:Reboot/1.0.0",
+            "description": "Force failover of Redis instances to simulate backend zonal outage",
             "duration": "PT5M",
             "parameters": [
               {
-                "name": "abruptShutdown",
-                "type": "boolean",
-                "default": "false",
-                "required": false,
-                "description": "Whether to perform an abrupt shutdown"
+                "key": "RebootType",
+                "value": "PrimaryNode"
               }
             ]
+          },
+          {
+            "name": "custom-runbook-1",
+            "actionId": "urn:csci:microsoft:Automation:StartRunbook/1.0.0",
+            "description": "Custom Runbook 1",
+            "duration": "PT30M",
+            "parameters": [
+              {
+                "key": "RunbookParameters",
+                "value": "%%{parameters.customRunbook1ParametersJson}%%"
+              }
+            ],
+            "externalResource": {
+              "resourceId": "%%{parameters.customRunbook1ResourceId}%%"
+            }
           }
         ]
       }
@@ -46,43 +89,86 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/myVMShutdownScenario",
-        "name": "myVMShutdownScenario",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/zoneDownScenario",
+        "name": "zoneDownScenario",
         "type": "Microsoft.Chaos/workspaces/scenarios",
         "properties": {
           "provisioningState": "Succeeded",
-          "version": "1.0.0",
-          "description": "This scenario demonstrates shutting down virtual machines to test application resilience to infrastructure failures.",
+          "version": "1.0",
+          "description": "Induces an outage of all discovered VM and VMSS instances in the target zone with an option to invoke custom scripted actions using Automation Runbooks. Additionally, it forces failover of discovered Redis instances to simulate backend zonal outage.",
           "parameters": [
             {
               "name": "duration",
               "type": "string",
-              "default": "PT5M",
+              "default": "PT15M",
               "required": false,
-              "description": "Duration of the shutdown in ISO 8601 format"
+              "description": "The duration of the outage scenario."
             },
             {
-              "name": "targetResourceIds",
-              "type": "array",
-              "required": true,
-              "description": "Array of target virtual machine resource IDs"
+              "name": "customRunbook1ResourceId",
+              "type": "string",
+              "required": false,
+              "description": "Optional custom runbook 1 resource ID. If not provided, this action will be skipped."
+            },
+            {
+              "name": "customRunbook1ParametersJson",
+              "type": "string",
+              "required": false,
+              "default": "{}",
+              "description": "Optional custom runbook 1 parameters in JSON format."
             }
           ],
           "actions": [
             {
-              "name": "shutdownAction",
-              "actionId": "microsoft-compute-shutdown/1.0",
-              "description": "Shutdown virtual machines to test resilience",
+              "name": "vmssZoneDown",
+              "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+              "description": "Force shutdown VMSS instances in target zone",
+              "duration": "%%{parameters.duration}%%",
+              "parameters": [
+                {
+                  "key": "zones",
+                  "value": "%%{filters.zones}%%"
+                }
+              ]
+            },
+            {
+              "name": "vmZoneDown",
+              "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+              "description": "Force shutdown VM instances in target zone",
+              "duration": "%%{parameters.duration}%%",
+              "parameters": [
+                {
+                  "key": "zones",
+                  "value": "%%{filters.zones}%%"
+                }
+              ]
+            },
+            {
+              "name": "redisFailover",
+              "actionId": "urn:csci:microsoft:azureClusteredCacheForRedis:Reboot/1.0.0",
+              "description": "Force failover of Redis instances to simulate backend zonal outage",
               "duration": "PT5M",
               "parameters": [
                 {
-                  "name": "abruptShutdown",
-                  "type": "boolean",
-                  "default": "false",
-                  "required": false,
-                  "description": "Whether to perform an abrupt shutdown"
+                  "key": "RebootType",
+                  "value": "PrimaryNode"
                 }
               ]
+            },
+            {
+              "name": "custom-runbook-1",
+              "actionId": "urn:csci:microsoft:Automation:StartRunbook/1.0.0",
+              "description": "Custom Runbook 1",
+              "duration": "PT30M",
+              "parameters": [
+                {
+                  "key": "RunbookParameters",
+                  "value": "%%{parameters.customRunbook1ParametersJson}%%"
+                }
+              ],
+              "externalResource": {
+                "resourceId": "%%{parameters.customRunbook1ResourceId}%%"
+              }
             }
           ]
         },
@@ -99,43 +185,86 @@
     },
     "201": {
       "body": {
-        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/myVMShutdownScenario",
-        "name": "myVMShutdownScenario",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/zoneDownScenario",
+        "name": "zoneDownScenario",
         "type": "Microsoft.Chaos/workspaces/scenarios",
         "properties": {
           "provisioningState": "Creating",
-          "version": "1.0.0",
-          "description": "This scenario demonstrates shutting down virtual machines to test application resilience to infrastructure failures.",
+          "version": "1.0",
+          "description": "Induces an outage of all discovered VM and VMSS instances in the target zone with an option to invoke custom scripted actions using Automation Runbooks. Additionally, it forces failover of discovered Redis instances to simulate backend zonal outage.",
           "parameters": [
             {
               "name": "duration",
               "type": "string",
-              "default": "PT5M",
+              "default": "PT15M",
               "required": false,
-              "description": "Duration of the shutdown in ISO 8601 format"
+              "description": "The duration of the outage scenario."
             },
             {
-              "name": "targetResourceIds",
-              "type": "array",
-              "required": true,
-              "description": "Array of target virtual machine resource IDs"
+              "name": "customRunbook1ResourceId",
+              "type": "string",
+              "required": false,
+              "description": "Optional custom runbook 1 resource ID. If not provided, this action will be skipped."
+            },
+            {
+              "name": "customRunbook1ParametersJson",
+              "type": "string",
+              "required": false,
+              "default": "{}",
+              "description": "Optional custom runbook 1 parameters in JSON format."
             }
           ],
           "actions": [
             {
-              "name": "shutdownAction",
-              "actionId": "microsoft-compute-shutdown/1.0",
-              "description": "Shutdown virtual machines to test resilience",
+              "name": "vmssZoneDown",
+              "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+              "description": "Force shutdown VMSS instances in target zone",
+              "duration": "%%{parameters.duration}%%",
+              "parameters": [
+                {
+                  "key": "zones",
+                  "value": "%%{filters.zones}%%"
+                }
+              ]
+            },
+            {
+              "name": "vmZoneDown",
+              "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+              "description": "Force shutdown VM instances in target zone",
+              "duration": "%%{parameters.duration}%%",
+              "parameters": [
+                {
+                  "key": "zones",
+                  "value": "%%{filters.zones}%%"
+                }
+              ]
+            },
+            {
+              "name": "redisFailover",
+              "actionId": "urn:csci:microsoft:azureClusteredCacheForRedis:Reboot/1.0.0",
+              "description": "Force failover of Redis instances to simulate backend zonal outage",
               "duration": "PT5M",
               "parameters": [
                 {
-                  "name": "abruptShutdown",
-                  "type": "boolean",
-                  "default": "false",
-                  "required": false,
-                  "description": "Whether to perform an abrupt shutdown"
+                  "key": "RebootType",
+                  "value": "PrimaryNode"
                 }
               ]
+            },
+            {
+              "name": "custom-runbook-1",
+              "actionId": "urn:csci:microsoft:Automation:StartRunbook/1.0.0",
+              "description": "Custom Runbook 1",
+              "duration": "PT30M",
+              "parameters": [
+                {
+                  "key": "RunbookParameters",
+                  "value": "%%{parameters.customRunbook1ParametersJson}%%"
+                }
+              ],
+              "externalResource": {
+                "resourceId": "%%{parameters.customRunbook1ResourceId}%%"
+              }
             }
           ]
         },

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-05-01-preview/Scenarios_Get.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-05-01-preview/Scenarios_Get.json
@@ -2,50 +2,93 @@
   "parameters": {
     "api-version": "2026-05-01-preview",
     "workspaceName": "exampleWorkspace",
-    "scenarioName": "12345678-1234-1234-1234-123456789012",
+    "scenarioName": "zoneDownScenario",
     "resourceGroupName": "exampleRG",
     "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
   },
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012",
-        "name": "12345678-1234-1234-1234-123456789012",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/zoneDownScenario",
+        "name": "zoneDownScenario",
         "type": "Microsoft.Chaos/workspaces/scenarios",
         "properties": {
           "provisioningState": "Succeeded",
-          "version": "1.0.0",
-          "description": "This scenario demonstrates shutting down virtual machines to test application resilience to infrastructure failures.",
+          "version": "1.0",
+          "description": "Induces an outage of all discovered VM and VMSS instances in the target zone with an option to invoke custom scripted actions using Automation Runbooks. Additionally, it forces failover of discovered Redis instances to simulate backend zonal outage.",
           "parameters": [
             {
               "name": "duration",
               "type": "string",
-              "default": "PT5M",
+              "default": "PT15M",
               "required": false,
-              "description": "Duration of the shutdown in ISO 8601 format"
+              "description": "The duration of the outage scenario."
             },
             {
-              "name": "targetResourceIds",
-              "type": "array",
-              "required": true,
-              "description": "Array of target virtual machine resource IDs"
+              "name": "customRunbook1ResourceId",
+              "type": "string",
+              "required": false,
+              "description": "Optional custom runbook 1 resource ID. If not provided, this action will be skipped."
+            },
+            {
+              "name": "customRunbook1ParametersJson",
+              "type": "string",
+              "required": false,
+              "default": "{}",
+              "description": "Optional custom runbook 1 parameters in JSON format."
             }
           ],
           "actions": [
             {
-              "name": "shutdownAction",
-              "actionId": "microsoft-compute-shutdown/1.0",
-              "description": "Shutdown virtual machines to test resilience",
+              "name": "vmssZoneDown",
+              "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+              "description": "Force shutdown VMSS instances in target zone",
+              "duration": "%%{parameters.duration}%%",
+              "parameters": [
+                {
+                  "key": "zones",
+                  "value": "%%{filters.zones}%%"
+                }
+              ]
+            },
+            {
+              "name": "vmZoneDown",
+              "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+              "description": "Force shutdown VM instances in target zone",
+              "duration": "%%{parameters.duration}%%",
+              "parameters": [
+                {
+                  "key": "zones",
+                  "value": "%%{filters.zones}%%"
+                }
+              ]
+            },
+            {
+              "name": "redisFailover",
+              "actionId": "urn:csci:microsoft:azureClusteredCacheForRedis:Reboot/1.0.0",
+              "description": "Force failover of Redis instances to simulate backend zonal outage",
               "duration": "PT5M",
               "parameters": [
                 {
-                  "name": "abruptShutdown",
-                  "type": "boolean",
-                  "default": "false",
-                  "required": false,
-                  "description": "Whether to perform an abrupt shutdown"
+                  "key": "RebootType",
+                  "value": "PrimaryNode"
                 }
               ]
+            },
+            {
+              "name": "custom-runbook-1",
+              "actionId": "urn:csci:microsoft:Automation:StartRunbook/1.0.0",
+              "description": "Custom Runbook 1",
+              "duration": "PT30M",
+              "parameters": [
+                {
+                  "key": "RunbookParameters",
+                  "value": "%%{parameters.customRunbook1ParametersJson}%%"
+                }
+              ],
+              "externalResource": {
+                "resourceId": "%%{parameters.customRunbook1ResourceId}%%"
+              }
             }
           ],
           "recommendation": {

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-05-01-preview/Scenarios_ListAll.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-05-01-preview/Scenarios_ListAll.json
@@ -10,43 +10,86 @@
       "body": {
         "value": [
           {
-            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012",
-            "name": "12345678-1234-1234-1234-123456789012",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/zoneDownScenario",
+            "name": "zoneDownScenario",
             "type": "Microsoft.Chaos/workspaces/scenarios",
             "properties": {
               "provisioningState": "Succeeded",
-              "version": "1.0.0",
-              "description": "This scenario demonstrates shutting down virtual machines to test application resilience to infrastructure failures.",
+              "version": "1.0",
+              "description": "Induces an outage of all discovered VM and VMSS instances in the target zone with an option to invoke custom scripted actions using Automation Runbooks. Additionally, it forces failover of discovered Redis instances to simulate backend zonal outage.",
               "parameters": [
                 {
                   "name": "duration",
                   "type": "string",
-                  "default": "PT5M",
+                  "default": "PT15M",
                   "required": false,
-                  "description": "Duration of the shutdown in ISO 8601 format"
+                  "description": "The duration of the outage scenario."
                 },
                 {
-                  "name": "targetResourceIds",
-                  "type": "array",
-                  "required": true,
-                  "description": "Array of target virtual machine resource IDs"
+                  "name": "customRunbook1ResourceId",
+                  "type": "string",
+                  "required": false,
+                  "description": "Optional custom runbook 1 resource ID. If not provided, this action will be skipped."
+                },
+                {
+                  "name": "customRunbook1ParametersJson",
+                  "type": "string",
+                  "required": false,
+                  "default": "{}",
+                  "description": "Optional custom runbook 1 parameters in JSON format."
                 }
               ],
               "actions": [
                 {
-                  "name": "shutdownAction",
-                  "actionId": "microsoft-compute-shutdown/1.0",
-                  "description": "Shutdown virtual machines to test resilience",
+                  "name": "vmssZoneDown",
+                  "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+                  "description": "Force shutdown VMSS instances in target zone",
+                  "duration": "%%{parameters.duration}%%",
+                  "parameters": [
+                    {
+                      "key": "zones",
+                      "value": "%%{filters.zones}%%"
+                    }
+                  ]
+                },
+                {
+                  "name": "vmZoneDown",
+                  "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+                  "description": "Force shutdown VM instances in target zone",
+                  "duration": "%%{parameters.duration}%%",
+                  "parameters": [
+                    {
+                      "key": "zones",
+                      "value": "%%{filters.zones}%%"
+                    }
+                  ]
+                },
+                {
+                  "name": "redisFailover",
+                  "actionId": "urn:csci:microsoft:azureClusteredCacheForRedis:Reboot/1.0.0",
+                  "description": "Force failover of Redis instances to simulate backend zonal outage",
                   "duration": "PT5M",
                   "parameters": [
                     {
-                      "name": "abruptShutdown",
-                      "type": "boolean",
-                      "default": "false",
-                      "required": false,
-                      "description": "Whether to perform an abrupt shutdown"
+                      "key": "RebootType",
+                      "value": "PrimaryNode"
                     }
                   ]
+                },
+                {
+                  "name": "custom-runbook-1",
+                  "actionId": "urn:csci:microsoft:Automation:StartRunbook/1.0.0",
+                  "description": "Custom Runbook 1",
+                  "duration": "PT30M",
+                  "parameters": [
+                    {
+                      "key": "RunbookParameters",
+                      "value": "%%{parameters.customRunbook1ParametersJson}%%"
+                    }
+                  ],
+                  "externalResource": {
+                    "resourceId": "%%{parameters.customRunbook1ResourceId}%%"
+                  }
                 }
               ],
               "recommendation": {
@@ -64,41 +107,39 @@
             }
           },
           {
-            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/87654321-4321-4321-4321-210987654321",
-            "name": "87654321-4321-4321-4321-210987654321",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/networkLatencyScenario",
+            "name": "networkLatencyScenario",
             "type": "Microsoft.Chaos/workspaces/scenarios",
             "properties": {
               "provisioningState": "Succeeded",
               "version": "1.1.0",
-              "description": "This scenario introduces network latency to simulate poor network conditions and test application performance under network stress.",
+              "description": "Introduces network latency to simulate poor network conditions and test application performance under network stress.",
               "parameters": [
+                {
+                  "name": "duration",
+                  "type": "string",
+                  "default": "PT10M",
+                  "required": false,
+                  "description": "The duration of the network latency injection."
+                },
                 {
                   "name": "latencyMs",
                   "type": "number",
                   "default": "100",
                   "required": false,
-                  "description": "Latency to inject in milliseconds"
-                },
-                {
-                  "name": "targetResourceIds",
-                  "type": "array",
-                  "required": true,
-                  "description": "Array of target network resource IDs"
+                  "description": "Latency to inject in milliseconds."
                 }
               ],
               "actions": [
                 {
-                  "name": "injectLatencyAction",
-                  "actionId": "microsoft-network-injectLatency/1.0",
+                  "name": "injectLatency",
+                  "actionId": "urn:csci:microsoft:network:injectLatency/1.0.0",
                   "description": "Inject network latency to test performance",
-                  "duration": "PT10M",
+                  "duration": "%%{parameters.duration}%%",
                   "parameters": [
                     {
-                      "name": "latencyMs",
-                      "type": "number",
-                      "default": "100",
-                      "required": false,
-                      "description": "Latency to inject in milliseconds"
+                      "key": "latencyMs",
+                      "value": "%%{parameters.latencyMs}%%"
                     }
                   ]
                 }

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-05-01-preview/examples/Scenarios_CreateOrUpdate.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-05-01-preview/examples/Scenarios_CreateOrUpdate.json
@@ -2,42 +2,85 @@
   "parameters": {
     "api-version": "2026-05-01-preview",
     "workspaceName": "exampleWorkspace",
-    "scenarioName": "myVMShutdownScenario",
+    "scenarioName": "zoneDownScenario",
     "resourceGroupName": "exampleRG",
     "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291",
     "resource": {
       "properties": {
-        "description": "This scenario demonstrates shutting down virtual machines to test application resilience to infrastructure failures.",
+        "description": "Induces an outage of all discovered VM and VMSS instances in the target zone with an option to invoke custom scripted actions using Automation Runbooks. Additionally, it forces failover of discovered Redis instances to simulate backend zonal outage.",
         "parameters": [
           {
             "name": "duration",
             "type": "string",
-            "default": "PT5M",
+            "default": "PT15M",
             "required": false,
-            "description": "Duration of the shutdown in ISO 8601 format"
+            "description": "The duration of the outage scenario."
           },
           {
-            "name": "targetResourceIds",
-            "type": "array",
-            "required": true,
-            "description": "Array of target virtual machine resource IDs"
+            "name": "customRunbook1ResourceId",
+            "type": "string",
+            "required": false,
+            "description": "Optional custom runbook 1 resource ID. If not provided, this action will be skipped."
+          },
+          {
+            "name": "customRunbook1ParametersJson",
+            "type": "string",
+            "required": false,
+            "default": "{}",
+            "description": "Optional custom runbook 1 parameters in JSON format."
           }
         ],
         "actions": [
           {
-            "name": "shutdownAction",
-            "actionId": "microsoft-compute-shutdown/1.0",
-            "description": "Shutdown virtual machines to test resilience",
+            "name": "vmssZoneDown",
+            "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+            "description": "Force shutdown VMSS instances in target zone",
+            "duration": "%%{parameters.duration}%%",
+            "parameters": [
+              {
+                "key": "zones",
+                "value": "%%{filters.zones}%%"
+              }
+            ]
+          },
+          {
+            "name": "vmZoneDown",
+            "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+            "description": "Force shutdown VM instances in target zone",
+            "duration": "%%{parameters.duration}%%",
+            "parameters": [
+              {
+                "key": "zones",
+                "value": "%%{filters.zones}%%"
+              }
+            ]
+          },
+          {
+            "name": "redisFailover",
+            "actionId": "urn:csci:microsoft:azureClusteredCacheForRedis:Reboot/1.0.0",
+            "description": "Force failover of Redis instances to simulate backend zonal outage",
             "duration": "PT5M",
             "parameters": [
               {
-                "name": "abruptShutdown",
-                "type": "boolean",
-                "default": "false",
-                "required": false,
-                "description": "Whether to perform an abrupt shutdown"
+                "key": "RebootType",
+                "value": "PrimaryNode"
               }
             ]
+          },
+          {
+            "name": "custom-runbook-1",
+            "actionId": "urn:csci:microsoft:Automation:StartRunbook/1.0.0",
+            "description": "Custom Runbook 1",
+            "duration": "PT30M",
+            "parameters": [
+              {
+                "key": "RunbookParameters",
+                "value": "%%{parameters.customRunbook1ParametersJson}%%"
+              }
+            ],
+            "externalResource": {
+              "resourceId": "%%{parameters.customRunbook1ResourceId}%%"
+            }
           }
         ]
       }
@@ -46,43 +89,86 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/myVMShutdownScenario",
-        "name": "myVMShutdownScenario",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/zoneDownScenario",
+        "name": "zoneDownScenario",
         "type": "Microsoft.Chaos/workspaces/scenarios",
         "properties": {
           "provisioningState": "Succeeded",
-          "version": "1.0.0",
-          "description": "This scenario demonstrates shutting down virtual machines to test application resilience to infrastructure failures.",
+          "version": "1.0",
+          "description": "Induces an outage of all discovered VM and VMSS instances in the target zone with an option to invoke custom scripted actions using Automation Runbooks. Additionally, it forces failover of discovered Redis instances to simulate backend zonal outage.",
           "parameters": [
             {
               "name": "duration",
               "type": "string",
-              "default": "PT5M",
+              "default": "PT15M",
               "required": false,
-              "description": "Duration of the shutdown in ISO 8601 format"
+              "description": "The duration of the outage scenario."
             },
             {
-              "name": "targetResourceIds",
-              "type": "array",
-              "required": true,
-              "description": "Array of target virtual machine resource IDs"
+              "name": "customRunbook1ResourceId",
+              "type": "string",
+              "required": false,
+              "description": "Optional custom runbook 1 resource ID. If not provided, this action will be skipped."
+            },
+            {
+              "name": "customRunbook1ParametersJson",
+              "type": "string",
+              "required": false,
+              "default": "{}",
+              "description": "Optional custom runbook 1 parameters in JSON format."
             }
           ],
           "actions": [
             {
-              "name": "shutdownAction",
-              "actionId": "microsoft-compute-shutdown/1.0",
-              "description": "Shutdown virtual machines to test resilience",
+              "name": "vmssZoneDown",
+              "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+              "description": "Force shutdown VMSS instances in target zone",
+              "duration": "%%{parameters.duration}%%",
+              "parameters": [
+                {
+                  "key": "zones",
+                  "value": "%%{filters.zones}%%"
+                }
+              ]
+            },
+            {
+              "name": "vmZoneDown",
+              "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+              "description": "Force shutdown VM instances in target zone",
+              "duration": "%%{parameters.duration}%%",
+              "parameters": [
+                {
+                  "key": "zones",
+                  "value": "%%{filters.zones}%%"
+                }
+              ]
+            },
+            {
+              "name": "redisFailover",
+              "actionId": "urn:csci:microsoft:azureClusteredCacheForRedis:Reboot/1.0.0",
+              "description": "Force failover of Redis instances to simulate backend zonal outage",
               "duration": "PT5M",
               "parameters": [
                 {
-                  "name": "abruptShutdown",
-                  "type": "boolean",
-                  "default": "false",
-                  "required": false,
-                  "description": "Whether to perform an abrupt shutdown"
+                  "key": "RebootType",
+                  "value": "PrimaryNode"
                 }
               ]
+            },
+            {
+              "name": "custom-runbook-1",
+              "actionId": "urn:csci:microsoft:Automation:StartRunbook/1.0.0",
+              "description": "Custom Runbook 1",
+              "duration": "PT30M",
+              "parameters": [
+                {
+                  "key": "RunbookParameters",
+                  "value": "%%{parameters.customRunbook1ParametersJson}%%"
+                }
+              ],
+              "externalResource": {
+                "resourceId": "%%{parameters.customRunbook1ResourceId}%%"
+              }
             }
           ]
         },
@@ -99,43 +185,86 @@
     },
     "201": {
       "body": {
-        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/myVMShutdownScenario",
-        "name": "myVMShutdownScenario",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/zoneDownScenario",
+        "name": "zoneDownScenario",
         "type": "Microsoft.Chaos/workspaces/scenarios",
         "properties": {
           "provisioningState": "Creating",
-          "version": "1.0.0",
-          "description": "This scenario demonstrates shutting down virtual machines to test application resilience to infrastructure failures.",
+          "version": "1.0",
+          "description": "Induces an outage of all discovered VM and VMSS instances in the target zone with an option to invoke custom scripted actions using Automation Runbooks. Additionally, it forces failover of discovered Redis instances to simulate backend zonal outage.",
           "parameters": [
             {
               "name": "duration",
               "type": "string",
-              "default": "PT5M",
+              "default": "PT15M",
               "required": false,
-              "description": "Duration of the shutdown in ISO 8601 format"
+              "description": "The duration of the outage scenario."
             },
             {
-              "name": "targetResourceIds",
-              "type": "array",
-              "required": true,
-              "description": "Array of target virtual machine resource IDs"
+              "name": "customRunbook1ResourceId",
+              "type": "string",
+              "required": false,
+              "description": "Optional custom runbook 1 resource ID. If not provided, this action will be skipped."
+            },
+            {
+              "name": "customRunbook1ParametersJson",
+              "type": "string",
+              "required": false,
+              "default": "{}",
+              "description": "Optional custom runbook 1 parameters in JSON format."
             }
           ],
           "actions": [
             {
-              "name": "shutdownAction",
-              "actionId": "microsoft-compute-shutdown/1.0",
-              "description": "Shutdown virtual machines to test resilience",
+              "name": "vmssZoneDown",
+              "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+              "description": "Force shutdown VMSS instances in target zone",
+              "duration": "%%{parameters.duration}%%",
+              "parameters": [
+                {
+                  "key": "zones",
+                  "value": "%%{filters.zones}%%"
+                }
+              ]
+            },
+            {
+              "name": "vmZoneDown",
+              "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+              "description": "Force shutdown VM instances in target zone",
+              "duration": "%%{parameters.duration}%%",
+              "parameters": [
+                {
+                  "key": "zones",
+                  "value": "%%{filters.zones}%%"
+                }
+              ]
+            },
+            {
+              "name": "redisFailover",
+              "actionId": "urn:csci:microsoft:azureClusteredCacheForRedis:Reboot/1.0.0",
+              "description": "Force failover of Redis instances to simulate backend zonal outage",
               "duration": "PT5M",
               "parameters": [
                 {
-                  "name": "abruptShutdown",
-                  "type": "boolean",
-                  "default": "false",
-                  "required": false,
-                  "description": "Whether to perform an abrupt shutdown"
+                  "key": "RebootType",
+                  "value": "PrimaryNode"
                 }
               ]
+            },
+            {
+              "name": "custom-runbook-1",
+              "actionId": "urn:csci:microsoft:Automation:StartRunbook/1.0.0",
+              "description": "Custom Runbook 1",
+              "duration": "PT30M",
+              "parameters": [
+                {
+                  "key": "RunbookParameters",
+                  "value": "%%{parameters.customRunbook1ParametersJson}%%"
+                }
+              ],
+              "externalResource": {
+                "resourceId": "%%{parameters.customRunbook1ResourceId}%%"
+              }
             }
           ]
         },

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-05-01-preview/examples/Scenarios_Get.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-05-01-preview/examples/Scenarios_Get.json
@@ -2,50 +2,93 @@
   "parameters": {
     "api-version": "2026-05-01-preview",
     "workspaceName": "exampleWorkspace",
-    "scenarioName": "12345678-1234-1234-1234-123456789012",
+    "scenarioName": "zoneDownScenario",
     "resourceGroupName": "exampleRG",
     "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
   },
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012",
-        "name": "12345678-1234-1234-1234-123456789012",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/zoneDownScenario",
+        "name": "zoneDownScenario",
         "type": "Microsoft.Chaos/workspaces/scenarios",
         "properties": {
           "provisioningState": "Succeeded",
-          "version": "1.0.0",
-          "description": "This scenario demonstrates shutting down virtual machines to test application resilience to infrastructure failures.",
+          "version": "1.0",
+          "description": "Induces an outage of all discovered VM and VMSS instances in the target zone with an option to invoke custom scripted actions using Automation Runbooks. Additionally, it forces failover of discovered Redis instances to simulate backend zonal outage.",
           "parameters": [
             {
               "name": "duration",
               "type": "string",
-              "default": "PT5M",
+              "default": "PT15M",
               "required": false,
-              "description": "Duration of the shutdown in ISO 8601 format"
+              "description": "The duration of the outage scenario."
             },
             {
-              "name": "targetResourceIds",
-              "type": "array",
-              "required": true,
-              "description": "Array of target virtual machine resource IDs"
+              "name": "customRunbook1ResourceId",
+              "type": "string",
+              "required": false,
+              "description": "Optional custom runbook 1 resource ID. If not provided, this action will be skipped."
+            },
+            {
+              "name": "customRunbook1ParametersJson",
+              "type": "string",
+              "required": false,
+              "default": "{}",
+              "description": "Optional custom runbook 1 parameters in JSON format."
             }
           ],
           "actions": [
             {
-              "name": "shutdownAction",
-              "actionId": "microsoft-compute-shutdown/1.0",
-              "description": "Shutdown virtual machines to test resilience",
+              "name": "vmssZoneDown",
+              "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+              "description": "Force shutdown VMSS instances in target zone",
+              "duration": "%%{parameters.duration}%%",
+              "parameters": [
+                {
+                  "key": "zones",
+                  "value": "%%{filters.zones}%%"
+                }
+              ]
+            },
+            {
+              "name": "vmZoneDown",
+              "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+              "description": "Force shutdown VM instances in target zone",
+              "duration": "%%{parameters.duration}%%",
+              "parameters": [
+                {
+                  "key": "zones",
+                  "value": "%%{filters.zones}%%"
+                }
+              ]
+            },
+            {
+              "name": "redisFailover",
+              "actionId": "urn:csci:microsoft:azureClusteredCacheForRedis:Reboot/1.0.0",
+              "description": "Force failover of Redis instances to simulate backend zonal outage",
               "duration": "PT5M",
               "parameters": [
                 {
-                  "name": "abruptShutdown",
-                  "type": "boolean",
-                  "default": "false",
-                  "required": false,
-                  "description": "Whether to perform an abrupt shutdown"
+                  "key": "RebootType",
+                  "value": "PrimaryNode"
                 }
               ]
+            },
+            {
+              "name": "custom-runbook-1",
+              "actionId": "urn:csci:microsoft:Automation:StartRunbook/1.0.0",
+              "description": "Custom Runbook 1",
+              "duration": "PT30M",
+              "parameters": [
+                {
+                  "key": "RunbookParameters",
+                  "value": "%%{parameters.customRunbook1ParametersJson}%%"
+                }
+              ],
+              "externalResource": {
+                "resourceId": "%%{parameters.customRunbook1ResourceId}%%"
+              }
             }
           ],
           "recommendation": {

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-05-01-preview/examples/Scenarios_ListAll.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-05-01-preview/examples/Scenarios_ListAll.json
@@ -10,43 +10,86 @@
       "body": {
         "value": [
           {
-            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012",
-            "name": "12345678-1234-1234-1234-123456789012",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/zoneDownScenario",
+            "name": "zoneDownScenario",
             "type": "Microsoft.Chaos/workspaces/scenarios",
             "properties": {
               "provisioningState": "Succeeded",
-              "version": "1.0.0",
-              "description": "This scenario demonstrates shutting down virtual machines to test application resilience to infrastructure failures.",
+              "version": "1.0",
+              "description": "Induces an outage of all discovered VM and VMSS instances in the target zone with an option to invoke custom scripted actions using Automation Runbooks. Additionally, it forces failover of discovered Redis instances to simulate backend zonal outage.",
               "parameters": [
                 {
                   "name": "duration",
                   "type": "string",
-                  "default": "PT5M",
+                  "default": "PT15M",
                   "required": false,
-                  "description": "Duration of the shutdown in ISO 8601 format"
+                  "description": "The duration of the outage scenario."
                 },
                 {
-                  "name": "targetResourceIds",
-                  "type": "array",
-                  "required": true,
-                  "description": "Array of target virtual machine resource IDs"
+                  "name": "customRunbook1ResourceId",
+                  "type": "string",
+                  "required": false,
+                  "description": "Optional custom runbook 1 resource ID. If not provided, this action will be skipped."
+                },
+                {
+                  "name": "customRunbook1ParametersJson",
+                  "type": "string",
+                  "required": false,
+                  "default": "{}",
+                  "description": "Optional custom runbook 1 parameters in JSON format."
                 }
               ],
               "actions": [
                 {
-                  "name": "shutdownAction",
-                  "actionId": "microsoft-compute-shutdown/1.0",
-                  "description": "Shutdown virtual machines to test resilience",
+                  "name": "vmssZoneDown",
+                  "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+                  "description": "Force shutdown VMSS instances in target zone",
+                  "duration": "%%{parameters.duration}%%",
+                  "parameters": [
+                    {
+                      "key": "zones",
+                      "value": "%%{filters.zones}%%"
+                    }
+                  ]
+                },
+                {
+                  "name": "vmZoneDown",
+                  "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+                  "description": "Force shutdown VM instances in target zone",
+                  "duration": "%%{parameters.duration}%%",
+                  "parameters": [
+                    {
+                      "key": "zones",
+                      "value": "%%{filters.zones}%%"
+                    }
+                  ]
+                },
+                {
+                  "name": "redisFailover",
+                  "actionId": "urn:csci:microsoft:azureClusteredCacheForRedis:Reboot/1.0.0",
+                  "description": "Force failover of Redis instances to simulate backend zonal outage",
                   "duration": "PT5M",
                   "parameters": [
                     {
-                      "name": "abruptShutdown",
-                      "type": "boolean",
-                      "default": "false",
-                      "required": false,
-                      "description": "Whether to perform an abrupt shutdown"
+                      "key": "RebootType",
+                      "value": "PrimaryNode"
                     }
                   ]
+                },
+                {
+                  "name": "custom-runbook-1",
+                  "actionId": "urn:csci:microsoft:Automation:StartRunbook/1.0.0",
+                  "description": "Custom Runbook 1",
+                  "duration": "PT30M",
+                  "parameters": [
+                    {
+                      "key": "RunbookParameters",
+                      "value": "%%{parameters.customRunbook1ParametersJson}%%"
+                    }
+                  ],
+                  "externalResource": {
+                    "resourceId": "%%{parameters.customRunbook1ResourceId}%%"
+                  }
                 }
               ],
               "recommendation": {
@@ -64,41 +107,39 @@
             }
           },
           {
-            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/87654321-4321-4321-4321-210987654321",
-            "name": "87654321-4321-4321-4321-210987654321",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/networkLatencyScenario",
+            "name": "networkLatencyScenario",
             "type": "Microsoft.Chaos/workspaces/scenarios",
             "properties": {
               "provisioningState": "Succeeded",
               "version": "1.1.0",
-              "description": "This scenario introduces network latency to simulate poor network conditions and test application performance under network stress.",
+              "description": "Introduces network latency to simulate poor network conditions and test application performance under network stress.",
               "parameters": [
+                {
+                  "name": "duration",
+                  "type": "string",
+                  "default": "PT10M",
+                  "required": false,
+                  "description": "The duration of the network latency injection."
+                },
                 {
                   "name": "latencyMs",
                   "type": "number",
                   "default": "100",
                   "required": false,
-                  "description": "Latency to inject in milliseconds"
-                },
-                {
-                  "name": "targetResourceIds",
-                  "type": "array",
-                  "required": true,
-                  "description": "Array of target network resource IDs"
+                  "description": "Latency to inject in milliseconds."
                 }
               ],
               "actions": [
                 {
-                  "name": "injectLatencyAction",
-                  "actionId": "microsoft-network-injectLatency/1.0",
+                  "name": "injectLatency",
+                  "actionId": "urn:csci:microsoft:network:injectLatency/1.0.0",
                   "description": "Inject network latency to test performance",
-                  "duration": "PT10M",
+                  "duration": "%%{parameters.duration}%%",
                   "parameters": [
                     {
-                      "name": "latencyMs",
-                      "type": "number",
-                      "default": "100",
-                      "required": false,
-                      "description": "Latency to inject in milliseconds"
+                      "key": "latencyMs",
+                      "value": "%%{parameters.latencyMs}%%"
                     }
                   ]
                 }

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-05-01-preview/openapi.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-05-01-preview/openapi.json
@@ -6629,8 +6629,7 @@
         },
         "duration": {
           "type": "string",
-          "format": "duration",
-          "description": "ISO 8601 duration for how long the action runs (e.g., PT30M for 30 minutes)."
+          "description": "ISO 8601 duration for how long the action runs (e.g., PT30M for 30 minutes). Supports template macro syntax (%%\\{parameters.\\<name\\>\\}%%)."
         },
         "parameters": {
           "type": "array",
@@ -6648,13 +6647,11 @@
         },
         "waitBefore": {
           "type": "string",
-          "format": "duration",
-          "description": "ISO 8601 duration to wait before action starts (e.g., PT30S for 30 seconds)."
+          "description": "ISO 8601 duration to wait before action starts (e.g., PT30S for 30 seconds). Supports template macro syntax."
         },
         "timeout": {
           "type": "string",
-          "format": "duration",
-          "description": "ISO 8601 duration for maximum action execution time (for actions without inherent duration)."
+          "description": "ISO 8601 duration for maximum action execution time. Supports template macro syntax."
         },
         "externalResource": {
           "$ref": "#/definitions/ExternalResource",

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-05-01-preview/openapi.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-05-01-preview/openapi.json
@@ -6634,12 +6634,12 @@
         },
         "parameters": {
           "type": "array",
-          "description": "Action-specific parameters.",
+          "description": "Action-specific parameter values.",
           "items": {
-            "$ref": "#/definitions/ScenarioParameter"
+            "$ref": "#/definitions/KeyValuePair"
           },
           "x-ms-identifiers": [
-            "name"
+            "key"
           ]
         },
         "runAfter": {

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/scenario.models.tsp
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/scenario.models.tsp
@@ -154,9 +154,9 @@ model ScenarioAction {
   description?: string;
 
   /**
-   * ISO 8601 duration for how long the action runs (e.g., PT30M for 30 minutes).
+   * ISO 8601 duration for how long the action runs (e.g., PT30M for 30 minutes). Supports template macro syntax (%%\{parameters.\<name\>\}%%).
    */
-  duration: duration;
+  duration: string;
 
   /**
    * Action-specific parameter values.
@@ -170,14 +170,14 @@ model ScenarioAction {
   runAfter?: RunAfter;
 
   /**
-   * ISO 8601 duration to wait before action starts (e.g., PT30S for 30 seconds).
+   * ISO 8601 duration to wait before action starts (e.g., PT30S for 30 seconds). Supports template macro syntax.
    */
-  waitBefore?: duration;
+  waitBefore?: string;
 
   /**
-   * ISO 8601 duration for maximum action execution time (for actions without inherent duration).
+   * ISO 8601 duration for maximum action execution time. Supports template macro syntax.
    */
-  timeout?: duration;
+  timeout?: string;
 
   /**
    * External resource reference for the action.

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/scenario.models.tsp
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/scenario.models.tsp
@@ -3,6 +3,7 @@ import "@typespec/http";
 import "@azure-tools/typespec-azure-core";
 import "@azure-tools/typespec-azure-resource-manager";
 import "./workspace.models.tsp";
+import "./common.models.tsp";
 
 using TypeSpec.Rest;
 using Azure.ResourceManager;
@@ -158,10 +159,10 @@ model ScenarioAction {
   duration: duration;
 
   /**
-   * Action-specific parameters.
+   * Action-specific parameter values.
    */
-  @identifiers(#["name"])
-  parameters?: ScenarioParameter[];
+  @identifiers(#["key"])
+  parameters?: KeyValuePair[];
 
   /**
    * Action dependencies that control when this action starts.


### PR DESCRIPTION
## Summary

Fixes ScenarioAction model and examples for the 2026-05-01-preview API version to align with the BE scenario template format. Two changes:

1. **Action parameters use KeyValuePair instead of ScenarioParameter** — action-level parameters are runtime values (key/value pairs), not metadata definitions. Action metadata (type, required, description) belongs on the read-only Action resource, not in scenario action definitions.

2. **Duration fields changed from duration to string (Bug #37620364)** — ScenarioAction.duration, waitBefore, and timeout support template macro syntax (%%{parameters.name}%%) which gets resolved at execution time. The duration type generates System.TimeSpan in C# models, which cannot hold template strings and causes FormatException crashes in the GW.

## Scope

All changes are scoped to **V2 resources in 2026-05-01-preview only**. V1 experiment models (ContinuousAction, DelayAction) and older API versions (2024-11-01-preview, 2025-01-01) are untouched.

## Changes

### TypeSpec models
- **scenario.models.tsp**: Changed ScenarioAction.parameters from ScenarioParameter[] to KeyValuePair[]. Changed duration, waitBefore, timeout from duration to string.
- Added import ./common.models.tsp for KeyValuePair.

### Examples (2026-05-01-preview)
- **Scenarios_CreateOrUpdate.json**: Replaced generic VM shutdown with realistic Zone Down scenario showing template expressions (%%{parameters.duration}%%, %%{filters.zones}%%), multiple action types (VMSS shutdown, VM shutdown, Redis failover, custom runbook), and externalResource with template references.
- **Scenarios_Get.json**: Updated to match Zone Down scenario with recommendation data.
- **Scenarios_ListAll.json**: First item is Zone Down scenario, second is network latency scenario — both using template syntax.

### Generated swagger
- preview/2026-05-01-preview/openapi.json updated automatically via tsp compile.
- format: duration removed from ScenarioAction fields in 2026-05-01-preview only.
