### PR TITLE
Add @@usage(Model, Usage.input, "csharp") for C# ApiCompat compatibility

### DIFF
--- a/specification/appcomplianceautomation/AppComplianceAutomation.Management/client.tsp
+++ b/specification/appcomplianceautomation/AppComplianceAutomation.Management/client.tsp
@@ -233,3 +233,5 @@ using Microsoft.AppComplianceAutomation;
 @@usage(RecommendationSolution, Usage.input, "csharp");
 @@usage(OverviewStatus, Usage.input, "csharp");
 @@usage(ResponsibilityResource, Usage.input, "csharp");
+@@usage(ControlFamily, Usage.input, "csharp");
+@@usage(ComplianceResult, Usage.input, "csharp");

--- a/specification/appcomplianceautomation/AppComplianceAutomation.Management/client.tsp
+++ b/specification/appcomplianceautomation/AppComplianceAutomation.Management/client.tsp
@@ -224,3 +224,12 @@ using Microsoft.AppComplianceAutomation;
   "TriggerEvaluationProviderAction",
   "csharp"
 );
+
+// CSharp SDK: Preserve API compatibility — these output-only models were previously round-trip
+@@usage(Category, Usage.input, "csharp");
+@@usage(Control, Usage.input, "csharp");
+@@usage(Responsibility, Usage.input, "csharp");
+@@usage(Recommendation, Usage.input, "csharp");
+@@usage(RecommendationSolution, Usage.input, "csharp");
+@@usage(OverviewStatus, Usage.input, "csharp");
+@@usage(ResponsibilityResource, Usage.input, "csharp");

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection/client.tsp
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection/client.tsp
@@ -833,3 +833,10 @@ model BackupFindRestorableTimeRangesResponse
   "BackupFindRestorableTimeRangeResult",
   "csharp"
 );
+
+// CSharp SDK: Preserve API compatibility — output-only models were previously round-trip
+@@usage(DeletionInfo, Usage.input, "csharp");
+@@usage(ProtectionStatusDetails, Usage.input, "csharp");
+@@usage(JobExtendedInfo, Usage.input, "csharp");
+@@usage(JobSubTask, Usage.input, "csharp");
+@@usage(RestoreJobRecoveryPointDetails, Usage.input, "csharp");

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection/tspconfig.yaml
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection/tspconfig.yaml
@@ -42,6 +42,7 @@ options:
   "@azure-typespec/http-client-csharp-mgmt":
     namespace: "Azure.ResourceManager.DataProtectionBackup"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
+    api-version: "2025-09-01"
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/resource-manager"

