### PR TITLE
Add Hero Scenario 6 to Purview Unified Catalog HERO_SCENARIOS.md

### DIFF
--- a/.github/prompts/hero-scenarios-guidelines.md
+++ b/.github/prompts/hero-scenarios-guidelines.md
@@ -247,6 +247,57 @@ For each scenario, include:
   the API references them. For LROs, show the polling header
   in the initial response.
 
+### Spec Fidelity Rules
+
+Before writing any request or response example, check the spec
+definitions for the operations and models involved. Specifically:
+
+- **Property types must match the spec.** If a property is typed as
+  `uuid` (or `format: uuid`), every example value for that property
+  MUST be a valid UUID (e.g., `10013344-5566-7788-99aa-bbccddeeff00`).
+  Do NOT invent human-readable prefixed IDs like `cde-...`, `col-...`,
+  or `dp-...`. If a property is typed as `url` (or `format: uri`),
+  the value MUST include a scheme (e.g., `https://host.example.com`).
+- **Response shapes must match the operation's return type.** If an
+  operation returns a single object (not an array or paged list),
+  show a single object. If it returns a paged list, show the `value`
+  array wrapper. Do NOT show a batch response for an operation that
+  returns a single item — split into multiple calls instead.
+- **One API call per operation invocation.** If you need to perform the
+  same operation on multiple resources (e.g., ingest two columns, tag
+  two columns), show each call separately with its own request and
+  response. Do NOT combine them into a batch unless the API explicitly
+  supports batch semantics.
+
+### Narrative–Step Consistency
+
+Every claim in the scenario description, prerequisites, and success
+criteria MUST be backed by a corresponding API call in the steps:
+
+- If the story says "tags both CustomerEmail and AccountNumber," there
+  must be two tagging API calls — one for each column.
+- If the prerequisites mention a resource ID, that exact ID must appear
+  in a request body or URL path in the steps.
+- The success criteria must only claim outcomes that the steps actually
+  achieve. Do NOT list a success criterion for an action that was
+  described in the narrative but omitted from the steps.
+
+### Matching Existing Document Conventions
+
+When appending scenarios to an **existing** `hero-scenarios.md`, read
+the file first and adopt its conventions:
+
+- **URL path format**: If existing scenarios use short paths (e.g.,
+  `/dataAssets/query`) without an `api-version` query parameter, use
+  the same style. If they use full paths with version parameters,
+  match that instead. Do NOT mix conventions within the same document.
+- **ID format**: If existing scenarios use placeholder-style IDs
+  (e.g., `{domain-id}`), use the same pattern. If they use concrete
+  example UUIDs, generate concrete UUIDs.
+- **Section structure**: Match the heading levels, formatting, and
+  section ordering (e.g., Story → Prerequisites → Steps → Success
+  Criteria → Value Delivered) used by existing scenarios.
+
 ## Step 4 — Post the Suggestion
 
 **If no `hero-scenarios.md` exists**, use `add-comment` to post a PR comment

--- a/.github/prompts/hero-scenarios-guidelines.md
+++ b/.github/prompts/hero-scenarios-guidelines.md
@@ -247,57 +247,6 @@ For each scenario, include:
   the API references them. For LROs, show the polling header
   in the initial response.
 
