### PR TITLE
Add platformReleaseChannel property to Webapp Site model

### DIFF
--- a/specification/web/resource-manager/Microsoft.Web/AppService/models.tsp
+++ b/specification/web/resource-manager/Microsoft.Web/AppService/models.tsp
@@ -1046,6 +1046,23 @@ enum RedundancyMode {
 }
 
 /**
+ * The platform release channel for the site.
+ */
+@added(Versions.v2026_03_15)
+union PlatformReleaseChannel {
+  string,
+
+  /** Latest receives updates earliest. */
+  Latest: "Latest",
+
+  /** Standard receives updates after Latest. */
+  Standard: "Standard",
+
+  /** Extended receives updates last with extended support. */
+  Extended: "Extended",
+}
+
+/**
  * Specifies the scope of uniqueness for the default hostname during resource creation
  */
 #suppress "@azure-tools/typespec-azure-core/no-enum" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
@@ -2374,6 +2391,12 @@ model SiteProperties {
    */
   @visibility(Lifecycle.Read)
   sku?: string;
+
+  /**
+   * The platform release channel for the site. Latest receives updates earliest, followed by Standard, then Extended.
+   */
+  @added(Versions.v2026_03_15)
+  platformReleaseChannel?: PlatformReleaseChannel;
 }
 
 /**

--- a/specification/web/resource-manager/Microsoft.Web/AppService/stable/2026-03-15/openapi.json
+++ b/specification/web/resource-manager/Microsoft.Web/AppService/stable/2026-03-15/openapi.json
@@ -49224,6 +49224,36 @@
         }
       }
     },
+    "PlatformReleaseChannel": {
+      "type": "string",
+      "description": "The platform release channel for the site.",
+      "enum": [
+        "Latest",
+        "Standard",
+        "Extended"
+      ],
+      "x-ms-enum": {
+        "name": "PlatformReleaseChannel",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Latest",
+            "value": "Latest",
+            "description": "Latest receives updates earliest."
+          },
+          {
+            "name": "Standard",
+            "value": "Standard",
+            "description": "Standard receives updates after Latest."
+          },
+          {
+            "name": "Extended",
+            "value": "Extended",
+            "description": "Extended receives updates last with extended support."
+          }
+        ]
+      }
+    },
     "PremierAddOn": {
       "type": "object",
       "description": "Premier add-on.",
@@ -53724,6 +53754,10 @@
           "type": "string",
           "description": "Current SKU of application based on associated App Service Plan. Some valid SKU values are Free, Shared, Basic, Dynamic, FlexConsumption, Standard, Premium, PremiumV2, PremiumV3, Isolated, IsolatedV2",
           "readOnly": true
+        },
+        "platformReleaseChannel": {
+          "$ref": "#/definitions/PlatformReleaseChannel",
+          "description": "The platform release channel for the site. Latest receives updates earliest, followed by Standard, then Extended."
         }
       }
     },


### PR DESCRIPTION
Add platformReleaseChannel property to the Site model for the 2026-03-15 API version.

This adds:
- PlatformReleaseChannel union (Latest, Standard, Extended)
- platformReleaseChannel optional property to SiteProperties

Description
This PR adds the platformReleaseChannel property to the Site resource model
The Azure App Service platform supports a release channel configuration (Latest, Standard, or Extended) that controls the order in which platform updates are applied to web apps:

Related PRs
Azure CLI: https://github.com/Azure/azure-cli/pull/32811 — az webapp update --platform-release-channel support