### PR TITLE
Add read-only content_hash to hosted agent CodeConfiguration

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/Agents_CreateAgentFromCode_MaximumSet_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/Agents_CreateAgentFromCode_MaximumSet_Gen.json
@@ -47,7 +47,8 @@
             "entry_point": [
               "python",
               "main.py"
-            ]
+            ],
+            "content_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
           },
           "cpu": "0.25",
           "memory": "0.5Gi",

--- a/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/Agents_CreateAgentVersionFromCode_MaximumSet_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/Agents_CreateAgentVersionFromCode_MaximumSet_Gen.json
@@ -47,7 +47,8 @@
             "entry_point": [
               "python",
               "main.py"
-            ]
+            ],
+            "content_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
           },
           "cpu": "0.25",
           "memory": "0.5Gi",

--- a/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/Agents_UpdateAgentFromCode_MaximumSet_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/Agents_UpdateAgentFromCode_MaximumSet_Gen.json
@@ -47,7 +47,8 @@
             "entry_point": [
               "python",
               "main.py"
-            ]
+            ],
+            "content_hash": "f6e5d4c3b2a19876543210fedcba9876543210fedcba9876543210fedcba9876"
           },
           "cpu": "0.5",
           "memory": "1Gi",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -13032,6 +13032,11 @@
               "type": "string"
             },
             "description": "The entry point command and arguments for the code execution."
+          },
+          "content_hash": {
+            "type": "string",
+            "description": "The SHA-256 hex digest of the uploaded code zip. Set by the service from the `x-ms-code-zip-sha256` request header; read-only in responses and never accepted in request payloads.",
+            "readOnly": true
           }
         },
         "description": "Code-based deployment configuration for a hosted agent.",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -15271,6 +15271,11 @@
               "type": "string"
             },
             "description": "The entry point command and arguments for the code execution."
+          },
+          "content_hash": {
+            "type": "string",
+            "description": "The SHA-256 hex digest of the uploaded code zip. Set by the service from the `x-ms-code-zip-sha256` request header; read-only in responses and never accepted in request payloads.",
+            "readOnly": true
           }
         },
         "description": "Code-based deployment configuration for a hosted agent.",

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -415,6 +415,10 @@ model CodeConfiguration {
 
   @doc("The entry point command and arguments for the code execution.")
   entry_point: string[];
+
+  @visibility(Lifecycle.Read)
+  @doc("The SHA-256 hex digest of the uploaded code zip. Set by the service from the `x-ms-code-zip-sha256` request header; read-only in responses and never accepted in request payloads.")
+  content_hash?: string;
 }
 
 @doc("The hosted agent definition.")


### PR DESCRIPTION
## Summary

Adds a read-only `content_hash` property to `CodeConfiguration` under the hosted agent's `code_configuration`. The value is the SHA-256 hex digest of the uploaded code zip. Clients already supply it via the existing `x-ms-code-zip-sha256` request header; the service echoes it back on the agent/version resource so callers can verify integrity.

## Design

- `@visibility(Lifecycle.Read)` on the new property → emits `readOnly: true` in OpenAPI, so the field is excluded from request schemas and present in response schemas.
- Optional (`?`) to avoid requiring it on the wire.
- No route changes — the header is already bound on all three code-upload routes.
- No `@added` decorator needed — parent model is already gated by `AgentDefinitionOptInKeys.code_agents_v1_preview`.

## Changes

- `src/agents/models.tsp`: add read-only `content_hash?: string` to `model CodeConfiguration`.
- `openapi3/v1/microsoft-foundry-openapi3.json` and `openapi3/virtual-public-preview/microsoft-foundry-openapi3.json`: `content_hash` with `readOnly: true` in `CodeConfiguration`.
- Three `examples/2025-11-15-preview/Agents_*FromCode_MaximumSet_Gen.json` files: `content_hash` added to the response `code_configuration` only (request bodies unchanged).

## Validation

- `tsp compile` passes with no new warnings.
- `content_hash` is absent from request body schemas for the three code-upload routes and present (readOnly) in responses.