-### Spec Fidelity Rules
-
-Before writing any request or response example, check the spec
-definitions for the operations and models involved. Specifically:
-
-- **Property types must match the spec.** If a property is typed as
-  `uuid` (or `format: uuid`), every example value for that property
-  MUST be a valid UUID (e.g., `10013344-5566-7788-99aa-bbccddeeff00`).
-  Do NOT invent human-readable prefixed IDs like `cde-...`, `col-...`,
-  or `dp-...`. If a property is typed as `url` (or `format: uri`),
-  the value MUST include a scheme (e.g., `https://host.example.com`).
-- **Response shapes must match the operation's return type.** If an
-  operation returns a single object (not an array or paged list),
-  show a single object. If it returns a paged list, show the `value`
-  array wrapper. Do NOT show a batch response for an operation that
-  returns a single item — split into multiple calls instead.
-- **One API call per operation invocation.** If you need to perform the
-  same operation on multiple resources (e.g., ingest two columns, tag
-  two columns), show each call separately with its own request and
-  response. Do NOT combine them into a batch unless the API explicitly
-  supports batch semantics.
-
-### Narrative–Step Consistency
-
-Every claim in the scenario description, prerequisites, and success
-criteria MUST be backed by a corresponding API call in the steps:
-
-- If the story says "tags both CustomerEmail and AccountNumber," there
-  must be two tagging API calls — one for each column.
-- If the prerequisites mention a resource ID, that exact ID must appear
-  in a request body or URL path in the steps.
-- The success criteria must only claim outcomes that the steps actually
-  achieve. Do NOT list a success criterion for an action that was
-  described in the narrative but omitted from the steps.
-
-### Matching Existing Document Conventions
-
-When appending scenarios to an **existing** `hero-scenarios.md`, read
-the file first and adopt its conventions:
-
-- **URL path format**: If existing scenarios use short paths (e.g.,
-  `/dataAssets/query`) without an `api-version` query parameter, use
-  the same style. If they use full paths with version parameters,
-  match that instead. Do NOT mix conventions within the same document.
-- **ID format**: If existing scenarios use placeholder-style IDs
-  (e.g., `{domain-id}`), use the same pattern. If they use concrete
-  example UUIDs, generate concrete UUIDs.
-- **Section structure**: Match the heading levels, formatting, and
-  section ordering (e.g., Story → Prerequisites → Steps → Success
-  Criteria → Value Delivered) used by existing scenarios.
-
 ## Step 4 — Post the Suggestion
 
 **If no `hero-scenarios.md` exists**, use `add-comment` to post a PR comment

--- a/specification/purviewdatagovernance/Azure.Analytics.Purview.UnifiedCatalog/HERO_SCENARIOS.md
+++ b/specification/purviewdatagovernance/Azure.Analytics.Purview.UnifiedCatalog/HERO_SCENARIOS.md
@@ -439,6 +439,243 @@ curl -X POST "$PURVIEW_ENDPOINT/terms" \
 
 ---
 
