### PR TITLE
Add AKS Prepared Image Specification resource

### DIFF
--- a/specification/containerservice/cspell.yaml
+++ b/specification/containerservice/cspell.yaml
@@ -39,6 +39,7 @@ words:
   - oidc
   - ossku
   - pids
+  - preparedimgspec
   - reimaged
   - reimaging
   - rmem

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/cspell.yaml
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/cspell.yaml
@@ -1,0 +1,13 @@
+# This file configures spell checking. Items in "words" were initially populated
+# with words that might be spelling errors. Review these words and take
+# appropriate action. For more information, see: https://aka.ms/ci-fix#spell-check
+
+# Spell checking is not case sensitive
+# Keep word lists in alphabetical order so the file is easier to manage
+version: '0.2'
+import:
+  - ../../../cspell.yaml
+words:
+  - reimaged
+  - vhd
+  - vhds

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-02-02-preview/Operations_List.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-02-02-preview/Operations_List.json
@@ -1,0 +1,28 @@
+{
+  "title": "Operations_List",
+  "operationId": "Operations_List",
+  "parameters": {
+    "api-version": "2026-02-02-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.ContainerService/locations/operations/read",
+            "isDataAction": true,
+            "display": {
+              "provider": "Microsoft Container Service",
+              "resource": "Operation",
+              "operation": "Get Operation",
+              "description": "tulzcjyupeonkxrou"
+            },
+            "origin": "user",
+            "actionType": "Internal"
+          }
+        ],
+        "nextLink": "http://nextlink.contoso.com"
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-02-02-preview/PreparedImageSpecifications_CreateOrUpdate.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-02-02-preview/PreparedImageSpecifications_CreateOrUpdate.json
@@ -1,0 +1,117 @@
+{
+  "title": "PreparedImageSpecifications_CreateOrUpdate",
+  "operationId": "PreparedImageSpecifications_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-02-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification",
+    "resource": {
+      "properties": {
+        "containerImages": [
+          "redis:8.0.0"
+        ],
+        "customizationScripts": [
+          {
+            "name": "initialize-node",
+            "executionPoint": "NodeImageBuildTime",
+            "scriptType": "Bash",
+            "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt"
+          }
+        ],
+        "identityProfile": {
+          "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+        }
+      },
+      "tags": {
+        "team": "blue"
+      },
+      "location": "westus2"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "containerImages": [
+            "redis:8.0.0"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "eTag": "ETagValue",
+        "tags": {
+          "team": "blue"
+        },
+        "location": "westus2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+        "name": "my-prepared-image-specification",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+      },
+      "body": {
+        "properties": {
+          "containerImages": [
+            "redis:8.0.0"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "eTag": "ETagValue",
+        "tags": {
+          "team": "blue"
+        },
+        "location": "westus2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+        "name": "my-prepared-image-specification",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-02-02-preview/PreparedImageSpecifications_Delete.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-02-02-preview/PreparedImageSpecifications_Delete.json
@@ -1,0 +1,18 @@
+{
+  "title": "PreparedImageSpecifications_Delete",
+  "operationId": "PreparedImageSpecifications_Delete",
+  "parameters": {
+    "api-version": "2026-02-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-02-02-preview/PreparedImageSpecifications_DeleteVersion.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-02-02-preview/PreparedImageSpecifications_DeleteVersion.json
@@ -1,0 +1,19 @@
+{
+  "title": "PreparedImageSpecifications_DeleteVersion",
+  "operationId": "PreparedImageSpecifications_DeleteVersion",
+  "parameters": {
+    "api-version": "2026-02-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification",
+    "version": "20250101-abcd1234"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-02-02-preview/PreparedImageSpecifications_Get.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-02-02-preview/PreparedImageSpecifications_Get.json
@@ -1,0 +1,53 @@
+{
+  "title": "PreparedImageSpecifications_Get",
+  "operationId": "PreparedImageSpecifications_Get",
+  "parameters": {
+    "api-version": "2026-02-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "containerImages": [
+            "redis:8.0.0"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt",
+              "postScriptAction": "None"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "eTag": "ETagValue",
+        "tags": {
+          "team": "blue"
+        },
+        "location": "westus2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+        "name": "my-prepared-image-specification",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-02-02-preview/PreparedImageSpecifications_GetVersion.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-02-02-preview/PreparedImageSpecifications_GetVersion.json
@@ -1,0 +1,49 @@
+{
+  "title": "PreparedImageSpecifications_GetVersion",
+  "operationId": "PreparedImageSpecifications_GetVersion",
+  "parameters": {
+    "api-version": "2026-02-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification",
+    "version": "20250101-abcd1234"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "containerImages": [
+            "redis:8.0.0"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt",
+              "postScriptAction": "None"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification/versions/20250101-abcd1234",
+        "name": "20250101-abcd1234",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications/versions",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-02-02-preview/PreparedImageSpecifications_ListByResourceGroup.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-02-02-preview/PreparedImageSpecifications_ListByResourceGroup.json
@@ -1,0 +1,57 @@
+{
+  "title": "PreparedImageSpecifications_ListByResourceGroup",
+  "operationId": "PreparedImageSpecifications_ListByResourceGroup",
+  "parameters": {
+    "api-version": "2026-02-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "containerImages": [
+                "redis:8.0.0"
+              ],
+              "customizationScripts": [
+                {
+                  "name": "initialize-node",
+                  "executionPoint": "NodeImageBuildTime",
+                  "scriptType": "Bash",
+                  "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt",
+                  "postScriptAction": "None"
+                }
+              ],
+              "identityProfile": {
+                "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+                "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+              },
+              "version": "20250101-abcd1234",
+              "provisioningState": "Succeeded"
+            },
+            "eTag": "ETagValue",
+            "tags": {
+              "team": "blue"
+            },
+            "location": "westus2",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+            "name": "my-prepared-image-specification",
+            "type": "Microsoft.ContainerService/preparedImageSpecifications",
+            "systemData": {
+              "createdBy": "someUser",
+              "createdByType": "User",
+              "createdAt": "2025-05-02T04:08:43.702Z",
+              "lastModifiedBy": "someOtherUser",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/ah"
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-02-02-preview/PreparedImageSpecifications_ListBySubscription.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-02-02-preview/PreparedImageSpecifications_ListBySubscription.json
@@ -1,0 +1,56 @@
+{
+  "title": "PreparedImageSpecifications_ListBySubscription",
+  "operationId": "PreparedImageSpecifications_ListBySubscription",
+  "parameters": {
+    "api-version": "2026-02-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "containerImages": [
+                "redis:8.0.0"
+              ],
+              "customizationScripts": [
+                {
+                  "name": "initialize-node",
+                  "executionPoint": "NodeImageBuildTime",
+                  "scriptType": "Bash",
+                  "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt",
+                  "postScriptAction": "None"
+                }
+              ],
+              "identityProfile": {
+                "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+                "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+              },
+              "version": "20250101-abcd1234",
+              "provisioningState": "Succeeded"
+            },
+            "eTag": "ETagValue",
+            "tags": {
+              "team": "blue"
+            },
+            "location": "westus2",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+            "name": "my-prepared-image-specification",
+            "type": "Microsoft.ContainerService/preparedImageSpecifications",
+            "systemData": {
+              "createdBy": "someUser",
+              "createdByType": "User",
+              "createdAt": "2025-05-02T04:08:43.702Z",
+              "lastModifiedBy": "someOtherUser",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/ah"
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-02-02-preview/PreparedImageSpecifications_ListVersions.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-02-02-preview/PreparedImageSpecifications_ListVersions.json
@@ -1,0 +1,53 @@
+{
+  "title": "PreparedImageSpecifications_ListVersions",
+  "operationId": "PreparedImageSpecifications_ListVersions",
+  "parameters": {
+    "api-version": "2026-02-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "containerImages": [
+                "redis:8.0.0"
+              ],
+              "identityProfile": {
+                "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+                "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+              },
+              "version": "20250101-abcd1234",
+              "provisioningState": "Succeeded",
+              "customizationScripts": [
+                {
+                  "name": "initialize-node",
+                  "executionPoint": "NodeImageBuildTime",
+                  "scriptType": "Bash",
+                  "script": "echo 'Hello World'",
+                  "postScriptAction": "None"
+                }
+              ]
+            },
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification/versions/20250101-abcd1234",
+            "name": "20250101-abcd1234",
+            "type": "Microsoft.ContainerService/preparedImageSpecifications/versions",
+            "systemData": {
+              "createdBy": "someUser",
+              "createdByType": "User",
+              "createdAt": "2025-05-02T04:08:43.702Z",
+              "lastModifiedBy": "someOtherUser",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-02-02-preview/PreparedImageSpecifications_Update.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-02-02-preview/PreparedImageSpecifications_Update.json
@@ -1,0 +1,73 @@
+{
+  "title": "PreparedImageSpecifications_Update",
+  "operationId": "PreparedImageSpecifications_Update",
+  "parameters": {
+    "api-version": "2026-02-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification",
+    "properties": {
+      "tags": {
+        "key5558": "xufgvdnarflvwbcdkmhqhgbop"
+      },
+      "properties": {
+        "containerImages": [
+          "qmetlvqgbvhjnncyraxlhs"
+        ],
+        "customizationScripts": [
+          {
+            "name": "initialize-node",
+            "executionPoint": "NodeImageBuildTime",
+            "scriptType": "Bash",
+            "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt"
+          }
+        ],
+        "identityProfile": {
+          "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "containerImages": [
+            "qmetlvqgbvhjnncyraxlhs"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "eTag": "ETagValue",
+        "tags": {
+          "team": "blue"
+        },
+        "location": "westus2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+        "name": "my-prepared-image-specification",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/helpers.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/helpers.tsp
@@ -1,0 +1,21 @@
+import "@typespec/rest";
+
+using TypeSpec.Http;
+using TypeSpec.Rest;
+using TypeSpec.Versioning;
+using Azure.ResourceManager;
+using Azure.ResourceManager.Foundations;
+
+namespace Microsoft.ContainerService;
+
+alias IfMatchParameters<T extends Azure.ResourceManager.Foundations.Resource> = {
+  @header("If-Match")
+  @doc("The request should only proceed if the targeted resource's etag matches the value provided.")
+  ifMatch?: string;
+};
+
+alias IfNoneMatchParameters<T extends Azure.ResourceManager.Foundations.Resource> = {
+  @header("If-None-Match")
+  @doc("The request should only proceed if the targeted resource's etag does not match the value provided.")
+  ifNoneMatch?: string;
+};

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/main.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/main.tsp
@@ -1,0 +1,21 @@
+import "@typespec/versioning";
+import "@azure-tools/typespec-azure-resource-manager";
+import "./operations.tsp";
+
+using Azure.ResourceManager;
+using TypeSpec.Versioning;
+
+@armProviderNamespace
+@service(#{ title: "ContainerServicePreparedImageSpecificationClient" })
+@doc("Azure Kubernetes Prepared Image Specification api client.")
+@versioned(Versions)
+namespace Microsoft.ContainerService;
+
+interface Operations extends Azure.ResourceManager.Operations {}
+
+@doc("Azure Kubernetes Prepared Image Specification api versions.")
+enum Versions {
+  @doc("Azure Kubernetes Prepared Image Specification api version 2026-02-02-preview.")
+  @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v6)
+  v2026_02_02_preview: "2026-02-02-preview",
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/models.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/models.tsp
@@ -1,0 +1,221 @@
+import "@typespec/rest";
+import "@typespec/versioning";
+import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-azure-resource-manager";
+
+using TypeSpec.Http;
+using TypeSpec.Rest;
+using Azure.ResourceManager;
+
+namespace Microsoft.ContainerService;
+
+@doc("The Prepared Image Specification resource.")
+@resource("preparedImageSpecifications")
+model PreparedImageSpecification
+  is TrackedResource<PreparedImageSpecificationProperties> {
+  @doc("The name of the Prepared Image Specification resource.")
+  @pattern("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
+  @minLength(1)
+  @maxLength(63)
+  @key("preparedImageSpecificationName")
+  @path
+  @segment("preparedImageSpecifications")
+  @visibility(Lifecycle.Create, Lifecycle.Read)
+  name: string;
+
+  ...EntityTagProperty;
+}
+
+@doc("The properties of the Prepared Image Specification resource.")
+model PreparedImageSpecificationProperties {
+  @doc("The list of container images to cache on nodes. See https://kubernetes.io/docs/concepts/containers/images/#image-names")
+  containerImages?: string[];
+
+  @doc("""
+    The identity used to execute prepared image specification tasks during image build time and provisioning time. 
+    If not specified the default agentpool identity will be used.
+    This does not affect provisioned nodes.
+    """)
+  identityProfile?: PreparedImageSpecificationManagedIdentityProfile;
+
+  @visibility(Lifecycle.Read)
+  @doc("An auto-generated value that changes when the other fields of the image customization are changed.")
+  @pattern("^(?![.-])[A-Za-z0-9_.-]{1,128}$")
+  version?: string;
+
+  @visibility(Lifecycle.Read)
+  @doc("The provisioning state of the prepared image specification.")
+  provisioningState?: ProvisioningState;
+
+  @doc("The scripts to customize the node before or after image capture.")
+  @identifiers(#[])
+  customizationScripts?: PreparedImageSpecificationScript[];
+}
+
+@doc("The managed identity profile used by the prepared image specification.")
+model PreparedImageSpecificationManagedIdentityProfile {
+  @doc("The resource ID of the user-assigned managed identity.")
+  resourceId: Azure.Core.armResourceIdentifier<[
+    {
+      type: "Microsoft.ManagedIdentity/userAssignedIdentities";
+    }
+  ]>;
+
+  @visibility(Lifecycle.Read)
+  @doc("The object ID of the managed identity.")
+  objectId?: Azure.Core.uuid;
+
+  @visibility(Lifecycle.Read)
+  @doc("The client ID of the managed identity.")
+  clientId?: Azure.Core.uuid;
+}
+
+@doc("The managed identity profile used by the prepared image specification for update operations.")
+model PreparedImageSpecificationManagedIdentityProfileUpdate {
+  @doc("The resource ID of the user-assigned managed identity.")
+  resourceId?: Azure.Core.armResourceIdentifier<[
+    {
+      type: "Microsoft.ManagedIdentity/userAssignedIdentities";
+    }
+  ]>;
+}
+
+@doc("Prepared image specification script")
+model PreparedImageSpecificationScript {
+  @doc("""
+    The name for the customization script. 
+    Must be unique within the prepared image specification resource.
+    Can only contain lowercase alphanumeric,'-' or '.' characters.
+    """)
+  @pattern("^[a-z0-9]([a-z0-9\\.\\-]*[a-z0-9])?$")
+  @maxLength(263)
+  @key("preparedImageSpecificationScriptName")
+  @visibility(Lifecycle.Create, Lifecycle.Read)
+  name: string;
+
+  @doc("""
+    The stage at which the script is executed.
+    Specifying \`NodeImageBuildTime\` will ensure changes are persisted into the node image.
+    """)
+  executionPoint: ExecutionPoint;
+
+  @doc("The runtime environment for the script (e.g. Bash).")
+  @example("Bash")
+  scriptType: ScriptType;
+
+  @doc("The script content to be executed in plain text. Do not include secrets.")
+  @example("echo 'initializing node'")
+  script?: string;
+
+  @doc("The action to take after successful script execution.")
+  postScriptAction?: PostScriptAction;
+}
+
+@doc("Prepared image specification script for update operations")
+model PreparedImageSpecificationScriptUpdate {
+  @doc("The name for the customization script.")
+  @pattern("^[a-z0-9]([a-z0-9\\.\\-]*[a-z0-9])?$")
+  @maxLength(263)
+  name?: string;
+
+  @doc("The stage at which the script is executed.")
+  executionPoint?: ExecutionPoint;
+
+  @doc("The runtime environment for the script (e.g. Bash).")
+  @example("Bash")
+  scriptType?: ScriptType;
+
+  @doc("The script content to be executed in plain text. Do not include secrets.")
+  @example("echo 'initializing node'")
+  script?: string;
+
+  @doc("The action to take after successful script execution.")
+  postScriptAction?: PostScriptAction;
+}
+
+@doc("The updatable properties of the Prepared Image Specification resource.")
+model PreparedImageSpecificationPatchProperties {
+  @doc("The list of container images to cache on nodes. See https://kubernetes.io/docs/concepts/containers/images/#image-names")
+  containerImages?: string[];
+
+  @doc("The identity used to execute prepared image specification tasks during image build time and provisioning time.")
+  identityProfile?: PreparedImageSpecificationManagedIdentityProfileUpdate;
+
+  @doc("The scripts to customize the node before or after image capture.")
+  @identifiers(#[])
+  customizationScripts?: PreparedImageSpecificationScriptUpdate[];
+}
+
+@doc("Prepared image specification patch resource")
+model PreparedImageSpecificationPatch {
+  ...Azure.ResourceManager.Foundations.ArmTagsProperty;
+
+  @doc("Patchable prepared image specification properties.")
+  properties?: PreparedImageSpecificationPatchProperties;
+}
+
+@doc("The execution point for the script.")
+union ExecutionPoint {
+  string,
+
+  @doc("Execute during node image build time.")
+  nodeImageBuildTime: "NodeImageBuildTime",
+
+  @doc("Execute during node provisioning time.")
+  nodeProvisionTime: "NodeProvisionTime",
+}
+
+@doc("The script type.")
+union ScriptType {
+  string,
+
+  @doc("Bash script.")
+  bash: "Bash",
+
+  @doc("PowerShell script.")
+  powerShell: "PowerShell",
+}
+
+@doc("The action to take after the script finishes successfully.")
+union PostScriptAction {
+  string,
+
+  @doc("No post-script action is taken.")
+  none: "None",
+
+  @doc("Reboot the node after the script completes.")
+  rebootAfter: "RebootAfter",
+}
+
+@Azure.Core.lroStatus
+@doc("The provisioning state of the image customization.")
+union ProvisioningState {
+  ResourceProvisioningState,
+
+  @doc("Provisioning the resource is in progress")
+  Provisioning: "Provisioning",
+
+  @doc("Resource is being updated")
+  Updating: "Updating",
+
+  @doc("Resource is being deleted")
+  Deleting: "Deleting",
+
+  @doc("The change request has been accepted")
+  Accepted: "Accepted",
+}
+
+@parentResource(PreparedImageSpecification)
+@doc("A version of the Prepared Image Specification resource.")
+model PreparedImageSpecificationVersion
+  is ProxyResource<PreparedImageSpecificationProperties> {
+  @pattern("^(?![.-])[A-Za-z0-9_.-]{1,128}$")
+  @minLength(1)
+  @maxLength(128)
+  @doc("The version of the Prepared Image Specification.")
+  @key("version")
+  @path
+  @segment("versions")
+  @visibility(Lifecycle.Read)
+  name: string;
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/operations.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/operations.tsp
@@ -1,0 +1,54 @@
+import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-azure-resource-manager";
+import "./models.tsp";
+import "./helpers.tsp";
+
+using Azure.ResourceManager;
+
+namespace Microsoft.ContainerService;
+
+@armResourceOperations
+interface PreparedImageSpecifications {
+  @doc("Get a prepared image specification at the latest version.")
+  get is ArmResourceRead<PreparedImageSpecification>;
+  @doc("Create or update a prepared image specification resource. A new version is created only when the resource content changes.")
+  createOrUpdate is ArmResourceCreateOrUpdateAsync<
+    PreparedImageSpecification,
+    Azure.ResourceManager.Foundations.BaseParameters<PreparedImageSpecification> &
+      IfMatchParameters<PreparedImageSpecification> &
+      IfNoneMatchParameters<PreparedImageSpecification>
+  >;
+
+  @doc("Update a prepared image specification. A new version is created only when the resource content changes.")
+  update is ArmCustomPatchSync<
+    PreparedImageSpecification,
+    PatchModel = PreparedImageSpecificationPatch,
+    Parameters = IfMatchParameters<PreparedImageSpecification>
+  >;
+
+  @doc("Delete a prepared image specification. This operation will be blocked if the resource is in use.")
+  delete is ArmResourceDeleteWithoutOkAsync<
+    PreparedImageSpecification,
+    Azure.ResourceManager.Foundations.BaseParameters<PreparedImageSpecification> &
+      IfMatchParameters<PreparedImageSpecification>
+  >;
+
+  @doc("Delete a prepared image specification version. This operation will be blocked if the prepared image specification version is in use.")
+  deleteVersion is ArmResourceDeleteWithoutOkAsync<
+    PreparedImageSpecificationVersion,
+    Azure.ResourceManager.Foundations.BaseParameters<PreparedImageSpecificationVersion> &
+      IfMatchParameters<PreparedImageSpecificationVersion>
+  >;
+
+  @doc("List the prepared image specifications in a resource group at the latest version.")
+  listByResourceGroup is ArmResourceListByParent<PreparedImageSpecification>;
+
+  @doc("List the prepared image specifications in a subscription at the latest version.")
+  listBySubscription is ArmListBySubscription<PreparedImageSpecification>;
+
+  @doc("Get a prepared image specification at a particular version.")
+  getVersion is ArmResourceRead<PreparedImageSpecificationVersion>;
+
+  @doc("List all versions of a prepared image specification.")
+  listVersions is ArmResourceListByParent<PreparedImageSpecificationVersion>;
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/examples/Operations_List.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/examples/Operations_List.json
@@ -1,0 +1,28 @@
+{
+  "title": "Operations_List",
+  "operationId": "Operations_List",
+  "parameters": {
+    "api-version": "2026-02-02-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.ContainerService/locations/operations/read",
+            "isDataAction": true,
+            "display": {
+              "provider": "Microsoft Container Service",
+              "resource": "Operation",
+              "operation": "Get Operation",
+              "description": "tulzcjyupeonkxrou"
+            },
+            "origin": "user",
+            "actionType": "Internal"
+          }
+        ],
+        "nextLink": "http://nextlink.contoso.com"
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/examples/PreparedImageSpecifications_CreateOrUpdate.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/examples/PreparedImageSpecifications_CreateOrUpdate.json
@@ -1,0 +1,117 @@
+{
+  "title": "PreparedImageSpecifications_CreateOrUpdate",
+  "operationId": "PreparedImageSpecifications_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-02-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification",
+    "resource": {
+      "properties": {
+        "containerImages": [
+          "redis:8.0.0"
+        ],
+        "customizationScripts": [
+          {
+            "name": "initialize-node",
+            "executionPoint": "NodeImageBuildTime",
+            "scriptType": "Bash",
+            "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt"
+          }
+        ],
+        "identityProfile": {
+          "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+        }
+      },
+      "tags": {
+        "team": "blue"
+      },
+      "location": "westus2"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "containerImages": [
+            "redis:8.0.0"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "eTag": "ETagValue",
+        "tags": {
+          "team": "blue"
+        },
+        "location": "westus2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+        "name": "my-prepared-image-specification",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+      },
+      "body": {
+        "properties": {
+          "containerImages": [
+            "redis:8.0.0"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "eTag": "ETagValue",
+        "tags": {
+          "team": "blue"
+        },
+        "location": "westus2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+        "name": "my-prepared-image-specification",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/examples/PreparedImageSpecifications_Delete.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/examples/PreparedImageSpecifications_Delete.json
@@ -1,0 +1,18 @@
+{
+  "title": "PreparedImageSpecifications_Delete",
+  "operationId": "PreparedImageSpecifications_Delete",
+  "parameters": {
+    "api-version": "2026-02-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/examples/PreparedImageSpecifications_DeleteVersion.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/examples/PreparedImageSpecifications_DeleteVersion.json
@@ -1,0 +1,19 @@
+{
+  "title": "PreparedImageSpecifications_DeleteVersion",
+  "operationId": "PreparedImageSpecifications_DeleteVersion",
+  "parameters": {
+    "api-version": "2026-02-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification",
+    "version": "20250101-abcd1234"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/examples/PreparedImageSpecifications_Get.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/examples/PreparedImageSpecifications_Get.json
@@ -1,0 +1,53 @@
+{
+  "title": "PreparedImageSpecifications_Get",
+  "operationId": "PreparedImageSpecifications_Get",
+  "parameters": {
+    "api-version": "2026-02-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "containerImages": [
+            "redis:8.0.0"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt",
+              "postScriptAction": "None"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "eTag": "ETagValue",
+        "tags": {
+          "team": "blue"
+        },
+        "location": "westus2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+        "name": "my-prepared-image-specification",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/examples/PreparedImageSpecifications_GetVersion.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/examples/PreparedImageSpecifications_GetVersion.json
@@ -1,0 +1,49 @@
+{
+  "title": "PreparedImageSpecifications_GetVersion",
+  "operationId": "PreparedImageSpecifications_GetVersion",
+  "parameters": {
+    "api-version": "2026-02-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification",
+    "version": "20250101-abcd1234"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "containerImages": [
+            "redis:8.0.0"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt",
+              "postScriptAction": "None"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification/versions/20250101-abcd1234",
+        "name": "20250101-abcd1234",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications/versions",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/examples/PreparedImageSpecifications_ListByResourceGroup.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/examples/PreparedImageSpecifications_ListByResourceGroup.json
@@ -1,0 +1,57 @@
+{
+  "title": "PreparedImageSpecifications_ListByResourceGroup",
+  "operationId": "PreparedImageSpecifications_ListByResourceGroup",
+  "parameters": {
+    "api-version": "2026-02-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "containerImages": [
+                "redis:8.0.0"
+              ],
+              "customizationScripts": [
+                {
+                  "name": "initialize-node",
+                  "executionPoint": "NodeImageBuildTime",
+                  "scriptType": "Bash",
+                  "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt",
+                  "postScriptAction": "None"
+                }
+              ],
+              "identityProfile": {
+                "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+                "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+              },
+              "version": "20250101-abcd1234",
+              "provisioningState": "Succeeded"
+            },
+            "eTag": "ETagValue",
+            "tags": {
+              "team": "blue"
+            },
+            "location": "westus2",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+            "name": "my-prepared-image-specification",
+            "type": "Microsoft.ContainerService/preparedImageSpecifications",
+            "systemData": {
+              "createdBy": "someUser",
+              "createdByType": "User",
+              "createdAt": "2025-05-02T04:08:43.702Z",
+              "lastModifiedBy": "someOtherUser",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/ah"
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/examples/PreparedImageSpecifications_ListBySubscription.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/examples/PreparedImageSpecifications_ListBySubscription.json
@@ -1,0 +1,56 @@
+{
+  "title": "PreparedImageSpecifications_ListBySubscription",
+  "operationId": "PreparedImageSpecifications_ListBySubscription",
+  "parameters": {
+    "api-version": "2026-02-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "containerImages": [
+                "redis:8.0.0"
+              ],
+              "customizationScripts": [
+                {
+                  "name": "initialize-node",
+                  "executionPoint": "NodeImageBuildTime",
+                  "scriptType": "Bash",
+                  "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt",
+                  "postScriptAction": "None"
+                }
+              ],
+              "identityProfile": {
+                "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+                "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+              },
+              "version": "20250101-abcd1234",
+              "provisioningState": "Succeeded"
+            },
+            "eTag": "ETagValue",
+            "tags": {
+              "team": "blue"
+            },
+            "location": "westus2",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+            "name": "my-prepared-image-specification",
+            "type": "Microsoft.ContainerService/preparedImageSpecifications",
+            "systemData": {
+              "createdBy": "someUser",
+              "createdByType": "User",
+              "createdAt": "2025-05-02T04:08:43.702Z",
+              "lastModifiedBy": "someOtherUser",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/ah"
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/examples/PreparedImageSpecifications_ListVersions.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/examples/PreparedImageSpecifications_ListVersions.json
@@ -1,0 +1,53 @@
+{
+  "title": "PreparedImageSpecifications_ListVersions",
+  "operationId": "PreparedImageSpecifications_ListVersions",
+  "parameters": {
+    "api-version": "2026-02-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "containerImages": [
+                "redis:8.0.0"
+              ],
+              "identityProfile": {
+                "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+                "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+              },
+              "version": "20250101-abcd1234",
+              "provisioningState": "Succeeded",
+              "customizationScripts": [
+                {
+                  "name": "initialize-node",
+                  "executionPoint": "NodeImageBuildTime",
+                  "scriptType": "Bash",
+                  "script": "echo 'Hello World'",
+                  "postScriptAction": "None"
+                }
+              ]
+            },
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification/versions/20250101-abcd1234",
+            "name": "20250101-abcd1234",
+            "type": "Microsoft.ContainerService/preparedImageSpecifications/versions",
+            "systemData": {
+              "createdBy": "someUser",
+              "createdByType": "User",
+              "createdAt": "2025-05-02T04:08:43.702Z",
+              "lastModifiedBy": "someOtherUser",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/examples/PreparedImageSpecifications_Update.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/examples/PreparedImageSpecifications_Update.json
@@ -1,0 +1,73 @@
+{
+  "title": "PreparedImageSpecifications_Update",
+  "operationId": "PreparedImageSpecifications_Update",
+  "parameters": {
+    "api-version": "2026-02-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification",
+    "properties": {
+      "tags": {
+        "key5558": "xufgvdnarflvwbcdkmhqhgbop"
+      },
+      "properties": {
+        "containerImages": [
+          "qmetlvqgbvhjnncyraxlhs"
+        ],
+        "customizationScripts": [
+          {
+            "name": "initialize-node",
+            "executionPoint": "NodeImageBuildTime",
+            "scriptType": "Bash",
+            "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt"
+          }
+        ],
+        "identityProfile": {
+          "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "containerImages": [
+            "qmetlvqgbvhjnncyraxlhs"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "eTag": "ETagValue",
+        "tags": {
+          "team": "blue"
+        },
+        "location": "westus2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+        "name": "my-prepared-image-specification",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/preparedimagespecification.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/preparedimagespecification.json
@@ -1,0 +1,1039 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "ContainerServicePreparedImageSpecificationClient",
+    "version": "2026-02-02-preview",
+    "description": "Azure Kubernetes Prepared Image Specification api client.",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Operations"
+    },
+    {
+      "name": "PreparedImageSpecifications"
+    }
+  ],
+  "paths": {
+    "/providers/Microsoft.ContainerService/operations": {
+      "get": {
+        "operationId": "Operations_List",
+        "tags": [
+          "Operations"
+        ],
+        "description": "List the operations for the provider",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/OperationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Operations_List": {
+            "$ref": "./examples/Operations_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.ContainerService/preparedImageSpecifications": {
+      "get": {
+        "operationId": "PreparedImageSpecifications_ListBySubscription",
+        "tags": [
+          "PreparedImageSpecifications"
+        ],
+        "description": "List the prepared image specifications in a subscription at the latest version.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecificationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PreparedImageSpecifications_ListBySubscription": {
+            "$ref": "./examples/PreparedImageSpecifications_ListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/preparedImageSpecifications": {
+      "get": {
+        "operationId": "PreparedImageSpecifications_ListByResourceGroup",
+        "tags": [
+          "PreparedImageSpecifications"
+        ],
+        "description": "List the prepared image specifications in a resource group at the latest version.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecificationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PreparedImageSpecifications_ListByResourceGroup": {
+            "$ref": "./examples/PreparedImageSpecifications_ListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/preparedImageSpecifications/{preparedImageSpecificationName}": {
+      "get": {
+        "operationId": "PreparedImageSpecifications_Get",
+        "tags": [
+          "PreparedImageSpecifications"
+        ],
+        "description": "Get a prepared image specification at the latest version.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "preparedImageSpecificationName",
+            "in": "path",
+            "description": "The name of the Prepared Image Specification resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecification"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PreparedImageSpecifications_Get": {
+            "$ref": "./examples/PreparedImageSpecifications_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "PreparedImageSpecifications_CreateOrUpdate",
+        "tags": [
+          "PreparedImageSpecifications"
+        ],
+        "description": "Create or update a prepared image specification resource. A new version is created only when the resource content changes.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "The request should only proceed if the targeted resource's etag matches the value provided.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "ifMatch"
+          },
+          {
+            "name": "If-None-Match",
+            "in": "header",
+            "description": "The request should only proceed if the targeted resource's etag does not match the value provided.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "ifNoneMatch"
+          },
+          {
+            "name": "preparedImageSpecificationName",
+            "in": "path",
+            "description": "The name of the Prepared Image Specification resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecification"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'PreparedImageSpecification' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecification"
+            }
+          },
+          "201": {
+            "description": "Resource 'PreparedImageSpecification' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecification"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PreparedImageSpecifications_CreateOrUpdate": {
+            "$ref": "./examples/PreparedImageSpecifications_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "PreparedImageSpecifications_Update",
+        "tags": [
+          "PreparedImageSpecifications"
+        ],
+        "description": "Update a prepared image specification. A new version is created only when the resource content changes.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "preparedImageSpecificationName",
+            "in": "path",
+            "description": "The name of the Prepared Image Specification resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "The request should only proceed if the targeted resource's etag matches the value provided.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "ifMatch"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecificationPatch"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecification"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PreparedImageSpecifications_Update": {
+            "$ref": "./examples/PreparedImageSpecifications_Update.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "PreparedImageSpecifications_Delete",
+        "tags": [
+          "PreparedImageSpecifications"
+        ],
+        "description": "Delete a prepared image specification. This operation will be blocked if the resource is in use.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "The request should only proceed if the targeted resource's etag matches the value provided.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "ifMatch"
+          },
+          {
+            "name": "preparedImageSpecificationName",
+            "in": "path",
+            "description": "The name of the Prepared Image Specification resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PreparedImageSpecifications_Delete": {
+            "$ref": "./examples/PreparedImageSpecifications_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/preparedImageSpecifications/{preparedImageSpecificationName}/versions": {
+      "get": {
+        "operationId": "PreparedImageSpecifications_ListVersions",
+        "tags": [
+          "PreparedImageSpecifications"
+        ],
+        "description": "List all versions of a prepared image specification.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "preparedImageSpecificationName",
+            "in": "path",
+            "description": "The name of the Prepared Image Specification resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecificationVersionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PreparedImageSpecifications_ListVersions": {
+            "$ref": "./examples/PreparedImageSpecifications_ListVersions.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/preparedImageSpecifications/{preparedImageSpecificationName}/versions/{version}": {
+      "get": {
+        "operationId": "PreparedImageSpecifications_GetVersion",
+        "tags": [
+          "PreparedImageSpecifications"
+        ],
+        "description": "Get a prepared image specification at a particular version.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "preparedImageSpecificationName",
+            "in": "path",
+            "description": "The name of the Prepared Image Specification resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The version of the Prepared Image Specification.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128,
+            "pattern": "^(?![.-])[A-Za-z0-9_.-]{1,128}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecificationVersion"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PreparedImageSpecifications_GetVersion": {
+            "$ref": "./examples/PreparedImageSpecifications_GetVersion.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "PreparedImageSpecifications_DeleteVersion",
+        "tags": [
+          "PreparedImageSpecifications"
+        ],
+        "description": "Delete a prepared image specification version. This operation will be blocked if the prepared image specification version is in use.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "The request should only proceed if the targeted resource's etag matches the value provided.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "ifMatch"
+          },
+          {
+            "name": "preparedImageSpecificationName",
+            "in": "path",
+            "description": "The name of the Prepared Image Specification resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The version of the Prepared Image Specification.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128,
+            "pattern": "^(?![.-])[A-Za-z0-9_.-]{1,128}$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PreparedImageSpecifications_DeleteVersion": {
+            "$ref": "./examples/PreparedImageSpecifications_DeleteVersion.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    }
+  },
+  "definitions": {
+    "Azure.Core.uuid": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Universally Unique Identifier"
+    },
+    "ExecutionPoint": {
+      "type": "string",
+      "description": "The execution point for the script.",
+      "enum": [
+        "NodeImageBuildTime",
+        "NodeProvisionTime"
+      ],
+      "x-ms-enum": {
+        "name": "ExecutionPoint",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "nodeImageBuildTime",
+            "value": "NodeImageBuildTime",
+            "description": "Execute during node image build time."
+          },
+          {
+            "name": "nodeProvisionTime",
+            "value": "NodeProvisionTime",
+            "description": "Execute during node provisioning time."
+          }
+        ]
+      }
+    },
+    "PostScriptAction": {
+      "type": "string",
+      "description": "The action to take after the script finishes successfully.",
+      "enum": [
+        "None",
+        "RebootAfter"
+      ],
+      "x-ms-enum": {
+        "name": "PostScriptAction",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "none",
+            "value": "None",
+            "description": "No post-script action is taken."
+          },
+          {
+            "name": "rebootAfter",
+            "value": "RebootAfter",
+            "description": "Reboot the node after the script completes."
+          }
+        ]
+      }
+    },
+    "PreparedImageSpecification": {
+      "type": "object",
+      "description": "The Prepared Image Specification resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PreparedImageSpecificationProperties",
+          "description": "The resource-specific properties for this resource."
+        },
+        "eTag": {
+          "type": "string",
+          "description": "If eTag is provided in the response body, it may also be provided as a header per the normal etag convention.  Entity tags are used for comparing two or more entities from the same requested resource. HTTP/1.1 uses entity tags in the etag (section 14.19), If-Match (section 14.24), If-None-Match (section 14.26), and If-Range (section 14.27) header fields.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "PreparedImageSpecificationListResult": {
+      "type": "object",
+      "description": "The response of a PreparedImageSpecification list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PreparedImageSpecification items on this page",
+          "items": {
+            "$ref": "#/definitions/PreparedImageSpecification"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PreparedImageSpecificationManagedIdentityProfile": {
+      "type": "object",
+      "description": "The managed identity profile used by the prepared image specification.",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The resource ID of the user-assigned managed identity.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.ManagedIdentity/userAssignedIdentities"
+              }
+            ]
+          }
+        },
+        "objectId": {
+          "$ref": "#/definitions/Azure.Core.uuid",
+          "description": "The object ID of the managed identity.",
+          "readOnly": true
+        },
+        "clientId": {
+          "$ref": "#/definitions/Azure.Core.uuid",
+          "description": "The client ID of the managed identity.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "resourceId"
+      ]
+    },
+    "PreparedImageSpecificationManagedIdentityProfileUpdate": {
+      "type": "object",
+      "description": "The managed identity profile used by the prepared image specification for update operations.",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The resource ID of the user-assigned managed identity.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.ManagedIdentity/userAssignedIdentities"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "PreparedImageSpecificationPatch": {
+      "type": "object",
+      "description": "Prepared image specification patch resource",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/PreparedImageSpecificationPatchProperties",
+          "description": "Patchable prepared image specification properties."
+        }
+      }
+    },
+    "PreparedImageSpecificationPatchProperties": {
+      "type": "object",
+      "description": "The updatable properties of the Prepared Image Specification resource.",
+      "properties": {
+        "containerImages": {
+          "type": "array",
+          "description": "The list of container images to cache on nodes. See https://kubernetes.io/docs/concepts/containers/images/#image-names",
+          "items": {
+            "type": "string"
+          }
+        },
+        "identityProfile": {
+          "$ref": "#/definitions/PreparedImageSpecificationManagedIdentityProfileUpdate",
+          "description": "The identity used to execute prepared image specification tasks during image build time and provisioning time."
+        },
+        "customizationScripts": {
+          "type": "array",
+          "description": "The scripts to customize the node before or after image capture.",
+          "items": {
+            "$ref": "#/definitions/PreparedImageSpecificationScriptUpdate"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "PreparedImageSpecificationProperties": {
+      "type": "object",
+      "description": "The properties of the Prepared Image Specification resource.",
+      "properties": {
+        "containerImages": {
+          "type": "array",
+          "description": "The list of container images to cache on nodes. See https://kubernetes.io/docs/concepts/containers/images/#image-names",
+          "items": {
+            "type": "string"
+          }
+        },
+        "identityProfile": {
+          "$ref": "#/definitions/PreparedImageSpecificationManagedIdentityProfile",
+          "description": "The identity used to execute prepared image specification tasks during image build time and provisioning time. \nIf not specified the default agentpool identity will be used.\nThis does not affect provisioned nodes."
+        },
+        "version": {
+          "type": "string",
+          "description": "An auto-generated value that changes when the other fields of the image customization are changed.",
+          "pattern": "^(?![.-])[A-Za-z0-9_.-]{1,128}$",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "The provisioning state of the prepared image specification.",
+          "readOnly": true
+        },
+        "customizationScripts": {
+          "type": "array",
+          "description": "The scripts to customize the node before or after image capture.",
+          "items": {
+            "$ref": "#/definitions/PreparedImageSpecificationScript"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "PreparedImageSpecificationScript": {
+      "type": "object",
+      "description": "Prepared image specification script",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name for the customization script. \nMust be unique within the prepared image specification resource.\nCan only contain lowercase alphanumeric,'-' or '.' characters.",
+          "maxLength": 263,
+          "pattern": "^[a-z0-9]([a-z0-9\\.\\-]*[a-z0-9])?$",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "executionPoint": {
+          "$ref": "#/definitions/ExecutionPoint",
+          "description": "The stage at which the script is executed.\nSpecifying `NodeImageBuildTime` will ensure changes are persisted into the node image."
+        },
+        "scriptType": {
+          "$ref": "#/definitions/ScriptType",
+          "description": "The runtime environment for the script (e.g. Bash)."
+        },
+        "script": {
+          "type": "string",
+          "description": "The script content to be executed in plain text. Do not include secrets."
+        },
+        "postScriptAction": {
+          "$ref": "#/definitions/PostScriptAction",
+          "description": "The action to take after successful script execution."
+        }
+      },
+      "required": [
+        "name",
+        "executionPoint",
+        "scriptType"
+      ]
+    },
+    "PreparedImageSpecificationScriptUpdate": {
+      "type": "object",
+      "description": "Prepared image specification script for update operations",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name for the customization script.",
+          "maxLength": 263,
+          "pattern": "^[a-z0-9]([a-z0-9\\.\\-]*[a-z0-9])?$"
+        },
+        "executionPoint": {
+          "$ref": "#/definitions/ExecutionPoint",
+          "description": "The stage at which the script is executed."
+        },
+        "scriptType": {
+          "$ref": "#/definitions/ScriptType",
+          "description": "The runtime environment for the script (e.g. Bash)."
+        },
+        "script": {
+          "type": "string",
+          "description": "The script content to be executed in plain text. Do not include secrets."
+        },
+        "postScriptAction": {
+          "$ref": "#/definitions/PostScriptAction",
+          "description": "The action to take after successful script execution."
+        }
+      }
+    },
+    "PreparedImageSpecificationVersion": {
+      "type": "object",
+      "description": "A version of the Prepared Image Specification resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PreparedImageSpecificationProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "PreparedImageSpecificationVersionListResult": {
+      "type": "object",
+      "description": "The response of a PreparedImageSpecificationVersion list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PreparedImageSpecificationVersion items on this page",
+          "items": {
+            "$ref": "#/definitions/PreparedImageSpecificationVersion"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ProvisioningState": {
+      "type": "string",
+      "description": "The provisioning state of the image customization.",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Provisioning",
+        "Updating",
+        "Deleting",
+        "Accepted"
+      ],
+      "x-ms-enum": {
+        "name": "ProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Resource has been created."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Resource creation failed."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Resource creation was canceled."
+          },
+          {
+            "name": "Provisioning",
+            "value": "Provisioning",
+            "description": "Provisioning the resource is in progress"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Resource is being updated"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Resource is being deleted"
+          },
+          {
+            "name": "Accepted",
+            "value": "Accepted",
+            "description": "The change request has been accepted"
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "ScriptType": {
+      "type": "string",
+      "description": "The script type.",
+      "enum": [
+        "Bash",
+        "PowerShell"
+      ],
+      "x-ms-enum": {
+        "name": "ScriptType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "bash",
+            "value": "Bash",
+            "description": "Bash script."
+          },
+          {
+            "name": "powerShell",
+            "value": "PowerShell",
+            "description": "PowerShell script."
+          }
+        ]
+      }
+    }
+  },
+  "parameters": {}
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/readme.csharp.md
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/readme.csharp.md
@@ -1,0 +1,15 @@
+## C#
+
+These settings apply only when `--csharp` is specified on the command line.
+Please also specify `--csharp-sdks-folder=<path to "SDKs" directory of your azure-sdk-for-net clone>`.
+
+```yaml $(csharp)
+csharp:
+  azure-arm: true
+  license-header: MICROSOFT_MIT_NO_VERSION
+  payload-flattening-threshold: 1
+  clear-output-folder: true
+  client-side-validation: false
+  namespace: Microsoft.ContainerService.PreparedImageSpecification
+  output-folder: $(csharp-sdks-folder)/containerservice/management/Microsoft.ContainerService.PreparedImageSpecification/GeneratedProtocol
+```

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/readme.go.md
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/readme.go.md
@@ -1,0 +1,11 @@
+## Go
+
+These settings apply only when `--go` is specified on the command line.
+
+``` yaml $(go) && $(track2)
+license-header: MICROSOFT_MIT_NO_VERSION
+module-name: sdk/resourcemanager/containerservicepreparedimagespecification/armcontainerservicepreparedimagespecification
+module: github.com/Azure/azure-sdk-for-go/$(module-name)
+output-folder: $(go-sdk-folder)/$(module-name)
+azure-arm: true
+```

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/readme.java.md
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/readme.java.md
@@ -1,0 +1,35 @@
+## Java
+
+These settings apply only when `--java` is specified on the command line.
+Please also specify `--azure-libraries-for-java-folder=<path to the root directory of your azure-sdk-for-java clone>`.
+
+```yaml $(java)
+azure-arm: true
+fluent: true
+namespace: com.azure.resourcemanager.containerservice.preparedimgspec
+license-header: MICROSOFT_MIT_NO_CODEGEN
+payload-flattening-threshold: 1
+output-folder: $(azure-libraries-for-java-folder)/azure-mgmt-containerservice-preparedimagespecification
+title: ContainerServicePreparedImageSpecificationManagementClient
+description: "Azure Kubernetes Prepared Image Specification Manager Client"
+```
+
+### Java multi-api
+
+```yaml $(java) && $(multiapi)
+batch:
+  - tag: package-2026-02-02-preview
+```
+
+### Tag: package-2026-02-02-preview and java
+
+These settings apply only when `--tag=package-2026-02-02-preview` is specified on the command line.
+Please also specify `--azure-libraries-for-java-folder=<path to the root directory of your azure-sdk-for-java clone>`.
+
+```yaml $(tag) == 'package-2026-02-02-preview' && $(java) && $(multiapi)
+java:
+  namespace: com.azure.resourcemanager.containerservice.preparedimgspec.v2026_02_02_preview
+  output-folder: $(azure-libraries-for-java-folder)/sdk/containerservice/mgmt-v2026_02_02_preview
+regenerate-manager: true
+generate-interface: true
+```

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/readme.md
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/readme.md
@@ -1,0 +1,63 @@
+# preparedimagespecification
+
+> see https://aka.ms/autorest
+> This is the AutoRest configuration file for ContainerServicePreparedImageSpecification.
+
+## Getting Started
+
+To build SDKs for the Prepared Image Specification API, install AutoRest via `npm` (`npm install -g autorest`) and then run:
+
+> `autorest readme.md`
+> To see additional help and options, run:
+
+> `autorest --help`
+> For other options on installation see [Installing AutoRest](https://aka.ms/autorest/install) on the AutoRest github page.
+
+---
+
+## Configuration
+
+### Basic Information
+
+These are the global settings for the ContainerServices API.
+
+```yaml
+openapi-type: arm
+tag: package-2026-02-02-preview
+```
+
+### Tag: package-2026-02-02-preview
+
+These settings apply only when `--tag=package-2026-02-02-preview` is specified on the command line.
+
+```yaml $(tag) == 'package-2026-02-02-preview'
+input-file:
+  - preview/2026-02-02-preview/preparedimagespecification.json
+```
+
+---
+
+## C#
+
+See configuration in [readme.csharp.md](./readme.csharp.md)
+
+## Go
+
+See configuration in [readme.go.md](./readme.go.md)
+
+## Python
+
+See configuration in [readme.python.md](./readme.python.md)
+
+## Java
+
+See configuration in [readme.java.md](./readme.java.md)
+
+## Suppression
+
+``` yaml
+directive:
+  - suppress: GuidUsage
+    from: preparedimagespecification.json
+    reason: Managed identity objectId and clientId properties are standard Azure resource GUIDs.
+```

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/readme.nodejs.md
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/readme.nodejs.md
@@ -1,0 +1,14 @@
+## Node.js
+
+These settings apply only when `--nodejs` is specified on the command line.
+Please also specify `--node-sdks-folder=<path to root folder of your azure-sdk-for-node clone>`.
+
+``` yaml $(nodejs)
+nodejs:
+  azure-arm: true
+  package-name: azure-arm-containerservicepreparedimagespecification
+  output-folder: $(node-sdks-folder)/lib/services/containerservicepreparedimagespecification
+  generate-license-txt: true
+  generate-package-json: true
+  generate-readme-md: true
+```

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/readme.python.md
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/readme.python.md
@@ -1,0 +1,19 @@
+## Python
+
+These settings apply only when `--python` is specified on the command line.
+Please also specify `--python-sdks-folder=<path to the root directory of your azure-sdk-for-python clone>`.
+
+```yaml $(python)
+azure-arm: true
+license-header: MICROSOFT_MIT_NO_VERSION
+package-name: azure-mgmt-containerservice-preparedimagespecification
+namespace: azure.mgmt.containerservice.preparedimagespecification
+package-version: 3.0.0
+clear-output-folder: true
+title: ContainerServicePreparedImageSpecificationMgmtClient
+```
+
+```yaml $(python)
+no-namespace-folders: true
+output-folder: $(python-sdks-folder)/containerservice/azure-mgmt-containerservicepreparedimagespecification/azure/mgmt/containerservicepreparedimagespecification
+```

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/tspconfig.yaml
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/tspconfig.yaml
@@ -1,0 +1,55 @@
+parameters:
+  "service-dir":
+    default: "sdk/containerservicepreparedimagespecification"
+emit:
+  - "@azure-tools/typespec-autorest"
+output-dir: "{project-root}"
+options:
+  "@azure-tools/typespec-autorest":
+    azure-resource-provider-folder: "resource-manager"
+    emit-common-types-schema: "never"
+    emitter-output-dir: "{output-dir}"
+    output-file: "{version-status}/{version}/preparedimagespecification.json"
+    arm-types-dir: "{project-root}/../../../../common-types/resource-management"
+    examples-dir: "{project-root}/examples"
+    use-read-only-status-schema: true
+  "@azure-tools/typespec-csharp":
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
+    flavor: azure
+    clear-output-folder: true
+    namespace: "Azure.ResourceManager.ContainerServicePreparedImageSpecification"
+  "@azure-tools/typespec-java":
+    namespace: "com.azure.resourcemanager.containerservice.preparedimgspec"
+    package-dir: "azure-resourcemanager-containerservice-preparedimgspec"
+    emitter-output-dir: "{output-dir}/{service-dir}/azure-resourcemanager-containerservice-preparedimgspec"
+    service-name: "Container Service Prepared Image Specification"
+    flavor: azure
+  "@azure-tools/typespec-go":
+    service-dir: "sdk/resourcemanager/containerservicepreparedimagespecification"
+    package-dir: "armcontainerservicepreparedimagespecification"
+    emitter-output-dir: "{output-dir}/{service-dir}/armcontainerservicepreparedimagespecification"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armcontainerservicepreparedimagespecification"
+    fix-const-stuttering: true
+    flavor: "azure"
+    generate-samples: true
+    generate-fakes: true
+    head-as-boolean: true
+    inject-spans: true
+  "@azure-tools/typespec-python":
+    emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-containerservicepreparedimagespecification"
+    flavor: "azure"
+    namespace: "azure.mgmt.containerservicepreparedimagespecification"
+    service-dir: "sdk/containerservice"
+    generate-test: true
+    generate-sample: true
+  "@azure-tools/typespec-ts":
+    service-dir: "sdk/containerservice"
+    package-dir: "arm-containerservicepreparedimagespecification"
+    flavor: azure
+    experimental-extensible-enums: true
+    emitter-output-dir: "{output-dir}/{service-dir}/arm-containerservicepreparedimagespecification"
+    package-details:
+      name: "@azure/arm-containerservicepreparedimagespecification"
+linter:
+  extends:
+    - "@azure-tools/typespec-azure-rulesets/resource-manager"

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/suppressions.yaml
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/suppressions.yaml
@@ -1,0 +1,3 @@
+- tool: TypeSpecRequirement
+  path: ./preparedimagespecification/preview/2026-02-02-preview/preparedimagespecification.json
+  reason: False positive in TypeSpec-Requirement path parsing for service names containing 'specification'

--- a/specification/suppressions.yaml
+++ b/specification/suppressions.yaml
@@ -1,6 +1,11 @@
 # Managed centrally by the Azure SDK Team
 # Remove suppressions as specs are fixed
 
+- tool: TypeSpecRequirement
+  reason: False positive in TypeSpec-Requirement path parsing for service names containing 'specification'
+  paths:
+    - containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/preparedimagespecification.json
+
 - tool: TypeSpecValidation
   rules: [FolderStructure]
   sub-rules: [MustUseV2]
@@ -107,9 +112,6 @@
     - migrate/AssessmentProjects.Management/WebAppCompoundAssessments.Management
     - migrate/Waves.Management
     - mission/Mission.Management
-    - monitor/Microsoft.Monitor.Management
-    - monitor/Microsoft.Monitor.Operations.Management
-    - monitor/Microsoft.Monitor.PipelineGroups.Management
     - monitor/Monitor.Ingestion
     - monitor/Monitor.Query.Logs
     - monitor/Monitor.Query.Metrics

--- a/specification/suppressions.yaml
+++ b/specification/suppressions.yaml
@@ -1,11 +1,6 @@
 # Managed centrally by the Azure SDK Team
 # Remove suppressions as specs are fixed
 
-- tool: TypeSpecRequirement
-  reason: False positive in TypeSpec-Requirement path parsing for service names containing 'specification'
-  paths:
-    - containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/preparedimagespecification.json
-
 - tool: TypeSpecValidation
   rules: [FolderStructure]
   sub-rules: [MustUseV2]


### PR DESCRIPTION
## Summary
Add the AKS Prepared Image Specification resource as an isolated change on top of `dev-containerservice-Microsoft.ContainerService-2026-03`.

## Included in this PR
- new `preparedimagespecification` TypeSpec project and generated preview OpenAPI
- prepared image specification examples for create, get, list, update, and delete flows
- companion cspell and suppression updates required for this spec

## Notes
- this branch is a clean transplant of the prepared-image-spec work onto the AKS `2026-03` development branch
- kept as a draft so it can be published later when ready