### PR TITLE
Make propagateStaticRoutes read/write

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
@@ -22481,7 +22481,6 @@ model StaticRoutesConfig {
   /**
    * Boolean indicating whether static routes on this connection are automatically propagate to route tables which this connection propagates to.
    */
-  @visibility(Lifecycle.Read)
   propagateStaticRoutes?: boolean;
 
   /**

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/virtualWan.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/virtualWan.json
@@ -8798,8 +8798,7 @@
       "properties": {
         "propagateStaticRoutes": {
           "type": "boolean",
-          "description": "Boolean indicating whether static routes on this connection are automatically propagate to route tables which this connection propagates to.",
-          "readOnly": true
+          "description": "Boolean indicating whether static routes on this connection are automatically propagate to route tables which this connection propagates to."
         },
         "vnetLocalRouteOverrideCriteria": {
           "$ref": "./common.json#/definitions/VnetLocalRouteOverrideCriteria",

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/virtualWan.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/virtualWan.json
@@ -8802,8 +8802,7 @@
       "properties": {
         "propagateStaticRoutes": {
           "type": "boolean",
-          "description": "Boolean indicating whether static routes on this connection are automatically propagate to route tables which this connection propagates to.",
-          "readOnly": true
+          "description": "Boolean indicating whether static routes on this connection are automatically propagate to route tables which this connection propagates to."
         },
         "vnetLocalRouteOverrideCriteria": {
           "$ref": "./common.json#/definitions/VnetLocalRouteOverrideCriteria",


### PR DESCRIPTION
## Description
Making _propagateStaticRoutes_ read/write to address this [IcM](https://portal.microsofticm.com/imp/v5/incidents/details/21000000994850/summary) and to be in sync with the backend functionality.

## Validation
Prettier and TypeSpec

## Validation
This removes an incorrect _readOnly: true_ annotation from _propagateStaticRoutes_ in _StaticRoutesConfig_. Per OAD rule 1029 documentation: _"not a breaking change if from 'true' to 'false'"_ , making a property writable is non-breaking for existing clients. Additionally, the backend has always accepted writes, the spec annotation was wrong.