+## 🎯 **Hero Scenario 6: Register a Production Table as a Governed Data Asset, Import Its Column Schema, and Tag Sensitive Columns for Compliance**
+
+**Goal**: Bring a production database table under active governance by registering it as a data asset, importing its column schema from Data Map, tagging sensitive columns with critical data elements for regulatory compliance, and linking the asset to a data product for discoverability.
+
+**Difficulty**: ⭐⭐⭐⭐ (Advanced)
+**Time to Complete**: 15-20 minutes
+
+### **The Story**
+
+A data steward at a financial services company needs to bring a production Azure SQL table that holds customer transaction records under active governance. The table was already scanned by Microsoft Purview Data Map. She registers it as a data asset, imports its column schema from Data Map, tags the `CustomerEmail` and `AccountNumber` columns with pre-defined critical data elements to satisfy PCI-DSS requirements, and links the asset to the "Payments Data Product" so downstream consumers can discover it through the catalog.
+
+### **Prerequisites**
+- Purview endpoint configured and authenticated
+- An Azure SQL table already scanned in Microsoft Purview Data Map (Data Map asset ID `87530cc2-5a0f-4f84-befb-2af6f6f60000`; column IDs `a1174096-2a8c-4f8d-9cb4-e23512d85d43` for `CustomerEmail` and `b8d2b3f5-85cc-4d20-968b-be8d957c6716` for `AccountNumber`)
+- A "Customer Email" critical data element (`cde-1001-3344-5566-7788-99aabbccddee`) and a "Payments Data Product" (`dp-9001-3344-5566-7788-99aabbccddee`) already exist in the catalog
+
+### **Step-by-Step Walkthrough**
+
+#### **Step 1: Create the Data Asset, Linking It to the Scanned Data Map Table**
+
+```http
+POST /datagovernance/catalog/dataAssets?api-version=2026-03-20-preview
+Content-Type: application/json
+Authorization: Bearer {token}
+
+{
+  "source": {
+    "assetId": "87530cc2-5a0f-4f84-befb-2af6f6f60000"
+  },
+  "contacts": {
+    "owner": [
+      {
+        "id": "4e74f902-62f5-49f4-8258-92ed2b8537ba",
+        "description": "Jane — Data Steward"
+      }
+    ]
+  }
+}
+```
+
+**Expected Response** (201 Created):
+```json
+{
+  "id": "da001122-3344-5566-7788-99aabbccddee",
+  "name": "transactions_prod",
+  "type": "AzureSqlTable",
+  "typeProperties": {
+    "serverEndpoint": "paymentssql.database.windows.net",
+    "databaseName": "payments",
+    "schemaName": "dbo",
+    "tableName": "transactions"
+  },
+  "source": {
+    "type": "DataMap",
+    "assetId": "87530cc2-5a0f-4f84-befb-2af6f6f60000",
+    "assetType": "azure_sql_table",
+    "fqn": "mssql://payments-sql.database.windows.net/payments/dbo/transactions",
+    "accountName": "payments-sql",
+    "lastRefreshedAt": "2026-03-20T12:00:00.000Z",
+    "lastRefreshedBy": "4e74f902-62f5-49f4-8258-92ed2b8537ba"
+  },
+  "contacts": {
+    "owner": [
+      {
+        "id": "4e74f902-62f5-49f4-8258-92ed2b8537ba",
+        "description": "Jane — Data Steward"
+      }
+    ]
+  },
+  "systemData": {
+    "provisioningState": "Succeeded",
+    "createdAt": "2026-03-20T12:00:00.000Z",
+    "createdBy": "4e74f902-62f5-49f4-8258-92ed2b8537ba"
+  }
+}
+```
+
+#### **Step 2: Ingest the Table's Columns from Data Map into the Catalog**
+
+```http
+POST /datagovernance/catalog/dataColumns/ingest?api-version=2026-03-20-preview
+Content-Type: application/json
+Authorization: Bearer {token}
+
+{
+  "requests": [
+    {
+      "dataMapAssetId": "87530cc2-5a0f-4f84-befb-2af6f6f60000",
+      "dataMapColumnId": "a1174096-2a8c-4f8d-9cb4-e23512d85d43"
+    },
+    {
+      "dataMapAssetId": "87530cc2-5a0f-4f84-befb-2af6f6f60000",
+      "dataMapColumnId": "b8d2b3f5-85cc-4d20-968b-be8d957c6716"
+    }
+  ]
+}
+```
+
+**Expected Response** (200 OK):
+```json
+{
+  "id": "col-aaaa-1111-2222-3333-444455556666",
+  "source": {
+    "type": "DataMap",
+    "assetId": "87530cc2-5a0f-4f84-befb-2af6f6f60000",
+    "columnId": "a1174096-2a8c-4f8d-9cb4-e23512d85d43"
+  }
+}
+```
+
+#### **Step 3: Query Columns to Retrieve Their Catalog IDs and Verify Ingestion**
+
+```http
+POST /datagovernance/catalog/dataColumns/query?api-version=2026-03-20-preview
+Content-Type: application/json
+Authorization: Bearer {token}
+
+{
+  "filter": {
+    "sourceAssetId": {
+      "eq": "87530cc2-5a0f-4f84-befb-2af6f6f60000"
+    }
+  },
+  "includingOrphans": false,
+  "includeColumnDetails": true,
+  "skip": 0,
+  "top": 20
+}
+```
+
+**Expected Response** (200 OK):
+```json
+{
+  "value": [
+    {
+      "id": "col-aaaa-1111-2222-3333-444455556666",
+      "source": {
+        "type": "DataMap",
+        "assetId": "87530cc2-5a0f-4f84-befb-2af6f6f60000",
+        "columnId": "a1174096-2a8c-4f8d-9cb4-e23512d85d43"
+      },
+      "columnDetails": {
+        "name": "CustomerEmail",
+        "description": "Primary customer email address",
+        "dataType": "nvarchar",
+        "qualifiedName": "mssql://payments-sql.database.windows.net/payments/dbo/transactions#CustomerEmail"
+      }
+    },
+    {
+      "id": "col-bbbb-1111-2222-3333-444455556666",
+      "source": {
+        "type": "DataMap",
+        "assetId": "87530cc2-5a0f-4f84-befb-2af6f6f60000",
+        "columnId": "b8d2b3f5-85cc-4d20-968b-be8d957c6716"
+      },
+      "columnDetails": {
+        "name": "AccountNumber",
+        "description": "Customer payment account number",
+        "dataType": "nvarchar",
+        "qualifiedName": "mssql://payments-sql.database.windows.net/payments/dbo/transactions#AccountNumber"
+      }
+    }
+  ]
+}
+```
+
+#### **Step 4: Tag the CustomerEmail Column with the "Customer Email" Critical Data Element**
+
+```http
+POST /datagovernance/catalog/dataColumns/col-aaaa-1111-2222-3333-444455556666/relationships?entityType=CRITICALDATAELEMENT&api-version=2026-03-20-preview
+Content-Type: application/json
+Authorization: Bearer {token}
+
+{
+  "relationshipType": "Related",
+  "entityId": "cde-1001-3344-5566-7788-99aabbccddee",
+  "description": "CustomerEmail column maps to the PCI-DSS-regulated Customer Email critical data element"
+}
+```
+
+**Expected Response** (200 OK):
+```json
+{
+  "relationshipType": "Related",
+  "entityId": "cde-1001-3344-5566-7788-99aabbccddee",
+  "description": "CustomerEmail column maps to the PCI-DSS-regulated Customer Email critical data element",
+  "systemData": {
+    "createdBy": "4e74f902-62f5-49f4-8258-92ed2b8537ba",
+    "lastModifiedBy": "4e74f902-62f5-49f4-8258-92ed2b8537ba",
+    "createdAt": "2026-03-20T12:10:00.000Z",
+    "lastModifiedAt": "2026-03-20T12:10:00.000Z"
+  }
+}
+```
+
+#### **Step 5: Link the Data Asset to the "Payments Data Product"**
+
+```http
+POST /datagovernance/catalog/dataAssets/da001122-3344-5566-7788-99aabbccddee/relationships?entityType=DATAPRODUCT&api-version=2026-03-20-preview
+Content-Type: application/json
+Authorization: Bearer {token}
+
+{
+  "entityId": "dp-9001-3344-5566-7788-99aabbccddee",
+  "relationshipType": "Related",
+  "description": "transactions_prod is an underlying table powering the Payments Data Product"
+}
+```
+
+**Expected Response** (200 OK):
+```json
+{
+  "entityId": "dp-9001-3344-5566-7788-99aabbccddee",
+  "relationshipType": "Related",
+  "description": "transactions_prod is an underlying table powering the Payments Data Product",
+  "systemData": {
+    "createdBy": "4e74f902-62f5-49f4-8258-92ed2b8537ba",
+    "lastModifiedBy": "4e74f902-62f5-49f4-8258-92ed2b8537ba",
+    "createdAt": "2026-03-20T12:15:00.000Z",
+    "lastModifiedAt": "2026-03-20T12:15:00.000Z"
+  }
+}
+```
+
+### **Success Criteria**
+- ✅ Registered the production table as a governed data asset linked to Data Map
+- ✅ Imported column schema (CustomerEmail, AccountNumber) into the catalog
+- ✅ Tagged sensitive columns with critical data elements for PCI-DSS compliance
+- ✅ Linked the data asset to the Payments Data Product for consumer discoverability
+
+### **Value Delivered**
+- **Compliance coverage**: Physical schema columns are mapped to regulatory critical data elements, providing an audit trail for PCI-DSS/GDPR obligations
+- **Discoverability**: The data asset appears as a linked resource in the "Payments Data Product" so consumers know exactly which tables are involved
+- **Lineage traceability**: Data Map provenance is preserved in every column (`source.columnId`), so the path from raw storage to governed catalog is always traceable
+
+---
+
 ## 📋 **Scenario Priority Matrix**
 
 | Scenario | Frequency | Business Impact | Technical Complexity |
