### PR TITLE
Add C# provisioning emitter config for ServiceNetworking

### DIFF
--- a/specification/servicenetworking/resource-manager/Microsoft.ServiceNetworking/ServiceNetworking/tspconfig.yaml
+++ b/specification/servicenetworking/resource-manager/Microsoft.ServiceNetworking/ServiceNetworking/tspconfig.yaml
@@ -49,3 +49,4 @@ options:
   "@azure-typespec/http-client-csharp-provisioning":
     namespace: "Azure.Provisioning.ServiceNetworking"
     emitter-output-dir: "{output-dir}/sdk/servicenetworking/{namespace}"
+    api-version: "2025-01-01"

--- a/specification/servicenetworking/resource-manager/Microsoft.ServiceNetworking/ServiceNetworking/tspconfig.yaml
+++ b/specification/servicenetworking/resource-manager/Microsoft.ServiceNetworking/ServiceNetworking/tspconfig.yaml
@@ -46,3 +46,6 @@ options:
   "@azure-typespec/http-client-csharp-mgmt":
     namespace: "Azure.ResourceManager.ServiceNetworking"
     emitter-output-dir: "{output-dir}/sdk/servicenetworking/{namespace}"
+  "@azure-typespec/http-client-csharp-provisioning":
+    namespace: "Azure.Provisioning.ServiceNetworking"
+    emitter-output-dir: "{output-dir}/sdk/servicenetworking/{namespace}"


### PR DESCRIPTION
Adds the `@azure-typespec/http-client-csharp-provisioning` emitter options block to the ServiceNetworking `tspconfig.yaml` so that the parallel `Azure.Provisioning.ServiceNetworking` SDK library can be generated from the same TypeSpec spec.

Mirrors the precedent set by the MySQL FlexibleServers config.

No behavioral change for existing emitters (`@azure-typespec/http-client-csharp-mgmt` etc.).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>