--- a/specification/resources/resource-manager/Microsoft.Resources/deploymentStacks/client.tsp
+++ b/specification/resources/resource-manager/Microsoft.Resources/deploymentStacks/client.tsp
@@ -159,3 +159,4 @@ namespace Microsoft.Resources.DeploymentStacks {
 
 // CSharp SDK: Preserve API compatibility — output-only model was previously round-trip
 @@usage(DeploymentExtension, Usage.input, "csharp");
+@@usage(Azure.ResourceManager.Foundations.ErrorAdditionalInfo, Usage.input, "csharp");

--- a/specification/resources/resource-manager/Microsoft.Resources/deploymentStacks/client.tsp
+++ b/specification/resources/resource-manager/Microsoft.Resources/deploymentStacks/client.tsp
@@ -156,3 +156,6 @@ namespace Microsoft.Resources.DeploymentStacks {
   Azure.ResourceManager.Foundations.ProxyResource,
   "csharp"
 );
+
+// CSharp SDK: Preserve API compatibility — output-only model was previously round-trip
+@@usage(DeploymentExtension, Usage.input, "csharp");

--- a/specification/resources/resource-manager/Microsoft.Resources/deploymentStacks/client.tsp
+++ b/specification/resources/resource-manager/Microsoft.Resources/deploymentStacks/client.tsp
@@ -159,4 +159,7 @@ namespace Microsoft.Resources.DeploymentStacks {
 
 // CSharp SDK: Preserve API compatibility — output-only model was previously round-trip
 @@usage(DeploymentExtension, Usage.input, "csharp");
-@@usage(Azure.ResourceManager.Foundations.ErrorAdditionalInfo, Usage.input, "csharp");
+@@usage(Azure.ResourceManager.Foundations.ErrorAdditionalInfo,
+  Usage.input,
+  "csharp"
+);

--- a/specification/search/resource-manager/Microsoft.Search/Search/client.tsp
+++ b/specification/search/resource-manager/Microsoft.Search/Search/client.tsp
@@ -1125,6 +1125,14 @@ model SearchServiceNetworkSecurityPerimeterInboundRuleSubscription {
   Usage.input,
   "csharp"
 );
+@@usage(Azure.ResourceManager.CommonTypes.AccessRule,
+  Usage.input,
+  "csharp"
+);
+@@usage(Azure.ResourceManager.CommonTypes.AccessRuleProperties,
+  Usage.input,
+  "csharp"
+);
 @@alternateType(Azure.ResourceManager.CommonTypes.NetworkSecurityPerimeter.location,
   azureLocation,
   "csharp"

--- a/specification/search/resource-manager/Microsoft.Search/Search/client.tsp
+++ b/specification/search/resource-manager/Microsoft.Search/Search/client.tsp
@@ -1125,10 +1125,7 @@ model SearchServiceNetworkSecurityPerimeterInboundRuleSubscription {
   Usage.input,
   "csharp"
 );
-@@usage(Azure.ResourceManager.CommonTypes.AccessRule,
-  Usage.input,
-  "csharp"
-);
+@@usage(Azure.ResourceManager.CommonTypes.AccessRule, Usage.input, "csharp");
 @@usage(Azure.ResourceManager.CommonTypes.AccessRuleProperties,
   Usage.input,
   "csharp"

--- a/specification/search/resource-manager/Microsoft.Search/Search/client.tsp
+++ b/specification/search/resource-manager/Microsoft.Search/Search/client.tsp
@@ -1120,6 +1120,11 @@ model SearchServiceNetworkSecurityPerimeterInboundRuleSubscription {
   "SearchServiceNetworkSecurityPerimeter",
   "csharp"
 );
+// CSharp SDK: Preserve API compatibility — output-only model was previously round-trip
+@@usage(Azure.ResourceManager.CommonTypes.NetworkSecurityPerimeter,
+  Usage.input,
+  "csharp"
+);
 @@alternateType(Azure.ResourceManager.CommonTypes.NetworkSecurityPerimeter.location,
   azureLocation,
   "csharp"

--- a/specification/storage/Storage.Management/client.tsp
+++ b/specification/storage/Storage.Management/client.tsp
@@ -1063,15 +1063,33 @@ enum ProvisioningStateEnum {
 );
 
 // CSharp SDK: Preserve API compatibility — output-only models were previously round-trip
-@@usage(ImmutabilityPolicyProperties, Azure.ClientGenerator.Core.Usage.input, "csharp");
+@@usage(ImmutabilityPolicyProperties,
+  Azure.ClientGenerator.Core.Usage.input,
+  "csharp"
+);
 @@usage(BlobRestoreStatus, Azure.ClientGenerator.Core.Usage.input, "csharp");
 @@usage(GeoReplicationStats, Azure.ClientGenerator.Core.Usage.input, "csharp");
 @@usage(LegalHoldProperties, Azure.ClientGenerator.Core.Usage.input, "csharp");
 @@usage(TagProperty, Azure.ClientGenerator.Core.Usage.input, "csharp");
-@@usage(ProtectedAppendWritesHistory, Azure.ClientGenerator.Core.Usage.input, "csharp");
+@@usage(ProtectedAppendWritesHistory,
+  Azure.ClientGenerator.Core.Usage.input,
+  "csharp"
+);
 @@usage(Endpoints, Azure.ClientGenerator.Core.Usage.input, "csharp");
-@@usage(StorageAccountInternetEndpoints, Azure.ClientGenerator.Core.Usage.input, "csharp");
-@@usage(StorageAccountIpv6Endpoints, Azure.ClientGenerator.Core.Usage.input, "csharp");
+@@usage(StorageAccountInternetEndpoints,
+  Azure.ClientGenerator.Core.Usage.input,
+  "csharp"
+);
+@@usage(StorageAccountIpv6Endpoints,
+  Azure.ClientGenerator.Core.Usage.input,
+  "csharp"
+);
 @@usage(KeyCreationTime, Azure.ClientGenerator.Core.Usage.input, "csharp");
-@@usage(StorageAccountMicrosoftEndpoints, Azure.ClientGenerator.Core.Usage.input, "csharp");
-@@usage(UpdateHistoryProperty, Azure.ClientGenerator.Core.Usage.input, "csharp");
+@@usage(StorageAccountMicrosoftEndpoints,
+  Azure.ClientGenerator.Core.Usage.input,
+  "csharp"
+);
+@@usage(UpdateHistoryProperty,
+  Azure.ClientGenerator.Core.Usage.input,
+  "csharp"
+);

--- a/specification/storage/Storage.Management/client.tsp
+++ b/specification/storage/Storage.Management/client.tsp
@@ -1063,15 +1063,15 @@ enum ProvisioningStateEnum {
 );
 
 // CSharp SDK: Preserve API compatibility — output-only models were previously round-trip
-@@usage(ImmutabilityPolicyProperties, Usage.input, "csharp");
-@@usage(BlobRestoreStatus, Usage.input, "csharp");
-@@usage(GeoReplicationStats, Usage.input, "csharp");
-@@usage(LegalHoldProperties, Usage.input, "csharp");
-@@usage(TagProperty, Usage.input, "csharp");
-@@usage(ProtectedAppendWritesHistory, Usage.input, "csharp");
-@@usage(Endpoints, Usage.input, "csharp");
-@@usage(StorageAccountInternetEndpoints, Usage.input, "csharp");
-@@usage(StorageAccountIpv6Endpoints, Usage.input, "csharp");
-@@usage(KeyCreationTime, Usage.input, "csharp");
-@@usage(StorageAccountMicrosoftEndpoints, Usage.input, "csharp");
-@@usage(UpdateHistoryProperty, Usage.input, "csharp");
+@@usage(ImmutabilityPolicyProperties, Azure.ClientGenerator.Core.Usage.input, "csharp");
+@@usage(BlobRestoreStatus, Azure.ClientGenerator.Core.Usage.input, "csharp");
+@@usage(GeoReplicationStats, Azure.ClientGenerator.Core.Usage.input, "csharp");
+@@usage(LegalHoldProperties, Azure.ClientGenerator.Core.Usage.input, "csharp");
+@@usage(TagProperty, Azure.ClientGenerator.Core.Usage.input, "csharp");
+@@usage(ProtectedAppendWritesHistory, Azure.ClientGenerator.Core.Usage.input, "csharp");
+@@usage(Endpoints, Azure.ClientGenerator.Core.Usage.input, "csharp");
+@@usage(StorageAccountInternetEndpoints, Azure.ClientGenerator.Core.Usage.input, "csharp");
+@@usage(StorageAccountIpv6Endpoints, Azure.ClientGenerator.Core.Usage.input, "csharp");
+@@usage(KeyCreationTime, Azure.ClientGenerator.Core.Usage.input, "csharp");
+@@usage(StorageAccountMicrosoftEndpoints, Azure.ClientGenerator.Core.Usage.input, "csharp");
+@@usage(UpdateHistoryProperty, Azure.ClientGenerator.Core.Usage.input, "csharp");

--- a/specification/storage/Storage.Management/client.tsp
+++ b/specification/storage/Storage.Management/client.tsp
@@ -1061,3 +1061,17 @@ enum ProvisioningStateEnum {
   ProvisioningStateEnum,
   "java"
 );
+
+// CSharp SDK: Preserve API compatibility — output-only models were previously round-trip
+@@usage(ImmutabilityPolicyProperties, Usage.input, "csharp");
+@@usage(BlobRestoreStatus, Usage.input, "csharp");
+@@usage(GeoReplicationStats, Usage.input, "csharp");
+@@usage(LegalHoldProperties, Usage.input, "csharp");
+@@usage(TagProperty, Usage.input, "csharp");
+@@usage(ProtectedAppendWritesHistory, Usage.input, "csharp");
+@@usage(Endpoints, Usage.input, "csharp");
+@@usage(StorageAccountInternetEndpoints, Usage.input, "csharp");
+@@usage(StorageAccountIpv6Endpoints, Usage.input, "csharp");
+@@usage(KeyCreationTime, Usage.input, "csharp");
+@@usage(StorageAccountMicrosoftEndpoints, Usage.input, "csharp");
+@@usage(UpdateHistoryProperty, Usage.input, "csharp");


### PR DESCRIPTION
### Description

After TCGC 0.67.2 correctly reclassified output-only models, several C# GA libraries lost public constructors and property setters in the generated code, causing ApiCompat failures. This PR adds `@@usage(Model, Usage.input, "csharp")` to preserve backward compatibility for these types.

### Affected Libraries

| Library | Types | Count |
|---|---|---|
| **AppComplianceAutomation** | `Category`, `Control`, `Responsibility`, `Recommendation`, `RecommendationSolution`, `OverviewStatus`, `ResponsibilityResource` | 7 |
| **Resources.DeploymentStacks** | `DeploymentExtension` | 1 |
| **Search** | `Azure.ResourceManager.CommonTypes.NetworkSecurityPerimeter` | 1 |
| **Storage** | `ImmutabilityPolicyProperties`, `BlobRestoreStatus`, `GeoReplicationStats`, `LegalHoldProperties`, `TagProperty`, `ProtectedAppendWritesHistory`, `Endpoints`, `StorageAccountInternetEndpoints`, `StorageAccountIpv6Endpoints`, `KeyCreationTime`, `StorageAccountMicrosoftEndpoints`, `UpdateHistoryProperty` | 12 |
| **DataProtectionBackup** | `DeletionInfo`, `ProtectionStatusDetails`, `JobExtendedInfo`, `JobSubTask`, `RestoreJobRecoveryPointDetails` | 5 |

### Context

Triggered by the mgmt generator validate-typespec PR: Azure/azure-sdk-for-net#58438