@@ -448,5 +685,6 @@ curl -X POST "$PURVIEW_ENDPOINT/terms" \
 | Data Products | ⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐ |
 | Critical Data Elements | ⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐⭐ |
 | Domain & OKR Management | ⭐⭐ | ⭐⭐⭐⭐ | ⭐⭐⭐ |
+| Asset Registration & Column Tagging | ⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐ |
 
 These hero scenarios represent the most valuable and commonly used patterns for the Purview Data Catalog API, providing clear pathways for developers to achieve meaningful business outcomes.

--- a/specification/purviewdatagovernance/Azure.Analytics.Purview.UnifiedCatalog/HERO_SCENARIOS.md
+++ b/specification/purviewdatagovernance/Azure.Analytics.Purview.UnifiedCatalog/HERO_SCENARIOS.md
@@ -453,14 +453,14 @@ A data steward at a financial services company needs to bring a production Azure
 ### **Prerequisites**
 - Purview endpoint configured and authenticated
 - An Azure SQL table already scanned in Microsoft Purview Data Map (Data Map asset ID `87530cc2-5a0f-4f84-befb-2af6f6f60000`; column IDs `a1174096-2a8c-4f8d-9cb4-e23512d85d43` for `CustomerEmail` and `b8d2b3f5-85cc-4d20-968b-be8d957c6716` for `AccountNumber`)
