### PR TITLE
DiskRP Swagger — Add snapshotAccessState to DiskRestorePointProperties for InstantAccess

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeDisk/examples/2026-03-02/diskRestorePointExamples/DiskRestorePoint_Get_WithInstantAccess.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeDisk/examples/2026-03-02/diskRestorePointExamples/DiskRestorePoint_Get_WithInstantAccess.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "subscriptionId": "{subscription-id}",
+    "resourceGroupName": "myResourceGroup",
+    "restorePointCollectionName": "rpc",
+    "vmRestorePointName": "vmrp",
+    "diskRestorePointName": "TestDisk45ceb03433006d1baee_5c1528-43e2-4c77-9c55-a78bf5a5fc88",
+    "api-version": "2026-03-02"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/{subscription-id}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/restorePointCollections/rpc/restorePoints/vmrp/diskRestorePoints/TestDisk45ceb03433006d1baee_5c1528-43e2-4c77-9c55-a78bf5a5fc88",
+        "name": "TestDisk45ceb03433006d1baee_5c1528-43e2-4c77-9c55-a78bf5a5fc88",
+        "properties": {
+          "timeCreated": "2026-03-02T04:41:35.079872+00:00",
+          "sourceResourceId": "/subscriptions/{subscriptionId}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/disks/TestDisk45ceb03433006d1baee",
+          "osType": "Windows",
+          "hyperVGeneration": "V2",
+          "familyId": "f22e934b-c768-447f-8c44-ada4b40224ec",
+          "sourceUniqueId": "d633885d-d102-4481-901e-5b2413d1a7be",
+          "networkAccessPolicy": "AllowAll",
+          "publicNetworkAccess": "Disabled",
+          "completionPercent": 100,
+          "logicalSectorSize": 4096,
+          "snapshotAccessState": "InstantAccess"
+        }
+      }
+    }
+  },
+  "operationId": "DiskRestorePoint_Get",
+  "title": "get a disk restorePoint resource with InstantAccess snapshotAccessState."
+}

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeDisk/models.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeDisk/models.tsp
@@ -1571,6 +1571,13 @@ model DiskRestorePointProperties {
    */
   @visibility(Lifecycle.Read)
   logicalSectorSize?: int32;
+
+  /**
+   * The state of snapshot which determines the access availability of the snapshot.
+   */
+  @visibility(Lifecycle.Read)
+  @added(Versions.v2026_03_02)
+  snapshotAccessState?: SnapshotAccessState;
 }
 
 /**

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-02/DiskRP.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-02/DiskRP.json
@@ -1829,6 +1829,9 @@
           }
         },
         "x-ms-examples": {
+          "get a disk restorePoint resource with InstantAccess snapshotAccessState.": {
+            "$ref": "./examples/diskRestorePointExamples/DiskRestorePoint_Get_WithInstantAccess.json"
+          },
           "get an incremental disk restorePoint resource.": {
             "$ref": "./examples/diskRestorePointExamples/DiskRestorePoint_Get.json"
           },
@@ -3472,6 +3475,11 @@
           "type": "integer",
           "format": "int32",
           "description": "Logical sector size in bytes for disk restore points of UltraSSD_LRS and PremiumV2_LRS disks. Supported values are 512 and 4096. 4096 is the default.",
+          "readOnly": true
+        },
+        "snapshotAccessState": {
+          "$ref": "#/definitions/Common.SnapshotAccessState",
+          "description": "The state of snapshot which determines the access availability of the snapshot.",
           "readOnly": true
         }
       }

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-02/examples/diskRestorePointExamples/DiskRestorePoint_Get_WithInstantAccess.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-02/examples/diskRestorePointExamples/DiskRestorePoint_Get_WithInstantAccess.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "subscriptionId": "{subscription-id}",
+    "resourceGroupName": "myResourceGroup",
+    "restorePointCollectionName": "rpc",
+    "vmRestorePointName": "vmrp",
+    "diskRestorePointName": "TestDisk45ceb03433006d1baee_5c1528-43e2-4c77-9c55-a78bf5a5fc88",
+    "api-version": "2026-03-02"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/{subscription-id}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/restorePointCollections/rpc/restorePoints/vmrp/diskRestorePoints/TestDisk45ceb03433006d1baee_5c1528-43e2-4c77-9c55-a78bf5a5fc88",
+        "name": "TestDisk45ceb03433006d1baee_5c1528-43e2-4c77-9c55-a78bf5a5fc88",
+        "properties": {
+          "timeCreated": "2026-03-02T04:41:35.079872+00:00",
+          "sourceResourceId": "/subscriptions/{subscriptionId}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/disks/TestDisk45ceb03433006d1baee",
+          "osType": "Windows",
+          "hyperVGeneration": "V2",
+          "familyId": "f22e934b-c768-447f-8c44-ada4b40224ec",
+          "sourceUniqueId": "d633885d-d102-4481-901e-5b2413d1a7be",
+          "networkAccessPolicy": "AllowAll",
+          "publicNetworkAccess": "Disabled",
+          "completionPercent": 100,
+          "logicalSectorSize": 4096,
+          "snapshotAccessState": "InstantAccess"
+        }
+      }
+    }
+  },
+  "operationId": "DiskRestorePoint_Get",
+  "title": "get a disk restorePoint resource with InstantAccess snapshotAccessState."
+}


### PR DESCRIPTION
# ARM (Control Plane) API Specification Update Pull Request

## Purpose of this PR

- [x] Other, please clarify:
    - Add snapshotAccessState property to DiskRestorePointProperties starting from API version 2026-03-02

## Due diligence checklist

- [x] I confirm this PR is modifying Azure Resource Manager (ARM) related specifications, and not data plane related specifications.
- [x] I have reviewed following Resource Provider guidelines, including ARM resource provider contract and REST guidelines.
- [x] A release plan has been created.

## Summary

Adds \snapshotAccessState\ (read-only) to \DiskRestorePointProperties\ for the InstantAccess Restore Point feature. This property already exists on \SnapshotProperties\ and uses the existing \SnapshotAccessState\ enum from \common/models.tsp\. The DiskRP backend already computes and returns this field.

### Changes
- \ComputeDisk/models.tsp\ — Added \snapshotAccessState\ to \DiskRestorePointProperties\
- \stable/2026-03-02/DiskRP.json\ — Generated swagger output
- Example JSON files for DiskRestorePoint GET with InstantAccess
