### PR TITLE
Add csharp customizations for ServiceGroups migration

### DIFF
--- a/specification/management/resource-manager/Microsoft.Management/ServiceGroups/client.tsp
+++ b/specification/management/resource-manager/Microsoft.Management/ServiceGroups/client.tsp
@@ -11,3 +11,13 @@ namespace Microsoft.Management;
   "ServiceGroupsManagementClient",
   "javascript"
 );
+
+// Rename the ServiceGroups interface to avoid C# namespace-type name conflict
+// (namespace segment "ServiceGroups" would conflict with the interface type)
+@@clientName(ServiceGroups, "ServiceGroupClient", "csharp");
+
+// Rename ServiceGroupCollectionResponse to avoid AZC0030 (model name ending with 'Response')
+@@clientName(ServiceGroupCollectionResponse,
+  "ServiceGroupCollectionResult",
+  "csharp"
+);


### PR DESCRIPTION
Add C#-scoped `@@clientName` decorators to `client.tsp` for the `Azure.ResourceManager.ServiceGroups` SDK migration from Swagger to TypeSpec.

## Decorators added

| Decorator | Purpose |
|-----------|---------|
| `@@clientName(ServiceGroups, "ServiceGroupClient", "csharp")` | Avoid C# namespace-type name conflict |
| `@@clientName(ServiceGroupCollectionResponse, "ServiceGroupCollectionResult", "csharp")` | AZC0030 compliance |

## Related SDK PR
Azure/azure-sdk-for-net#58532