-- A "Customer Email" critical data element (`cde-1001-3344-5566-7788-99aabbccddee`) and a "Payments Data Product" (`dp-9001-3344-5566-7788-99aabbccddee`) already exist in the catalog
+- A "Customer Email" critical data element (`10013344-5566-7788-99aa-bbccddeeff00`) and a "Payments Data Product" (`90013344-5566-7788-99aa-bbccddeeff00`) already exist in the catalog
 
 ### **Step-by-Step Walkthrough**
 
 #### **Step 1: Create the Data Asset, Linking It to the Scanned Data Map Table**
 
 ```http
-POST /datagovernance/catalog/dataAssets?api-version=2026-03-20-preview
+POST /dataAssets
 Content-Type: application/json
 Authorization: Bearer {token}
 
@@ -486,7 +486,7 @@ Authorization: Bearer {token}
   "name": "transactions_prod",
   "type": "AzureSqlTable",
   "typeProperties": {
-    "serverEndpoint": "paymentssql.database.windows.net",
+    "serverEndpoint": "https://payments-sql.database.windows.net",
     "databaseName": "payments",
     "schemaName": "dbo",
     "tableName": "transactions"
@@ -518,8 +518,10 @@ Authorization: Bearer {token}
 
 #### **Step 2: Ingest the Table's Columns from Data Map into the Catalog**
 
+Ingest each column individually. First, the `CustomerEmail` column:
+
 ```http
-POST /datagovernance/catalog/dataColumns/ingest?api-version=2026-03-20-preview
+POST /dataColumns/ingest
 Content-Type: application/json
 Authorization: Bearer {token}
 
@@ -528,7 +530,32 @@ Authorization: Bearer {token}
     {
       "dataMapAssetId": "87530cc2-5a0f-4f84-befb-2af6f6f60000",
       "dataMapColumnId": "a1174096-2a8c-4f8d-9cb4-e23512d85d43"
-    },
+    }
+  ]
+}
+```
+
+**Expected Response** (200 OK):
+```json
+{
+  "id": "aaaaaa11-1111-2222-3333-444455556666",
+  "source": {
+    "type": "DataMap",
+    "assetId": "87530cc2-5a0f-4f84-befb-2af6f6f60000",
+    "columnId": "a1174096-2a8c-4f8d-9cb4-e23512d85d43"
+  }
+}
+```
+
+Then, the `AccountNumber` column:
+
+```http
+POST /dataColumns/ingest
+Content-Type: application/json
+Authorization: Bearer {token}
+
+{
+  "requests": [
     {
       "dataMapAssetId": "87530cc2-5a0f-4f84-befb-2af6f6f60000",
       "dataMapColumnId": "b8d2b3f5-85cc-4d20-968b-be8d957c6716"
@@ -540,11 +567,11 @@ Authorization: Bearer {token}
 **Expected Response** (200 OK):
 ```json
 {
-  "id": "col-aaaa-1111-2222-3333-444455556666",
+  "id": "bbbbbb11-1111-2222-3333-444455556666",
   "source": {
     "type": "DataMap",
     "assetId": "87530cc2-5a0f-4f84-befb-2af6f6f60000",
-    "columnId": "a1174096-2a8c-4f8d-9cb4-e23512d85d43"
+    "columnId": "b8d2b3f5-85cc-4d20-968b-be8d957c6716"
   }
 }
 ```
@@ -552,7 +579,7 @@ Authorization: Bearer {token}
 #### **Step 3: Query Columns to Retrieve Their Catalog IDs and Verify Ingestion**
 
 ```http
-POST /datagovernance/catalog/dataColumns/query?api-version=2026-03-20-preview
+POST /dataColumns/query
 Content-Type: application/json
 Authorization: Bearer {token}
 
@@ -574,7 +601,7 @@ Authorization: Bearer {token}
 {
   "value": [
     {
-      "id": "col-aaaa-1111-2222-3333-444455556666",
+      "id": "aaaaaa11-1111-2222-3333-444455556666",
       "source": {
         "type": "DataMap",
         "assetId": "87530cc2-5a0f-4f84-befb-2af6f6f60000",
@@ -588,7 +615,7 @@ Authorization: Bearer {token}
       }
     },
     {
-      "id": "col-bbbb-1111-2222-3333-444455556666",
+      "id": "bbbbbb11-1111-2222-3333-444455556666",
       "source": {
         "type": "DataMap",
         "assetId": "87530cc2-5a0f-4f84-befb-2af6f6f60000",
@@ -605,16 +632,18 @@ Authorization: Bearer {token}
 }
 ```
 
-#### **Step 4: Tag the CustomerEmail Column with the "Customer Email" Critical Data Element**
+#### **Step 4: Tag Sensitive Columns with Critical Data Elements for PCI-DSS Compliance**
+
+Tag the `CustomerEmail` column:
 
 ```http
-POST /datagovernance/catalog/dataColumns/col-aaaa-1111-2222-3333-444455556666/relationships?entityType=CRITICALDATAELEMENT&api-version=2026-03-20-preview
+POST /dataColumns/aaaaaa11-1111-2222-3333-444455556666/relationships?entityType=CRITICALDATAELEMENT
 Content-Type: application/json
 Authorization: Bearer {token}
 
 {
   "relationshipType": "Related",
-  "entityId": "cde-1001-3344-5566-7788-99aabbccddee",
+  "entityId": "10013344-5566-7788-99aa-bbccddeeff00",
   "description": "CustomerEmail column maps to the PCI-DSS-regulated Customer Email critical data element"
 }
 ```
@@ -623,7 +652,7 @@ Authorization: Bearer {token}
 ```json
 {
   "relationshipType": "Related",
-  "entityId": "cde-1001-3344-5566-7788-99aabbccddee",
+  "entityId": "10013344-5566-7788-99aa-bbccddeeff00",
   "description": "CustomerEmail column maps to the PCI-DSS-regulated Customer Email critical data element",
   "systemData": {
     "createdBy": "4e74f902-62f5-49f4-8258-92ed2b8537ba",
@@ -634,15 +663,44 @@ Authorization: Bearer {token}
 }
 ```
 
-#### **Step 5: Link the Data Asset to the "Payments Data Product"**
+Tag the `AccountNumber` column:
 
 ```http
-POST /datagovernance/catalog/dataAssets/da001122-3344-5566-7788-99aabbccddee/relationships?entityType=DATAPRODUCT&api-version=2026-03-20-preview
+POST /dataColumns/bbbbbb11-1111-2222-3333-444455556666/relationships?entityType=CRITICALDATAELEMENT
 Content-Type: application/json
 Authorization: Bearer {token}
 
 {
-  "entityId": "dp-9001-3344-5566-7788-99aabbccddee",
+  "relationshipType": "Related",
+  "entityId": "10013344-5566-7788-99aa-bbccddeeff00",
+  "description": "AccountNumber column maps to the PCI-DSS-regulated Customer Email critical data element"
+}
+```
+
+**Expected Response** (200 OK):
+```json
+{
+  "relationshipType": "Related",
+  "entityId": "10013344-5566-7788-99aa-bbccddeeff00",
+  "description": "AccountNumber column maps to the PCI-DSS-regulated Customer Email critical data element",
+  "systemData": {
+    "createdBy": "4e74f902-62f5-49f4-8258-92ed2b8537ba",
+    "lastModifiedBy": "4e74f902-62f5-49f4-8258-92ed2b8537ba",
+    "createdAt": "2026-03-20T12:10:30.000Z",
+    "lastModifiedAt": "2026-03-20T12:10:30.000Z"
+  }
+}
+```
+
+#### **Step 5: Link the Data Asset to the "Payments Data Product"**
+
+```http
+POST /dataAssets/da001122-3344-5566-7788-99aabbccddee/relationships?entityType=DATAPRODUCT
+Content-Type: application/json
+Authorization: Bearer {token}
+
+{
+  "entityId": "90013344-5566-7788-99aa-bbccddeeff00",
   "relationshipType": "Related",
   "description": "transactions_prod is an underlying table powering the Payments Data Product"
 }
@@ -651,7 +709,7 @@ Authorization: Bearer {token}
 **Expected Response** (200 OK):
 ```json
 {
-  "entityId": "dp-9001-3344-5566-7788-99aabbccddee",
+  "entityId": "90013344-5566-7788-99aa-bbccddeeff00",
   "relationshipType": "Related",
   "description": "transactions_prod is an underlying table powering the Payments Data Product",
   "systemData": {


### PR DESCRIPTION
## Summary

Adds **Hero Scenario 6** to `specification/purviewdatagovernance/Azure.Analytics.Purview.UnifiedCatalog/HERO_SCENARIOS.md`.

### Scenario: Register a production table as a governed data asset, import its column schema, and tag sensitive columns for compliance

A data steward brings a production Azure SQL table under active governance by:
1. Registering it as a data asset linked to a scanned Data Map table
2. Ingesting its column schema from Data Map into the catalog
3. Tagging sensitive columns (`CustomerEmail`, `AccountNumber`) with critical data elements for PCI-DSS compliance
4. Linking the asset to a data product for downstream discoverability

This scenario was suggested by the Hero Scenario Suggestion workflow in [PR #41793 comment](https://github.com/Azure/azure-rest-api-specs/pull/41793#issuecomment-4239951879). It covers the write operations for DataAssets and the new DataColumn APIs that were not represented in the existing scenarios (1–5).

### Changes
- Added Hero Scenario 6 with full step-by-step walkthrough (5 steps with request/response examples)
- Updated the Scenario Priority Matrix to include the new scenario