### PR TITLE
Add AcceleratorCapacity resource type for CognitiveServices 2026-03-15-preview

### DIFF
--- a/specification/cognitiveservices/CognitiveServices.Management/AcceleratorCapacity.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/AcceleratorCapacity.tsp
@@ -1,0 +1,73 @@
+import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-azure-resource-manager";
+import "@typespec/openapi";
+import "@typespec/rest";
+import "@typespec/versioning";
+import "./models.tsp";
+
+using TypeSpec.Rest;
+using Azure.ResourceManager;
+using TypeSpec.Http;
+using TypeSpec.OpenAPI;
+using TypeSpec.Versioning;
+
+namespace Microsoft.CognitiveServices;
+
+/**
+ * Accelerator capacity information for Cognitive Services managed compute deployments.
+ * Provides available accelerator capacity per type and region at the subscription level.
+ */
+@added(Versions.v2026_03_15_preview)
+@subscriptionResource
+model AcceleratorCapacity
+  is Azure.ResourceManager.ProxyResource<AcceleratorCapacityProperties> {
+  ...ResourceNameParameter<
+    Resource = AcceleratorCapacity,
+    KeyName = "acceleratorCapacityName",
+    SegmentName = "acceleratorCapacities",
+    NamePattern = ""
+  >;
+}
+
+@added(Versions.v2026_03_15_preview)
+#suppress "@azure-tools/typespec-azure-resource-manager/no-resource-delete-operation" "'AcceleratorCapacities' is a read-only resource type that does not support delete operations"
+@armResourceOperations(#{ omitTags: true })
+interface AcceleratorCapacities {
+  /**
+   * Gets the accelerator capacities for a subscription. Returns available capacity
+   * per accelerator type, including deployment size information.
+   */
+  @tag("AcceleratorCapacities")
+  list is ArmResourceListByParent<
+    AcceleratorCapacity,
+    BaseParameters = Azure.ResourceManager.Foundations.SubscriptionBaseParameters,
+    Parameters = {
+      /**
+       * The offer name to query capacity for (required).
+       */
+      @query("offer")
+      offer: string;
+
+      /**
+       * Optional accelerator type filter to narrow results to a specific accelerator type.
+       */
+      @query("acceleratorType")
+      acceleratorType?: string;
+
+      /**
+       * Optional deployment resource ID. When provided, returns capacity for the specific region
+       * where the deployment is hosted rather than the best available region.
+       */
+      @query("deploymentId")
+      deploymentId?: string;
+    },
+    Response = AcceleratorCapacityListResult
+  >;
+}
+
+@@doc(AcceleratorCapacity.name,
+  "The name of the accelerator capacity resource."
+);
+@@doc(AcceleratorCapacity.properties,
+  "Properties of the accelerator capacity resource."
+);

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-03-15-preview/ListAcceleratorCapacities.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-03-15-preview/ListAcceleratorCapacities.json
@@ -1,0 +1,66 @@
+{
+  "operationId": "AcceleratorCapacities_List",
+  "title": "List Accelerator Capacities",
+  "parameters": {
+    "subscriptionId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "api-version": "2026-03-15-preview",
+    "offer": "MaaP"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/providers/Microsoft.CognitiveServices/acceleratorCapacities/Azure.A100",
+            "name": "Azure.A100",
+            "type": "Microsoft.CognitiveServices/acceleratorCapacities",
+            "properties": {
+              "acceleratorType": "Azure.A100",
+              "location": "eastus",
+              "availableAccelerators": 16,
+              "deploymentSizeCapacities": [
+                {
+                  "modelInstanceAcceleratorCount": 1,
+                  "totalAvailableCapacity": 16,
+                  "largestDeploymentCapacity": 8
+                },
+                {
+                  "modelInstanceAcceleratorCount": 2,
+                  "totalAvailableCapacity": 8,
+                  "largestDeploymentCapacity": 4
+                },
+                {
+                  "modelInstanceAcceleratorCount": 4,
+                  "totalAvailableCapacity": 4,
+                  "largestDeploymentCapacity": 2
+                }
+              ]
+            }
+          },
+          {
+            "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/providers/Microsoft.CognitiveServices/acceleratorCapacities/Azure.H100",
+            "name": "Azure.H100",
+            "type": "Microsoft.CognitiveServices/acceleratorCapacities",
+            "properties": {
+              "acceleratorType": "Azure.H100",
+              "location": "westus2",
+              "availableAccelerators": 32,
+              "deploymentSizeCapacities": [
+                {
+                  "modelInstanceAcceleratorCount": 1,
+                  "totalAvailableCapacity": 32,
+                  "largestDeploymentCapacity": 16
+                },
+                {
+                  "modelInstanceAcceleratorCount": 8,
+                  "totalAvailableCapacity": 4,
+                  "largestDeploymentCapacity": 2
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/main.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/main.tsp
@@ -38,6 +38,7 @@ import "./ManagedNetworkSettingsPropertiesBasicResource.tsp";
 import "./AgentApplication.tsp";
 import "./AgentDeploymentResource.tsp";
 import "./ComputeOperation.tsp";
+import "./AcceleratorCapacity.tsp";
 import "./routes.tsp";
 
 using TypeSpec.Rest;
@@ -78,6 +79,11 @@ enum Versions {
    * The 2026-03-01 API version.
    */
   v2026_03_01: "2026-03-01",
+
+  /**
+   * The 2026-03-15-preview API version.
+   */
+  v2026_03_15_preview: "2026-03-15-preview",
 }
 
 interface Operations extends Azure.ResourceManager.Operations {}

--- a/specification/cognitiveservices/CognitiveServices.Management/models.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/models.tsp
@@ -5698,3 +5698,79 @@ model RaiPolicyListResult {
  */
 #suppress "@azure-tools/typespec-azure-resource-manager/no-empty-model" "Empty model 'RaiBlocklistItemsBulkDeleteRequest' preserved for backward compatibility with existing API surface"
 model RaiBlocklistItemsBulkDeleteRequest is Array<string>;
+
+/**
+ * Properties of an accelerator capacity resource.
+ */
+@added(Versions.v2026_03_15_preview)
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" "AcceleratorCapacity is a read-only resource that does not have a provisioning state"
+model AcceleratorCapacityProperties {
+  /**
+   * The type of accelerator (e.g., Azure.A100, Azure.H100).
+   */
+  @visibility(Lifecycle.Read)
+  acceleratorType?: string;
+
+  /**
+   * The Azure region where the capacity is available.
+   */
+  @visibility(Lifecycle.Read)
+  location?: string;
+
+  /**
+   * The number of available accelerators in the region.
+   */
+  @visibility(Lifecycle.Read)
+  availableAccelerators?: int32;
+
+  /**
+   * Capacity information broken down by deployment size.
+   */
+  @visibility(Lifecycle.Read)
+  @identifiers(#[])
+  deploymentSizeCapacities?: DeploymentSizeCapacity[];
+}
+
+/**
+ * Capacity information for a specific deployment size.
+ */
+@added(Versions.v2026_03_15_preview)
+model DeploymentSizeCapacity {
+  /**
+   * The number of accelerators required per model instance.
+   */
+  @visibility(Lifecycle.Read)
+  modelInstanceAcceleratorCount?: int32;
+
+  /**
+   * The total available capacity for this deployment size.
+   */
+  @visibility(Lifecycle.Read)
+  totalAvailableCapacity?: int32;
+
+  /**
+   * The largest contiguous deployment capacity available for this deployment size.
+   */
+  @visibility(Lifecycle.Read)
+  largestDeploymentCapacity?: int32;
+}
+
+/**
+ * The list of accelerator capacities response.
+ */
+@added(Versions.v2026_03_15_preview)
+model AcceleratorCapacityListResult {
+  /**
+   * The link used to get the next page of accelerator capacities.
+   */
+  @nextLink
+  nextLink?: string;
+
+  /**
+   * Gets the list of accelerator capacities.
+   */
+  @pageItems
+  @visibility(Lifecycle.Read)
+  @identifiers(#["id"])
+  value?: AcceleratorCapacity[];
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-03-15-preview/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-03-15-preview/cognitiveservices.json
@@ -1,0 +1,16540 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "CognitiveServicesManagementClient",
+    "version": "2026-03-15-preview",
+    "description": "Cognitive Services Management Client",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "CognitiveServicesAccounts"
+    },
+    {
+      "name": "Operations"
+    },
+    {
+      "name": "PrivateLinkResources"
+    },
+    {
+      "name": "TestRaiExternalSafetyProvider"
+    },
+    {
+      "name": "PrivateEndpointConnections"
+    },
+    {
+      "name": "Deployments"
+    },
+    {
+      "name": "CommitmentPlans"
+    },
+    {
+      "name": "CognitiveServicesCommitmentPlans"
+    },
+    {
+      "name": "EncryptionScopes"
+    },
+    {
+      "name": "RaiPolicies"
+    },
+    {
+      "name": "SubscriptionRaiPolicy"
+    },
+    {
+      "name": "RaiBlocklists"
+    },
+    {
+      "name": "RaiTopics"
+    },
+    {
+      "name": "RaiExternalSafetyProvider"
+    },
+    {
+      "name": "RaiToolLabels"
+    },
+    {
+      "name": "RaiContentFilters"
+    },
+    {
+      "name": "NetworkSecurityPerimeterConfigurations"
+    },
+    {
+      "name": "DefenderForAISettings"
+    },
+    {
+      "name": "CognitiveServicesProjects"
+    },
+    {
+      "name": "AccountConnectionResource"
+    },
+    {
+      "name": "ProjectConnectionResource"
+    },
+    {
+      "name": "AccountCapabilityHost"
+    },
+    {
+      "name": "ProjectCapabilityHost"
+    },
+    {
+      "name": "QuotaTier"
+    },
+    {
+      "name": "ManagedNetwork"
+    },
+    {
+      "name": "AgentApplication"
+    },
+    {
+      "name": "AgentDeployment"
+    },
+    {
+      "name": "AcceleratorCapacities"
+    },
+    {
+      "name": "Skus"
+    },
+    {
+      "name": "Usages"
+    },
+    {
+      "name": "CommitmentTiers"
+    },
+    {
+      "name": "Models"
+    },
+    {
+      "name": "ModelCapacities"
+    }
+  ],
+  "paths": {
+    "/providers/Microsoft.CognitiveServices/operations": {
+      "get": {
+        "operationId": "Operations_List",
+        "tags": [
+          "Operations"
+        ],
+        "description": "Lists all the available Cognitive Services account operations.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/OperationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/acceleratorCapacities": {
+      "get": {
+        "operationId": "AcceleratorCapacities_List",
+        "tags": [
+          "AcceleratorCapacities"
+        ],
+        "description": "Gets the accelerator capacities for a subscription. Returns available capacity\nper accelerator type, including deployment size information.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "offer",
+            "in": "query",
+            "description": "The offer name to query capacity for (required).",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "acceleratorType",
+            "in": "query",
+            "description": "Optional accelerator type filter to narrow results to a specific accelerator type.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "deploymentId",
+            "in": "query",
+            "description": "Optional deployment resource ID. When provided, returns capacity for the specific region\nwhere the deployment is hosted rather than the best available region.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/AcceleratorCapacityListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Accelerator Capacities": {
+            "$ref": "./examples/ListAcceleratorCapacities.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/accounts": {
+      "get": {
+        "operationId": "Accounts_List",
+        "tags": [
+          "CognitiveServicesAccounts"
+        ],
+        "description": "Returns all the resources of a particular type belonging to a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/AccountListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/calculateModelCapacity": {
+      "post": {
+        "operationId": "calculateModelCapacity",
+        "tags": [
+          "CognitiveServicesAccounts"
+        ],
+        "description": "Model capacity calculator.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The request body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CalculateModelCapacityParameter"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/CalculateModelCapacityResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/checkDomainAvailability": {
+      "post": {
+        "operationId": "CheckDomainAvailability",
+        "tags": [
+          "CognitiveServicesAccounts"
+        ],
+        "description": "Check whether a domain is available.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The request body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CheckDomainAvailabilityParameter"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/DomainAvailability"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/commitmentPlans": {
+      "get": {
+        "operationId": "CommitmentPlans_ListPlansBySubscription",
+        "tags": [
+          "CognitiveServicesCommitmentPlans"
+        ],
+        "description": "Returns all the resources of a particular type belonging to a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/CommitmentPlanListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/deletedAccounts": {
+      "get": {
+        "operationId": "DeletedAccounts_List",
+        "tags": [
+          "CognitiveServicesAccounts"
+        ],
+        "description": "Returns all the resources of a particular type belonging to a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/AccountListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/locations/{location}/checkSkuAvailability": {
+      "post": {
+        "operationId": "CheckSkuAvailability",
+        "tags": [
+          "CognitiveServicesAccounts"
+        ],
+        "description": "Check available SKUs.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The request body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CheckSkuAvailabilityParameter"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/SkuAvailabilityListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/locations/{location}/commitmentTiers": {
+      "get": {
+        "operationId": "CommitmentTiers_List",
+        "tags": [
+          "CommitmentTiers"
+        ],
+        "description": "List Commitment Tiers.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/LocationParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/CommitmentTierListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/locations/{location}/modelCapacities": {
+      "get": {
+        "operationId": "LocationBasedModelCapacities_List",
+        "tags": [
+          "ModelCapacities"
+        ],
+        "description": "List Location Based ModelCapacities.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "modelFormat",
+            "in": "query",
+            "description": "The format of the Model",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "modelName",
+            "in": "query",
+            "description": "The name of the Model",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "modelVersion",
+            "in": "query",
+            "description": "The version of the Model",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ModelCapacityListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/locations/{location}/models": {
+      "get": {
+        "operationId": "Models_List",
+        "tags": [
+          "Models"
+        ],
+        "description": "List Models.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/LocationParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ModelListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/locations/{location}/raiContentFilters": {
+      "get": {
+        "operationId": "RaiContentFilters_List",
+        "tags": [
+          "RaiContentFilters"
+        ],
+        "description": "List Content Filters types.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/LocationParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/RaiContentFilterListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/locations/{location}/raiContentFilters/{filterName}": {
+      "get": {
+        "operationId": "RaiContentFilters_Get",
+        "tags": [
+          "RaiContentFilters"
+        ],
+        "description": "Get Content Filters by Name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "filterName",
+            "in": "path",
+            "description": "The name of the RAI Content Filter.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RaiContentFilter"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/locations/{location}/resourceGroups/{resourceGroupName}/deletedAccounts/{accountName}": {
+      "get": {
+        "operationId": "DeletedAccounts_Get",
+        "tags": [
+          "CognitiveServicesAccounts"
+        ],
+        "description": "Returns a Cognitive Services account specified by the parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/LocationParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Account"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "DeletedAccounts_Purge",
+        "tags": [
+          "CognitiveServicesAccounts"
+        ],
+        "description": "Deletes a Cognitive Services account from the resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/LocationParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/locations/{location}/usages": {
+      "get": {
+        "operationId": "Usages_List",
+        "tags": [
+          "Usages"
+        ],
+        "description": "Get usages for the requested subscription",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "An OData filter expression that describes a subset of usages to return. The supported parameter is name.value (name of the metric, can have an or of multiple names).",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/UsageListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/modelCapacities": {
+      "get": {
+        "operationId": "ModelCapacities_List",
+        "tags": [
+          "ModelCapacities"
+        ],
+        "description": "List ModelCapacities.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "modelFormat",
+            "in": "query",
+            "description": "The format of the Model",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "modelName",
+            "in": "query",
+            "description": "The name of the Model",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "modelVersion",
+            "in": "query",
+            "description": "The version of the Model",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ModelCapacityListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/quotaTiers": {
+      "get": {
+        "operationId": "QuotaTiers_ListBySubscription",
+        "tags": [
+          "QuotaTier"
+        ],
+        "description": "Returns all the resources of a particular type belonging to a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/QuotaTierListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/quotaTiers/{default}": {
+      "get": {
+        "operationId": "QuotaTiers_Get",
+        "tags": [
+          "QuotaTier"
+        ],
+        "summary": "Gets the Quota Tier for a subscription",
+        "description": "Gets the Quota Tier information for the given subscription. QuotaTiers is a subscription wide resource type. It holds current tier information.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "default",
+            "in": "path",
+            "description": "Default parameter. Leave the value as default.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/QuotaTier"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "QuotaTiers_CreateOrUpdate",
+        "tags": [
+          "QuotaTier"
+        ],
+        "summary": "Updates the Quota Tier resource for a subscription.",
+        "description": "Update the Quota Tier information for the given subscription. QuotaTiers is a subscription wide resource type. It holds current tier information.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "default",
+            "in": "path",
+            "description": "Default parameter. Leave the value as default.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "tier",
+            "in": "body",
+            "description": "The parameters to provide for the quota tier resource.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/QuotaTier"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'QuotaTier' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/QuotaTier"
+            }
+          },
+          "201": {
+            "description": "Resource 'QuotaTier' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/QuotaTier"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "QuotaTiers_Update",
+        "tags": [
+          "QuotaTier"
+        ],
+        "summary": "Updates the Quota Tier resource for a subscription. The only properties that can be updated are  \"tierUpgradePolicy\"",
+        "description": "Update the Quota Tier information for the given subscription. QuotaTiers is a subscription wide resource type. It holds current tier information.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "default",
+            "in": "path",
+            "description": "Default parameter. Leave the value as default.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "tier",
+            "in": "body",
+            "description": "The parameters to provide for the quota tier resource.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/QuotaTier"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/QuotaTier"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/raiExternalSafetyProviders": {
+      "get": {
+        "operationId": "RaiExternalSafetyProviders_List",
+        "tags": [
+          "RaiExternalSafetyProvider"
+        ],
+        "description": "Gets the safety providers associated with the subscription",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RaiExternalSafetyProviderResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/raiExternalSafetyProviders/{safetyProviderName}": {
+      "get": {
+        "operationId": "RaiExternalSafetyProvider_Get",
+        "tags": [
+          "RaiExternalSafetyProvider"
+        ],
+        "description": "Gets the specified external safety provider associated with the Subscription",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "safetyProviderName",
+            "in": "path",
+            "description": "The name of the Rai External Safety Provider associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RaiExternalSafetyProviderSchema"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "RaiExternalSafetyProvider_CreateOrUpdate",
+        "tags": [
+          "RaiExternalSafetyProvider"
+        ],
+        "description": "Create the rai safety provider associated with the subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "safetyProviderName",
+            "in": "path",
+            "description": "The name of the Rai External Safety Provider associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "safetyProvider",
+            "in": "body",
+            "description": "Properties describing the rai external safety provider.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RaiExternalSafetyProviderSchema"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'RaiExternalSafetyProviderSchema' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RaiExternalSafetyProviderSchema"
+            }
+          },
+          "201": {
+            "description": "Resource 'RaiExternalSafetyProvider' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RaiExternalSafetyProvider"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "RaiExternalSafetyProvider_Delete",
+        "tags": [
+          "RaiExternalSafetyProvider"
+        ],
+        "description": "Deletes the specified custom topic associated with the subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "safetyProviderName",
+            "in": "path",
+            "description": "The name of the Rai External Safety Provider associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/raiPolicy/{raiPolicyName}": {
+      "get": {
+        "operationId": "SubscriptionRaiPolicy_Get",
+        "tags": [
+          "SubscriptionRaiPolicy"
+        ],
+        "description": "Gets the specified Content Filters associated with the Subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "raiPolicyName",
+            "in": "path",
+            "description": "The name of the RaiPolicy associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RaiPolicy"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "SubscriptionRaiPolicy_CreateOrUpdate",
+        "tags": [
+          "SubscriptionRaiPolicy"
+        ],
+        "description": "Update the state of specified Content Filters associated with the subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "raiPolicyName",
+            "in": "path",
+            "description": "The name of the RaiPolicy associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiPolicy",
+            "in": "body",
+            "description": "Properties describing the Content Filters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RaiPolicy"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'RaiPolicy' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RaiPolicy"
+            }
+          },
+          "201": {
+            "description": "Resource 'RaiPolicy' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RaiPolicy"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "SubscriptionRaiPolicy_Delete",
+        "tags": [
+          "SubscriptionRaiPolicy"
+        ],
+        "description": "Deletes the specified Content Filters associated with the subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "raiPolicyName",
+            "in": "path",
+            "description": "The name of the RaiPolicy associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/skus": {
+      "get": {
+        "operationId": "ResourceSkus_List",
+        "tags": [
+          "Skus",
+          "CognitiveServicesAccounts"
+        ],
+        "description": "Gets the list of Microsoft.CognitiveServices SKUs available for your Subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ResourceSkuListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts": {
+      "get": {
+        "operationId": "Accounts_ListByResourceGroup",
+        "tags": [
+          "CognitiveServicesAccounts"
+        ],
+        "description": "Returns all the resources of a particular type belonging to a resource group",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/AccountListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}": {
+      "get": {
+        "operationId": "Accounts_Get",
+        "tags": [
+          "CognitiveServicesAccounts"
+        ],
+        "description": "Returns a Cognitive Services account specified by the parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Account"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "Accounts_Create",
+        "tags": [
+          "CognitiveServicesAccounts"
+        ],
+        "description": "Create Cognitive Services Account. Accounts is a resource group wide resource type. It holds the keys for developer to access intelligent APIs. It's also the resource type for billing.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "account",
+            "in": "body",
+            "description": "The parameters to provide for the created account.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Account"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Account' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Account"
+            }
+          },
+          "201": {
+            "description": "Resource 'Account' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Account"
+            },
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/Account"
+            },
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/Account"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "Accounts_Update",
+        "tags": [
+          "CognitiveServicesAccounts"
+        ],
+        "description": "Updates a Cognitive Services account",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "account",
+            "in": "body",
+            "description": "The parameters to provide for the created account.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Account"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Account"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/Account"
+            },
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/Account"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "Accounts_Delete",
+        "tags": [
+          "CognitiveServicesAccounts"
+        ],
+        "description": "Deletes a Cognitive Services account from the resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/capabilityHosts": {
+      "get": {
+        "operationId": "AccountCapabilityHosts_List",
+        "tags": [
+          "AccountCapabilityHost"
+        ],
+        "summary": "List capabilityHost.",
+        "description": "List capabilityHost.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CapabilityHostResourceArmPaginatedResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/capabilityHosts/{capabilityHostName}": {
+      "get": {
+        "operationId": "AccountCapabilityHosts_Get",
+        "tags": [
+          "AccountCapabilityHost"
+        ],
+        "summary": "Get account capabilityHost.",
+        "description": "Get account capabilityHost.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "capabilityHostName",
+            "in": "path",
+            "description": "The name of the capability host associated with the Cognitive Services Resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9\\-_]{0,254}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CapabilityHost"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "AccountCapabilityHosts_CreateOrUpdate",
+        "tags": [
+          "AccountCapabilityHost"
+        ],
+        "summary": "Create or update account capabilityHost.",
+        "description": "Create or update account capabilityHost.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "capabilityHostName",
+            "in": "path",
+            "description": "The name of the capability host associated with the Cognitive Services Resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9\\-_]{0,254}$"
+          },
+          {
+            "name": "capabilityHost",
+            "in": "body",
+            "description": "CapabilityHost definition.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CapabilityHost"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CapabilityHost"
+            }
+          },
+          "201": {
+            "description": "Resource 'CapabilityHost' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/CapabilityHost"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "x-ms-async-operation-timeout": {
+                "type": "string",
+                "format": "duration",
+                "description": "Timeout for the client to use when polling the asynchronous operation."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "original-uri",
+          "final-state-schema": "#/definitions/CapabilityHost"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "AccountCapabilityHosts_Delete",
+        "tags": [
+          "AccountCapabilityHost"
+        ],
+        "summary": "Delete account capabilityHost.",
+        "description": "Delete account capabilityHost.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "capabilityHostName",
+            "in": "path",
+            "description": "The name of the capability host associated with the Cognitive Services Resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9\\-_]{0,254}$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "x-ms-async-operation-timeout": {
+                "type": "string",
+                "format": "duration",
+                "description": "Timeout for the client to use when polling the asynchronous operation."
+              }
+            }
+          },
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/commitmentPlans": {
+      "get": {
+        "operationId": "CommitmentPlans_List",
+        "tags": [
+          "CommitmentPlans"
+        ],
+        "description": "Gets the commitmentPlans associated with the Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/CommitmentPlanListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/commitmentPlans/{commitmentPlanName}": {
+      "get": {
+        "operationId": "CommitmentPlans_Get",
+        "tags": [
+          "CommitmentPlans"
+        ],
+        "description": "Gets the specified commitmentPlans associated with the Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "commitmentPlanName",
+            "in": "path",
+            "description": "The name of the commitmentPlan associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CommitmentPlan"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "CommitmentPlans_CreateOrUpdate",
+        "tags": [
+          "CommitmentPlans"
+        ],
+        "description": "Update the state of specified commitmentPlans associated with the Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "commitmentPlanName",
+            "in": "path",
+            "description": "The name of the commitmentPlan associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "commitmentPlan",
+            "in": "body",
+            "description": "The commitmentPlan properties.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CommitmentPlan"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'CommitmentPlan' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/CommitmentPlan"
+            }
+          },
+          "201": {
+            "description": "Resource 'CommitmentPlan' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/CommitmentPlan"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "CommitmentPlans_Delete",
+        "tags": [
+          "CommitmentPlans"
+        ],
+        "description": "Deletes the specified commitmentPlan associated with the Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "commitmentPlanName",
+            "in": "path",
+            "description": "The name of the commitmentPlan associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/connections": {
+      "get": {
+        "operationId": "AccountConnections_List",
+        "tags": [
+          "AccountConnectionResource"
+        ],
+        "summary": "Lists all the available  Cognitive Services account connections under the specified account.",
+        "description": "Lists all the available  Cognitive Services account connections under the specified account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "target",
+            "in": "query",
+            "description": "Target of the connection.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "category",
+            "in": "query",
+            "description": "Category of the connection.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "includeAll",
+            "in": "query",
+            "description": "query parameter that indicates if get connection call should return both connections and datastores",
+            "required": false,
+            "type": "boolean",
+            "default": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectionPropertiesV2BasicResourceArmPaginatedResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/connections/{connectionName}": {
+      "get": {
+        "operationId": "AccountConnections_Get",
+        "tags": [
+          "AccountConnectionResource"
+        ],
+        "summary": "Lists Cognitive Services account connection by name.",
+        "description": "Lists Cognitive Services account connection by name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "Friendly name of the connection",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectionPropertiesV2BasicResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "AccountConnections_Create",
+        "tags": [
+          "AccountConnectionResource"
+        ],
+        "summary": "Create or update Cognitive Services account connection under the specified account.",
+        "description": "Create or update Cognitive Services account connection under the specified account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "Friendly name of the connection",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          },
+          {
+            "name": "connection",
+            "in": "body",
+            "description": "The object for creating or updating a new account connection",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/ConnectionPropertiesV2BasicResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ConnectionPropertiesV2BasicResource' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ConnectionPropertiesV2BasicResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "AccountConnections_Update",
+        "tags": [
+          "AccountConnectionResource"
+        ],
+        "summary": "Update Cognitive Services account connection under the specified account.",
+        "description": "Update Cognitive Services account connection under the specified account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "Friendly name of the connection",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          },
+          {
+            "name": "connection",
+            "in": "body",
+            "description": "Parameters for account connection update.",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/ConnectionUpdateContent"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectionPropertiesV2BasicResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "AccountConnections_Delete",
+        "tags": [
+          "AccountConnectionResource"
+        ],
+        "summary": "Delete Cognitive Services account connection by name.",
+        "description": "Delete Cognitive Services account connection by name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "Friendly name of the connection",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/defenderForAISettings": {
+      "get": {
+        "operationId": "DefenderForAISettings_List",
+        "tags": [
+          "DefenderForAISettings"
+        ],
+        "description": "Lists the Defender for AI settings.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DefenderForAISettingResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/defenderForAISettings/{defenderForAISettingName}": {
+      "get": {
+        "operationId": "DefenderForAISettings_Get",
+        "tags": [
+          "DefenderForAISettings"
+        ],
+        "description": "Gets the specified Defender for AI setting by name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "defenderForAISettingName",
+            "in": "path",
+            "description": "The name of the defender for AI setting.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DefenderForAISetting"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "DefenderForAISettings_CreateOrUpdate",
+        "tags": [
+          "DefenderForAISettings"
+        ],
+        "description": "Creates or Updates the specified Defender for AI setting.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "defenderForAISettingName",
+            "in": "path",
+            "description": "The name of the defender for AI setting.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "defenderForAISettings",
+            "in": "body",
+            "description": "Properties describing the Defender for AI setting.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DefenderForAISetting"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'DefenderForAISetting' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/DefenderForAISetting"
+            }
+          },
+          "201": {
+            "description": "Resource 'DefenderForAISetting' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/DefenderForAISetting"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "DefenderForAISettings_Update",
+        "tags": [
+          "DefenderForAISettings"
+        ],
+        "description": "Updates the specified Defender for AI setting.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "defenderForAISettingName",
+            "in": "path",
+            "description": "The name of the defender for AI setting.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "defenderForAISettings",
+            "in": "body",
+            "description": "Properties describing the Defender for AI setting.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DefenderForAISetting"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DefenderForAISetting"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/deployments": {
+      "get": {
+        "operationId": "Deployments_List",
+        "tags": [
+          "Deployments"
+        ],
+        "description": "Gets the deployments associated with the Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/DeploymentListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/deployments/{deploymentName}": {
+      "get": {
+        "operationId": "Deployments_Get",
+        "tags": [
+          "Deployments"
+        ],
+        "description": "Gets the specified deployments associated with the Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "description": "The name of the deployment associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Deployment"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "Deployments_CreateOrUpdate",
+        "tags": [
+          "Deployments"
+        ],
+        "description": "Update the state of specified deployments associated with the Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "description": "The name of the deployment associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "deployment",
+            "in": "body",
+            "description": "The deployment properties.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Deployment"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Deployment' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Deployment"
+            }
+          },
+          "201": {
+            "description": "Resource 'Deployment' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Deployment"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/Deployment"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "Deployments_Update",
+        "tags": [
+          "Deployments"
+        ],
+        "description": "Update specified deployments associated with the Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "description": "The name of the deployment associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "deployment",
+            "in": "body",
+            "description": "The deployment properties.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PatchResourceTagsAndSku"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Deployment"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/Deployment"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "Deployments_Delete",
+        "tags": [
+          "Deployments"
+        ],
+        "description": "Deletes the specified deployment associated with the Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "description": "The name of the deployment associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/deployments/{deploymentName}/pause": {
+      "post": {
+        "operationId": "Deployments_Pause",
+        "tags": [
+          "Deployments"
+        ],
+        "summary": "Pause a deployment",
+        "description": "Pauses inferencing on a deployment by setting the deploymentState to 'Paused' (see #/definitions/DeploymentProperties/properties/deploymentState). Only Standard, DataZoneStandard, and GlobalStandard SKUs support this operation. Inference requests to the paused deployment endpoint will receive HTTP 423 (Locked). This operation is idempotent.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "description": "The name of the deployment associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Deployment"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/deployments/{deploymentName}/resume": {
+      "post": {
+        "operationId": "Deployments_Resume",
+        "tags": [
+          "Deployments"
+        ],
+        "summary": "Resume a deployment",
+        "description": "Resumes inferencing on a previously paused deployment by setting the deploymentState to 'Running' (see #/definitions/DeploymentProperties/properties/deploymentState). This operation is idempotent and can be safely called on already running deployments.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "description": "The name of the deployment associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Deployment"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/deployments/{deploymentName}/skus": {
+      "get": {
+        "operationId": "Deployments_ListSkus",
+        "tags": [
+          "Deployments"
+        ],
+        "description": "Lists the specified deployments skus associated with the Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "description": "The name of the deployment associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DeploymentSkuListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/encryptionScopes": {
+      "get": {
+        "operationId": "EncryptionScopes_List",
+        "tags": [
+          "EncryptionScopes"
+        ],
+        "description": "Gets the content filters associated with the Azure OpenAI account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/EncryptionScopeListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/encryptionScopes/{encryptionScopeName}": {
+      "get": {
+        "operationId": "EncryptionScopes_Get",
+        "tags": [
+          "EncryptionScopes"
+        ],
+        "description": "Gets the specified EncryptionScope associated with the Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "encryptionScopeName",
+            "in": "path",
+            "description": "The name of the encryptionScope associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EncryptionScope"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "EncryptionScopes_CreateOrUpdate",
+        "tags": [
+          "EncryptionScopes"
+        ],
+        "description": "Update the state of specified encryptionScope associated with the Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "encryptionScopeName",
+            "in": "path",
+            "description": "The name of the encryptionScope associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "encryptionScope",
+            "in": "body",
+            "description": "The encryptionScope properties.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EncryptionScope"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'EncryptionScope' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/EncryptionScope"
+            }
+          },
+          "201": {
+            "description": "Resource 'EncryptionScope' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/EncryptionScope"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "EncryptionScopes_Delete",
+        "tags": [
+          "EncryptionScopes"
+        ],
+        "description": "Deletes the specified encryptionScope associated with the Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "encryptionScopeName",
+            "in": "path",
+            "description": "The name of the encryptionScope associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/listKeys": {
+      "post": {
+        "operationId": "Accounts_ListKeys",
+        "tags": [
+          "CognitiveServicesAccounts"
+        ],
+        "description": "Lists the account keys for the specified Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ApiKeys"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/managedNetworks": {
+      "get": {
+        "operationId": "ManagedNetworkSettings_List",
+        "tags": [
+          "ManagedNetwork"
+        ],
+        "summary": "List API for managed network settings of a cognitive services account.",
+        "description": "List API for managed network settings of a cognitive services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ManagedNetworkListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/managedNetworks/{managedNetworkName}": {
+      "get": {
+        "operationId": "ManagedNetworkSettings_Get",
+        "tags": [
+          "ManagedNetwork"
+        ],
+        "summary": "Get API for managed network settings of a cognitive services account.",
+        "description": "Get API for managed network settings of a cognitive services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "managedNetworkName",
+            "in": "path",
+            "description": "Name of the managedNetwork associated with the cognitive services account. Only 'default' is supported.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ManagedNetworkSettingsPropertiesBasicResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "ManagedNetworkSettings_Put",
+        "tags": [
+          "ManagedNetwork"
+        ],
+        "summary": "PUT API for managed network settings of a cognitive services account.",
+        "description": "PUT API for managed network settings of a cognitive services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "managedNetworkName",
+            "in": "path",
+            "description": "Name of the managedNetwork associated with the cognitive services account. Only 'default' is supported.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "The Managed Network Settings object of the account.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ManagedNetworkSettingsPropertiesBasicResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ManagedNetworkSettingsPropertiesBasicResource' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ManagedNetworkSettingsPropertiesBasicResource"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ManagedNetworkSettingsPropertiesBasicResource"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "ManagedNetworkSettings_Patch",
+        "tags": [
+          "ManagedNetwork"
+        ],
+        "summary": "Patch API for managed network settings of a cognitive services account.",
+        "description": "Patch API for managed network settings of a cognitive services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "managedNetworkName",
+            "in": "path",
+            "description": "Name of the managedNetwork associated with the cognitive services account. Only 'default' is supported.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "The Managed Network Settings object of the account.",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/ManagedNetworkSettingsPropertiesBasicResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ManagedNetworkSettingsPropertiesBasicResource"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ManagedNetworkSettingsPropertiesBasicResource"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/managedNetworks/{managedNetworkName}/batchOutboundRules": {
+      "post": {
+        "operationId": "OutboundRules_Post",
+        "tags": [
+          "ManagedNetwork"
+        ],
+        "summary": "The POST API for updating the outbound rules of the managed network associated with the cognitive services account.",
+        "description": "The POST API for updating the outbound rules of the managed network associated with the cognitive services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "managedNetworkName",
+            "in": "path",
+            "description": "Name of the managedNetwork associated with the cognitive services account. Only 'default' is supported.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "The Managed Network Settings object of the account.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ManagedNetworkSettingsBasicResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/OutboundRuleListResult"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/OutboundRuleListResult"
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/managedNetworks/{managedNetworkName}/outboundRules": {
+      "get": {
+        "operationId": "OutboundRule_List",
+        "tags": [
+          "ManagedNetwork"
+        ],
+        "summary": "The GET API for retrieving the list of outbound rules of the managed network associated with the cognitive services account.",
+        "description": "The GET API for retrieving the list of outbound rules of the managed network associated with the cognitive services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "managedNetworkName",
+            "in": "path",
+            "description": "Name of the managedNetwork associated with the cognitive services account. Only 'default' is supported.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/OutboundRuleListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/managedNetworks/{managedNetworkName}/outboundRules/{ruleName}": {
+      "get": {
+        "operationId": "OutboundRule_Get",
+        "tags": [
+          "ManagedNetwork"
+        ],
+        "summary": "The GET API for retrieving a single outbound rule of the managed network associated with the cognitive services account.",
+        "description": "The GET API for retrieving a single outbound rule of the managed network associated with the cognitive services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "managedNetworkName",
+            "in": "path",
+            "description": "Name of the managedNetwork associated with the cognitive services account. Only 'default' is supported.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          },
+          {
+            "name": "ruleName",
+            "in": "path",
+            "description": "Name of the cognitive services account managed network outbound rule",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/OutboundRuleBasicResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "OutboundRule_CreateOrUpdate",
+        "tags": [
+          "ManagedNetwork"
+        ],
+        "summary": "The PUT API for creating or updating a single outbound rule of the managed network associated with the cognitive services account.",
+        "description": "The PUT API for creating or updating a single outbound rule of the managed network associated with the cognitive services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "managedNetworkName",
+            "in": "path",
+            "description": "Name of the managedNetwork associated with the cognitive services account. Only 'default' is supported.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          },
+          {
+            "name": "ruleName",
+            "in": "path",
+            "description": "Name of the cognitive services account managed network outbound rule",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OutboundRuleBasicResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'OutboundRuleBasicResource' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/OutboundRuleBasicResource"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/OutboundRuleBasicResource"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "OutboundRule_Delete",
+        "tags": [
+          "ManagedNetwork"
+        ],
+        "summary": "The DELETE API for deleting a single outbound rule of the managed network associated with the cognitive services account.",
+        "description": "The DELETE API for deleting a single outbound rule of the managed network associated with the cognitive services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "managedNetworkName",
+            "in": "path",
+            "description": "Name of the managedNetwork associated with the cognitive services account. Only 'default' is supported.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          },
+          {
+            "name": "ruleName",
+            "in": "path",
+            "description": "Name of the cognitive services account managed network outbound rule",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/managedNetworks/{managedNetworkName}/provision": {
+      "post": {
+        "operationId": "ManagedNetworkProvisions_ProvisionManagedNetwork",
+        "tags": [
+          "ManagedNetwork"
+        ],
+        "summary": "Provisions the managed network of a cognitive services account.",
+        "description": "Provisions the managed network of a cognitive services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "managedNetworkName",
+            "in": "path",
+            "description": "Name of the managedNetwork associated with the cognitive services account. Only 'default' is supported.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Managed Network Provisioning Options for a cognitive services account.",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/ManagedNetworkProvisionOptions"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ManagedNetworkProvisionStatus"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ManagedNetworkProvisionStatus"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/models": {
+      "get": {
+        "operationId": "Accounts_ListModels",
+        "tags": [
+          "CognitiveServicesAccounts"
+        ],
+        "description": "List available Models for the requested Cognitive Services account",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AccountModelListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/networkSecurityPerimeterConfigurations": {
+      "get": {
+        "operationId": "NetworkSecurityPerimeterConfigurations_List",
+        "tags": [
+          "NetworkSecurityPerimeterConfigurations"
+        ],
+        "description": "Gets a list of NSP configurations for an account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/networkSecurityPerimeterConfigurations/{nspConfigurationName}": {
+      "get": {
+        "operationId": "NetworkSecurityPerimeterConfigurations_Get",
+        "tags": [
+          "NetworkSecurityPerimeterConfigurations"
+        ],
+        "description": "Gets the specified NSP configurations for an account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "nspConfigurationName",
+            "in": "path",
+            "description": "The name of the NSP Configuration.",
+            "required": true,
+            "type": "string",
+            "pattern": "^.*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityPerimeterConfiguration"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/networkSecurityPerimeterConfigurations/{nspConfigurationName}/reconcile": {
+      "post": {
+        "operationId": "NetworkSecurityPerimeterConfigurations_Reconcile",
+        "tags": [
+          "NetworkSecurityPerimeterConfigurations"
+        ],
+        "description": "Reconcile the NSP configuration for an account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "nspConfigurationName",
+            "in": "path",
+            "description": "The name of the NSP Configuration.",
+            "required": true,
+            "type": "string",
+            "pattern": "^.*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityPerimeterConfiguration"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/NetworkSecurityPerimeterConfiguration"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/privateEndpointConnections": {
+      "get": {
+        "operationId": "PrivateEndpointConnections_List",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "Gets the private endpoint connections associated with the Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnectionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/privateEndpointConnections/{privateEndpointConnectionName}": {
+      "get": {
+        "operationId": "PrivateEndpointConnections_Get",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "Gets the specified private endpoint connection associated with the Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The name of the private endpoint connection associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "PrivateEndpointConnections_CreateOrUpdate",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "Update the state of specified private endpoint connection associated with the Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The name of the private endpoint connection associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The private endpoint connection properties.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'PrivateEndpointConnection' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            },
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/PrivateEndpointConnection"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "PrivateEndpointConnections_Delete",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "Deletes the specified private endpoint connection associated with the Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The name of the private endpoint connection associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/privateLinkResources": {
+      "get": {
+        "operationId": "PrivateLinkResources_List",
+        "tags": [
+          "PrivateLinkResources"
+        ],
+        "description": "Gets the private link resources that need to be created for a Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateLinkResourceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects": {
+      "get": {
+        "operationId": "Projects_List",
+        "tags": [
+          "CognitiveServicesProjects"
+        ],
+        "description": "Returns all the projects in a Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ProjectListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}": {
+      "get": {
+        "operationId": "Projects_Get",
+        "tags": [
+          "CognitiveServicesProjects"
+        ],
+        "description": "Returns a Cognitive Services project specified by the parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Project"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "Projects_Create",
+        "tags": [
+          "CognitiveServicesProjects"
+        ],
+        "description": "Create Cognitive Services Account's Project. Project is a sub-resource of an account which give AI developer it's individual container to work on.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "project",
+            "in": "body",
+            "description": "The parameters to provide for the created project.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Project"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Project' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Project"
+            }
+          },
+          "201": {
+            "description": "Resource 'Project' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Project"
+            },
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/Project"
+            },
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/Project"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "Projects_Update",
+        "tags": [
+          "CognitiveServicesProjects"
+        ],
+        "description": "Updates a Cognitive Services Project",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "project",
+            "in": "body",
+            "description": "The parameters to provide for the created project.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Project"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Project"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/Project"
+            },
+            "headers": {
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/Project"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "Projects_Delete",
+        "tags": [
+          "CognitiveServicesProjects"
+        ],
+        "description": "Deletes a Cognitive Services project from the resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}/applications": {
+      "get": {
+        "operationId": "AgentApplications_List",
+        "tags": [
+          "AgentApplication"
+        ],
+        "summary": "Lists Agent Applications in the project.",
+        "description": "Lists Agent Applications in the project.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "count",
+            "in": "query",
+            "description": "Number of agent applications to be retrieved in a page of results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "default": 30
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Number of agent applications to skip.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "Continuation token for pagination.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "names",
+            "in": "query",
+            "description": "Names of agent applications to retrieve.",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "searchText",
+            "in": "query",
+            "description": "Search text for filtering agent applications.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "description": "Field to order by.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderByAsc",
+            "in": "query",
+            "description": "Whether to order in ascending order.",
+            "required": false,
+            "type": "boolean",
+            "default": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AgentApplicationResourceArmPaginatedResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}/applications/{name}": {
+      "get": {
+        "operationId": "AgentApplications_Get",
+        "tags": [
+          "AgentApplication"
+        ],
+        "summary": "Gets an Agent Application by name.",
+        "description": "Gets an Agent Application by name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name for the Agent Application.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AgentApplication"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "AgentApplications_CreateOrUpdate",
+        "tags": [
+          "AgentApplication"
+        ],
+        "summary": "Creates or updates an Agent Application (asynchronous).",
+        "description": "Creates or updates an Agent Application (asynchronous).",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name for the Agent Application.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Agent Application definition object.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AgentApplication"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AgentApplication"
+            }
+          },
+          "201": {
+            "description": "Resource 'AgentApplication' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/AgentApplication"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "URI to poll for asynchronous operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "x-ms-async-operation-timeout": {
+                "type": "string",
+                "format": "duration",
+                "description": "Timeout for the client to use when polling the asynchronous operation."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/AgentApplication"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "AgentApplications_Delete",
+        "tags": [
+          "AgentApplication"
+        ],
+        "summary": "Delete Agent Application.",
+        "description": "Delete Agent Application.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name for the Agent Application.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}/applications/{appName}/agentDeployments": {
+      "get": {
+        "operationId": "AgentDeployments_List",
+        "tags": [
+          "AgentDeployment"
+        ],
+        "summary": "Lists Agent Deployments in the application.",
+        "description": "Lists Agent Deployments in the application.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "The name of the application associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "count",
+            "in": "query",
+            "description": "Number of agent deployments to be retrieved in a page of results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "default": 30
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "Continuation token for pagination.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "names",
+            "in": "query",
+            "description": "Names of agent deployments to retrieve.",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "description": "Field to order by.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderByAsc",
+            "in": "query",
+            "description": "Whether to order in ascending order.",
+            "required": false,
+            "type": "boolean",
+            "default": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AgentDeploymentResourceArmPaginatedResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}/applications/{appName}/agentDeployments/{deploymentName}": {
+      "get": {
+        "operationId": "AgentDeployments_Get",
+        "tags": [
+          "AgentDeployment"
+        ],
+        "summary": "Gets an Agent Deployment by name.",
+        "description": "Gets an Agent Deployment by name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "The name of the application associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "description": "The name of the deployment associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AgentDeployment"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "AgentDeployments_CreateOrUpdate",
+        "tags": [
+          "AgentDeployment"
+        ],
+        "summary": "Creates or updates an Agent Deployment (asynchronous).",
+        "description": "Creates or updates an Agent Deployment (asynchronous).",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "The name of the application associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "description": "The name of the deployment associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Agent Deployment definition object.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AgentDeployment"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AgentDeployment"
+            }
+          },
+          "201": {
+            "description": "Resource 'AgentDeployment' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/AgentDeployment"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "URI to poll for asynchronous operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "x-ms-async-operation-timeout": {
+                "type": "string",
+                "format": "duration",
+                "description": "Timeout for the client to use when polling the asynchronous operation."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/AgentDeployment"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "AgentDeployments_Delete",
+        "tags": [
+          "AgentDeployment"
+        ],
+        "summary": "Delete Agent Deployment.",
+        "description": "Delete Agent Deployment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "The name of the application associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "description": "The name of the deployment associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}/applications/{appName}/agentDeployments/{deploymentName}/start": {
+      "post": {
+        "operationId": "AgentDeployments_Start",
+        "tags": [
+          "AgentDeployment"
+        ],
+        "summary": "Starts an Agent Deployment.",
+        "description": "Starts an Agent Deployment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "The name of the application associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "description": "The name of the deployment associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}/applications/{appName}/agentDeployments/{deploymentName}/stop": {
+      "post": {
+        "operationId": "AgentDeployments_Stop",
+        "tags": [
+          "AgentDeployment"
+        ],
+        "summary": "Stops an Agent Deployment.",
+        "description": "Stops an Agent Deployment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "The name of the application associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "description": "The name of the deployment associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}/applications/{name}/disable": {
+      "post": {
+        "operationId": "AgentApplications_Disable",
+        "tags": [
+          "AgentApplication"
+        ],
+        "summary": "Disables an Agent Application.",
+        "description": "Disables an Agent Application.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name for the Agent Application.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}/applications/{name}/enable": {
+      "post": {
+        "operationId": "AgentApplications_Enable",
+        "tags": [
+          "AgentApplication"
+        ],
+        "summary": "Enables an Agent Application.",
+        "description": "Enables an Agent Application.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name for the Agent Application.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}/applications/{name}/listAgents": {
+      "post": {
+        "operationId": "AgentApplications_ListAgents",
+        "tags": [
+          "AgentApplication"
+        ],
+        "summary": "Lists agents for an Agent Application.",
+        "description": "Lists agents for an Agent Application.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name for the Agent Application.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AgentReferenceResourceArmPaginatedResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}/capabilityHosts": {
+      "get": {
+        "operationId": "ProjectCapabilityHosts_List",
+        "tags": [
+          "ProjectCapabilityHost"
+        ],
+        "summary": "List capabilityHost.",
+        "description": "List capabilityHost.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ProjectCapabilityHostResourceArmPaginatedResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}/capabilityHosts/{capabilityHostName}": {
+      "get": {
+        "operationId": "ProjectCapabilityHosts_Get",
+        "tags": [
+          "ProjectCapabilityHost"
+        ],
+        "summary": "Get project capabilityHost.",
+        "description": "Get project capabilityHost.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "capabilityHostName",
+            "in": "path",
+            "description": "The name of the capability host associated with the Cognitive Services Resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9\\-_]{0,254}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ProjectCapabilityHost"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "ProjectCapabilityHosts_CreateOrUpdate",
+        "tags": [
+          "ProjectCapabilityHost"
+        ],
+        "summary": "Create or update project capabilityHost.",
+        "description": "Create or update project capabilityHost.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "capabilityHostName",
+            "in": "path",
+            "description": "The name of the capability host associated with the Cognitive Services Resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9\\-_]{0,254}$"
+          },
+          {
+            "name": "capabilityHost",
+            "in": "body",
+            "description": "CapabilityHost definition.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ProjectCapabilityHost"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ProjectCapabilityHost"
+            }
+          },
+          "201": {
+            "description": "The request has succeeded and a new resource has been created as a result.",
+            "schema": {
+              "$ref": "#/definitions/ProjectCapabilityHost"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "x-ms-async-operation-timeout": {
+                "type": "string",
+                "format": "duration",
+                "description": "Timeout for the client to use when polling the asynchronous operation."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "original-uri",
+          "final-state-schema": "#/definitions/ProjectCapabilityHost"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "ProjectCapabilityHosts_Delete",
+        "tags": [
+          "ProjectCapabilityHost"
+        ],
+        "summary": "Delete project capabilityHost.",
+        "description": "Delete project capabilityHost.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "capabilityHostName",
+            "in": "path",
+            "description": "The name of the capability host associated with the Cognitive Services Resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9\\-_]{0,254}$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "x-ms-async-operation-timeout": {
+                "type": "string",
+                "format": "duration",
+                "description": "Timeout for the client to use when polling the asynchronous operation."
+              }
+            }
+          },
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}/connections": {
+      "get": {
+        "operationId": "ProjectConnections_List",
+        "tags": [
+          "ProjectConnectionResource"
+        ],
+        "summary": "Lists all the available Cognitive Services project connections under the specified project.",
+        "description": "Lists all the available Cognitive Services project connections under the specified project.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "target",
+            "in": "query",
+            "description": "Target of the connection.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "category",
+            "in": "query",
+            "description": "Category of the connection.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "includeAll",
+            "in": "query",
+            "description": "query parameter that indicates if get connection call should return both connections and datastores",
+            "required": false,
+            "type": "boolean",
+            "default": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectionPropertiesV2BasicResourceArmPaginatedResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}/connections/{connectionName}": {
+      "get": {
+        "operationId": "ProjectConnections_Get",
+        "tags": [
+          "ProjectConnectionResource"
+        ],
+        "summary": "Lists Cognitive Services project connection by name.",
+        "description": "Lists Cognitive Services project connection by name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "Friendly name of the connection",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectionPropertiesV2BasicResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "ProjectConnections_Create",
+        "tags": [
+          "ProjectConnectionResource"
+        ],
+        "summary": "Create or update Cognitive Services project connection under the specified project.",
+        "description": "Create or update Cognitive Services project connection under the specified project.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "Friendly name of the connection",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          },
+          {
+            "name": "connection",
+            "in": "body",
+            "description": "The object for creating or updating a new account connection",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/ConnectionPropertiesV2BasicResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ConnectionPropertiesV2BasicResource' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ConnectionPropertiesV2BasicResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "ProjectConnections_Update",
+        "tags": [
+          "ProjectConnectionResource"
+        ],
+        "summary": "Update Cognitive Services project connection under the specified project.",
+        "description": "Update Cognitive Services project connection under the specified project.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "Friendly name of the connection",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          },
+          {
+            "name": "connection",
+            "in": "body",
+            "description": "Parameters for account connection update.",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/ConnectionUpdateContent"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectionPropertiesV2BasicResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "ProjectConnections_Delete",
+        "tags": [
+          "ProjectConnectionResource"
+        ],
+        "summary": "Delete Cognitive Services project connection by name.",
+        "description": "Delete Cognitive Services project connection by name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "Friendly name of the connection",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/raiBlocklists": {
+      "get": {
+        "operationId": "RaiBlocklists_List",
+        "tags": [
+          "RaiBlocklists"
+        ],
+        "description": "Gets the custom blocklists associated with the Azure OpenAI account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/RaiBlockListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/raiBlocklists/{raiBlocklistName}": {
+      "get": {
+        "operationId": "RaiBlocklists_Get",
+        "tags": [
+          "RaiBlocklists"
+        ],
+        "description": "Gets the specified custom blocklist associated with the Azure OpenAI account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiBlocklistName",
+            "in": "path",
+            "description": "The name of the RaiBlocklist associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RaiBlocklist"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "RaiBlocklists_CreateOrUpdate",
+        "tags": [
+          "RaiBlocklists"
+        ],
+        "description": "Update the state of specified blocklist associated with the Azure OpenAI account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiBlocklistName",
+            "in": "path",
+            "description": "The name of the RaiBlocklist associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiBlocklist",
+            "in": "body",
+            "description": "Properties describing the custom blocklist.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RaiBlocklist"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'RaiBlocklist' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RaiBlocklist"
+            }
+          },
+          "201": {
+            "description": "Resource 'RaiBlocklist' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RaiBlocklist"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "RaiBlocklists_Delete",
+        "tags": [
+          "RaiBlocklists"
+        ],
+        "description": "Deletes the specified custom blocklist associated with the Azure OpenAI account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiBlocklistName",
+            "in": "path",
+            "description": "The name of the RaiBlocklist associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/raiBlocklists/{raiBlocklistName}/addRaiBlocklistItems": {
+      "post": {
+        "operationId": "RaiBlocklistItems_BatchAdd",
+        "tags": [
+          "RaiBlocklists"
+        ],
+        "description": "Batch operation to add blocklist items.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiBlocklistName",
+            "in": "path",
+            "description": "The name of the RaiBlocklist associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiBlocklistItems",
+            "in": "body",
+            "description": "Properties describing the custom blocklist items.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RaiBlocklistItemsBulkAddRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RaiBlocklist"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/raiBlocklists/{raiBlocklistName}/deleteRaiBlocklistItems": {
+      "post": {
+        "operationId": "RaiBlocklistItems_BatchDelete",
+        "tags": [
+          "RaiBlocklists"
+        ],
+        "description": "Batch operation to delete blocklist items.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiBlocklistName",
+            "in": "path",
+            "description": "The name of the RaiBlocklist associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiBlocklistItemsNames",
+            "in": "body",
+            "description": "List of RAI Blocklist Items Names.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RaiBlocklistItemsBulkDeleteRequest"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/raiBlocklists/{raiBlocklistName}/raiBlocklistItems": {
+      "get": {
+        "operationId": "RaiBlocklistItems_List",
+        "tags": [
+          "RaiBlocklists"
+        ],
+        "description": "Gets the blocklist items associated with the custom blocklist.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiBlocklistName",
+            "in": "path",
+            "description": "The name of the RaiBlocklist associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RaiBlockListItemsResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/raiBlocklists/{raiBlocklistName}/raiBlocklistItems/{raiBlocklistItemName}": {
+      "get": {
+        "operationId": "RaiBlocklistItems_Get",
+        "tags": [
+          "RaiBlocklists"
+        ],
+        "description": "Gets the specified custom blocklist Item associated with the custom blocklist.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiBlocklistName",
+            "in": "path",
+            "description": "The name of the RaiBlocklist associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiBlocklistItemName",
+            "in": "path",
+            "description": "The name of the RaiBlocklist Item associated with the custom blocklist",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RaiBlocklistItem"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "RaiBlocklistItems_CreateOrUpdate",
+        "tags": [
+          "RaiBlocklists"
+        ],
+        "description": "Update the state of specified blocklist item associated with the Azure OpenAI account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiBlocklistName",
+            "in": "path",
+            "description": "The name of the RaiBlocklist associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiBlocklistItemName",
+            "in": "path",
+            "description": "The name of the RaiBlocklist Item associated with the custom blocklist",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiBlocklistItem",
+            "in": "body",
+            "description": "Properties describing the custom blocklist.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RaiBlocklistItem"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'RaiBlocklistItem' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RaiBlocklistItem"
+            }
+          },
+          "201": {
+            "description": "Resource 'RaiBlocklistItem' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RaiBlocklistItem"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "RaiBlocklistItems_Delete",
+        "tags": [
+          "RaiBlocklists"
+        ],
+        "description": "Deletes the specified blocklist Item associated with the custom blocklist.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiBlocklistName",
+            "in": "path",
+            "description": "The name of the RaiBlocklist associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiBlocklistItemName",
+            "in": "path",
+            "description": "The name of the RaiBlocklist Item associated with the custom blocklist",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/raiPolicies": {
+      "get": {
+        "operationId": "RaiPolicies_List",
+        "tags": [
+          "RaiPolicies"
+        ],
+        "description": "Gets the content filters associated with the Azure OpenAI account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/RaiPolicyListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/raiPolicies/{raiPolicyName}": {
+      "get": {
+        "operationId": "RaiPolicies_Get",
+        "tags": [
+          "RaiPolicies"
+        ],
+        "description": "Gets the specified Content Filters associated with the Azure OpenAI account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiPolicyName",
+            "in": "path",
+            "description": "The name of the RaiPolicy associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RaiPolicy"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "RaiPolicies_CreateOrUpdate",
+        "tags": [
+          "RaiPolicies"
+        ],
+        "description": "Update the state of specified Content Filters associated with the Azure OpenAI account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiPolicyName",
+            "in": "path",
+            "description": "The name of the RaiPolicy associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiPolicy",
+            "in": "body",
+            "description": "Properties describing the Content Filters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RaiPolicy"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'RaiPolicy' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RaiPolicy"
+            }
+          },
+          "201": {
+            "description": "Resource 'RaiPolicy' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RaiPolicy"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "RaiPolicies_Delete",
+        "tags": [
+          "RaiPolicies"
+        ],
+        "description": "Deletes the specified Content Filters associated with the Azure OpenAI account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiPolicyName",
+            "in": "path",
+            "description": "The name of the RaiPolicy associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/raiToolLabels": {
+      "get": {
+        "operationId": "RaiToolLabels_List",
+        "tags": [
+          "RaiToolLabels"
+        ],
+        "description": "Lists all RAI Tool Labels associated with the Azure OpenAI account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RaiToolLabelResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/raiToolLabels/{raiToolConnectionName}": {
+      "get": {
+        "operationId": "RaiToolLabels_Get",
+        "tags": [
+          "RaiToolLabels"
+        ],
+        "description": "Gets the specified RAI Tool Label associated with the Azure OpenAI account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiToolConnectionName",
+            "in": "path",
+            "description": "The name of the Rai Tool Label",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RaiToolLabel"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "RaiToolLabels_CreateOrUpdate",
+        "tags": [
+          "RaiToolLabels"
+        ],
+        "description": "Creates the RAI Tool Label associated with the Azure OpenAI account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiToolConnectionName",
+            "in": "path",
+            "description": "The name of the Rai Tool Label",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiToolLabel",
+            "in": "body",
+            "description": "Properties describing the RAI Tool Label.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RaiToolLabel"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'RaiToolLabel' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RaiToolLabel"
+            }
+          },
+          "201": {
+            "description": "Resource 'RaiToolLabel' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RaiToolLabel"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "RaiToolLabels_Delete",
+        "tags": [
+          "RaiToolLabels"
+        ],
+        "description": "Deletes the specified RAI Tool Label associated with the Azure OpenAI account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiToolConnectionName",
+            "in": "path",
+            "description": "The name of the Rai Tool Label",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/raitopics": {
+      "get": {
+        "operationId": "RaiTopics_List",
+        "tags": [
+          "RaiTopics"
+        ],
+        "description": "Gets the custom topics associated with the Azure OpenAI account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RaiTopicResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/raitopics/{raiTopicName}": {
+      "get": {
+        "operationId": "RaiTopics_Get",
+        "tags": [
+          "RaiTopics"
+        ],
+        "description": "Gets the specified custom topic associated with the Azure OpenAI account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiTopicName",
+            "in": "path",
+            "description": "The name of the Rai Topic associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RaiTopic"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "RaiTopics_CreateOrUpdate",
+        "tags": [
+          "RaiTopics"
+        ],
+        "description": "Create the rai topic associated with the Azure OpenAI account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiTopicName",
+            "in": "path",
+            "description": "The name of the Rai Topic associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiTopic",
+            "in": "body",
+            "description": "Properties describing the rai topic.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RaiTopic"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'RaiTopic' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RaiTopic"
+            }
+          },
+          "201": {
+            "description": "Resource 'RaiTopic' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RaiTopic"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "RaiTopics_Delete",
+        "tags": [
+          "RaiTopics"
+        ],
+        "description": "Deletes the specified custom topic associated with the Azure OpenAI account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiTopicName",
+            "in": "path",
+            "description": "The name of the Rai Topic associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/regenerateKey": {
+      "post": {
+        "operationId": "Accounts_RegenerateKey",
+        "tags": [
+          "CognitiveServicesAccounts"
+        ],
+        "description": "Regenerates the specified account key for the specified Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "regenerate key parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RegenerateKeyParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ApiKeys"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/skus": {
+      "get": {
+        "operationId": "Accounts_ListSkus",
+        "tags": [
+          "CognitiveServicesAccounts"
+        ],
+        "description": "List available SKUs for the requested Cognitive Services account",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AccountSkuListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/testRaiExternalSafetyProvider/{safetyProviderName}": {
+      "put": {
+        "operationId": "TestRaiExternalSafetyProvider_CreateOrUpdate",
+        "tags": [
+          "TestRaiExternalSafetyProvider"
+        ],
+        "description": "Test the rai safety provider associated with the subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "safetyProviderName",
+            "in": "path",
+            "description": "The name of the Rai External Safety Provider associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "safetyProvider",
+            "in": "body",
+            "description": "Properties describing the rai external safety provider.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RaiExternalSafetyProviderSchema"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RaiExternalSafetyProviderSchema"
+            }
+          },
+          "201": {
+            "description": "Resource 'RaiExternalSafetyProviderSchema' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RaiExternalSafetyProviderSchema"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/usages": {
+      "get": {
+        "operationId": "Accounts_ListUsages",
+        "tags": [
+          "CognitiveServicesAccounts"
+        ],
+        "description": "Get usages for the requested Cognitive Services account",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "An OData filter expression that describes a subset of usages to return. The supported parameter is name.value (name of the metric, can have an or of multiple names).",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/UsageListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/commitmentPlans": {
+      "get": {
+        "operationId": "CommitmentPlans_ListPlansByResourceGroup",
+        "tags": [
+          "CognitiveServicesCommitmentPlans"
+        ],
+        "description": "Returns all the resources of a particular type belonging to a resource group",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/CommitmentPlanListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/commitmentPlans/{commitmentPlanName}": {
+      "get": {
+        "operationId": "CommitmentPlans_GetPlan",
+        "tags": [
+          "CognitiveServicesCommitmentPlans"
+        ],
+        "description": "Returns a Cognitive Services commitment plan specified by the parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "commitmentPlanName",
+            "in": "path",
+            "description": "The name of the commitmentPlan associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CommitmentPlan"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "CommitmentPlans_CreateOrUpdatePlan",
+        "tags": [
+          "CognitiveServicesCommitmentPlans"
+        ],
+        "description": "Create Cognitive Services commitment plan.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "commitmentPlanName",
+            "in": "path",
+            "description": "The name of the commitmentPlan associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "commitmentPlan",
+            "in": "body",
+            "description": "The parameters to provide for the created commitment plan.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CommitmentPlan"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'CommitmentPlan' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/CommitmentPlan"
+            }
+          },
+          "201": {
+            "description": "Resource 'CommitmentPlan' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/CommitmentPlan"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/CommitmentPlan"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "CommitmentPlans_UpdatePlan",
+        "tags": [
+          "CognitiveServicesCommitmentPlans"
+        ],
+        "description": "Create Cognitive Services commitment plan.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "commitmentPlanName",
+            "in": "path",
+            "description": "The name of the commitmentPlan associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "commitmentPlan",
+            "in": "body",
+            "description": "The parameters to provide for the created commitment plan.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PatchResourceTagsAndSku"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CommitmentPlan"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/CommitmentPlan"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "CommitmentPlans_DeletePlan",
+        "tags": [
+          "CognitiveServicesCommitmentPlans"
+        ],
+        "description": "Deletes a Cognitive Services commitment plan from the resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "commitmentPlanName",
+            "in": "path",
+            "description": "The name of the commitmentPlan associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/commitmentPlans/{commitmentPlanName}/accountAssociations": {
+      "get": {
+        "operationId": "CommitmentPlans_ListAssociations",
+        "tags": [
+          "CommitmentPlans"
+        ],
+        "description": "Gets the associations of the Cognitive Services commitment plan.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "commitmentPlanName",
+            "in": "path",
+            "description": "The name of the commitmentPlan associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/CommitmentPlanAccountAssociationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/commitmentPlans/{commitmentPlanName}/accountAssociations/{commitmentPlanAssociationName}": {
+      "get": {
+        "operationId": "CommitmentPlans_GetAssociation",
+        "tags": [
+          "CommitmentPlans"
+        ],
+        "description": "Gets the association of the Cognitive Services commitment plan.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "commitmentPlanName",
+            "in": "path",
+            "description": "The name of the commitmentPlan associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "commitmentPlanAssociationName",
+            "in": "path",
+            "description": "The name of the commitment plan association with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CommitmentPlanAccountAssociation"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "CommitmentPlans_CreateOrUpdateAssociation",
+        "tags": [
+          "CommitmentPlans"
+        ],
+        "description": "Create or update the association of the Cognitive Services commitment plan.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "commitmentPlanName",
+            "in": "path",
+            "description": "The name of the commitmentPlan associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "commitmentPlanAssociationName",
+            "in": "path",
+            "description": "The name of the commitment plan association with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "association",
+            "in": "body",
+            "description": "The commitmentPlan properties.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CommitmentPlanAccountAssociation"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'CommitmentPlanAccountAssociation' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/CommitmentPlanAccountAssociation"
+            }
+          },
+          "201": {
+            "description": "Resource 'CommitmentPlanAccountAssociation' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/CommitmentPlanAccountAssociation"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/CommitmentPlanAccountAssociation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "CommitmentPlans_DeleteAssociation",
+        "tags": [
+          "CommitmentPlans"
+        ],
+        "description": "Deletes the association of the Cognitive Services commitment plan.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "commitmentPlanName",
+            "in": "path",
+            "description": "The name of the commitmentPlan associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "commitmentPlanAssociationName",
+            "in": "path",
+            "description": "The name of the commitment plan association with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    }
+  },
+  "definitions": {
+    "AADAuthTypeConnectionProperties": {
+      "type": "object",
+      "description": "This connection type covers the AAD auth for any applicable Azure service",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ConnectionPropertiesV2"
+        }
+      ],
+      "x-ms-discriminator-value": "AAD"
+    },
+    "AbusePenalty": {
+      "type": "object",
+      "description": "The abuse penalty.",
+      "properties": {
+        "action": {
+          "$ref": "#/definitions/AbusePenaltyAction",
+          "description": "The action of AbusePenalty."
+        },
+        "rateLimitPercentage": {
+          "type": "number",
+          "format": "float",
+          "description": "The percentage of rate limit."
+        },
+        "expiration": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The datetime of expiration of the AbusePenalty."
+        }
+      }
+    },
+    "AbusePenaltyAction": {
+      "type": "string",
+      "description": "The action of AbusePenalty.",
+      "enum": [
+        "Throttle",
+        "Block"
+      ],
+      "x-ms-enum": {
+        "name": "AbusePenaltyAction",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Throttle",
+            "value": "Throttle"
+          },
+          {
+            "name": "Block",
+            "value": "Block"
+          }
+        ]
+      }
+    },
+    "AcceleratorCapacity": {
+      "type": "object",
+      "description": "Accelerator capacity information for Cognitive Services managed compute deployments.\nProvides available accelerator capacity per type and region at the subscription level.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AcceleratorCapacityProperties",
+          "description": "Properties of the accelerator capacity resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "AcceleratorCapacityListResult": {
+      "type": "object",
+      "description": "The list of accelerator capacities response.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of accelerator capacities."
+        },
+        "value": {
+          "type": "array",
+          "description": "Gets the list of accelerator capacities.",
+          "items": {
+            "$ref": "#/definitions/AcceleratorCapacity"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "id"
+          ]
+        }
+      }
+    },
+    "AcceleratorCapacityProperties": {
+      "type": "object",
+      "description": "Properties of an accelerator capacity resource.",
+      "properties": {
+        "acceleratorType": {
+          "type": "string",
+          "description": "The type of accelerator (e.g., Azure.A100, Azure.H100).",
+          "readOnly": true
+        },
+        "location": {
+          "type": "string",
+          "description": "The Azure region where the capacity is available.",
+          "readOnly": true
+        },
+        "availableAccelerators": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of available accelerators in the region.",
+          "readOnly": true
+        },
+        "deploymentSizeCapacities": {
+          "type": "array",
+          "description": "Capacity information broken down by deployment size.",
+          "items": {
+            "$ref": "#/definitions/DeploymentSizeCapacity"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "AccessKeyAuthTypeConnectionProperties": {
+      "type": "object",
+      "properties": {
+        "credentials": {
+          "$ref": "#/definitions/ConnectionAccessKey"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ConnectionPropertiesV2"
+        }
+      ],
+      "x-ms-discriminator-value": "AccessKey"
+    },
+    "Account": {
+      "type": "object",
+      "description": "Cognitive Services account is an Azure resource representing the provisioned account, it's type, location and SKU.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AccountProperties",
+          "description": "Properties of Cognitive Services account."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "etag": {
+          "type": "string",
+          "description": "Resource Etag.",
+          "readOnly": true
+        },
+        "kind": {
+          "type": "string",
+          "description": "The kind (type) of cognitive service account."
+        },
+        "sku": {
+          "$ref": "#/definitions/Sku",
+          "description": "The resource model definition representing SKU"
+        },
+        "identity": {
+          "$ref": "#/definitions/Identity",
+          "description": "Identity for the resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "AccountKeyAuthTypeConnectionProperties": {
+      "type": "object",
+      "description": "This connection type covers the account key connection for Azure storage",
+      "properties": {
+        "credentials": {
+          "$ref": "#/definitions/ConnectionAccountKey",
+          "description": "Account key object for connection credential."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ConnectionPropertiesV2"
+        }
+      ],
+      "x-ms-discriminator-value": "AccountKey"
+    },
+    "AccountListResult": {
+      "type": "object",
+      "description": "The list of cognitive services accounts operation response.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of accounts."
+        },
+        "value": {
+          "type": "array",
+          "description": "Gets the list of Cognitive Services accounts and their properties.",
+          "items": {
+            "$ref": "#/definitions/Account"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "AccountModel": {
+      "type": "object",
+      "description": "Cognitive Services account Model.",
+      "properties": {
+        "baseModel": {
+          "$ref": "#/definitions/DeploymentModel",
+          "description": "Properties of Cognitive Services account deployment model."
+        },
+        "isDefaultVersion": {
+          "type": "boolean",
+          "description": "If the model is default version."
+        },
+        "skus": {
+          "type": "array",
+          "description": "The list of Model Sku.",
+          "items": {
+            "$ref": "#/definitions/ModelSku"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "maxCapacity": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The max capacity."
+        },
+        "capabilities": {
+          "type": "object",
+          "description": "The capabilities.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "finetuneCapabilities": {
+          "type": "object",
+          "description": "The capabilities for finetune models.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "deprecation": {
+          "$ref": "#/definitions/ModelDeprecationInfo",
+          "description": "Cognitive Services account ModelDeprecationInfo."
+        },
+        "replacementConfig": {
+          "$ref": "#/definitions/ReplacementConfig",
+          "description": "Configuration for model replacement."
+        },
+        "modelCatalogAssetId": {
+          "type": "string",
+          "description": "Asset identifier for the model in the model catalog."
+        },
+        "lifecycleStatus": {
+          "$ref": "#/definitions/ModelLifecycleStatus",
+          "description": "Model lifecycle status."
+        },
+        "systemData": {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/systemData",
+          "description": "Metadata pertaining to creation and last modification of the resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/DeploymentModel"
+        }
+      ]
+    },
+    "AccountModelListResult": {
+      "type": "object",
+      "description": "The list of cognitive services accounts operation response.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of Model."
+        },
+        "value": {
+          "type": "array",
+          "description": "Gets the list of Cognitive Services accounts Model and their properties.",
+          "items": {
+            "$ref": "#/definitions/AccountModel"
+          },
+          "x-ms-identifiers": [
+            "name",
+            "format",
+            "version"
+          ]
+        }
+      }
+    },
+    "AccountProperties": {
+      "type": "object",
+      "description": "Properties of Cognitive Services account.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "Gets the status of the cognitive services account at the time the operation was called.",
+          "readOnly": true
+        },
+        "endpoint": {
+          "type": "string",
+          "description": "Endpoint of the created account.",
+          "readOnly": true
+        },
+        "internalId": {
+          "type": "string",
+          "description": "The internal identifier (deprecated, do not use this property).",
+          "readOnly": true
+        },
+        "capabilities": {
+          "type": "array",
+          "description": "Gets the capabilities of the cognitive services account. Each item indicates the capability of a specific feature. The values are read-only and for reference only.",
+          "items": {
+            "$ref": "#/definitions/SkuCapability"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "isMigrated": {
+          "type": "boolean",
+          "description": "If the resource is migrated from an existing key.",
+          "readOnly": true
+        },
+        "migrationToken": {
+          "type": "string",
+          "description": "Resource migration token."
+        },
+        "skuChangeInfo": {
+          "$ref": "#/definitions/SkuChangeInfo",
+          "description": "Sku change info of account.",
+          "readOnly": true
+        },
+        "customSubDomainName": {
+          "type": "string",
+          "description": "Optional subdomain name used for token-based authentication."
+        },
+        "networkAcls": {
+          "$ref": "#/definitions/NetworkRuleSet",
+          "description": "A collection of rules governing the accessibility from specific network locations."
+        },
+        "encryption": {
+          "$ref": "#/definitions/Encryption",
+          "description": "The encryption properties for this resource."
+        },
+        "userOwnedStorage": {
+          "type": "array",
+          "description": "The storage accounts for this resource.",
+          "items": {
+            "$ref": "#/definitions/UserOwnedStorage"
+          },
+          "x-ms-identifiers": [
+            "resourceId"
+          ]
+        },
+        "amlWorkspace": {
+          "$ref": "#/definitions/UserOwnedAmlWorkspace",
+          "description": "The user owned AML account properties."
+        },
+        "privateEndpointConnections": {
+          "type": "array",
+          "description": "The private endpoint connection associated with the Cognitive Services account.",
+          "items": {
+            "$ref": "#/definitions/PrivateEndpointConnection"
+          },
+          "readOnly": true
+        },
+        "publicNetworkAccess": {
+          "$ref": "#/definitions/PublicNetworkAccess",
+          "description": "Whether or not public endpoint access is allowed for this account."
+        },
+        "apiProperties": {
+          "$ref": "#/definitions/ApiProperties",
+          "description": "The api properties for special APIs."
+        },
+        "dateCreated": {
+          "type": "string",
+          "description": "Gets the date of cognitive services account creation.",
+          "readOnly": true
+        },
+        "callRateLimit": {
+          "$ref": "#/definitions/CallRateLimit",
+          "description": "The call rate limit Cognitive Services account.",
+          "readOnly": true
+        },
+        "dynamicThrottlingEnabled": {
+          "type": "boolean",
+          "description": "The flag to enable dynamic throttling."
+        },
+        "storedCompletionsDisabled": {
+          "type": "boolean",
+          "description": "The flag to disable stored completions."
+        },
+        "quotaLimit": {
+          "$ref": "#/definitions/QuotaLimit",
+          "readOnly": true
+        },
+        "restrictOutboundNetworkAccess": {
+          "type": "boolean"
+        },
+        "allowedFqdnList": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "disableLocalAuth": {
+          "type": "boolean"
+        },
+        "endpoints": {
+          "type": "object",
+          "description": "Dictionary of <string>",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "restore": {
+          "type": "boolean",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ]
+        },
+        "deletionDate": {
+          "type": "string",
+          "description": "The deletion date, only available for deleted account.",
+          "readOnly": true
+        },
+        "scheduledPurgeDate": {
+          "type": "string",
+          "description": "The scheduled purge date, only available for deleted account.",
+          "readOnly": true
+        },
+        "locations": {
+          "$ref": "#/definitions/MultiRegionSettings",
+          "description": "The multiregion settings of Cognitive Services account."
+        },
+        "commitmentPlanAssociations": {
+          "type": "array",
+          "description": "The commitment plan associations of Cognitive Services account.",
+          "items": {
+            "$ref": "#/definitions/CommitmentPlanAssociation"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "commitmentPlanId"
+          ]
+        },
+        "abusePenalty": {
+          "$ref": "#/definitions/AbusePenalty",
+          "description": "The abuse penalty.",
+          "readOnly": true
+        },
+        "raiMonitorConfig": {
+          "$ref": "#/definitions/RaiMonitorConfig",
+          "description": "Cognitive Services Rai Monitor Config."
+        },
+        "networkInjections": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NetworkInjection"
+          }
+        },
+        "allowProjectManagement": {
+          "type": "boolean",
+          "description": "Specifies whether this resource support project management as child resources, used as containers for access management, data isolation and cost in AI Foundry."
+        },
+        "defaultProject": {
+          "type": "string",
+          "description": "Specifies the project, by project name, that is targeted when data plane endpoints are called without a project parameter."
+        },
+        "associatedProjects": {
+          "type": "array",
+          "description": "Specifies the projects, by project name, that are associated with this resource.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "AccountSku": {
+      "type": "object",
+      "description": "Cognitive Services resource type and SKU.",
+      "properties": {
+        "resourceType": {
+          "type": "string",
+          "description": "Resource Namespace and Type"
+        },
+        "sku": {
+          "$ref": "#/definitions/Sku",
+          "description": "The SKU of Cognitive Services account."
+        }
+      }
+    },
+    "AccountSkuListResult": {
+      "type": "object",
+      "description": "The list of cognitive services accounts operation response.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "Gets the list of Cognitive Services accounts and their properties.",
+          "items": {
+            "$ref": "#/definitions/AccountSku"
+          },
+          "x-ms-identifiers": [
+            "sku/name",
+            "resourceType"
+          ]
+        }
+      }
+    },
+    "ActionType": {
+      "type": "string",
+      "description": "Enum. Indicates the action type. \"Internal\" refers to actions that are for internal only APIs.",
+      "enum": [
+        "Internal"
+      ],
+      "x-ms-enum": {
+        "name": "ActionType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Internal",
+            "value": "Internal"
+          }
+        ]
+      }
+    },
+    "AgentApplication": {
+      "type": "object",
+      "description": "Agent Application resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AgenticApplicationProperties",
+          "description": "[Required] Additional attributes of the entity."
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "AgentApplicationResourceArmPaginatedResult": {
+      "type": "object",
+      "description": "A paginated list of Agent Application entities.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link to the next page of Agent Application objects. If null, there are no additional pages.",
+          "x-nullable": true
+        },
+        "value": {
+          "type": "array",
+          "description": "An array of objects of type Agent Application.",
+          "items": {
+            "$ref": "#/definitions/AgentApplication"
+          }
+        }
+      }
+    },
+    "AgentCard": {
+      "type": "object",
+      "description": "Represents a detailed description of an agent, including its name, functionality, hosting information, supported interaction modes, and available skills.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Human-readable name for the Agent (e.g., 'Recipe Agent').",
+          "x-nullable": true
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of the Agent's function.",
+          "x-nullable": true
+        },
+        "url": {
+          "type": "string",
+          "description": "URL address where the Agent is hosted.",
+          "x-nullable": true
+        },
+        "provider": {
+          "$ref": "#/definitions/ProviderInfo",
+          "description": "Service provider information for the Agent.",
+          "x-nullable": true
+        },
+        "version": {
+          "type": "string",
+          "description": "Version of the Agent (format defined by provider, e.g., '1.0.0').",
+          "x-nullable": true
+        },
+        "documentationUrl": {
+          "type": "string",
+          "description": "URL for the Agent's documentation.",
+          "x-nullable": true
+        },
+        "defaultInputModes": {
+          "type": "array",
+          "description": "Default interaction modes supported by the Agent across all skills.",
+          "x-nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "defaultOutputModes": {
+          "type": "array",
+          "description": "Default output modes supported by the Agent across all skills.",
+          "x-nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "skills": {
+          "type": "array",
+          "description": "Collection of capability units the Agent can perform.",
+          "x-nullable": true,
+          "items": {
+            "$ref": "#/definitions/Skill"
+          }
+        }
+      }
+    },
+    "AgentDeployment": {
+      "type": "object",
+      "description": "Agent Deployment resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AgentDeploymentProperties",
+          "description": "[Required] Additional attributes of the entity."
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "AgentDeploymentProperties": {
+      "type": "object",
+      "description": "Type representing an agent deployment as a management construct.",
+      "properties": {
+        "displayName": {
+          "type": "string",
+          "description": "Gets or sets the display name of the deployment.",
+          "x-nullable": true
+        },
+        "deploymentId": {
+          "type": "string",
+          "description": "Gets or sets the unique identifier of the deployment.",
+          "x-nullable": true
+        },
+        "state": {
+          "$ref": "#/definitions/AgentDeploymentState",
+          "description": "Gets or sets the current operational state of the deployment (and, intrinsically, of the comprising agents).",
+          "x-nullable": true
+        },
+        "protocols": {
+          "type": "array",
+          "description": "Gets or sets the supported protocol types and versions exposed by this deployment.",
+          "x-nullable": true,
+          "items": {
+            "$ref": "#/definitions/AgentProtocolVersion"
+          }
+        },
+        "agents": {
+          "type": "array",
+          "description": "Returns a flat list of agent:version deployed in this deployment.",
+          "x-nullable": true,
+          "items": {
+            "$ref": "#/definitions/VersionedAgentReference"
+          }
+        },
+        "deploymentType": {
+          "$ref": "#/definitions/AgentDeploymentType",
+          "description": "Gets or sets the type of deployment for the agent."
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/AgentDeploymentProvisioningState",
+          "description": "Gets or sets the provisioning state of the agent deployment.",
+          "readOnly": true
+        }
+      },
+      "discriminator": "deploymentType",
+      "required": [
+        "deploymentType"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ResourceBase"
+        }
+      ]
+    },
+    "AgentDeploymentProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of an agentic deployment, as an Azure resource.",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Creating",
+        "Updating",
+        "Deleting"
+      ],
+      "x-ms-enum": {
+        "name": "AgentDeploymentProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "The deployment was successfully completed."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "The deployment failed."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "The deployment was canceled."
+          },
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "The deployment is being created."
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "The deployment is being updated."
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "The deployment is being deleted."
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "AgentDeploymentResourceArmPaginatedResult": {
+      "type": "object",
+      "description": "A paginated list of Agent Deployment entities.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link to the next page of Agent Deployment objects. If null, there are no additional pages.",
+          "x-nullable": true
+        },
+        "value": {
+          "type": "array",
+          "description": "An array of objects of type Agent Deployment.",
+          "items": {
+            "$ref": "#/definitions/AgentDeployment"
+          }
+        }
+      }
+    },
+    "AgentDeploymentState": {
+      "type": "string",
+      "description": "Current operational state of the agentic functionality represented by this deployment.",
+      "enum": [
+        "Starting",
+        "Running",
+        "Stopping",
+        "Stopped",
+        "Failed",
+        "Deleting",
+        "Deleted",
+        "Updating"
+      ],
+      "x-ms-enum": {
+        "name": "AgentDeploymentState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Starting",
+            "value": "Starting",
+            "description": "The deployment is starting."
+          },
+          {
+            "name": "Running",
+            "value": "Running",
+            "description": "The deployment started/is operational."
+          },
+          {
+            "name": "Stopping",
+            "value": "Stopping",
+            "description": "The deployment is being stopped."
+          },
+          {
+            "name": "Stopped",
+            "value": "Stopped",
+            "description": "The deployment was stopped."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "The deployment failed."
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "The deployment is being deleted."
+          },
+          {
+            "name": "Deleted",
+            "value": "Deleted",
+            "description": "The deployment was deleted."
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "The deployment is being updated."
+          }
+        ]
+      }
+    },
+    "AgentDeploymentType": {
+      "type": "string",
+      "description": "Specifies the type of deployment for an agent, indicating how the underlying compute and network infrastructure is managed.",
+      "enum": [
+        "Managed",
+        "Hosted",
+        "Custom"
+      ],
+      "x-ms-enum": {
+        "name": "AgentDeploymentType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Managed",
+            "value": "Managed",
+            "description": "The underlying infra is managed by the platform in the deployer's subscription"
+          },
+          {
+            "name": "Hosted",
+            "value": "Hosted",
+            "description": "The underlying infra is owned by the platform"
+          },
+          {
+            "name": "Custom",
+            "value": "Custom",
+            "description": "The underlying infra is provisioned by the deployer (BYO)"
+          }
+        ]
+      }
+    },
+    "AgentProtocol": {
+      "type": "string",
+      "description": "Protocol used by the agent/exposed by a deployment.",
+      "enum": [
+        "Agent",
+        "A2A",
+        "Responses"
+      ],
+      "x-ms-enum": {
+        "name": "AgentProtocol",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Agent",
+            "value": "Agent",
+            "description": "Agent protocol (aka Active)"
+          },
+          {
+            "name": "A2A",
+            "value": "A2A",
+            "description": "Agent2Agent standard"
+          },
+          {
+            "name": "Responses",
+            "value": "Responses",
+            "description": "OpenAI-compatible"
+          }
+        ]
+      }
+    },
+    "AgentProtocolVersion": {
+      "type": "object",
+      "description": "Type modeling the protocol and version used by an agent/exposed by a deployment.",
+      "properties": {
+        "protocol": {
+          "$ref": "#/definitions/AgentProtocol",
+          "description": "The protocol used by the agent/exposed by a deployment."
+        },
+        "version": {
+          "type": "string",
+          "description": "The version of the protocol.",
+          "x-nullable": true
+        }
+      }
+    },
+    "AgentReference": {
+      "type": "object",
+      "description": "Agent Reference resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AgentReferenceProperties",
+          "description": "[Required] Additional attributes of the entity."
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "AgentReferenceProperties": {
+      "type": "object",
+      "description": "Type modeling a reference to a version of an agent definition.",
+      "properties": {
+        "agentId": {
+          "type": "string",
+          "description": "Gets the agent's unique identifier within the organization (subscription).",
+          "x-nullable": true
+        },
+        "agentName": {
+          "type": "string",
+          "description": "Gets the agent's name (unique within the project/app).",
+          "x-nullable": true
+        }
+      }
+    },
+    "AgentReferenceResourceArmPaginatedResult": {
+      "type": "object",
+      "description": "A paginated list of Agent Reference entities.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link to the next page of Agent Reference objects. If null, there are no additional pages.",
+          "x-nullable": true
+        },
+        "value": {
+          "type": "array",
+          "description": "An array of objects of type Agent Reference.",
+          "x-nullable": true,
+          "items": {
+            "$ref": "#/definitions/AgentReference"
+          }
+        }
+      }
+    },
+    "AgenticApplicationProperties": {
+      "type": "object",
+      "description": "Resource type representing an agentic application as a management construct.",
+      "properties": {
+        "displayName": {
+          "type": "string",
+          "description": "The display name of the application.",
+          "x-nullable": true
+        },
+        "baseUrl": {
+          "type": "string",
+          "description": "The application's dedicated invocation endpoint.",
+          "x-nullable": true
+        },
+        "agents": {
+          "type": "array",
+          "description": "The list of agent definitions comprising this application, returned as references to the objects under the parent project; use this to obtain a flat list of all agent-version pairs represented by this application.",
+          "x-nullable": true,
+          "items": {
+            "$ref": "#/definitions/AgentReferenceProperties"
+          }
+        },
+        "agentIdentityBlueprint": {
+          "$ref": "#/definitions/AssignedIdentity",
+          "description": "The EntraId Agentic Blueprint of the application.",
+          "x-nullable": true
+        },
+        "defaultInstanceIdentity": {
+          "$ref": "#/definitions/AssignedIdentity",
+          "description": "The (default) agent instance identity of the application.",
+          "x-nullable": true
+        },
+        "authorizationPolicy": {
+          "$ref": "#/definitions/ApplicationAuthorizationPolicy",
+          "description": "Gets or sets the authorization policy associated with this agentic application instance.",
+          "x-nullable": true
+        },
+        "trafficRoutingPolicy": {
+          "$ref": "#/definitions/ApplicationTrafficRoutingPolicy",
+          "description": "Gets or sets the traffic routing policy for the application's deployments.",
+          "x-nullable": true
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/AgenticApplicationProvisioningState",
+          "description": "Provisioning state of the application.",
+          "readOnly": true
+        },
+        "isEnabled": {
+          "type": "boolean",
+          "description": "Enabledstate of the application.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ResourceBase"
+        }
+      ]
+    },
+    "AgenticApplicationProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of an agentic application.",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Creating",
+        "Updating",
+        "Deleting"
+      ],
+      "x-ms-enum": {
+        "name": "AgenticApplicationProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "The application was successfully provisioned."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "The application provisioning failed."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "The application provisioning was canceled."
+          },
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "The application is being created."
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "The application is being updated."
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "The application is being deleted."
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "ApiKeyAuthConnectionProperties": {
+      "type": "object",
+      "description": "This connection type covers the generic ApiKey auth connection categories, for examples:\nAzureOpenAI:\nCategory:= AzureOpenAI\nAuthType:= ApiKey (as type discriminator)\nCredentials:= {ApiKey} as .ApiKey\nTarget:= {ApiBase}\n\nCognitiveService:\nCategory:= CognitiveService\nAuthType:= ApiKey (as type discriminator)\nCredentials:= {SubscriptionKey} as ApiKey\nTarget:= ServiceRegion={serviceRegion}\n\nCognitiveSearch:\nCategory:= CognitiveSearch\nAuthType:= ApiKey (as type discriminator)\nCredentials:= {Key} as ApiKey\nTarget:= {Endpoint}\n\nUse Metadata property bag for ApiType, ApiVersion, Kind and other metadata fields",
+      "properties": {
+        "credentials": {
+          "$ref": "#/definitions/ConnectionApiKey",
+          "description": "Api key object for connection credential."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ConnectionPropertiesV2"
+        }
+      ],
+      "x-ms-discriminator-value": "ApiKey"
+    },
+    "ApiKeys": {
+      "type": "object",
+      "description": "The access keys for the cognitive services account.",
+      "properties": {
+        "key1": {
+          "type": "string",
+          "description": "Gets the value of key 1."
+        },
+        "key2": {
+          "type": "string",
+          "description": "Gets the value of key 2."
+        }
+      }
+    },
+    "ApiProperties": {
+      "type": "object",
+      "description": "The api properties for special APIs.",
+      "properties": {
+        "qnaRuntimeEndpoint": {
+          "type": "string",
+          "description": "(QnAMaker Only) The runtime endpoint of QnAMaker."
+        },
+        "qnaAzureSearchEndpointKey": {
+          "type": "string",
+          "description": "(QnAMaker Only) The Azure Search endpoint key of QnAMaker."
+        },
+        "qnaAzureSearchEndpointId": {
+          "type": "string",
+          "description": "(QnAMaker Only) The Azure Search endpoint id of QnAMaker."
+        },
+        "statisticsEnabled": {
+          "type": "boolean",
+          "description": "(Bing Search Only) The flag to enable statistics of Bing Search."
+        },
+        "eventHubConnectionString": {
+          "type": "string",
+          "description": "(Personalization Only) The flag to enable statistics of Bing Search.",
+          "maxLength": 1000,
+          "pattern": "^( *)Endpoint=sb://(.*);( *)SharedAccessKeyName=(.*);( *)SharedAccessKey=(.*)$"
+        },
+        "storageAccountConnectionString": {
+          "type": "string",
+          "description": "(Personalization Only) The storage account connection string.",
+          "maxLength": 1000,
+          "pattern": "^(( *)DefaultEndpointsProtocol=(http|https)( *);( *))?AccountName=(.*)AccountKey=(.*)EndpointSuffix=(.*)$"
+        },
+        "aadClientId": {
+          "type": "string",
+          "description": "(Metrics Advisor Only) The Azure AD Client Id (Application Id).",
+          "maxLength": 500
+        },
+        "aadTenantId": {
+          "type": "string",
+          "description": "(Metrics Advisor Only) The Azure AD Tenant Id.",
+          "maxLength": 500
+        },
+        "superUser": {
+          "type": "string",
+          "description": "(Metrics Advisor Only) The super user of Metrics Advisor.",
+          "maxLength": 500
+        },
+        "websiteName": {
+          "type": "string",
+          "description": "(Metrics Advisor Only) The website name of Metrics Advisor.",
+          "maxLength": 500
+        }
+      },
+      "additionalProperties": {}
+    },
+    "ApplicationAuthorizationPolicy": {
+      "type": "object",
+      "description": "Represents a policy for authorizing applications based on specified authentication and authorization schemes.",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/BuiltInAuthorizationScheme",
+          "description": "Authorization scheme type."
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "type"
+      ]
+    },
+    "ApplicationTrafficRoutingPolicy": {
+      "type": "object",
+      "description": "Type representing an application traffic policy as a property of an agentic application.",
+      "properties": {
+        "protocol": {
+          "$ref": "#/definitions/TrafficRoutingProtocol",
+          "description": "Methodology used to route traffic to the application's deployments."
+        },
+        "rules": {
+          "type": "array",
+          "description": "Gets or sets the collection of traffic routing rules.",
+          "x-nullable": true,
+          "items": {
+            "$ref": "#/definitions/TrafficRoutingRule"
+          }
+        }
+      }
+    },
+    "AssignedIdentity": {
+      "type": "object",
+      "description": "Type representing an identity assignment",
+      "properties": {
+        "kind": {
+          "$ref": "#/definitions/IdentityKind",
+          "description": "Specifies the kind of Entra identity described by this object."
+        },
+        "type": {
+          "$ref": "#/definitions/IdentityManagementType",
+          "description": "Enumeration of identity types, from the perspective of management."
+        },
+        "clientId": {
+          "type": "string",
+          "description": "The client ID of the identity."
+        },
+        "principalId": {
+          "type": "string",
+          "description": "The principal ID of the identity."
+        },
+        "tenantId": {
+          "type": "string",
+          "description": "The tenant ID of the identity."
+        },
+        "subject": {
+          "type": "string",
+          "description": "The subject of this identity assignment.",
+          "x-nullable": true
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/IdentityProvisioningState",
+          "description": "Represents the provisioning state of an identity resource.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "kind",
+        "type",
+        "clientId",
+        "principalId",
+        "tenantId"
+      ]
+    },
+    "Azure.Core.uuid": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Universally Unique Identifier"
+    },
+    "BillingMeterInfo": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "meterId": {
+          "type": "string"
+        },
+        "unit": {
+          "type": "string"
+        }
+      }
+    },
+    "BuiltInAuthorizationScheme": {
+      "type": "string",
+      "description": "Authorization scheme type.",
+      "enum": [
+        "Default",
+        "OrganizationScope",
+        "Channels",
+        "Custom"
+      ],
+      "x-ms-enum": {
+        "name": "BuiltInAuthorizationScheme",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Default",
+            "value": "Default",
+            "description": "Standard AzureML RBAC"
+          },
+          {
+            "name": "OrganizationScope",
+            "value": "OrganizationScope",
+            "description": "Claim-based, requires membership in the tenant"
+          },
+          {
+            "name": "Channels",
+            "value": "Channels",
+            "description": "Channels-specific (AzureBotService) authorization"
+          },
+          {
+            "name": "Custom",
+            "value": "Custom",
+            "description": "Custom scheme defined by the application author"
+          }
+        ]
+      }
+    },
+    "ByPassSelection": {
+      "type": "string",
+      "description": "Setting for trusted services.",
+      "enum": [
+        "None",
+        "AzureServices"
+      ],
+      "x-ms-enum": {
+        "name": "ByPassSelection",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None"
+          },
+          {
+            "name": "AzureServices",
+            "value": "AzureServices"
+          }
+        ]
+      }
+    },
+    "CalculateModelCapacityParameter": {
+      "type": "object",
+      "description": "Calculate Model Capacity parameter.",
+      "properties": {
+        "model": {
+          "$ref": "#/definitions/DeploymentModel",
+          "description": "Properties of Cognitive Services account deployment model."
+        },
+        "skuName": {
+          "type": "string",
+          "description": "The name of SKU."
+        },
+        "workloads": {
+          "type": "array",
+          "description": "List of Model Capacity Calculator Workload.",
+          "items": {
+            "$ref": "#/definitions/ModelCapacityCalculatorWorkload"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "CalculateModelCapacityResult": {
+      "type": "object",
+      "description": "Calculate Model Capacity result.",
+      "properties": {
+        "model": {
+          "$ref": "#/definitions/DeploymentModel",
+          "description": "Properties of Cognitive Services account deployment model."
+        },
+        "skuName": {
+          "type": "string"
+        },
+        "estimatedCapacity": {
+          "$ref": "#/definitions/CalculateModelCapacityResultEstimatedCapacity",
+          "description": "Model Estimated Capacity."
+        }
+      }
+    },
+    "CalculateModelCapacityResultEstimatedCapacity": {
+      "type": "object",
+      "description": "Model Estimated Capacity.",
+      "properties": {
+        "value": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "deployableValue": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "CallRateLimit": {
+      "type": "object",
+      "description": "The call rate limit Cognitive Services account.",
+      "properties": {
+        "count": {
+          "type": "number",
+          "format": "float",
+          "description": "The count value of Call Rate Limit."
+        },
+        "renewalPeriod": {
+          "type": "number",
+          "format": "float",
+          "description": "The renewal period in seconds of Call Rate Limit."
+        },
+        "rules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ThrottlingRule"
+          },
+          "x-ms-identifiers": [
+            "key"
+          ]
+        }
+      }
+    },
+    "CapabilityHost": {
+      "type": "object",
+      "description": "Azure Resource Manager resource envelope.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/CapabilityHostProperties",
+          "description": "[Required] Additional attributes of the entity."
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "CapabilityHostKind": {
+      "type": "string",
+      "enum": [
+        "Agents"
+      ],
+      "x-ms-enum": {
+        "name": "CapabilityHostKind",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Agents",
+            "value": "Agents"
+          }
+        ]
+      }
+    },
+    "CapabilityHostProperties": {
+      "type": "object",
+      "properties": {
+        "aiServicesConnections": {
+          "type": "array",
+          "description": "List of AI services connections.",
+          "x-nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "capabilityHostKind": {
+          "$ref": "#/definitions/CapabilityHostKind",
+          "description": "Kind of this capability host."
+        },
+        "customerSubnet": {
+          "type": "string",
+          "description": "Customer subnet info to help set up this capability host.",
+          "x-nullable": true
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/CapabilityHostProvisioningState",
+          "description": "Provisioning state for the CapabilityHost.",
+          "readOnly": true
+        },
+        "storageConnections": {
+          "type": "array",
+          "description": "List of connection names from those available in the account or project to be used as a storage resource.",
+          "x-nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "threadStorageConnections": {
+          "type": "array",
+          "description": "List of connection names from those available in the account or project to be used for Thread storage.",
+          "x-nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "vectorStoreConnections": {
+          "type": "array",
+          "description": "List of connection names from those available in the account or project to be used for vector database (e.g. CosmosDB).",
+          "x-nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "enablePublicHostingEnvironment": {
+          "type": "boolean",
+          "description": "Whether public hosting environment is enabled for the capability host"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ResourceBase"
+        }
+      ]
+    },
+    "CapabilityHostProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of capability host.",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Creating",
+        "Updating",
+        "Deleting"
+      ],
+      "x-ms-enum": {
+        "name": "CapabilityHostProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled"
+          },
+          {
+            "name": "Creating",
+            "value": "Creating"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting"
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "CapabilityHostResourceArmPaginatedResult": {
+      "type": "object",
+      "description": "A paginated list of Capability Host entities.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link to the next page of Capability Host objects. If null, there are no additional pages.",
+          "x-nullable": true
+        },
+        "value": {
+          "type": "array",
+          "description": "An array of objects of type Capability Host.",
+          "items": {
+            "$ref": "#/definitions/CapabilityHost"
+          }
+        }
+      }
+    },
+    "CapacityConfig": {
+      "type": "object",
+      "description": "The capacity configuration.",
+      "properties": {
+        "minimum": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The minimum capacity."
+        },
+        "maximum": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum capacity."
+        },
+        "step": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The minimal incremental between allowed values for capacity."
+        },
+        "default": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The default capacity."
+        },
+        "allowedValues": {
+          "type": "array",
+          "description": "The array of allowed values for capacity.",
+          "items": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      }
+    },
+    "ChannelsBuiltInAuthorizationPolicy": {
+      "type": "object",
+      "description": "Represents a built-in authorization policy specific to Azure Bot Service/Channels authentication.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ApplicationAuthorizationPolicy"
+        }
+      ],
+      "x-ms-discriminator-value": "Channels"
+    },
+    "CheckDomainAvailabilityParameter": {
+      "type": "object",
+      "description": "Check Domain availability parameter.",
+      "properties": {
+        "subdomainName": {
+          "type": "string",
+          "description": "The subdomain name to use."
+        },
+        "type": {
+          "type": "string",
+          "description": "The Type of the resource."
+        },
+        "kind": {
+          "type": "string",
+          "description": "The kind (type) of cognitive service account."
+        }
+      },
+      "required": [
+        "subdomainName",
+        "type"
+      ]
+    },
+    "CheckSkuAvailabilityParameter": {
+      "type": "object",
+      "description": "Check SKU availability parameter.",
+      "properties": {
+        "skus": {
+          "type": "array",
+          "description": "The SKU of the resource.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "The kind (type) of cognitive service account."
+        },
+        "type": {
+          "type": "string",
+          "description": "The Type of the resource."
+        }
+      },
+      "required": [
+        "skus",
+        "kind",
+        "type"
+      ]
+    },
+    "CommitmentCost": {
+      "type": "object",
+      "description": "Cognitive Services account commitment cost.",
+      "properties": {
+        "commitmentMeterId": {
+          "type": "string",
+          "description": "Commitment meter Id."
+        },
+        "overageMeterId": {
+          "type": "string",
+          "description": "Overage meter Id."
+        }
+      }
+    },
+    "CommitmentPeriod": {
+      "type": "object",
+      "description": "Cognitive Services account commitment period.",
+      "properties": {
+        "tier": {
+          "type": "string",
+          "description": "Commitment period commitment tier."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Commitment period commitment count."
+        },
+        "quota": {
+          "$ref": "#/definitions/CommitmentQuota",
+          "description": "Cognitive Services account commitment quota.",
+          "readOnly": true
+        },
+        "startDate": {
+          "type": "string",
+          "description": "Commitment period start date.",
+          "readOnly": true
+        },
+        "endDate": {
+          "type": "string",
+          "description": "Commitment period end date.",
+          "readOnly": true
+        }
+      }
+    },
+    "CommitmentPlan": {
+      "type": "object",
+      "description": "Cognitive Services account commitment plan.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/CommitmentPlanProperties",
+          "description": "Properties of Cognitive Services account commitment plan."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "etag": {
+          "type": "string",
+          "description": "Resource Etag.",
+          "readOnly": true
+        },
+        "kind": {
+          "type": "string",
+          "description": "The kind (type) of cognitive service account."
+        },
+        "sku": {
+          "$ref": "#/definitions/Sku",
+          "description": "The resource model definition representing SKU"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "CommitmentPlanAccountAssociation": {
+      "type": "object",
+      "description": "The commitment plan association.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/CommitmentPlanAccountAssociationProperties",
+          "description": "Properties of Cognitive Services account commitment plan association.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "Resource Etag.",
+          "readOnly": true
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "CommitmentPlanAccountAssociationListResult": {
+      "type": "object",
+      "description": "The list of cognitive services Commitment Plan Account Association operation response.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of Commitment Plan Account Association."
+        },
+        "value": {
+          "type": "array",
+          "description": "Gets the list of Cognitive Services Commitment Plan Account Association and their properties.",
+          "items": {
+            "$ref": "#/definitions/CommitmentPlanAccountAssociation"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "id"
+          ]
+        }
+      }
+    },
+    "CommitmentPlanAccountAssociationProperties": {
+      "type": "object",
+      "description": "The commitment plan account association properties.",
+      "properties": {
+        "accountId": {
+          "type": "string",
+          "description": "The Azure resource id of the account."
+        }
+      }
+    },
+    "CommitmentPlanAssociation": {
+      "type": "object",
+      "description": "The commitment plan association.",
+      "properties": {
+        "commitmentPlanId": {
+          "type": "string",
+          "description": "The Azure resource id of the commitment plan."
+        },
+        "commitmentPlanLocation": {
+          "type": "string",
+          "description": "The location of of the commitment plan."
+        }
+      }
+    },
+    "CommitmentPlanListResult": {
+      "type": "object",
+      "description": "The list of cognitive services accounts operation response.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of CommitmentPlan."
+        },
+        "value": {
+          "type": "array",
+          "description": "Gets the list of Cognitive Services accounts CommitmentPlan and their properties.",
+          "items": {
+            "$ref": "#/definitions/CommitmentPlan"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "CommitmentPlanProperties": {
+      "type": "object",
+      "description": "Properties of Cognitive Services account commitment plan.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/CommitmentPlanProvisioningState",
+          "description": "Gets the status of the resource at the time the operation was called.",
+          "readOnly": true
+        },
+        "commitmentPlanGuid": {
+          "type": "string",
+          "description": "Commitment plan guid."
+        },
+        "hostingModel": {
+          "$ref": "#/definitions/HostingModel",
+          "description": "Account hosting model."
+        },
+        "planType": {
+          "type": "string",
+          "description": "Commitment plan type."
+        },
+        "current": {
+          "$ref": "#/definitions/CommitmentPeriod",
+          "description": "Cognitive Services account commitment period."
+        },
+        "autoRenew": {
+          "type": "boolean",
+          "description": "AutoRenew commitment plan."
+        },
+        "next": {
+          "$ref": "#/definitions/CommitmentPeriod",
+          "description": "Cognitive Services account commitment period."
+        },
+        "last": {
+          "$ref": "#/definitions/CommitmentPeriod",
+          "description": "Cognitive Services account commitment period.",
+          "readOnly": true
+        },
+        "provisioningIssues": {
+          "type": "array",
+          "description": "The list of ProvisioningIssue.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "CommitmentPlanProvisioningState": {
+      "type": "string",
+      "description": "Gets the status of the resource at the time the operation was called.",
+      "enum": [
+        "Accepted",
+        "Creating",
+        "Deleting",
+        "Moving",
+        "Failed",
+        "Succeeded",
+        "Canceled"
+      ],
+      "x-ms-enum": {
+        "name": "CommitmentPlanProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Accepted",
+            "value": "Accepted"
+          },
+          {
+            "name": "Creating",
+            "value": "Creating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting"
+          },
+          {
+            "name": "Moving",
+            "value": "Moving"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled"
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "CommitmentQuota": {
+      "type": "object",
+      "description": "Cognitive Services account commitment quota.",
+      "properties": {
+        "quantity": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Commitment quota quantity."
+        },
+        "unit": {
+          "type": "string",
+          "description": "Commitment quota unit."
+        }
+      }
+    },
+    "CommitmentTier": {
+      "type": "object",
+      "description": "Cognitive Services account commitment tier.",
+      "properties": {
+        "kind": {
+          "type": "string",
+          "description": "The kind (type) of cognitive service account."
+        },
+        "skuName": {
+          "type": "string",
+          "description": "The name of the SKU. Ex - P3. It is typically a letter+number code"
+        },
+        "hostingModel": {
+          "$ref": "#/definitions/HostingModel",
+          "description": "Account hosting model."
+        },
+        "planType": {
+          "type": "string",
+          "description": "Commitment plan type."
+        },
+        "tier": {
+          "type": "string",
+          "description": "Commitment period commitment tier."
+        },
+        "maxCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Commitment period commitment max count."
+        },
+        "quota": {
+          "$ref": "#/definitions/CommitmentQuota",
+          "description": "Cognitive Services account commitment quota."
+        },
+        "cost": {
+          "$ref": "#/definitions/CommitmentCost",
+          "description": "Cognitive Services account commitment cost."
+        }
+      }
+    },
+    "CommitmentTierListResult": {
+      "type": "object",
+      "description": "The list of cognitive services accounts operation response.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of CommitmentTier."
+        },
+        "value": {
+          "type": "array",
+          "description": "Gets the list of Cognitive Services accounts CommitmentTier and their properties.",
+          "items": {
+            "$ref": "#/definitions/CommitmentTier"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "kind",
+            "tier",
+            "skuName",
+            "hostingModel",
+            "planType"
+          ]
+        }
+      }
+    },
+    "ConnectionAccessKey": {
+      "type": "object",
+      "properties": {
+        "accessKeyId": {
+          "type": "string"
+        },
+        "secretAccessKey": {
+          "type": "string",
+          "format": "password",
+          "x-ms-secret": true
+        }
+      }
+    },
+    "ConnectionAccountKey": {
+      "type": "object",
+      "description": "Account key object for connection credential.",
+      "properties": {
+        "key": {
+          "type": "string",
+          "format": "password",
+          "x-ms-secret": true
+        }
+      }
+    },
+    "ConnectionApiKey": {
+      "type": "object",
+      "description": "Api key object for connection credential.",
+      "properties": {
+        "key": {
+          "type": "string",
+          "format": "password",
+          "x-ms-secret": true
+        }
+      }
+    },
+    "ConnectionAuthType": {
+      "type": "string",
+      "description": "Authentication type of the connection target",
+      "enum": [
+        "PAT",
+        "ManagedIdentity",
+        "UsernamePassword",
+        "None",
+        "SAS",
+        "AccountKey",
+        "ServicePrincipal",
+        "AccessKey",
+        "ApiKey",
+        "CustomKeys",
+        "OAuth2",
+        "AAD",
+        "DelegatedSAS",
+        "ProjectManagedIdentity",
+        "AccountManagedIdentity",
+        "UserEntraToken",
+        "AgentUserImpersonation",
+        "AgenticIdentityToken",
+        "AgenticUser"
+      ],
+      "x-ms-enum": {
+        "name": "ConnectionAuthType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "PAT",
+            "value": "PAT"
+          },
+          {
+            "name": "ManagedIdentity",
+            "value": "ManagedIdentity"
+          },
+          {
+            "name": "UsernamePassword",
+            "value": "UsernamePassword"
+          },
+          {
+            "name": "None",
+            "value": "None"
+          },
+          {
+            "name": "SAS",
+            "value": "SAS"
+          },
+          {
+            "name": "AccountKey",
+            "value": "AccountKey"
+          },
+          {
+            "name": "ServicePrincipal",
+            "value": "ServicePrincipal"
+          },
+          {
+            "name": "AccessKey",
+            "value": "AccessKey"
+          },
+          {
+            "name": "ApiKey",
+            "value": "ApiKey"
+          },
+          {
+            "name": "CustomKeys",
+            "value": "CustomKeys"
+          },
+          {
+            "name": "OAuth2",
+            "value": "OAuth2"
+          },
+          {
+            "name": "AAD",
+            "value": "AAD"
+          },
+          {
+            "name": "DelegatedSAS",
+            "value": "DelegatedSAS"
+          },
+          {
+            "name": "ProjectManagedIdentity",
+            "value": "ProjectManagedIdentity"
+          },
+          {
+            "name": "AccountManagedIdentity",
+            "value": "AccountManagedIdentity"
+          },
+          {
+            "name": "UserEntraToken",
+            "value": "UserEntraToken"
+          },
+          {
+            "name": "AgentUserImpersonation",
+            "value": "AgentUserImpersonation"
+          },
+          {
+            "name": "AgenticIdentityToken",
+            "value": "AgenticIdentityToken"
+          },
+          {
+            "name": "AgenticUser",
+            "value": "AgenticUser"
+          }
+        ]
+      }
+    },
+    "ConnectionCategory": {
+      "type": "string",
+      "description": "Category of the connection",
+      "enum": [
+        "PythonFeed",
+        "ContainerRegistry",
+        "Git",
+        "S3",
+        "Snowflake",
+        "AzureKeyVault",
+        "AzureSqlDb",
+        "AzureSynapseAnalytics",
+        "AzureMySqlDb",
+        "AzurePostgresDb",
+        "ADLSGen2",
+        "AzureContainerAppEnvironment",
+        "Redis",
+        "ApiKey",
+        "AzureOpenAI",
+        "AIServices",
+        "CognitiveSearch",
+        "CognitiveService",
+        "CustomKeys",
+        "AzureBlob",
+        "AzureStorageAccount",
+        "AzureOneLake",
+        "CosmosDb",
+        "CosmosDbMongoDbApi",
+        "AzureDataExplorer",
+        "AzureMariaDb",
+        "AzureDatabricksDeltaLake",
+        "AzureSqlMi",
+        "AzureTableStorage",
+        "AmazonRdsForOracle",
+        "AmazonRdsForSqlServer",
+        "AmazonRedshift",
+        "Db2",
+        "Drill",
+        "GoogleBigQuery",
+        "Greenplum",
+        "Hbase",
+        "Hive",
+        "Impala",
+        "Informix",
+        "MariaDb",
+        "MicrosoftAccess",
+        "MySql",
+        "Netezza",
+        "Oracle",
+        "Phoenix",
+        "PostgreSql",
+        "Presto",
+        "SapOpenHub",
+        "SapBw",
+        "SapHana",
+        "SapTable",
+        "Spark",
+        "SqlServer",
+        "Sybase",
+        "Teradata",
+        "Vertica",
+        "Pinecone",
+        "Databricks",
+        "Cassandra",
+        "Couchbase",
+        "MongoDbV2",
+        "MongoDbAtlas",
+        "AmazonS3Compatible",
+        "FileServer",
+        "FtpServer",
+        "GoogleCloudStorage",
+        "Hdfs",
+        "OracleCloudStorage",
+        "Sftp",
+        "GenericHttp",
+        "ODataRest",
+        "Odbc",
+        "GenericRest",
+        "RemoteTool",
+        "AmazonMws",
+        "Concur",
+        "Dynamics",
+        "DynamicsAx",
+        "DynamicsCrm",
+        "GoogleAdWords",
+        "Hubspot",
+        "Jira",
+        "Magento",
+        "Marketo",
+        "Office365",
+        "Eloqua",
+        "Responsys",
+        "OracleServiceCloud",
+        "PayPal",
+        "QuickBooks",
+        "Salesforce",
+        "SalesforceServiceCloud",
+        "SalesforceMarketingCloud",
+        "SapCloudForCustomer",
+        "SapEcc",
+        "ServiceNow",
+        "SharePointOnlineList",
+        "Shopify",
+        "Square",
+        "WebTable",
+        "Xero",
+        "Zoho",
+        "GenericContainerRegistry",
+        "Elasticsearch",
+        "AppInsights",
+        "AppConfig",
+        "OpenAI",
+        "Serp",
+        "BingLLMSearch",
+        "Serverless",
+        "ManagedOnlineEndpoint",
+        "ApiManagement",
+        "ModelGateway",
+        "GroundingWithBingSearch",
+        "GroundingWithCustomSearch",
+        "Sharepoint",
+        "MicrosoftFabric",
+        "PowerPlatformEnvironment",
+        "RemoteA2A"
+      ],
+      "x-ms-enum": {
+        "name": "ConnectionCategory",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "PythonFeed",
+            "value": "PythonFeed"
+          },
+          {
+            "name": "ContainerRegistry",
+            "value": "ContainerRegistry"
+          },
+          {
+            "name": "Git",
+            "value": "Git"
+          },
+          {
+            "name": "S3",
+            "value": "S3"
+          },
+          {
+            "name": "Snowflake",
+            "value": "Snowflake"
+          },
+          {
+            "name": "AzureKeyVault",
+            "value": "AzureKeyVault"
+          },
+          {
+            "name": "AzureSqlDb",
+            "value": "AzureSqlDb"
+          },
+          {
+            "name": "AzureSynapseAnalytics",
+            "value": "AzureSynapseAnalytics"
+          },
+          {
+            "name": "AzureMySqlDb",
+            "value": "AzureMySqlDb"
+          },
+          {
+            "name": "AzurePostgresDb",
+            "value": "AzurePostgresDb"
+          },
+          {
+            "name": "ADLSGen2",
+            "value": "ADLSGen2"
+          },
+          {
+            "name": "AzureContainerAppEnvironment",
+            "value": "AzureContainerAppEnvironment"
+          },
+          {
+            "name": "Redis",
+            "value": "Redis"
+          },
+          {
+            "name": "ApiKey",
+            "value": "ApiKey"
+          },
+          {
+            "name": "AzureOpenAI",
+            "value": "AzureOpenAI"
+          },
+          {
+            "name": "AIServices",
+            "value": "AIServices"
+          },
+          {
+            "name": "CognitiveSearch",
+            "value": "CognitiveSearch"
+          },
+          {
+            "name": "CognitiveService",
+            "value": "CognitiveService"
+          },
+          {
+            "name": "CustomKeys",
+            "value": "CustomKeys"
+          },
+          {
+            "name": "AzureBlob",
+            "value": "AzureBlob"
+          },
+          {
+            "name": "AzureStorageAccount",
+            "value": "AzureStorageAccount"
+          },
+          {
+            "name": "AzureOneLake",
+            "value": "AzureOneLake"
+          },
+          {
+            "name": "CosmosDb",
+            "value": "CosmosDb"
+          },
+          {
+            "name": "CosmosDbMongoDbApi",
+            "value": "CosmosDbMongoDbApi"
+          },
+          {
+            "name": "AzureDataExplorer",
+            "value": "AzureDataExplorer"
+          },
+          {
+            "name": "AzureMariaDb",
+            "value": "AzureMariaDb"
+          },
+          {
+            "name": "AzureDatabricksDeltaLake",
+            "value": "AzureDatabricksDeltaLake"
+          },
+          {
+            "name": "AzureSqlMi",
+            "value": "AzureSqlMi"
+          },
+          {
+            "name": "AzureTableStorage",
+            "value": "AzureTableStorage"
+          },
+          {
+            "name": "AmazonRdsForOracle",
+            "value": "AmazonRdsForOracle"
+          },
+          {
+            "name": "AmazonRdsForSqlServer",
+            "value": "AmazonRdsForSqlServer"
+          },
+          {
+            "name": "AmazonRedshift",
+            "value": "AmazonRedshift"
+          },
+          {
+            "name": "Db2",
+            "value": "Db2"
+          },
+          {
+            "name": "Drill",
+            "value": "Drill"
+          },
+          {
+            "name": "GoogleBigQuery",
+            "value": "GoogleBigQuery"
+          },
+          {
+            "name": "Greenplum",
+            "value": "Greenplum"
+          },
+          {
+            "name": "Hbase",
+            "value": "Hbase"
+          },
+          {
+            "name": "Hive",
+            "value": "Hive"
+          },
+          {
+            "name": "Impala",
+            "value": "Impala"
+          },
+          {
+            "name": "Informix",
+            "value": "Informix"
+          },
+          {
+            "name": "MariaDb",
+            "value": "MariaDb"
+          },
+          {
+            "name": "MicrosoftAccess",
+            "value": "MicrosoftAccess"
+          },
+          {
+            "name": "MySql",
+            "value": "MySql"
+          },
+          {
+            "name": "Netezza",
+            "value": "Netezza"
+          },
+          {
+            "name": "Oracle",
+            "value": "Oracle"
+          },
+          {
+            "name": "Phoenix",
+            "value": "Phoenix"
+          },
+          {
+            "name": "PostgreSql",
+            "value": "PostgreSql"
+          },
+          {
+            "name": "Presto",
+            "value": "Presto"
+          },
+          {
+            "name": "SapOpenHub",
+            "value": "SapOpenHub"
+          },
+          {
+            "name": "SapBw",
+            "value": "SapBw"
+          },
+          {
+            "name": "SapHana",
+            "value": "SapHana"
+          },
+          {
+            "name": "SapTable",
+            "value": "SapTable"
+          },
+          {
+            "name": "Spark",
+            "value": "Spark"
+          },
+          {
+            "name": "SqlServer",
+            "value": "SqlServer"
+          },
+          {
+            "name": "Sybase",
+            "value": "Sybase"
+          },
+          {
+            "name": "Teradata",
+            "value": "Teradata"
+          },
+          {
+            "name": "Vertica",
+            "value": "Vertica"
+          },
+          {
+            "name": "Pinecone",
+            "value": "Pinecone"
+          },
+          {
+            "name": "Databricks",
+            "value": "Databricks"
+          },
+          {
+            "name": "Cassandra",
+            "value": "Cassandra"
+          },
+          {
+            "name": "Couchbase",
+            "value": "Couchbase"
+          },
+          {
+            "name": "MongoDbV2",
+            "value": "MongoDbV2"
+          },
+          {
+            "name": "MongoDbAtlas",
+            "value": "MongoDbAtlas"
+          },
+          {
+            "name": "AmazonS3Compatible",
+            "value": "AmazonS3Compatible"
+          },
+          {
+            "name": "FileServer",
+            "value": "FileServer"
+          },
+          {
+            "name": "FtpServer",
+            "value": "FtpServer"
+          },
+          {
+            "name": "GoogleCloudStorage",
+            "value": "GoogleCloudStorage"
+          },
+          {
+            "name": "Hdfs",
+            "value": "Hdfs"
+          },
+          {
+            "name": "OracleCloudStorage",
+            "value": "OracleCloudStorage"
+          },
+          {
+            "name": "Sftp",
+            "value": "Sftp"
+          },
+          {
+            "name": "GenericHttp",
+            "value": "GenericHttp"
+          },
+          {
+            "name": "ODataRest",
+            "value": "ODataRest"
+          },
+          {
+            "name": "Odbc",
+            "value": "Odbc"
+          },
+          {
+            "name": "GenericRest",
+            "value": "GenericRest"
+          },
+          {
+            "name": "RemoteTool",
+            "value": "RemoteTool"
+          },
+          {
+            "name": "AmazonMws",
+            "value": "AmazonMws"
+          },
+          {
+            "name": "Concur",
+            "value": "Concur"
+          },
+          {
+            "name": "Dynamics",
+            "value": "Dynamics"
+          },
+          {
+            "name": "DynamicsAx",
+            "value": "DynamicsAx"
+          },
+          {
+            "name": "DynamicsCrm",
+            "value": "DynamicsCrm"
+          },
+          {
+            "name": "GoogleAdWords",
+            "value": "GoogleAdWords"
+          },
+          {
+            "name": "Hubspot",
+            "value": "Hubspot"
+          },
+          {
+            "name": "Jira",
+            "value": "Jira"
+          },
+          {
+            "name": "Magento",
+            "value": "Magento"
+          },
+          {
+            "name": "Marketo",
+            "value": "Marketo"
+          },
+          {
+            "name": "Office365",
+            "value": "Office365"
+          },
+          {
+            "name": "Eloqua",
+            "value": "Eloqua"
+          },
+          {
+            "name": "Responsys",
+            "value": "Responsys"
+          },
+          {
+            "name": "OracleServiceCloud",
+            "value": "OracleServiceCloud"
+          },
+          {
+            "name": "PayPal",
+            "value": "PayPal"
+          },
+          {
+            "name": "QuickBooks",
+            "value": "QuickBooks"
+          },
+          {
+            "name": "Salesforce",
+            "value": "Salesforce"
+          },
+          {
+            "name": "SalesforceServiceCloud",
+            "value": "SalesforceServiceCloud"
+          },
+          {
+            "name": "SalesforceMarketingCloud",
+            "value": "SalesforceMarketingCloud"
+          },
+          {
+            "name": "SapCloudForCustomer",
+            "value": "SapCloudForCustomer"
+          },
+          {
+            "name": "SapEcc",
+            "value": "SapEcc"
+          },
+          {
+            "name": "ServiceNow",
+            "value": "ServiceNow"
+          },
+          {
+            "name": "SharePointOnlineList",
+            "value": "SharePointOnlineList"
+          },
+          {
+            "name": "Shopify",
+            "value": "Shopify"
+          },
+          {
+            "name": "Square",
+            "value": "Square"
+          },
+          {
+            "name": "WebTable",
+            "value": "WebTable"
+          },
+          {
+            "name": "Xero",
+            "value": "Xero"
+          },
+          {
+            "name": "Zoho",
+            "value": "Zoho"
+          },
+          {
+            "name": "GenericContainerRegistry",
+            "value": "GenericContainerRegistry"
+          },
+          {
+            "name": "Elasticsearch",
+            "value": "Elasticsearch"
+          },
+          {
+            "name": "AppInsights",
+            "value": "AppInsights"
+          },
+          {
+            "name": "AppConfig",
+            "value": "AppConfig"
+          },
+          {
+            "name": "OpenAI",
+            "value": "OpenAI"
+          },
+          {
+            "name": "Serp",
+            "value": "Serp"
+          },
+          {
+            "name": "BingLLMSearch",
+            "value": "BingLLMSearch"
+          },
+          {
+            "name": "Serverless",
+            "value": "Serverless"
+          },
+          {
+            "name": "ManagedOnlineEndpoint",
+            "value": "ManagedOnlineEndpoint"
+          },
+          {
+            "name": "ApiManagement",
+            "value": "ApiManagement"
+          },
+          {
+            "name": "ModelGateway",
+            "value": "ModelGateway"
+          },
+          {
+            "name": "GroundingWithBingSearch",
+            "value": "GroundingWithBingSearch"
+          },
+          {
+            "name": "GroundingWithCustomSearch",
+            "value": "GroundingWithCustomSearch"
+          },
+          {
+            "name": "Sharepoint",
+            "value": "Sharepoint"
+          },
+          {
+            "name": "MicrosoftFabric",
+            "value": "MicrosoftFabric"
+          },
+          {
+            "name": "PowerPlatformEnvironment",
+            "value": "PowerPlatformEnvironment"
+          },
+          {
+            "name": "RemoteA2A",
+            "value": "RemoteA2A"
+          }
+        ]
+      }
+    },
+    "ConnectionGroup": {
+      "type": "string",
+      "description": "Group based on connection category",
+      "enum": [
+        "Azure",
+        "AzureAI",
+        "Database",
+        "NoSQL",
+        "File",
+        "GenericProtocol",
+        "ServicesAndApps"
+      ],
+      "x-ms-enum": {
+        "name": "ConnectionGroup",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Azure",
+            "value": "Azure"
+          },
+          {
+            "name": "AzureAI",
+            "value": "AzureAI"
+          },
+          {
+            "name": "Database",
+            "value": "Database"
+          },
+          {
+            "name": "NoSQL",
+            "value": "NoSQL"
+          },
+          {
+            "name": "File",
+            "value": "File"
+          },
+          {
+            "name": "GenericProtocol",
+            "value": "GenericProtocol"
+          },
+          {
+            "name": "ServicesAndApps",
+            "value": "ServicesAndApps"
+          }
+        ]
+      }
+    },
+    "ConnectionManagedIdentity": {
+      "type": "object",
+      "properties": {
+        "clientId": {
+          "type": "string"
+        },
+        "resourceId": {
+          "type": "string"
+        }
+      }
+    },
+    "ConnectionOAuth2": {
+      "type": "object",
+      "description": "ClientId and ClientSecret are required. Other properties are optional\ndepending on each OAuth2 provider's implementation.",
+      "properties": {
+        "authUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "Required by Concur connection category"
+        },
+        "clientId": {
+          "$ref": "#/definitions/Azure.Core.uuid",
+          "description": "Client id in the format of UUID"
+        },
+        "clientSecret": {
+          "type": "string",
+          "format": "password",
+          "x-ms-secret": true
+        },
+        "developerToken": {
+          "type": "string",
+          "format": "password",
+          "description": "Required by GoogleAdWords connection category",
+          "x-ms-secret": true
+        },
+        "password": {
+          "type": "string",
+          "format": "password",
+          "x-ms-secret": true
+        },
+        "refreshToken": {
+          "type": "string",
+          "format": "password",
+          "description": "Required by GoogleBigQuery, GoogleAdWords, Hubspot, QuickBooks, Square, Xero, Zoho\nwhere user needs to get RefreshToken offline",
+          "x-ms-secret": true
+        },
+        "tenantId": {
+          "type": "string",
+          "description": "Required by QuickBooks and Xero connection categories"
+        },
+        "username": {
+          "type": "string",
+          "description": "Concur, ServiceNow auth server AccessToken grant type is 'Password'\nwhich requires UsernamePassword"
+        }
+      }
+    },
+    "ConnectionPersonalAccessToken": {
+      "type": "object",
+      "properties": {
+        "pat": {
+          "type": "string",
+          "format": "password",
+          "x-ms-secret": true
+        }
+      }
+    },
+    "ConnectionPropertiesV2": {
+      "type": "object",
+      "description": "Connection property base schema.",
+      "properties": {
+        "authType": {
+          "$ref": "#/definitions/ConnectionAuthType",
+          "description": "Authentication type of the connection target"
+        },
+        "category": {
+          "$ref": "#/definitions/ConnectionCategory",
+          "description": "Category of the connection"
+        },
+        "createdByWorkspaceArmId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "A type definition that refers the id to an Azure Resource Manager resource.",
+          "readOnly": true
+        },
+        "error": {
+          "type": "string",
+          "description": "Provides the error message if the connection fails"
+        },
+        "expiryTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "group": {
+          "$ref": "#/definitions/ConnectionGroup",
+          "description": "Group based on connection category",
+          "readOnly": true
+        },
+        "isSharedToAll": {
+          "type": "boolean"
+        },
+        "metadata": {
+          "type": "object",
+          "description": "Store user metadata for this connection",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "peRequirement": {
+          "$ref": "#/definitions/ManagedPERequirement",
+          "description": "Specifies how private endpoints are used with this connection: 'Required', 'NotRequired', or 'NotApplicable'."
+        },
+        "peStatus": {
+          "$ref": "#/definitions/ManagedPEStatus",
+          "description": "Specifies the status of private endpoints for this connection: 'Inactive', 'Active', or 'NotApplicable'."
+        },
+        "sharedUserList": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "target": {
+          "type": "string",
+          "description": "The connection URL to be used."
+        },
+        "useWorkspaceManagedIdentity": {
+          "type": "boolean"
+        }
+      },
+      "discriminator": "authType",
+      "required": [
+        "authType"
+      ]
+    },
+    "ConnectionPropertiesV2BasicResource": {
+      "type": "object",
+      "description": "Connection base resource schema.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ConnectionPropertiesV2",
+          "description": "Connection property base schema."
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ConnectionPropertiesV2BasicResourceArmPaginatedResult": {
+      "type": "object",
+      "properties": {
+        "nextLink": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ConnectionPropertiesV2BasicResource"
+          }
+        }
+      }
+    },
+    "ConnectionServicePrincipal": {
+      "type": "object",
+      "properties": {
+        "clientId": {
+          "type": "string"
+        },
+        "clientSecret": {
+          "type": "string",
+          "format": "password",
+          "x-ms-secret": true
+        },
+        "tenantId": {
+          "type": "string"
+        }
+      }
+    },
+    "ConnectionSharedAccessSignature": {
+      "type": "object",
+      "properties": {
+        "sas": {
+          "type": "string",
+          "format": "password",
+          "x-ms-secret": true
+        }
+      }
+    },
+    "ConnectionUpdateContent": {
+      "type": "object",
+      "description": "The properties that the Cognitive services connection will be updated with.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ConnectionPropertiesV2",
+          "description": "The properties that the Cognitive services connection will be updated with."
+        }
+      }
+    },
+    "ConnectionUsernamePassword": {
+      "type": "object",
+      "properties": {
+        "password": {
+          "type": "string",
+          "format": "password",
+          "x-ms-secret": true
+        },
+        "securityToken": {
+          "type": "string",
+          "format": "password",
+          "description": "Optional, required by connections like SalesForce for extra security in addition to UsernamePassword",
+          "x-ms-secret": true
+        },
+        "username": {
+          "type": "string"
+        }
+      }
+    },
+    "ContentLevel": {
+      "type": "string",
+      "description": "Level at which content is filtered.",
+      "enum": [
+        "Low",
+        "Medium",
+        "High"
+      ],
+      "x-ms-enum": {
+        "name": "ContentLevel",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Low",
+            "value": "Low"
+          },
+          {
+            "name": "Medium",
+            "value": "Medium"
+          },
+          {
+            "name": "High",
+            "value": "High"
+          }
+        ]
+      }
+    },
+    "CreatedByType": {
+      "type": "string",
+      "description": "The type of identity that created the resource.",
+      "enum": [
+        "User",
+        "Application",
+        "ManagedIdentity",
+        "Key"
+      ],
+      "x-ms-enum": {
+        "name": "CreatedByType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "User",
+            "value": "User"
+          },
+          {
+            "name": "Application",
+            "value": "Application"
+          },
+          {
+            "name": "ManagedIdentity",
+            "value": "ManagedIdentity"
+          },
+          {
+            "name": "Key",
+            "value": "Key"
+          }
+        ]
+      }
+    },
+    "CustomBlocklistConfig": {
+      "type": "object",
+      "description": "Gets or sets the source to which filter applies.",
+      "properties": {
+        "source": {
+          "$ref": "#/definitions/RaiPolicyContentSource",
+          "description": "Content source to apply the Content Filters."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/RaiBlocklistConfig"
+        }
+      ]
+    },
+    "CustomKeys": {
+      "type": "object",
+      "description": "Custom Keys credential object",
+      "properties": {
+        "keys": {
+          "type": "object",
+          "description": "Dictionary of <string>",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "CustomKeysConnectionProperties": {
+      "type": "object",
+      "description": "Category:= CustomKeys\nAuthType:= CustomKeys (as type discriminator)\nCredentials:= {CustomKeys} as CustomKeys\nTarget:= {any value}\nUse Metadata property bag for ApiVersion and other metadata fields",
+      "properties": {
+        "credentials": {
+          "$ref": "#/definitions/CustomKeys",
+          "description": "Custom Keys credential object"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ConnectionPropertiesV2"
+        }
+      ],
+      "x-ms-discriminator-value": "CustomKeys"
+    },
+    "DefenderForAISetting": {
+      "type": "object",
+      "description": "The Defender for AI resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/DefenderForAISettingProperties",
+          "description": "The Defender for AI resource properties.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "Resource Etag.",
+          "readOnly": true
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "DefenderForAISettingProperties": {
+      "type": "object",
+      "description": "The Defender for AI resource properties.",
+      "properties": {
+        "state": {
+          "$ref": "#/definitions/DefenderForAISettingState",
+          "description": "Defender for AI state on the AI resource."
+        }
+      }
+    },
+    "DefenderForAISettingResult": {
+      "type": "object",
+      "description": "The list of cognitive services Defender for AI Settings.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of Defender for AI Settings."
+        },
+        "value": {
+          "type": "array",
+          "description": "The list of Defender for AI Settings.",
+          "items": {
+            "$ref": "#/definitions/DefenderForAISetting"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      }
+    },
+    "DefenderForAISettingState": {
+      "type": "string",
+      "description": "Defender for AI state on the AI resource.",
+      "enum": [
+        "Disabled",
+        "Enabled"
+      ],
+      "x-ms-enum": {
+        "name": "DefenderForAISettingState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Disabled",
+            "value": "Disabled"
+          },
+          {
+            "name": "Enabled",
+            "value": "Enabled"
+          }
+        ]
+      }
+    },
+    "Deployment": {
+      "type": "object",
+      "description": "Cognitive Services account deployment.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/DeploymentProperties",
+          "description": "Properties of Cognitive Services account deployment."
+        },
+        "sku": {
+          "$ref": "#/definitions/Sku",
+          "description": "The resource model definition representing SKU"
+        },
+        "etag": {
+          "type": "string",
+          "description": "Resource Etag.",
+          "readOnly": true
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "DeploymentCapacitySettings": {
+      "type": "object",
+      "description": "Internal use only.",
+      "properties": {
+        "designatedCapacity": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The designated capacity.",
+          "minimum": 0
+        },
+        "priority": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The priority of this capacity setting.",
+          "minimum": 0
+        }
+      }
+    },
+    "DeploymentListResult": {
+      "type": "object",
+      "description": "The list of cognitive services accounts operation response.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of Deployment."
+        },
+        "value": {
+          "type": "array",
+          "description": "Gets the list of Cognitive Services accounts Deployment and their properties.",
+          "items": {
+            "$ref": "#/definitions/Deployment"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "DeploymentModel": {
+      "type": "object",
+      "description": "Properties of Cognitive Services account deployment model.",
+      "properties": {
+        "publisher": {
+          "type": "string",
+          "description": "Deployment model publisher."
+        },
+        "format": {
+          "type": "string",
+          "description": "Deployment model format."
+        },
+        "name": {
+          "type": "string",
+          "description": "Deployment model name."
+        },
+        "version": {
+          "type": "string",
+          "description": "Optional. Deployment model version. If version is not specified, a default version will be assigned. The default version is different for different models and might change when there is new version available for a model. Default version for a model could be found from list models API."
+        },
+        "source": {
+          "type": "string",
+          "description": "Optional. Deployment model source ARM resource ID."
+        },
+        "sourceAccount": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Optional. Source of the model, another Microsoft.CognitiveServices accounts ARM resource ID.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.CognitiveServices/accounts"
+              }
+            ]
+          }
+        },
+        "callRateLimit": {
+          "$ref": "#/definitions/CallRateLimit",
+          "description": "The call rate limit Cognitive Services account.",
+          "readOnly": true
+        }
+      }
+    },
+    "DeploymentModelVersionUpgradeOption": {
+      "type": "string",
+      "description": "Deployment model version upgrade option.",
+      "enum": [
+        "OnceNewDefaultVersionAvailable",
+        "OnceCurrentVersionExpired",
+        "NoAutoUpgrade"
+      ],
+      "x-ms-enum": {
+        "name": "DeploymentModelVersionUpgradeOption",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "OnceNewDefaultVersionAvailable",
+            "value": "OnceNewDefaultVersionAvailable"
+          },
+          {
+            "name": "OnceCurrentVersionExpired",
+            "value": "OnceCurrentVersionExpired"
+          },
+          {
+            "name": "NoAutoUpgrade",
+            "value": "NoAutoUpgrade"
+          }
+        ]
+      }
+    },
+    "DeploymentProperties": {
+      "type": "object",
+      "description": "Properties of Cognitive Services account deployment.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/DeploymentProvisioningState",
+          "description": "Gets the status of the resource at the time the operation was called.",
+          "readOnly": true
+        },
+        "model": {
+          "$ref": "#/definitions/DeploymentModel",
+          "description": "Properties of Cognitive Services account deployment model."
+        },
+        "scaleSettings": {
+          "$ref": "#/definitions/DeploymentScaleSettings",
+          "description": "Properties of Cognitive Services account deployment model. (Deprecated, please use Deployment.sku instead.)"
+        },
+        "capabilities": {
+          "type": "object",
+          "description": "The capabilities.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "raiPolicyName": {
+          "type": "string",
+          "description": "The name of RAI policy."
+        },
+        "callRateLimit": {
+          "$ref": "#/definitions/CallRateLimit",
+          "description": "The call rate limit Cognitive Services account.",
+          "readOnly": true
+        },
+        "rateLimits": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ThrottlingRule"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "key"
+          ]
+        },
+        "versionUpgradeOption": {
+          "$ref": "#/definitions/DeploymentModelVersionUpgradeOption",
+          "description": "Deployment model version upgrade option."
+        },
+        "dynamicThrottlingEnabled": {
+          "type": "boolean",
+          "description": "If the dynamic throttling is enabled.",
+          "readOnly": true
+        },
+        "currentCapacity": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The current capacity."
+        },
+        "capacitySettings": {
+          "$ref": "#/definitions/DeploymentCapacitySettings",
+          "description": "Internal use only."
+        },
+        "parentDeploymentName": {
+          "type": "string",
+          "description": "The name of parent deployment."
+        },
+        "spilloverDeploymentName": {
+          "type": "string",
+          "description": "Specifies the deployment name that should serve requests when the request would have otherwise been throttled due to reaching current deployment throughput limit."
+        },
+        "serviceTier": {
+          "$ref": "#/definitions/ServiceTier",
+          "description": "The service tier for the deployment. Determines the pricing and performance level for request processing. Use 'Default' for standard pricing or 'Priority' for higher-priority processing with premium pricing. Note: Pause operations are only supported on Standard, DataZoneStandard, and GlobalStandard SKUs.",
+          "x-nullable": true
+        },
+        "deploymentState": {
+          "$ref": "#/definitions/DeploymentState",
+          "description": "The state of the deployment. Controls whether the deployment is accepting inference requests. Use 'Running' for active deployments that process requests, or 'Paused' to temporarily stop inference while preserving the deployment configuration.",
+          "x-nullable": true
+        },
+        "routing": {
+          "$ref": "#/definitions/DeploymentRouting",
+          "description": "Routing configuration for the model-router deployment. This property is only applicable when the deployed model is 'model-router' version 2025-11-18 or later. Allows you to select the models subset for routing and the routing mode (balanced, quality, cost) for routing across all supported models or the model subset."
+        }
+      }
+    },
+    "DeploymentProvisioningState": {
+      "type": "string",
+      "description": "Gets the status of the resource at the time the operation was called.",
+      "enum": [
+        "Accepted",
+        "Creating",
+        "Deleting",
+        "Moving",
+        "Failed",
+        "Succeeded",
+        "Disabled",
+        "Canceled"
+      ],
+      "x-ms-enum": {
+        "name": "DeploymentProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Accepted",
+            "value": "Accepted"
+          },
+          {
+            "name": "Creating",
+            "value": "Creating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting"
+          },
+          {
+            "name": "Moving",
+            "value": "Moving"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded"
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled"
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "DeploymentRouting": {
+      "type": "object",
+      "description": "Routing configuration for the model-router deployment. Specifies how requests are routed across multiple models.",
+      "properties": {
+        "mode": {
+          "type": "string",
+          "description": "The model-router routing mode that determines how requests are distributed across models.",
+          "default": "balanced",
+          "enum": [
+            "cost",
+            "balanced",
+            "quality"
+          ],
+          "x-ms-enum": {
+            "name": "RoutingMode",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Cost",
+                "value": "cost",
+                "description": "Route requests to minimize cost while meeting performance requirements."
+              },
+              {
+                "name": "Balanced",
+                "value": "balanced",
+                "description": "Balance cost and quality when routing requests across models."
+              },
+              {
+                "name": "Quality",
+                "value": "quality",
+                "description": "Route requests to maximize quality regardless of cost."
+              }
+            ]
+          }
+        },
+        "models": {
+          "type": "array",
+          "description": "Optional. The list of model-router supported models that the model router can use to route requests across. If not specified, the model router will route to all available models specified in the model-router version.",
+          "items": {
+            "$ref": "#/definitions/DeploymentModel"
+          },
+          "x-ms-identifiers": [
+            "name",
+            "version"
+          ]
+        }
+      }
+    },
+    "DeploymentScaleSettings": {
+      "type": "object",
+      "description": "Properties of Cognitive Services account deployment model. (Deprecated, please use Deployment.sku instead.)",
+      "properties": {
+        "scaleType": {
+          "$ref": "#/definitions/DeploymentScaleType",
+          "description": "Deployment scale type."
+        },
+        "capacity": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Deployment capacity."
+        },
+        "activeCapacity": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Deployment active capacity. This value might be different from `capacity` if customer recently updated `capacity`.",
+          "readOnly": true
+        }
+      }
+    },
+    "DeploymentScaleType": {
+      "type": "string",
+      "description": "Deployment scale type.",
+      "enum": [
+        "Standard",
+        "Manual"
+      ],
+      "x-ms-enum": {
+        "name": "DeploymentScaleType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Standard",
+            "value": "Standard"
+          },
+          {
+            "name": "Manual",
+            "value": "Manual"
+          }
+        ]
+      }
+    },
+    "DeploymentSizeCapacity": {
+      "type": "object",
+      "description": "Capacity information for a specific deployment size.",
+      "properties": {
+        "modelInstanceAcceleratorCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of accelerators required per model instance.",
+          "readOnly": true
+        },
+        "totalAvailableCapacity": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The total available capacity for this deployment size.",
+          "readOnly": true
+        },
+        "largestDeploymentCapacity": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The largest contiguous deployment capacity available for this deployment size.",
+          "readOnly": true
+        }
+      }
+    },
+    "DeploymentSkuListResult": {
+      "type": "object",
+      "description": "The list of cognitive services accounts operation response.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of deployment skus."
+        },
+        "value": {
+          "type": "array",
+          "description": "Gets the list of Cognitive Services accounts deployment skus.",
+          "items": {
+            "$ref": "#/definitions/SkuResource"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "resourceType"
+          ]
+        }
+      }
+    },
+    "DeploymentState": {
+      "type": "string",
+      "description": "The state of the deployment. Controls whether the deployment is accepting inference requests. Use 'Running' for active deployments that process requests, or 'Paused' to temporarily stop inference while preserving the deployment configuration.",
+      "enum": [
+        "Running",
+        "Paused"
+      ],
+      "x-ms-enum": {
+        "name": "DeploymentState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Running",
+            "value": "Running",
+            "description": "The deployment is running and accepting inference requests."
+          },
+          {
+            "name": "Paused",
+            "value": "Paused",
+            "description": "The deployment is paused and not accepting inference requests."
+          }
+        ]
+      }
+    },
+    "DeprecationStatus": {
+      "type": "string",
+      "description": "Indicates whether the deprecation date is a confirmed planned end-of-life date or an estimated deprecation date. When 'Planned', the deprecation date represents a confirmed and communicated model end-of-life date. When 'Tentative', the deprecation date is an estimated timeline that may be subject to change.",
+      "enum": [
+        "Planned",
+        "Tentative"
+      ],
+      "x-ms-enum": {
+        "name": "DeprecationStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Planned",
+            "value": "Planned"
+          },
+          {
+            "name": "Tentative",
+            "value": "Tentative"
+          }
+        ]
+      }
+    },
+    "DomainAvailability": {
+      "type": "object",
+      "description": "Domain availability.",
+      "properties": {
+        "isSubdomainAvailable": {
+          "type": "boolean",
+          "description": "Indicates the given SKU is available or not."
+        },
+        "reason": {
+          "type": "string",
+          "description": "Reason why the SKU is not available."
+        },
+        "subdomainName": {
+          "type": "string",
+          "description": "The subdomain name to use."
+        },
+        "type": {
+          "type": "string",
+          "description": "The Type of the resource."
+        },
+        "kind": {
+          "type": "string",
+          "description": "The kind (type) of cognitive service account."
+        }
+      }
+    },
+    "Encryption": {
+      "type": "object",
+      "description": "Properties to configure Encryption",
+      "properties": {
+        "keyVaultProperties": {
+          "$ref": "#/definitions/KeyVaultProperties",
+          "description": "Properties of KeyVault"
+        },
+        "keySource": {
+          "type": "string",
+          "description": "Enumerates the possible value of keySource for Encryption",
+          "default": "Microsoft.KeyVault",
+          "enum": [
+            "Microsoft.CognitiveServices",
+            "Microsoft.KeyVault"
+          ],
+          "x-ms-enum": {
+            "name": "KeySource",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Microsoft.CognitiveServices",
+                "value": "Microsoft.CognitiveServices"
+              },
+              {
+                "name": "Microsoft.KeyVault",
+                "value": "Microsoft.KeyVault"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "EncryptionScope": {
+      "type": "object",
+      "description": "Cognitive Services EncryptionScope",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/EncryptionScopeProperties",
+          "description": "Properties of Cognitive Services EncryptionScope."
+        },
+        "etag": {
+          "type": "string",
+          "description": "Resource Etag.",
+          "readOnly": true
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "EncryptionScopeListResult": {
+      "type": "object",
+      "description": "The list of cognitive services EncryptionScopes.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of EncryptionScope."
+        },
+        "value": {
+          "type": "array",
+          "description": "The list of EncryptionScope.",
+          "items": {
+            "$ref": "#/definitions/EncryptionScope"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      }
+    },
+    "EncryptionScopeProperties": {
+      "type": "object",
+      "description": "Properties to EncryptionScope",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/EncryptionScopeProvisioningState",
+          "description": "Gets the status of the resource at the time the operation was called.",
+          "readOnly": true
+        },
+        "state": {
+          "$ref": "#/definitions/EncryptionScopeState",
+          "description": "The encryptionScope state."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Encryption"
+        }
+      ]
+    },
+    "EncryptionScopeProvisioningState": {
+      "type": "string",
+      "description": "Gets the status of the resource at the time the operation was called.",
+      "enum": [
+        "Accepted",
+        "Creating",
+        "Deleting",
+        "Moving",
+        "Failed",
+        "Succeeded",
+        "Canceled"
+      ],
+      "x-ms-enum": {
+        "name": "EncryptionScopeProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Accepted",
+            "value": "Accepted"
+          },
+          {
+            "name": "Creating",
+            "value": "Creating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting"
+          },
+          {
+            "name": "Moving",
+            "value": "Moving"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled"
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "EncryptionScopeState": {
+      "type": "string",
+      "description": "The encryptionScope state.",
+      "enum": [
+        "Disabled",
+        "Enabled"
+      ],
+      "x-ms-enum": {
+        "name": "EncryptionScopeState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Disabled",
+            "value": "Disabled"
+          },
+          {
+            "name": "Enabled",
+            "value": "Enabled"
+          }
+        ]
+      }
+    },
+    "FirewallSku": {
+      "type": "string",
+      "description": "Firewall Sku used for FQDN Rules",
+      "enum": [
+        "Standard",
+        "Basic"
+      ],
+      "x-ms-enum": {
+        "name": "FirewallSku",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Standard",
+            "value": "Standard"
+          },
+          {
+            "name": "Basic",
+            "value": "Basic"
+          }
+        ]
+      }
+    },
+    "FqdnOutboundRule": {
+      "type": "object",
+      "description": "FQDN Outbound Rule for the managed network of a cognitive services account.",
+      "properties": {
+        "destination": {
+          "type": "string"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/OutboundRule"
+        }
+      ],
+      "x-ms-discriminator-value": "FQDN"
+    },
+    "HostedAgentDeployment": {
+      "type": "object",
+      "description": "Represents a hosted agent deployment where the underlying infrastructure is owned by the platform.",
+      "properties": {
+        "minReplicas": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the minimum number of replicas for this hosted deployment.",
+          "minimum": 0
+        },
+        "maxReplicas": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the maximum number of replicas for this hosted deployment.",
+          "minimum": 0
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AgentDeploymentProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "Hosted"
+    },
+    "HostingModel": {
+      "type": "string",
+      "description": "Account hosting model.",
+      "enum": [
+        "Web",
+        "ConnectedContainer",
+        "DisconnectedContainer",
+        "ProvisionedWeb"
+      ],
+      "x-ms-enum": {
+        "name": "HostingModel",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Web",
+            "value": "Web"
+          },
+          {
+            "name": "ConnectedContainer",
+            "value": "ConnectedContainer"
+          },
+          {
+            "name": "DisconnectedContainer",
+            "value": "DisconnectedContainer"
+          },
+          {
+            "name": "ProvisionedWeb",
+            "value": "ProvisionedWeb"
+          }
+        ]
+      }
+    },
+    "Identity": {
+      "type": "object",
+      "description": "Identity for the resource.",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/ResourceIdentityType",
+          "description": "The identity type."
+        },
+        "tenantId": {
+          "type": "string",
+          "description": "The tenant ID of resource.",
+          "readOnly": true
+        },
+        "principalId": {
+          "type": "string",
+          "description": "The principal ID of resource identity.",
+          "readOnly": true
+        },
+        "userAssignedIdentities": {
+          "type": "object",
+          "description": "The list of user assigned identities associated with the resource. The user identity dictionary key references will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}",
+          "additionalProperties": {
+            "$ref": "#/definitions/UserAssignedIdentity"
+          }
+        }
+      }
+    },
+    "IdentityKind": {
+      "type": "string",
+      "description": "Specifies the kind of Entra identity described by this object.",
+      "enum": [
+        "AgentBlueprint",
+        "AgentInstance",
+        "AgenticUser",
+        "Managed",
+        "None"
+      ],
+      "x-ms-enum": {
+        "name": "IdentityKind",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "AgentBlueprint",
+            "value": "AgentBlueprint",
+            "description": "Represents a class identity, used for agentic applications."
+          },
+          {
+            "name": "AgentInstance",
+            "value": "AgentInstance",
+            "description": "Represents an instance identity."
+          },
+          {
+            "name": "AgenticUser",
+            "value": "AgenticUser",
+            "description": "Represents an agentic instance identity with user-like traits."
+          },
+          {
+            "name": "Managed",
+            "value": "Managed",
+            "description": "Represents a classic managed identity."
+          },
+          {
+            "name": "None",
+            "value": "None",
+            "description": "No identity."
+          }
+        ]
+      }
+    },
+    "IdentityManagementType": {
+      "type": "string",
+      "description": "Enumeration of identity types, from the perspective of management.",
+      "enum": [
+        "System",
+        "User",
+        "None"
+      ],
+      "x-ms-enum": {
+        "name": "IdentityManagementType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "System",
+            "value": "System",
+            "description": "Platform-managed identity."
+          },
+          {
+            "name": "User",
+            "value": "User",
+            "description": "User-managed identity."
+          },
+          {
+            "name": "None",
+            "value": "None",
+            "description": "No identity."
+          }
+        ]
+      }
+    },
+    "IdentityProvisioningState": {
+      "type": "string",
+      "description": "Represents the provisioning state of an identity resource.",
+      "enum": [
+        "Creating",
+        "Updating",
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Deleting"
+      ],
+      "x-ms-enum": {
+        "name": "IdentityProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "Identity is being created."
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Identity is being updated."
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Identity has been successfully provisioned."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Identity provisioning has failed."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Identity provisioning has been canceled."
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Identity is being deleted."
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "IpRule": {
+      "type": "object",
+      "description": "A rule governing the accessibility from a specific ip address or ip range.",
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "An IPv4 address range in CIDR notation, such as '124.56.78.91' (simple IP address) or '124.56.78.0/24' (all addresses that start with 124.56.78)."
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "IsolationMode": {
+      "type": "string",
+      "description": "Isolation mode for the managed network of a cognitive services account.",
+      "enum": [
+        "Disabled",
+        "AllowInternetOutbound",
+        "AllowOnlyApprovedOutbound"
+      ],
+      "x-ms-enum": {
+        "name": "IsolationMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Disabled",
+            "value": "Disabled"
+          },
+          {
+            "name": "AllowInternetOutbound",
+            "value": "AllowInternetOutbound"
+          },
+          {
+            "name": "AllowOnlyApprovedOutbound",
+            "value": "AllowOnlyApprovedOutbound"
+          }
+        ]
+      }
+    },
+    "KeyName": {
+      "type": "string",
+      "description": "key name to generate (Key1|Key2)",
+      "enum": [
+        "Key1",
+        "Key2"
+      ],
+      "x-ms-enum": {
+        "name": "KeyName",
+        "modelAsString": false
+      }
+    },
+    "KeySource": {
+      "type": "string",
+      "description": "Enumerates the possible value of keySource for Encryption",
+      "enum": [
+        "Microsoft.CognitiveServices",
+        "Microsoft.KeyVault"
+      ],
+      "x-ms-enum": {
+        "name": "KeySource",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Microsoft.CognitiveServices",
+            "value": "Microsoft.CognitiveServices"
+          },
+          {
+            "name": "Microsoft.KeyVault",
+            "value": "Microsoft.KeyVault"
+          }
+        ]
+      }
+    },
+    "KeyVaultProperties": {
+      "type": "object",
+      "description": "Properties to configure keyVault Properties",
+      "properties": {
+        "keyName": {
+          "type": "string",
+          "description": "Name of the Key from KeyVault"
+        },
+        "keyVersion": {
+          "type": "string",
+          "description": "Version of the Key from KeyVault"
+        },
+        "keyVaultUri": {
+          "type": "string",
+          "description": "Uri of KeyVault"
+        },
+        "identityClientId": {
+          "type": "string"
+        }
+      }
+    },
+    "ManagedAgentDeployment": {
+      "type": "object",
+      "description": "Represents a managed agent deployment where the underlying infrastructure is managed by the platform in the deployer's subscription.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AgentDeploymentProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "Managed"
+    },
+    "ManagedIdentityAuthTypeConnectionProperties": {
+      "type": "object",
+      "properties": {
+        "credentials": {
+          "$ref": "#/definitions/ConnectionManagedIdentity"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ConnectionPropertiesV2"
+        }
+      ],
+      "x-ms-discriminator-value": "ManagedIdentity"
+    },
+    "ManagedNetworkKind": {
+      "type": "string",
+      "description": "The Kind of the managed network. Users can switch from V1 to V2 for granular access controls, but cannot switch back to V1 once V2 is enabled.",
+      "enum": [
+        "V1",
+        "V2"
+      ],
+      "x-ms-enum": {
+        "name": "ManagedNetworkKind",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "V1",
+            "value": "V1"
+          },
+          {
+            "name": "V2",
+            "value": "V2"
+          }
+        ]
+      }
+    },
+    "ManagedNetworkListResult": {
+      "type": "object",
+      "description": "List of managed networks of a cognitive services account.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link to the next page constructed using the continuationToken.  If null, there are no additional pages."
+        },
+        "value": {
+          "type": "array",
+          "description": "The list of managed network settings of an account. Since this list may be incomplete, the nextLink field should be used to request the next list of cognitive services accounts.",
+          "items": {
+            "$ref": "#/definitions/ManagedNetworkSettingsPropertiesBasicResource"
+          }
+        }
+      }
+    },
+    "ManagedNetworkProvisionOptions": {
+      "type": "object",
+      "description": "Managed Network Provisioning options for managed network of a cognitive services account."
+    },
+    "ManagedNetworkProvisionStatus": {
+      "type": "object",
+      "description": "Status of the Provisioning for the managed network of a cognitive services account.",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/ManagedNetworkStatus",
+          "description": "Status for the managed network of a cognitive services account."
+        }
+      }
+    },
+    "ManagedNetworkProvisioningState": {
+      "type": "string",
+      "enum": [
+        "Deferred",
+        "Updating",
+        "Succeeded",
+        "Failed",
+        "Deleting",
+        "Deleted"
+      ],
+      "x-ms-enum": {
+        "name": "ManagedNetworkProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Deferred",
+            "value": "Deferred"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting"
+          },
+          {
+            "name": "Deleted",
+            "value": "Deleted"
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "ManagedNetworkSettings": {
+      "type": "object",
+      "description": "Managed Network settings for a cognitive services account.",
+      "properties": {
+        "isolationMode": {
+          "$ref": "#/definitions/IsolationMode",
+          "description": "Isolation mode for the managed network of a cognitive services account."
+        },
+        "networkId": {
+          "type": "string",
+          "readOnly": true
+        },
+        "outboundRules": {
+          "type": "object",
+          "description": "Dictionary of <OutboundRule>",
+          "x-nullable": true,
+          "additionalProperties": {
+            "$ref": "#/definitions/OutboundRule"
+          }
+        },
+        "status": {
+          "$ref": "#/definitions/ManagedNetworkProvisionStatus",
+          "description": "Status of the Provisioning for the managed network of a cognitive services account."
+        },
+        "firewallSku": {
+          "$ref": "#/definitions/FirewallSku",
+          "description": "Firewall Sku used for FQDN Rules"
+        },
+        "managedNetworkKind": {
+          "$ref": "#/definitions/ManagedNetworkKind",
+          "description": "The Kind of the managed network. Users can switch from V1 to V2 for granular access controls, but cannot switch back to V1 once V2 is enabled."
+        },
+        "firewallPublicIpAddress": {
+          "type": "string",
+          "description": "Public IP address assigned to the Azure Firewall.",
+          "x-nullable": true,
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ManagedNetworkProvisioningState",
+          "description": "The provisioning state of the managed network settings.",
+          "readOnly": true
+        }
+      }
+    },
+    "ManagedNetworkSettingsBasicResource": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ManagedNetworkSettings",
+          "description": "Managed Network settings for a cognitive services account."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/Resource"
+        }
+      ]
+    },
+    "ManagedNetworkSettingsEx": {
+      "type": "object",
+      "properties": {
+        "changeableIsolationModes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IsolationMode"
+          },
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ManagedNetworkSettings"
+        }
+      ]
+    },
+    "ManagedNetworkSettingsProperties": {
+      "type": "object",
+      "description": "The properties of the managed network settings of a cognitive services account.",
+      "properties": {
+        "managedNetwork": {
+          "$ref": "#/definitions/ManagedNetworkSettingsEx",
+          "description": "Managed Network settings for a cognitive services account."
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ManagedNetworkProvisioningState",
+          "description": "The current deployment state of the managed network resource. The provisioningState is to indicate states for resource provisioning.",
+          "readOnly": true
+        }
+      }
+    },
+    "ManagedNetworkSettingsPropertiesBasicResource": {
+      "type": "object",
+      "description": "Concrete proxy resource types can be created by aliasing this type using a specific property type.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ManagedNetworkSettingsProperties",
+          "description": "The properties of the managed network settings of a cognitive services account."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ManagedNetworkStatus": {
+      "type": "string",
+      "description": "Status for the managed network of a cognitive services account.",
+      "enum": [
+        "Inactive",
+        "Active"
+      ],
+      "x-ms-enum": {
+        "name": "ManagedNetworkStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Inactive",
+            "value": "Inactive"
+          },
+          {
+            "name": "Active",
+            "value": "Active"
+          }
+        ]
+      }
+    },
+    "ManagedPERequirement": {
+      "type": "string",
+      "enum": [
+        "Required",
+        "NotRequired",
+        "NotApplicable"
+      ],
+      "x-ms-enum": {
+        "name": "ManagedPERequirement",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Required",
+            "value": "Required"
+          },
+          {
+            "name": "NotRequired",
+            "value": "NotRequired"
+          },
+          {
+            "name": "NotApplicable",
+            "value": "NotApplicable"
+          }
+        ]
+      }
+    },
+    "ManagedPEStatus": {
+      "type": "string",
+      "enum": [
+        "Inactive",
+        "Active",
+        "NotApplicable"
+      ],
+      "x-ms-enum": {
+        "name": "ManagedPEStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Inactive",
+            "value": "Inactive"
+          },
+          {
+            "name": "Active",
+            "value": "Active"
+          },
+          {
+            "name": "NotApplicable",
+            "value": "NotApplicable"
+          }
+        ]
+      }
+    },
+    "MetricName": {
+      "type": "object",
+      "description": "A metric name.",
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "The name of the metric."
+        },
+        "localizedValue": {
+          "type": "string",
+          "description": "The friendly name of the metric."
+        }
+      }
+    },
+    "Model": {
+      "type": "object",
+      "description": "Cognitive Services Model.",
+      "properties": {
+        "model": {
+          "$ref": "#/definitions/AccountModel",
+          "description": "Cognitive Services account Model."
+        },
+        "kind": {
+          "type": "string",
+          "description": "The kind (type) of cognitive service account."
+        },
+        "skuName": {
+          "type": "string",
+          "description": "The name of SKU."
+        },
+        "description": {
+          "type": "string",
+          "description": "The description of the model."
+        }
+      }
+    },
+    "ModelCapacityCalculatorWorkload": {
+      "type": "object",
+      "description": "Model Capacity Calculator Workload.",
+      "properties": {
+        "requestPerMinute": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Request per minute."
+        },
+        "requestParameters": {
+          "$ref": "#/definitions/ModelCapacityCalculatorWorkloadRequestParam",
+          "description": "Dictionary, Model Capacity Calculator Workload Parameters."
+        }
+      }
+    },
+    "ModelCapacityCalculatorWorkloadRequestParam": {
+      "type": "object",
+      "description": "Dictionary, Model Capacity Calculator Workload Parameters.",
+      "properties": {
+        "avgPromptTokens": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Average prompt tokens."
+        },
+        "avgGeneratedTokens": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Average generated tokens."
+        }
+      }
+    },
+    "ModelCapacityListResult": {
+      "type": "object",
+      "description": "The list of cognitive services accounts operation response.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of ModelSkuCapacity."
+        },
+        "value": {
+          "type": "array",
+          "description": "Gets the list of Cognitive Services accounts ModelSkuCapacity.",
+          "items": {
+            "$ref": "#/definitions/ModelCapacityListResultValueItem"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "model"
+          ]
+        }
+      }
+    },
+    "ModelCapacityListResultValueItem": {
+      "type": "object",
+      "properties": {
+        "location": {
+          "type": "string",
+          "description": "The location of the Model Sku Capacity."
+        },
+        "properties": {
+          "$ref": "#/definitions/ModelSkuCapacityProperties",
+          "description": "Cognitive Services account ModelSkuCapacity."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ModelDeprecationInfo": {
+      "type": "object",
+      "description": "Cognitive Services account ModelDeprecationInfo.",
+      "properties": {
+        "fineTune": {
+          "type": "string",
+          "description": "The datetime of deprecation of the fineTune Model."
+        },
+        "inference": {
+          "type": "string",
+          "description": "The datetime of deprecation of the inference Model."
+        },
+        "deprecationStatus": {
+          "$ref": "#/definitions/DeprecationStatus",
+          "description": "Indicates whether the deprecation date is a confirmed planned end-of-life date or an estimated deprecation date. When 'Planned', the deprecation date represents a confirmed and communicated model end-of-life date. When 'Tentative', the deprecation date is an estimated timeline that may be subject to change."
+        }
+      }
+    },
+    "ModelLifecycleStatus": {
+      "type": "string",
+      "description": "Model lifecycle status.",
+      "enum": [
+        "Stable",
+        "Preview",
+        "GenerallyAvailable",
+        "Deprecating",
+        "Deprecated",
+        "Legacy"
+      ],
+      "x-ms-enum": {
+        "name": "ModelLifecycleStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Stable",
+            "value": "Stable",
+            "description": "Legacy state. Replaced with GenerallyAvailable going forward."
+          },
+          {
+            "name": "Preview",
+            "value": "Preview",
+            "description": "Model is in preview and may be subject to changes."
+          },
+          {
+            "name": "GenerallyAvailable",
+            "value": "GenerallyAvailable",
+            "description": "Model is generally available for production use."
+          },
+          {
+            "name": "Deprecating",
+            "value": "Deprecating",
+            "description": "Model is being deprecated and will be removed in the future. Only customers with existing deployments can create new deployments with this model."
+          },
+          {
+            "name": "Deprecated",
+            "value": "Deprecated",
+            "description": "Model has been deprecated, also known as retired, and is no longer supported. Inference calls to deployments of models in this lifecycle state will return 410 errors."
+          },
+          {
+            "name": "Legacy",
+            "value": "Legacy",
+            "description": "Model is a legacy version that is no longer recommended for use. Customers should migrate to newer models. Check replacementConfig for upgrade information."
+          }
+        ]
+      }
+    },
+    "ModelListResult": {
+      "type": "object",
+      "description": "The list of cognitive services models.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of Model."
+        },
+        "value": {
+          "type": "array",
+          "description": "Gets the list of Cognitive Services accounts Model and their properties.",
+          "items": {
+            "$ref": "#/definitions/Model"
+          },
+          "x-ms-identifiers": [
+            "kind",
+            "skuName",
+            "/model/name",
+            "/model/format",
+            "/model/version"
+          ]
+        }
+      }
+    },
+    "ModelSku": {
+      "type": "object",
+      "description": "Describes an available Cognitive Services Model SKU.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the model SKU."
+        },
+        "usageName": {
+          "type": "string",
+          "description": "The usage name of the model SKU."
+        },
+        "deprecationDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The datetime of deprecation of the model SKU."
+        },
+        "capacity": {
+          "$ref": "#/definitions/CapacityConfig",
+          "description": "The capacity configuration."
+        },
+        "rateLimits": {
+          "type": "array",
+          "description": "The list of rateLimit.",
+          "items": {
+            "$ref": "#/definitions/CallRateLimit"
+          },
+          "x-ms-identifiers": []
+        },
+        "cost": {
+          "type": "array",
+          "description": "The list of billing meter info.",
+          "items": {
+            "$ref": "#/definitions/BillingMeterInfo"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "ModelSkuCapacityProperties": {
+      "type": "object",
+      "description": "Cognitive Services account ModelSkuCapacity.",
+      "properties": {
+        "model": {
+          "$ref": "#/definitions/DeploymentModel",
+          "description": "Properties of Cognitive Services account deployment model."
+        },
+        "skuName": {
+          "type": "string"
+        },
+        "availableCapacity": {
+          "type": "number",
+          "format": "float",
+          "description": "The available capacity for deployment with this model and sku."
+        },
+        "availableFinetuneCapacity": {
+          "type": "number",
+          "format": "float",
+          "description": "The available capacity for deployment with a fine-tune version of this model and sku."
+        }
+      }
+    },
+    "MultiRegionSettings": {
+      "type": "object",
+      "description": "The multiregion settings Cognitive Services account.",
+      "properties": {
+        "routingMethod": {
+          "$ref": "#/definitions/RoutingMethods",
+          "description": "Multiregion routing methods."
+        },
+        "regions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RegionSetting"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      }
+    },
+    "NetworkInjection": {
+      "type": "object",
+      "description": "Specifies in AI Foundry where virtual network injection occurs to secure scenarios like Agents entirely within the user's private network, eliminating public internet exposure while maintaining control over network configurations and resources.",
+      "properties": {
+        "scenario": {
+          "$ref": "#/definitions/ScenarioType",
+          "description": "Specifies what features in AI Foundry network injection applies to. Currently only supports 'agent' for agent scenarios. 'none' means no network injection."
+        },
+        "subnetArmId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Specify the subnet for which your Agent Client is injected into.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/virtualNetworks/subnets"
+              }
+            ]
+          }
+        },
+        "useMicrosoftManagedNetwork": {
+          "type": "boolean",
+          "description": "Boolean to enable Microsoft Managed Network for subnet delegation"
+        }
+      }
+    },
+    "NetworkRuleAction": {
+      "type": "string",
+      "description": "The default action when no rule from ipRules and from virtualNetworkRules match. This is only used after the bypass property has been evaluated.",
+      "enum": [
+        "Allow",
+        "Deny"
+      ],
+      "x-ms-enum": {
+        "name": "NetworkRuleAction",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Allow",
+            "value": "Allow"
+          },
+          {
+            "name": "Deny",
+            "value": "Deny"
+          }
+        ]
+      }
+    },
+    "NetworkRuleSet": {
+      "type": "object",
+      "description": "A set of rules governing the network accessibility.",
+      "properties": {
+        "defaultAction": {
+          "$ref": "#/definitions/NetworkRuleAction",
+          "description": "The default action when no rule from ipRules and from virtualNetworkRules match. This is only used after the bypass property has been evaluated."
+        },
+        "bypass": {
+          "$ref": "#/definitions/ByPassSelection",
+          "description": "Setting for trusted services."
+        },
+        "ipRules": {
+          "type": "array",
+          "description": "The list of IP address rules.",
+          "items": {
+            "$ref": "#/definitions/IpRule"
+          },
+          "x-ms-identifiers": []
+        },
+        "virtualNetworkRules": {
+          "type": "array",
+          "description": "The list of virtual network rules.",
+          "items": {
+            "$ref": "#/definitions/VirtualNetworkRule"
+          }
+        }
+      }
+    },
+    "NetworkSecurityPerimeter": {
+      "type": "object",
+      "description": "Information about a linked Network Security Perimeter",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Fully qualified identifier of the resource"
+        },
+        "perimeterGuid": {
+          "type": "string",
+          "description": "Guid of the resource"
+        },
+        "location": {
+          "type": "string",
+          "description": "Location of the resource"
+        }
+      }
+    },
+    "NetworkSecurityPerimeterAccessRule": {
+      "type": "object",
+      "description": "Network Security Perimeter Access Rule",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Network Security Perimeter Access Rule Name"
+        },
+        "properties": {
+          "$ref": "#/definitions/NetworkSecurityPerimeterAccessRuleProperties",
+          "description": "Properties of Network Security Perimeter Access Rule"
+        }
+      }
+    },
+    "NetworkSecurityPerimeterAccessRuleProperties": {
+      "type": "object",
+      "description": "The Properties of Network Security Perimeter Rule",
+      "properties": {
+        "direction": {
+          "$ref": "#/definitions/NspAccessRuleDirection",
+          "description": "Direction of Access Rule"
+        },
+        "addressPrefixes": {
+          "type": "array",
+          "description": "Address prefixes for inbound rules",
+          "items": {
+            "type": "string"
+          }
+        },
+        "subscriptions": {
+          "type": "array",
+          "description": "Subscriptions for inbound rules",
+          "items": {
+            "$ref": "#/definitions/NetworkSecurityPerimeterAccessRulePropertiesSubscriptionsItem"
+          }
+        },
+        "networkSecurityPerimeters": {
+          "type": "array",
+          "description": "NetworkSecurityPerimeters for inbound rules",
+          "items": {
+            "$ref": "#/definitions/NetworkSecurityPerimeter"
+          }
+        },
+        "fullyQualifiedDomainNames": {
+          "type": "array",
+          "description": "Fully qualified domain name for outbound rules",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "NetworkSecurityPerimeterAccessRulePropertiesSubscriptionsItem": {
+      "type": "object",
+      "description": "Subscription for inbound rule",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Fully qualified identifier of subscription"
+        }
+      }
+    },
+    "NetworkSecurityPerimeterConfiguration": {
+      "type": "object",
+      "description": "NSP Configuration for an Cognitive Services account.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationProperties",
+          "description": "NSP Configuration properties."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "NetworkSecurityPerimeterConfigurationAssociationInfo": {
+      "type": "object",
+      "description": "Network Security Perimeter Configuration Association Information",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the resource association"
+        },
+        "accessMode": {
+          "type": "string",
+          "description": "Access Mode of the resource association"
+        }
+      }
+    },
+    "NetworkSecurityPerimeterConfigurationList": {
+      "type": "object",
+      "description": "A list of NSP configurations for an Cognitive Services account.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "Array of NSP configurations List Result for an Cognitive Services account.",
+          "items": {
+            "$ref": "#/definitions/NetworkSecurityPerimeterConfiguration"
+          },
+          "x-ms-identifiers": [
+            "id"
+          ]
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "Link to retrieve next page of results."
+        }
+      }
+    },
+    "NetworkSecurityPerimeterConfigurationProperties": {
+      "type": "object",
+      "description": "The properties of an NSP Configuration.",
+      "properties": {
+        "provisioningState": {
+          "type": "string",
+          "description": "Provisioning state of NetworkSecurityPerimeter configuration",
+          "readOnly": true
+        },
+        "provisioningIssues": {
+          "type": "array",
+          "description": "List of Provisioning Issues",
+          "items": {
+            "$ref": "#/definitions/ProvisioningIssue"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "networkSecurityPerimeter": {
+          "$ref": "#/definitions/NetworkSecurityPerimeter",
+          "description": "Information about a linked Network Security Perimeter"
+        },
+        "resourceAssociation": {
+          "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationAssociationInfo",
+          "description": "Network Security Perimeter Configuration Association Information"
+        },
+        "profile": {
+          "$ref": "#/definitions/NetworkSecurityPerimeterProfileInfo",
+          "description": "Network Security Perimeter Profile Information"
+        }
+      }
+    },
+    "NetworkSecurityPerimeterProfileInfo": {
+      "type": "object",
+      "description": "Network Security Perimeter Profile Information",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the resource profile"
+        },
+        "accessRulesVersion": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Access rules version of the resource profile"
+        },
+        "accessRules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NetworkSecurityPerimeterAccessRule"
+          },
+          "x-ms-identifiers": []
+        },
+        "diagnosticSettingsVersion": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Current diagnostic settings version"
+        },
+        "enabledLogCategories": {
+          "type": "array",
+          "description": "List of enabled log categories",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "NoneAuthTypeConnectionProperties": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ConnectionPropertiesV2"
+        }
+      ],
+      "x-ms-discriminator-value": "None"
+    },
+    "NspAccessRuleDirection": {
+      "type": "string",
+      "description": "Direction of Access Rule",
+      "enum": [
+        "Inbound",
+        "Outbound"
+      ],
+      "x-ms-enum": {
+        "name": "NspAccessRuleDirection",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Inbound",
+            "value": "Inbound"
+          },
+          {
+            "name": "Outbound",
+            "value": "Outbound"
+          }
+        ]
+      }
+    },
+    "OAuth2AuthTypeConnectionProperties": {
+      "type": "object",
+      "properties": {
+        "credentials": {
+          "$ref": "#/definitions/ConnectionOAuth2",
+          "description": "ClientId and ClientSecret are required. Other properties are optional\ndepending on each OAuth2 provider's implementation."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ConnectionPropertiesV2"
+        }
+      ],
+      "x-ms-discriminator-value": "OAuth2"
+    },
+    "OrganizationSharedBuiltInAuthorizationPolicy": {
+      "type": "object",
+      "description": "Built-in authorization policy scoped to organization/tenant.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ApplicationAuthorizationPolicy"
+        }
+      ],
+      "x-ms-discriminator-value": "OrganizationScope"
+    },
+    "Origin": {
+      "type": "string",
+      "description": "The intended executor of the operation; as in Resource Based Access Control (RBAC) and audit logs UX. Default value is \"user,system\"",
+      "enum": [
+        "user",
+        "system",
+        "user,system"
+      ],
+      "x-ms-enum": {
+        "name": "Origin",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "user",
+            "value": "user"
+          },
+          {
+            "name": "system",
+            "value": "system"
+          },
+          {
+            "name": "user,system",
+            "value": "user,system"
+          }
+        ]
+      }
+    },
+    "OutboundRule": {
+      "type": "object",
+      "description": "Outbound Rule for the managed network of a cognitive services account.",
+      "properties": {
+        "category": {
+          "$ref": "#/definitions/RuleCategory",
+          "description": "Category of a managed network Outbound Rule of a cognitive services account."
+        },
+        "status": {
+          "$ref": "#/definitions/RuleStatus",
+          "description": "Type of a managed network Outbound Rule of a cognitive services account."
+        },
+        "type": {
+          "$ref": "#/definitions/RuleType",
+          "description": "Type of a managed network Outbound Rule of a cognitive services account."
+        },
+        "errorInformation": {
+          "type": "string",
+          "description": "Error information about an outbound rule of a cognitive services account if RuleStatus is failed.",
+          "readOnly": true
+        },
+        "parentRuleNames": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "type"
+      ]
+    },
+    "OutboundRuleBasicResource": {
+      "type": "object",
+      "description": "Concrete proxy resource types can be created by aliasing this type using a specific property type.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/OutboundRule",
+          "description": "Outbound Rule for the managed network of a cognitive services account."
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "OutboundRuleListResult": {
+      "type": "object",
+      "description": "List of outbound rules for the managed network of a cognitive services account.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link to the next page constructed using the continuationToken.  If null, there are no additional pages."
+        },
+        "value": {
+          "type": "array",
+          "description": "The list of cognitive services accounts. Since this list may be incomplete, the nextLink field should be used to request the next list of cognitive services accounts.",
+          "items": {
+            "$ref": "#/definitions/OutboundRuleBasicResource"
+          }
+        }
+      }
+    },
+    "PATAuthTypeConnectionProperties": {
+      "type": "object",
+      "properties": {
+        "credentials": {
+          "$ref": "#/definitions/ConnectionPersonalAccessToken"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ConnectionPropertiesV2"
+        }
+      ],
+      "x-ms-discriminator-value": "PAT"
+    },
+    "PatchResourceTags": {
+      "type": "object",
+      "description": "The object being used to update tags of a resource, in general used for PATCH operations.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        }
+      }
+    },
+    "PatchResourceTagsAndSku": {
+      "type": "object",
+      "description": "The object being used to update tags and sku of a resource, in general used for PATCH operations.",
+      "properties": {
+        "sku": {
+          "$ref": "#/definitions/Sku",
+          "description": "The resource model definition representing SKU"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/PatchResourceTags"
+        }
+      ]
+    },
+    "PrivateEndpointConnection": {
+      "type": "object",
+      "description": "The Private Endpoint Connection resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PrivateEndpointConnectionProperties",
+          "description": "Resource properties."
+        },
+        "etag": {
+          "type": "string",
+          "description": "Resource Etag.",
+          "readOnly": true
+        },
+        "location": {
+          "type": "string",
+          "description": "The location of the private endpoint connection"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "PrivateEndpointConnectionListResult": {
+      "type": "object",
+      "description": "A list of private endpoint connections",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "Array of private endpoint connections",
+          "items": {
+            "$ref": "#/definitions/PrivateEndpointConnection"
+          }
+        }
+      }
+    },
+    "PrivateEndpointConnectionProperties": {
+      "type": "object",
+      "description": "Properties of the PrivateEndpointConnectProperties.",
+      "properties": {
+        "privateEndpoint": {
+          "$ref": "../../../../../common-types/resource-management/v3/privatelinks.json#/definitions/PrivateEndpoint",
+          "description": "The resource of private end point."
+        },
+        "privateLinkServiceConnectionState": {
+          "$ref": "../../../../../common-types/resource-management/v3/privatelinks.json#/definitions/PrivateLinkServiceConnectionState",
+          "description": "A collection of information about the state of the connection between service consumer and provider."
+        },
+        "provisioningState": {
+          "$ref": "../../../../../common-types/resource-management/v3/privatelinks.json#/definitions/PrivateEndpointConnectionProvisioningState",
+          "description": "The provisioning state of the private endpoint connection resource.",
+          "readOnly": true
+        },
+        "groupIds": {
+          "type": "array",
+          "description": "The private link resource group ids.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "privateLinkServiceConnectionState"
+      ]
+    },
+    "PrivateEndpointOutboundRule": {
+      "type": "object",
+      "description": "Private Endpoint outbound rule for the managed network of a cognitive services account.",
+      "properties": {
+        "destination": {
+          "$ref": "#/definitions/PrivateEndpointOutboundRuleDestination",
+          "description": "Private Endpoint destination."
+        },
+        "fqdns": {
+          "type": "array",
+          "description": "List of FQDNs associated with the private endpoint outbound rule.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/OutboundRule"
+        }
+      ],
+      "x-ms-discriminator-value": "PrivateEndpoint"
+    },
+    "PrivateEndpointOutboundRuleDestination": {
+      "type": "object",
+      "description": "Private Endpoint destination for an outbound rule.",
+      "properties": {
+        "serviceResourceId": {
+          "type": "string",
+          "description": "The Azure resource ID of the target private endpoint service."
+        },
+        "subresourceTarget": {
+          "type": "string",
+          "description": "The subresource of the target service to connect to."
+        }
+      }
+    },
+    "PrivateLinkResource": {
+      "type": "object",
+      "description": "A private link resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PrivateLinkResourceProperties",
+          "description": "Resource properties."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/Resource"
+        }
+      ]
+    },
+    "PrivateLinkResourceListResult": {
+      "type": "object",
+      "description": "A list of private link resources",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "Array of private link resources",
+          "items": {
+            "$ref": "#/definitions/PrivateLinkResource"
+          }
+        }
+      }
+    },
+    "PrivateLinkResourceProperties": {
+      "type": "object",
+      "description": "Properties of a private link resource.",
+      "properties": {
+        "groupId": {
+          "type": "string",
+          "description": "The private link resource group id.",
+          "readOnly": true
+        },
+        "requiredMembers": {
+          "type": "array",
+          "description": "The private link resource required member names.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "requiredZoneNames": {
+          "type": "array",
+          "description": "The private link resource Private link DNS zone name.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "displayName": {
+          "type": "string",
+          "description": "The private link resource display name.",
+          "readOnly": true
+        }
+      }
+    },
+    "Project": {
+      "type": "object",
+      "description": "Cognitive Services project is an Azure resource representing the provisioned account's project, it's type, location and SKU.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ProjectProperties",
+          "description": "Properties of Cognitive Services project."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "etag": {
+          "type": "string",
+          "description": "Resource Etag.",
+          "readOnly": true
+        },
+        "identity": {
+          "$ref": "#/definitions/Identity",
+          "description": "Identity for the resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ProjectCapabilityHost": {
+      "type": "object",
+      "description": "Azure Resource Manager resource envelope for Project CapabilityHost.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ProjectCapabilityHostProperties",
+          "description": "[Required] Additional attributes of the entity."
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ProjectCapabilityHostProperties": {
+      "type": "object",
+      "properties": {
+        "aiServicesConnections": {
+          "type": "array",
+          "description": "List of AI services connections.",
+          "x-nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "vectorStoreConnections": {
+          "type": "array",
+          "description": "List of connection names from those available in the account or project to be used for vector database (e.g. CosmosDB).",
+          "x-nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "storageConnections": {
+          "type": "array",
+          "description": "List of connection names from those available in the account or project to be used as a storage resource.",
+          "x-nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "threadStorageConnections": {
+          "type": "array",
+          "description": "List of connection names from those available in the account or project to be used for Thread storage.",
+          "x-nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/CapabilityHostProvisioningState",
+          "description": "Provisioning state for the CapabilityHost.",
+          "readOnly": true
+        }
+      }
+    },
+    "ProjectCapabilityHostResourceArmPaginatedResult": {
+      "type": "object",
+      "description": "A paginated list of Project Capability Host entities.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link to the next page of Project Capability Host objects. If null, there are no additional pages.",
+          "x-nullable": true
+        },
+        "value": {
+          "type": "array",
+          "description": "An array of objects of type Project Capability Host.",
+          "items": {
+            "$ref": "#/definitions/ProjectCapabilityHost"
+          }
+        }
+      }
+    },
+    "ProjectListResult": {
+      "type": "object",
+      "description": "The list of cognitive services projects operation response.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of projects."
+        },
+        "value": {
+          "type": "array",
+          "description": "Gets the list of Cognitive Services projects and their properties.",
+          "items": {
+            "$ref": "#/definitions/Project"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "ProjectProperties": {
+      "type": "object",
+      "description": "Properties of Cognitive Services Project'.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "Gets the status of the cognitive services project at the time the operation was called.",
+          "readOnly": true
+        },
+        "displayName": {
+          "type": "string",
+          "description": "The display name of the Cognitive Services Project."
+        },
+        "description": {
+          "type": "string",
+          "description": "The description of the Cognitive Services Project."
+        },
+        "endpoints": {
+          "type": "object",
+          "description": "The list of endpoint for this Cognitive Services Project.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "isDefault": {
+          "type": "boolean",
+          "description": "Indicates whether the project is the default project for the account.",
+          "readOnly": true
+        }
+      }
+    },
+    "ProviderInfo": {
+      "type": "object",
+      "description": "Service provider information for the Agent",
+      "properties": {
+        "organization": {
+          "type": "string",
+          "description": "Organization name of the provider.",
+          "x-nullable": true
+        },
+        "url": {
+          "type": "string",
+          "description": "URL of the provider.",
+          "x-nullable": true
+        }
+      }
+    },
+    "ProvisioningIssue": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the NSP provisioning issue"
+        },
+        "properties": {
+          "$ref": "#/definitions/ProvisioningIssueProperties",
+          "description": "Properties of Provisioning Issue"
+        }
+      }
+    },
+    "ProvisioningIssueProperties": {
+      "type": "object",
+      "description": "Properties of Provisioning Issue",
+      "properties": {
+        "issueType": {
+          "type": "string",
+          "description": "Type of Issue"
+        },
+        "severity": {
+          "type": "string",
+          "description": "Severity of the issue"
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the issue"
+        },
+        "suggestedResourceIds": {
+          "type": "array",
+          "description": "IDs of resources that can be associated to the same perimeter to remediate the issue.",
+          "items": {
+            "type": "string",
+            "format": "arm-id",
+            "description": "A type definition that refers the id to an Azure Resource Manager resource."
+          }
+        },
+        "suggestedAccessRules": {
+          "type": "array",
+          "description": "Optional array, suggested access rules",
+          "items": {
+            "$ref": "#/definitions/NetworkSecurityPerimeterAccessRule"
+          }
+        }
+      }
+    },
+    "ProvisioningState": {
+      "type": "string",
+      "description": "Gets the status of the cognitive services account at the time the operation was called.",
+      "enum": [
+        "Accepted",
+        "Creating",
+        "Deleting",
+        "Moving",
+        "Failed",
+        "Succeeded",
+        "Canceled",
+        "ResolvingDNS"
+      ],
+      "x-ms-enum": {
+        "name": "ProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Accepted",
+            "value": "Accepted"
+          },
+          {
+            "name": "Creating",
+            "value": "Creating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting"
+          },
+          {
+            "name": "Moving",
+            "value": "Moving"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled"
+          },
+          {
+            "name": "ResolvingDNS",
+            "value": "ResolvingDNS"
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "PublicNetworkAccess": {
+      "type": "string",
+      "description": "Whether or not public endpoint access is allowed for this account.",
+      "enum": [
+        "Enabled",
+        "Disabled"
+      ],
+      "x-ms-enum": {
+        "name": "PublicNetworkAccess",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Enabled",
+            "value": "Enabled"
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled"
+          }
+        ]
+      }
+    },
+    "QuotaLimit": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "type": "number",
+          "format": "float"
+        },
+        "renewalPeriod": {
+          "type": "number",
+          "format": "float"
+        },
+        "rules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ThrottlingRule"
+          },
+          "x-ms-identifiers": [
+            "key"
+          ]
+        }
+      }
+    },
+    "QuotaTier": {
+      "type": "object",
+      "description": "The quota tier information for the subscription",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/QuotaTierProperties",
+          "description": "Properties of quota tier resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "QuotaTierListResult": {
+      "type": "object",
+      "description": "The list of Quota Tiers response.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of quota tiers."
+        },
+        "value": {
+          "type": "array",
+          "description": "Gets the list of Quota Tiers and their properties.",
+          "items": {
+            "$ref": "#/definitions/QuotaTier"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "id"
+          ]
+        }
+      }
+    },
+    "QuotaTierProperties": {
+      "type": "object",
+      "description": "Properties of Quota Tier resource'.",
+      "properties": {
+        "currentTierName": {
+          "type": "string",
+          "description": "Name of the current quota tier for the subscription.",
+          "readOnly": true
+        },
+        "tierUpgradePolicy": {
+          "$ref": "#/definitions/TierUpgradePolicy",
+          "description": "Gets the tier upgrade policy for the subscription."
+        },
+        "assignmentDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the current tier was assigned to the subscription (UTC).",
+          "readOnly": true
+        },
+        "tierUpgradeEligibilityInfo": {
+          "$ref": "#/definitions/QuotaTierUpgradeEligibilityInfo",
+          "description": "Information about the quota tier upgrade eligibility for the subscription.",
+          "x-nullable": true,
+          "readOnly": true
+        }
+      }
+    },
+    "QuotaTierUpgradeEligibilityInfo": {
+      "type": "object",
+      "description": "Information about the quota tier upgrade eligibility for the subscription.",
+      "properties": {
+        "nextTierName": {
+          "type": "string",
+          "description": "Name of the next quota tier for the subscription.",
+          "x-nullable": true
+        },
+        "upgradeAvailabilityStatus": {
+          "$ref": "#/definitions/UpgradeAvailabilityStatus",
+          "description": "Specifies whether an upgrade to the next quota tier is available."
+        },
+        "upgradeApplicableDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date after which the current tier will be upgraded to the next tier if the TierUpgradePolicy is \"OnceUpgradeIsAvailable\" (UTC).",
+          "x-nullable": true
+        },
+        "upgradeUnavailabilityReason": {
+          "type": "string",
+          "description": "Reason in case the subscription is not eligible for upgrade to the next tier.",
+          "x-nullable": true
+        }
+      }
+    },
+    "QuotaUsageStatus": {
+      "type": "string",
+      "description": "Cognitive Services account quota usage status.",
+      "enum": [
+        "Included",
+        "Blocked",
+        "InOverage",
+        "Unknown"
+      ],
+      "x-ms-enum": {
+        "name": "QuotaUsageStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Included",
+            "value": "Included"
+          },
+          {
+            "name": "Blocked",
+            "value": "Blocked"
+          },
+          {
+            "name": "InOverage",
+            "value": "InOverage"
+          },
+          {
+            "name": "Unknown",
+            "value": "Unknown"
+          }
+        ]
+      }
+    },
+    "RaiActionType": {
+      "type": "string",
+      "description": "The action types to apply to the content filters",
+      "enum": [
+        "None",
+        "BLOCKING",
+        "ANNOTATING",
+        "HITL",
+        "RETRY"
+      ],
+      "x-ms-enum": {
+        "name": "RaiActionType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None"
+          },
+          {
+            "name": "BLOCKING",
+            "value": "BLOCKING"
+          },
+          {
+            "name": "ANNOTATING",
+            "value": "ANNOTATING"
+          },
+          {
+            "name": "HITL",
+            "value": "HITL"
+          },
+          {
+            "name": "RETRY",
+            "value": "RETRY"
+          }
+        ]
+      }
+    },
+    "RaiBlockListItemsResult": {
+      "type": "object",
+      "description": "The list of cognitive services RAI Blocklist Items.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of RaiBlocklistItems."
+        },
+        "value": {
+          "type": "array",
+          "description": "The list of RaiBlocklistItems.",
+          "items": {
+            "$ref": "#/definitions/RaiBlocklistItem"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      }
+    },
+    "RaiBlockListResult": {
+      "type": "object",
+      "description": "The list of cognitive services RAI Blocklists.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of RaiBlocklists."
+        },
+        "value": {
+          "type": "array",
+          "description": "The list of RaiBlocklist.",
+          "items": {
+            "$ref": "#/definitions/RaiBlocklist"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      }
+    },
+    "RaiBlocklist": {
+      "type": "object",
+      "description": "Cognitive Services RaiBlocklist.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/RaiBlocklistProperties",
+          "description": "Properties of Cognitive Services RaiBlocklist."
+        },
+        "etag": {
+          "type": "string",
+          "description": "Resource Etag.",
+          "readOnly": true
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "RaiBlocklistConfig": {
+      "type": "object",
+      "description": "Azure OpenAI blocklist config.",
+      "properties": {
+        "blocklistName": {
+          "type": "string",
+          "description": "Name of ContentFilter."
+        },
+        "blocking": {
+          "type": "boolean",
+          "description": "If blocking would occur."
+        }
+      }
+    },
+    "RaiBlocklistItem": {
+      "type": "object",
+      "description": "Cognitive Services RaiBlocklist Item.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/RaiBlocklistItemProperties",
+          "description": "Properties of Cognitive Services RaiBlocklist Item."
+        },
+        "etag": {
+          "type": "string",
+          "description": "Resource Etag.",
+          "readOnly": true
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "RaiBlocklistItemBulkRequest": {
+      "type": "object",
+      "description": "The Cognitive Services RaiBlocklist Item request body.",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "properties": {
+          "$ref": "#/definitions/RaiBlocklistItemProperties",
+          "description": "Properties of Cognitive Services RaiBlocklist Item."
+        }
+      }
+    },
+    "RaiBlocklistItemProperties": {
+      "type": "object",
+      "description": "RAI Custom Blocklist Item properties.",
+      "properties": {
+        "pattern": {
+          "type": "string",
+          "description": "Pattern to match against."
+        },
+        "isRegex": {
+          "type": "boolean",
+          "description": "If the pattern is a regex pattern."
+        }
+      }
+    },
+    "RaiBlocklistItemsBulkAddRequest": {
+      "type": "array",
+      "description": "The list of Cognitive Services RaiBlocklist Items for batch add.",
+      "items": {
+        "$ref": "#/definitions/RaiBlocklistItemBulkRequest"
+      }
+    },
+    "RaiBlocklistItemsBulkDeleteRequest": {
+      "type": "array",
+      "description": "The list of Cognitive Services RaiBlocklist Items Names.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "RaiBlocklistProperties": {
+      "type": "object",
+      "description": "RAI Custom Blocklist properties.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Description of the block list."
+        }
+      }
+    },
+    "RaiContentFilter": {
+      "type": "object",
+      "description": "Azure OpenAI Content Filter.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/RaiContentFilterProperties",
+          "description": "Azure OpenAI Content Filter Properties."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "RaiContentFilterListResult": {
+      "type": "object",
+      "description": "The list of Content Filters.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of Content Filters."
+        },
+        "value": {
+          "type": "array",
+          "description": "The list of RaiContentFilter.",
+          "items": {
+            "$ref": "#/definitions/RaiContentFilter"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      }
+    },
+    "RaiContentFilterProperties": {
+      "type": "object",
+      "description": "Azure OpenAI Content Filter Properties.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of Content Filter."
+        },
+        "isMultiLevelFilter": {
+          "type": "boolean",
+          "description": "If the Content Filter has multi severity levels(Low, Medium, or High)."
+        },
+        "source": {
+          "$ref": "#/definitions/RaiPolicyContentSource",
+          "description": "Content source to apply the Content Filters."
+        }
+      }
+    },
+    "RaiExternalSafetyProvider": {
+      "type": "object",
+      "description": "Cognitive Services Rai External Safety provider.",
+      "properties": {
+        "etag": {
+          "type": "string",
+          "description": "Resource Etag.",
+          "readOnly": true
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "properties": {
+          "$ref": "#/definitions/RaiExternalSafetyProviderProperties",
+          "description": "Properties of Cognitive Services Rai External Safety provider."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "RaiExternalSafetyProviderProperties": {
+      "type": "object",
+      "description": "RAI External SafetyProvider properties.",
+      "properties": {
+        "providerId": {
+          "type": "string",
+          "description": "The unique identifier of the safety provider."
+        },
+        "providerName": {
+          "type": "string",
+          "description": "Name of the safety provider."
+        },
+        "mode": {
+          "type": "string",
+          "description": "Safety provider mode sync/async."
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Webhook URL for the safety provider."
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Creation time of the safety provider."
+        },
+        "lastModifiedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last modified time of the safety provider."
+        }
+      }
+    },
+    "RaiExternalSafetyProviderResult": {
+      "type": "object",
+      "description": "The list of cognitive services RAI External Safety Providers.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of Rai External Safety Provider."
+        },
+        "value": {
+          "type": "array",
+          "description": "The list of RaiExternalSafetyProvider.",
+          "items": {
+            "$ref": "#/definitions/RaiExternalSafetyProviderSchema"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      }
+    },
+    "RaiExternalSafetyProviderSchema": {
+      "type": "object",
+      "description": "Cognitive Services Rai External Safety provider Schema.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/RaiExternalSafetyProviderSchemaProperties",
+          "description": "Properties of Cognitive Services Rai External Safety provider."
+        },
+        "etag": {
+          "type": "string",
+          "description": "Resource Etag.",
+          "readOnly": true
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "RaiExternalSafetyProviderSchemaProperties": {
+      "type": "object",
+      "description": "RAI External SafetyProvider schema properties.",
+      "properties": {
+        "providerId": {
+          "type": "string",
+          "description": "The unique identifier of the safety provider."
+        },
+        "providerName": {
+          "type": "string",
+          "description": "Name of the safety provider."
+        },
+        "mode": {
+          "type": "string",
+          "description": "Safety provider mode sync/async."
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Webhook URL for the safety provider."
+        },
+        "secretName": {
+          "type": "string",
+          "description": "The name of the secret in Key Vault that contains the api key to access the webhook."
+        },
+        "managedIdentity": {
+          "type": "string",
+          "description": "The managed identity to access the Key Vault."
+        },
+        "keyVaultUri": {
+          "type": "string",
+          "format": "uri",
+          "description": "The Key Vault URI that contains the api key for safety provider urls."
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Creation time of the safety provider.",
+          "readOnly": true
+        },
+        "lastModifiedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last modified time of the safety provider.",
+          "readOnly": true
+        }
+      }
+    },
+    "RaiMonitorConfig": {
+      "type": "object",
+      "description": "Cognitive Services Rai Monitor Config.",
+      "properties": {
+        "adxStorageResourceId": {
+          "type": "string",
+          "description": "The storage resource Id."
+        },
+        "identityClientId": {
+          "type": "string",
+          "description": "The identity client Id to access the storage."
+        }
+      }
+    },
+    "RaiPolicy": {
+      "type": "object",
+      "description": "Cognitive Services RaiPolicy.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/RaiPolicyProperties",
+          "description": "Properties of Cognitive Services RaiPolicy."
+        },
+        "etag": {
+          "type": "string",
+          "description": "Resource Etag.",
+          "readOnly": true
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "RaiPolicyContentFilter": {
+      "type": "object",
+      "description": "Azure OpenAI Content Filter.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of ContentFilter."
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "If the ContentFilter is enabled."
+        },
+        "severityThreshold": {
+          "$ref": "#/definitions/ContentLevel",
+          "description": "Level at which content is filtered."
+        },
+        "blocking": {
+          "type": "boolean",
+          "description": "If blocking would occur."
+        },
+        "source": {
+          "$ref": "#/definitions/RaiPolicyContentSource",
+          "description": "Content source to apply the Content Filters."
+        },
+        "action": {
+          "$ref": "#/definitions/RaiActionType",
+          "description": "The action types to apply to the content filters"
+        }
+      }
+    },
+    "RaiPolicyContentSource": {
+      "type": "string",
+      "description": "Content source to apply the Content Filters.",
+      "enum": [
+        "Prompt",
+        "Completion",
+        "PreToolCall",
+        "PostToolCall",
+        "PreRun",
+        "PostRun"
+      ],
+      "x-ms-enum": {
+        "name": "RaiPolicyContentSource",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Prompt",
+            "value": "Prompt"
+          },
+          {
+            "name": "Completion",
+            "value": "Completion"
+          },
+          {
+            "name": "PreToolCall",
+            "value": "PreToolCall"
+          },
+          {
+            "name": "PostToolCall",
+            "value": "PostToolCall"
+          },
+          {
+            "name": "PreRun",
+            "value": "PreRun"
+          },
+          {
+            "name": "PostRun",
+            "value": "PostRun"
+          }
+        ]
+      }
+    },
+    "RaiPolicyListResult": {
+      "type": "object",
+      "description": "The list of cognitive services RaiPolicies.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of RaiPolicy."
+        },
+        "value": {
+          "type": "array",
+          "description": "The list of RaiPolicy.",
+          "items": {
+            "$ref": "#/definitions/RaiPolicy"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      }
+    },
+    "RaiPolicyMode": {
+      "type": "string",
+      "description": "Rai policy mode. The enum value mapping is as below: Default = 0, Deferred=1, Blocking=2, Asynchronous_filter =3. Please use 'Asynchronous_filter' after 2025-06-01. It is the same as 'Deferred' in previous version.",
+      "enum": [
+        "Default",
+        "Deferred",
+        "Blocking",
+        "Asynchronous_filter"
+      ],
+      "x-ms-enum": {
+        "name": "RaiPolicyMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Default",
+            "value": "Default"
+          },
+          {
+            "name": "Deferred",
+            "value": "Deferred"
+          },
+          {
+            "name": "Blocking",
+            "value": "Blocking"
+          },
+          {
+            "name": "Asynchronous_filter",
+            "value": "Asynchronous_filter"
+          }
+        ]
+      }
+    },
+    "RaiPolicyProperties": {
+      "type": "object",
+      "description": "Azure OpenAI Content Filters properties.",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/RaiPolicyType",
+          "description": "Content Filters policy type.",
+          "readOnly": true
+        },
+        "mode": {
+          "$ref": "#/definitions/RaiPolicyMode",
+          "description": "Rai policy mode. The enum value mapping is as below: Default = 0, Deferred=1, Blocking=2, Asynchronous_filter =3. Please use 'Asynchronous_filter' after 2025-06-01. It is the same as 'Deferred' in previous version."
+        },
+        "basePolicyName": {
+          "type": "string",
+          "description": "Name of Rai policy."
+        },
+        "contentFilters": {
+          "type": "array",
+          "description": "The list of Content Filters.",
+          "items": {
+            "$ref": "#/definitions/RaiPolicyContentFilter"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "customBlocklists": {
+          "type": "array",
+          "description": "The list of custom Blocklist.",
+          "items": {
+            "$ref": "#/definitions/CustomBlocklistConfig"
+          },
+          "x-ms-identifiers": []
+        },
+        "safetyProviders": {
+          "type": "array",
+          "description": "The list of Safety Providers.",
+          "items": {
+            "$ref": "#/definitions/SafetyProviderConfig"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "RaiPolicyType": {
+      "type": "string",
+      "description": "Content Filters policy type.",
+      "enum": [
+        "UserManaged",
+        "SystemManaged"
+      ],
+      "x-ms-enum": {
+        "name": "RaiPolicyType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "UserManaged",
+            "value": "UserManaged"
+          },
+          {
+            "name": "SystemManaged",
+            "value": "SystemManaged"
+          }
+        ]
+      }
+    },
+    "RaiSafetyProviderConfig": {
+      "type": "object",
+      "description": "Azure OpenAI RAI safety provider config.",
+      "properties": {
+        "safetyProviderName": {
+          "type": "string",
+          "description": "Name of RAI Safety Provider."
+        },
+        "blocking": {
+          "type": "boolean",
+          "description": "If blocking would occur."
+        }
+      }
+    },
+    "RaiToolLabel": {
+      "type": "object",
+      "description": "Cognitive Services RAI Tool Label resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/RaiToolLabelProperties",
+          "description": "Properties of the RAI Tool Label."
+        },
+        "etag": {
+          "type": "string",
+          "description": "Resource Etag.",
+          "readOnly": true
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "RaiToolLabelProperties": {
+      "type": "object",
+      "description": "RAI Tool Label properties.",
+      "properties": {
+        "toolConnectionName": {
+          "type": "string",
+          "description": "The unique tool connection name, e.g., 'Web_Search'."
+        },
+        "accountScope": {
+          "$ref": "#/definitions/RaiToolLabelPropertiesAccountScope",
+          "description": "Account-level tool label definition."
+        },
+        "projectScopes": {
+          "type": "array",
+          "description": "List of project-level tool label definitions.",
+          "items": {
+            "$ref": "#/definitions/RaiToolLabelPropertiesProjectScopesItem"
+          }
+        }
+      },
+      "required": [
+        "toolConnectionName"
+      ]
+    },
+    "RaiToolLabelPropertiesAccountScope": {
+      "type": "object",
+      "description": "Account-level tool label definition.",
+      "properties": {
+        "labelValues": {
+          "type": "object",
+          "description": "Dictionary of label key-value pairs for the account scope.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "RaiToolLabelPropertiesProjectScopesItem": {
+      "type": "object",
+      "properties": {
+        "project": {
+          "type": "string",
+          "description": "Project name to which this scope applies."
+        },
+        "labelValues": {
+          "type": "object",
+          "description": "Dictionary of label key-value pairs for the project scope.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "project",
+        "labelValues"
+      ]
+    },
+    "RaiToolLabelResult": {
+      "type": "object",
+      "description": "The list of Cognitive Services RAI Tool Labels.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of RaiToolLabels."
+        },
+        "value": {
+          "type": "array",
+          "description": "The list of RAI Tool Labels.",
+          "items": {
+            "$ref": "#/definitions/RaiToolLabel"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      }
+    },
+    "RaiTopic": {
+      "type": "object",
+      "description": "Cognitive Services Rai Topic.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/RaiTopicProperties",
+          "description": "Properties of Cognitive Services Rai Topic."
+        },
+        "etag": {
+          "type": "string",
+          "description": "Resource Etag.",
+          "readOnly": true
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "RaiTopicProperties": {
+      "type": "object",
+      "description": "RAI Custom Topic properties.",
+      "properties": {
+        "topicId": {
+          "type": "string",
+          "description": "The unique identifier of the custom topic."
+        },
+        "topicName": {
+          "type": "string",
+          "description": "The name of the custom topic."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the custom topic."
+        },
+        "sampleBlobUrl": {
+          "type": "string",
+          "description": "Sample blob url for the custom topic."
+        },
+        "status": {
+          "type": "string",
+          "description": "Status of the custom topic."
+        },
+        "failedReason": {
+          "type": "string",
+          "description": "Failed reason if the status is Failed."
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Creation time of the custom topic."
+        },
+        "lastModifiedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last modified time of the custom topic."
+        }
+      }
+    },
+    "RaiTopicResult": {
+      "type": "object",
+      "description": "The list of cognitive services RAI Topics.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of RaiTopics."
+        },
+        "value": {
+          "type": "array",
+          "description": "The list of RaiTopic.",
+          "items": {
+            "$ref": "#/definitions/RaiTopic"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      }
+    },
+    "RegenerateKeyParameters": {
+      "type": "object",
+      "description": "Regenerate key parameters.",
+      "properties": {
+        "keyName": {
+          "$ref": "#/definitions/KeyName",
+          "description": "key name to generate (Key1|Key2)"
+        }
+      },
+      "required": [
+        "keyName"
+      ]
+    },
+    "RegionSetting": {
+      "type": "object",
+      "description": "The call rate limit Cognitive Services account.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the region."
+        },
+        "value": {
+          "type": "number",
+          "format": "float",
+          "description": "A value for priority or weighted routing methods."
+        },
+        "customsubdomain": {
+          "type": "string",
+          "description": "Maps the region to the regional custom subdomain."
+        }
+      }
+    },
+    "ReplacementConfig": {
+      "type": "object",
+      "description": "Configuration for model replacement.",
+      "properties": {
+        "targetModelName": {
+          "type": "string",
+          "description": "The name of the replacement model."
+        },
+        "targetModelVersion": {
+          "type": "string",
+          "description": "The version of the replacement model."
+        },
+        "autoUpgradeStartDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date when automatic upgrade should start. This applies to deployments with the OnceNewDefaultVersionAvailable upgrade option."
+        },
+        "upgradeOnExpiryLeadTimeDays": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of days before deprecation date to trigger upgrade. This applies to deployments with the OnceCurrentVersionExpired upgrade option."
+        }
+      }
+    },
+    "RequestMatchPattern": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "method": {
+          "type": "string"
+        }
+      }
+    },
+    "ResourceBase": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "The asset description text.",
+          "x-nullable": true
+        },
+        "tags": {
+          "type": "object",
+          "description": "Tag dictionary. Tags can be added, removed, and updated.",
+          "x-nullable": true,
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ResourceIdentityType": {
+      "type": "string",
+      "description": "The identity type.",
+      "enum": [
+        "None",
+        "SystemAssigned",
+        "UserAssigned",
+        "SystemAssigned, UserAssigned"
+      ],
+      "x-ms-enum": {
+        "name": "ResourceIdentityType",
+        "modelAsString": false
+      }
+    },
+    "ResourceSku": {
+      "type": "object",
+      "description": "Describes an available Cognitive Services SKU.",
+      "properties": {
+        "resourceType": {
+          "type": "string",
+          "description": "The type of resource the SKU applies to."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of SKU."
+        },
+        "tier": {
+          "type": "string",
+          "description": "Specifies the tier of Cognitive Services account."
+        },
+        "kind": {
+          "type": "string",
+          "description": "The Kind of resources that are supported in this SKU."
+        },
+        "locations": {
+          "type": "array",
+          "description": "The set of locations that the SKU is available.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "restrictions": {
+          "type": "array",
+          "description": "The restrictions because of which SKU cannot be used. This is empty if there are no restrictions.",
+          "items": {
+            "$ref": "#/definitions/ResourceSkuRestrictions"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "ResourceSkuListResult": {
+      "type": "object",
+      "description": "The Get Skus operation response.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ResourceSku items on this page",
+          "items": {
+            "$ref": "#/definitions/ResourceSku"
+          },
+          "x-ms-identifiers": [
+            "resourceType",
+            "name",
+            "kind"
+          ]
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ResourceSkuRestrictionInfo": {
+      "type": "object",
+      "properties": {
+        "locations": {
+          "type": "array",
+          "description": "Locations where the SKU is restricted",
+          "items": {
+            "type": "string"
+          }
+        },
+        "zones": {
+          "type": "array",
+          "description": "List of availability zones where the SKU is restricted.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ResourceSkuRestrictions": {
+      "type": "object",
+      "description": "Describes restrictions of a SKU.",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/ResourceSkuRestrictionsType",
+          "description": "The type of restrictions."
+        },
+        "values": {
+          "type": "array",
+          "description": "The value of restrictions. If the restriction type is set to location. This would be different locations where the SKU is restricted.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "restrictionInfo": {
+          "$ref": "#/definitions/ResourceSkuRestrictionInfo",
+          "description": "The information about the restriction where the SKU cannot be used."
+        },
+        "reasonCode": {
+          "$ref": "#/definitions/ResourceSkuRestrictionsReasonCode",
+          "description": "The reason for restriction."
+        }
+      }
+    },
+    "ResourceSkuRestrictionsReasonCode": {
+      "type": "string",
+      "description": "The reason for restriction.",
+      "enum": [
+        "QuotaId",
+        "NotAvailableForSubscription"
+      ],
+      "x-ms-enum": {
+        "name": "ResourceSkuRestrictionsReasonCode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "QuotaId",
+            "value": "QuotaId"
+          },
+          {
+            "name": "NotAvailableForSubscription",
+            "value": "NotAvailableForSubscription"
+          }
+        ]
+      }
+    },
+    "ResourceSkuRestrictionsType": {
+      "type": "string",
+      "description": "The type of restrictions.",
+      "enum": [
+        "Location",
+        "Zone"
+      ],
+      "x-ms-enum": {
+        "name": "ResourceSkuRestrictionsType",
+        "modelAsString": false
+      }
+    },
+    "RoleBasedBuiltInAuthorizationPolicy": {
+      "type": "object",
+      "description": "Built-in role-based authorization policy.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ApplicationAuthorizationPolicy"
+        }
+      ],
+      "x-ms-discriminator-value": "Default"
+    },
+    "RoutingMethods": {
+      "type": "string",
+      "description": "Multiregion routing methods.",
+      "enum": [
+        "Priority",
+        "Weighted",
+        "Performance"
+      ],
+      "x-ms-enum": {
+        "name": "RoutingMethods",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Priority",
+            "value": "Priority"
+          },
+          {
+            "name": "Weighted",
+            "value": "Weighted"
+          },
+          {
+            "name": "Performance",
+            "value": "Performance"
+          }
+        ]
+      }
+    },
+    "RoutingMode": {
+      "type": "string",
+      "description": "The model-router routing mode that determines how requests are distributed across models.",
+      "enum": [
+        "cost",
+        "balanced",
+        "quality"
+      ],
+      "x-ms-enum": {
+        "name": "RoutingMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Cost",
+            "value": "cost",
+            "description": "Route requests to minimize cost while meeting performance requirements."
+          },
+          {
+            "name": "Balanced",
+            "value": "balanced",
+            "description": "Balance cost and quality when routing requests across models."
+          },
+          {
+            "name": "Quality",
+            "value": "quality",
+            "description": "Route requests to maximize quality regardless of cost."
+          }
+        ]
+      }
+    },
+    "RuleAction": {
+      "type": "string",
+      "description": "The action enum for a managed network outbound rule.",
+      "enum": [
+        "Allow",
+        "Deny"
+      ],
+      "x-ms-enum": {
+        "name": "RuleAction",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Allow",
+            "value": "Allow"
+          },
+          {
+            "name": "Deny",
+            "value": "Deny"
+          }
+        ]
+      }
+    },
+    "RuleCategory": {
+      "type": "string",
+      "description": "Category of a managed network Outbound Rule of a cognitive services account.",
+      "enum": [
+        "Required",
+        "Recommended",
+        "UserDefined",
+        "Dependency"
+      ],
+      "x-ms-enum": {
+        "name": "RuleCategory",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Required",
+            "value": "Required"
+          },
+          {
+            "name": "Recommended",
+            "value": "Recommended"
+          },
+          {
+            "name": "UserDefined",
+            "value": "UserDefined"
+          },
+          {
+            "name": "Dependency",
+            "value": "Dependency"
+          }
+        ]
+      }
+    },
+    "RuleStatus": {
+      "type": "string",
+      "description": "Type of a managed network Outbound Rule of a cognitive services account.",
+      "enum": [
+        "Inactive",
+        "Active",
+        "Provisioning",
+        "Deleting",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "RuleStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Inactive",
+            "value": "Inactive"
+          },
+          {
+            "name": "Active",
+            "value": "Active"
+          },
+          {
+            "name": "Provisioning",
+            "value": "Provisioning"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed"
+          }
+        ]
+      }
+    },
+    "RuleType": {
+      "type": "string",
+      "description": "Type of a managed network Outbound Rule of a cognitive services account.",
+      "enum": [
+        "FQDN",
+        "PrivateEndpoint",
+        "ServiceTag"
+      ],
+      "x-ms-enum": {
+        "name": "RuleType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "FQDN",
+            "value": "FQDN"
+          },
+          {
+            "name": "PrivateEndpoint",
+            "value": "PrivateEndpoint"
+          },
+          {
+            "name": "ServiceTag",
+            "value": "ServiceTag"
+          }
+        ]
+      }
+    },
+    "SASAuthTypeConnectionProperties": {
+      "type": "object",
+      "properties": {
+        "credentials": {
+          "$ref": "#/definitions/ConnectionSharedAccessSignature"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ConnectionPropertiesV2"
+        }
+      ],
+      "x-ms-discriminator-value": "SAS"
+    },
+    "SafetyProviderConfig": {
+      "type": "object",
+      "description": "Gets or sets the source to which safety providers applies.",
+      "properties": {
+        "source": {
+          "$ref": "#/definitions/RaiPolicyContentSource",
+          "description": "Content source to apply the Content Filters."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/RaiSafetyProviderConfig"
+        }
+      ]
+    },
+    "ScenarioType": {
+      "type": "string",
+      "description": "Specifies what features in AI Foundry network injection applies to. Currently only supports 'agent' for agent scenarios. 'none' means no network injection.",
+      "enum": [
+        "none",
+        "agent"
+      ],
+      "x-ms-enum": {
+        "name": "ScenarioType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "none",
+            "value": "none"
+          },
+          {
+            "name": "agent",
+            "value": "agent"
+          }
+        ]
+      }
+    },
+    "ServicePrincipalAuthTypeConnectionProperties": {
+      "type": "object",
+      "properties": {
+        "credentials": {
+          "$ref": "#/definitions/ConnectionServicePrincipal"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ConnectionPropertiesV2"
+        }
+      ],
+      "x-ms-discriminator-value": "ServicePrincipal"
+    },
+    "ServiceTagOutboundRule": {
+      "type": "object",
+      "description": "Service Tag outbound rule for the managed network of a cognitive services account.",
+      "properties": {
+        "destination": {
+          "$ref": "#/definitions/ServiceTagOutboundRuleDestination",
+          "description": "Service Tag destination."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/OutboundRule"
+        }
+      ],
+      "x-ms-discriminator-value": "ServiceTag"
+    },
+    "ServiceTagOutboundRuleDestination": {
+      "type": "object",
+      "description": "Service Tag destination for an outbound rule.",
+      "properties": {
+        "serviceTag": {
+          "type": "string",
+          "description": "Name of the Azure service tag to target."
+        },
+        "protocol": {
+          "type": "string",
+          "description": "Network protocol used by the service tag rule."
+        },
+        "portRanges": {
+          "type": "string",
+          "description": "Destination port ranges."
+        },
+        "action": {
+          "$ref": "#/definitions/RuleAction",
+          "description": "The action for the service tag outbound rule."
+        },
+        "addressPrefixes": {
+          "type": "array",
+          "description": "Optional address prefixes. If provided, the serviceTag property will be ignored.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ServiceTier": {
+      "type": "string",
+      "description": "The service tier for the deployment. Determines the pricing and performance level for request processing. Use 'Default' for standard pricing or 'Priority' for higher-priority processing with premium pricing. Note: Pause operations are only supported on Standard, DataZoneStandard, and GlobalStandard SKUs.",
+      "enum": [
+        "Default",
+        "Priority"
+      ],
+      "x-ms-enum": {
+        "name": "ServiceTier",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Default",
+            "value": "Default",
+            "description": "Default service tier meaning the request will be processed with the standard pricing and performance for the selected model."
+          },
+          {
+            "name": "Priority",
+            "value": "Priority",
+            "description": "Priority service tier meaning the request will be processed with higher pricing and performance for the selected model."
+          }
+        ]
+      }
+    },
+    "Skill": {
+      "type": "object",
+      "description": "Collection of capability units the Agent can perform",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique identifier for the skill.",
+          "x-nullable": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Human-readable name for the skill.",
+          "x-nullable": true
+        },
+        "description": {
+          "type": "string",
+          "description": "Skill description.",
+          "x-nullable": true
+        },
+        "tags": {
+          "type": "array",
+          "description": "Tags describing the skill's capability category (e.g., 'cooking', 'customer support').",
+          "x-nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "examples": {
+          "type": "array",
+          "description": "Example scenarios or prompts the skill can execute (e.g., 'I need a recipe for bread').",
+          "x-nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "inputModes": {
+          "type": "array",
+          "description": "Input MIME types supported by the skill (if different from default).",
+          "x-nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "outputModes": {
+          "type": "array",
+          "description": "Output MIME types supported by the skill (if different from default).",
+          "x-nullable": true,
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Sku": {
+      "type": "object",
+      "description": "The resource model definition representing SKU",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the SKU. Ex - P3. It is typically a letter+number code"
+        },
+        "tier": {
+          "$ref": "#/definitions/SkuTier",
+          "description": "This field is required to be implemented by the Resource Provider if the service has more than one tier, but is not required on a PUT."
+        },
+        "size": {
+          "type": "string",
+          "description": "The SKU size. When the name field is the combination of tier and some other value, this would be the standalone code."
+        },
+        "family": {
+          "type": "string",
+          "description": "If the service has different generations of hardware, for the same SKU, then that can be captured here."
+        },
+        "capacity": {
+          "type": "integer",
+          "format": "int32",
+          "description": "If the SKU supports scale out/in then the capacity integer should be included. If scale out/in is not possible for the resource this may be omitted."
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "SkuAvailability": {
+      "type": "object",
+      "description": "SKU availability.",
+      "properties": {
+        "kind": {
+          "type": "string",
+          "description": "The kind (type) of cognitive service account."
+        },
+        "type": {
+          "type": "string",
+          "description": "The Type of the resource."
+        },
+        "skuName": {
+          "type": "string",
+          "description": "The name of SKU."
+        },
+        "skuAvailable": {
+          "type": "boolean",
+          "description": "Indicates the given SKU is available or not."
+        },
+        "reason": {
+          "type": "string",
+          "description": "Reason why the SKU is not available."
+        },
+        "message": {
+          "type": "string",
+          "description": "Additional error message."
+        }
+      }
+    },
+    "SkuAvailabilityListResult": {
+      "type": "object",
+      "description": "Check SKU availability result list.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "Check SKU availability result list.",
+          "items": {
+            "$ref": "#/definitions/SkuAvailability"
+          },
+          "x-ms-identifiers": [
+            "skuName",
+            "type",
+            "kind"
+          ]
+        }
+      }
+    },
+    "SkuCapability": {
+      "type": "object",
+      "description": "SkuCapability indicates the capability of a certain feature.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the SkuCapability."
+        },
+        "value": {
+          "type": "string",
+          "description": "The value of the SkuCapability."
+        }
+      }
+    },
+    "SkuChangeInfo": {
+      "type": "object",
+      "description": "Sku change info of account.",
+      "properties": {
+        "countOfDowngrades": {
+          "type": "number",
+          "format": "float",
+          "description": "Gets the count of downgrades."
+        },
+        "countOfUpgradesAfterDowngrades": {
+          "type": "number",
+          "format": "float",
+          "description": "Gets the count of upgrades after downgrades."
+        },
+        "lastChangeDate": {
+          "type": "string",
+          "description": "Gets the last change date."
+        }
+      }
+    },
+    "SkuResource": {
+      "type": "object",
+      "description": "Properties of Cognitive Services account resource sku resource properties.",
+      "properties": {
+        "resourceType": {
+          "type": "string",
+          "description": "The resource type name."
+        },
+        "sku": {
+          "$ref": "#/definitions/Sku",
+          "description": "The resource model definition representing SKU"
+        },
+        "capacity": {
+          "$ref": "#/definitions/CapacityConfig",
+          "description": "The capacity configuration."
+        }
+      }
+    },
+    "SkuTier": {
+      "type": "string",
+      "description": "This field is required to be implemented by the Resource Provider if the service has more than one tier, but is not required on a PUT.",
+      "enum": [
+        "Free",
+        "Basic",
+        "Standard",
+        "Premium",
+        "Enterprise"
+      ],
+      "x-ms-enum": {
+        "name": "SkuTier",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Free",
+            "value": "Free"
+          },
+          {
+            "name": "Basic",
+            "value": "Basic"
+          },
+          {
+            "name": "Standard",
+            "value": "Standard"
+          },
+          {
+            "name": "Premium",
+            "value": "Premium"
+          },
+          {
+            "name": "Enterprise",
+            "value": "Enterprise"
+          }
+        ]
+      }
+    },
+    "ThrottlingRule": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "renewalPeriod": {
+          "type": "number",
+          "format": "float"
+        },
+        "count": {
+          "type": "number",
+          "format": "float"
+        },
+        "minCount": {
+          "type": "number",
+          "format": "float"
+        },
+        "dynamicThrottlingEnabled": {
+          "type": "boolean"
+        },
+        "matchPatterns": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RequestMatchPattern"
+          },
+          "x-ms-identifiers": [
+            "path",
+            "method"
+          ]
+        }
+      }
+    },
+    "TierUpgradePolicy": {
+      "type": "string",
+      "description": "Gets the tier upgrade policy for the subscription.",
+      "enum": [
+        "OnceUpgradeIsAvailable",
+        "NoAutoUpgrade"
+      ],
+      "x-ms-enum": {
+        "name": "TierUpgradePolicy",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "OnceUpgradeIsAvailable",
+            "value": "OnceUpgradeIsAvailable"
+          },
+          {
+            "name": "NoAutoUpgrade",
+            "value": "NoAutoUpgrade"
+          }
+        ]
+      }
+    },
+    "TrafficRoutingProtocol": {
+      "type": "string",
+      "description": "Traffic routing protocol, used to distribute an application's inbound traffic to its deployments.",
+      "enum": [
+        "FixedRatio"
+      ],
+      "x-ms-enum": {
+        "name": "TrafficRoutingProtocol",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "FixedRatio",
+            "value": "FixedRatio",
+            "description": "Percentage based routing"
+          }
+        ]
+      }
+    },
+    "TrafficRoutingRule": {
+      "type": "object",
+      "description": "Represents a rule for routing traffic to a specific deployment.",
+      "properties": {
+        "ruleId": {
+          "type": "string",
+          "description": "The identifier of this traffic routing rule.",
+          "x-nullable": true
+        },
+        "description": {
+          "type": "string",
+          "description": "A user-provided description for this traffic routing rule.",
+          "x-nullable": true
+        },
+        "deploymentId": {
+          "type": "string",
+          "description": "The unique identifier of the deployment to which traffic is routed by this rule.",
+          "x-nullable": true
+        },
+        "trafficPercentage": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the percentage of traffic allocated to this instance."
+        }
+      }
+    },
+    "UnitType": {
+      "type": "string",
+      "description": "The unit of the metric.",
+      "enum": [
+        "Count",
+        "Bytes",
+        "Seconds",
+        "Percent",
+        "CountPerSecond",
+        "BytesPerSecond",
+        "Milliseconds"
+      ],
+      "x-ms-enum": {
+        "name": "UnitType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Count",
+            "value": "Count"
+          },
+          {
+            "name": "Bytes",
+            "value": "Bytes"
+          },
+          {
+            "name": "Seconds",
+            "value": "Seconds"
+          },
+          {
+            "name": "Percent",
+            "value": "Percent"
+          },
+          {
+            "name": "CountPerSecond",
+            "value": "CountPerSecond"
+          },
+          {
+            "name": "BytesPerSecond",
+            "value": "BytesPerSecond"
+          },
+          {
+            "name": "Milliseconds",
+            "value": "Milliseconds"
+          }
+        ]
+      }
+    },
+    "UpgradeAvailabilityStatus": {
+      "type": "string",
+      "description": "Specifies whether an upgrade to the next quota tier is available.",
+      "enum": [
+        "Available",
+        "NotAvailable"
+      ],
+      "x-ms-enum": {
+        "name": "UpgradeAvailabilityStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Available",
+            "value": "Available"
+          },
+          {
+            "name": "NotAvailable",
+            "value": "NotAvailable"
+          }
+        ]
+      }
+    },
+    "Usage": {
+      "type": "object",
+      "description": "The usage data for a usage request.",
+      "properties": {
+        "unit": {
+          "$ref": "#/definitions/UnitType",
+          "description": "The unit of the metric."
+        },
+        "name": {
+          "$ref": "#/definitions/MetricName",
+          "description": "The name information for the metric."
+        },
+        "quotaPeriod": {
+          "type": "string",
+          "description": "The quota period used to summarize the usage values."
+        },
+        "limit": {
+          "type": "number",
+          "format": "double",
+          "description": "Maximum value for this metric."
+        },
+        "currentValue": {
+          "type": "number",
+          "format": "double",
+          "description": "Current value for this metric."
+        },
+        "nextResetTime": {
+          "type": "string",
+          "description": "Next reset time for current quota."
+        },
+        "status": {
+          "$ref": "#/definitions/QuotaUsageStatus",
+          "description": "Cognitive Services account quota usage status."
+        }
+      }
+    },
+    "UsageListResult": {
+      "type": "object",
+      "description": "The response to a list usage request.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of Usages."
+        },
+        "value": {
+          "type": "array",
+          "description": "The list of usages for Cognitive Service account.",
+          "items": {
+            "$ref": "#/definitions/Usage"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      }
+    },
+    "UserAssignedIdentity": {
+      "type": "object",
+      "description": "User-assigned managed identity.",
+      "properties": {
+        "principalId": {
+          "type": "string",
+          "description": "Azure Active Directory principal ID associated with this Identity.",
+          "readOnly": true
+        },
+        "clientId": {
+          "type": "string",
+          "description": "Client App Id associated with this identity.",
+          "readOnly": true
+        }
+      }
+    },
+    "UserOwnedAmlWorkspace": {
+      "type": "object",
+      "description": "The user owned AML account for Cognitive Services account.",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "description": "Full resource id of a AML account resource."
+        },
+        "identityClientId": {
+          "type": "string",
+          "description": "Identity Client id of a AML account resource."
+        }
+      }
+    },
+    "UserOwnedStorage": {
+      "type": "object",
+      "description": "The user owned storage for Cognitive Services account.",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "description": "Full resource id of a Microsoft.Storage resource."
+        },
+        "identityClientId": {
+          "type": "string"
+        }
+      }
+    },
+    "UsernamePasswordAuthTypeConnectionProperties": {
+      "type": "object",
+      "properties": {
+        "credentials": {
+          "$ref": "#/definitions/ConnectionUsernamePassword"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ConnectionPropertiesV2"
+        }
+      ],
+      "x-ms-discriminator-value": "UsernamePassword"
+    },
+    "VersionedAgentReference": {
+      "type": "object",
+      "description": "Type modeling a reference to a version of an agent definition.",
+      "properties": {
+        "agentVersion": {
+          "type": "string",
+          "description": "Gets the agent's version (unique for each agent lineage).",
+          "x-nullable": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AgentReferenceProperties"
+        }
+      ]
+    },
+    "VirtualNetworkRule": {
+      "type": "object",
+      "description": "A rule governing the accessibility from a specific virtual network.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Full resource id of a vnet subnet, such as '/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/subnet1'."
+        },
+        "state": {
+          "type": "string",
+          "description": "Gets the state of virtual network rule."
+        },
+        "ignoreMissingVnetServiceEndpoint": {
+          "type": "boolean",
+          "description": "Ignore missing vnet service endpoint or not."
+        }
+      },
+      "required": [
+        "id"
+      ]
+    }
+  },
+  "parameters": {}
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-03-15-preview/examples/ListAcceleratorCapacities.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-03-15-preview/examples/ListAcceleratorCapacities.json
@@ -1,0 +1,66 @@
+{
+  "operationId": "AcceleratorCapacities_List",
+  "title": "List Accelerator Capacities",
+  "parameters": {
+    "subscriptionId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "api-version": "2026-03-15-preview",
+    "offer": "MaaP"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/providers/Microsoft.CognitiveServices/acceleratorCapacities/Azure.A100",
+            "name": "Azure.A100",
+            "type": "Microsoft.CognitiveServices/acceleratorCapacities",
+            "properties": {
+              "acceleratorType": "Azure.A100",
+              "location": "eastus",
+              "availableAccelerators": 16,
+              "deploymentSizeCapacities": [
+                {
+                  "modelInstanceAcceleratorCount": 1,
+                  "totalAvailableCapacity": 16,
+                  "largestDeploymentCapacity": 8
+                },
+                {
+                  "modelInstanceAcceleratorCount": 2,
+                  "totalAvailableCapacity": 8,
+                  "largestDeploymentCapacity": 4
+                },
+                {
+                  "modelInstanceAcceleratorCount": 4,
+                  "totalAvailableCapacity": 4,
+                  "largestDeploymentCapacity": 2
+                }
+              ]
+            }
+          },
+          {
+            "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/providers/Microsoft.CognitiveServices/acceleratorCapacities/Azure.H100",
+            "name": "Azure.H100",
+            "type": "Microsoft.CognitiveServices/acceleratorCapacities",
+            "properties": {
+              "acceleratorType": "Azure.H100",
+              "location": "westus2",
+              "availableAccelerators": 32,
+              "deploymentSizeCapacities": [
+                {
+                  "modelInstanceAcceleratorCount": 1,
+                  "totalAvailableCapacity": 32,
+                  "largestDeploymentCapacity": 16
+                },
+                {
+                  "modelInstanceAcceleratorCount": 8,
+                  "totalAvailableCapacity": 4,
+                  "largestDeploymentCapacity": 2
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
# ARM (Control Plane) API Specification Update Pull Request

## Purpose of this PR

- [x] New API version for an existing resource provider.

## Due diligence checklist

- [x] I confirm this PR is modifying Azure Resource Manager (ARM) related specifications, and not data plane related specifications.
- [x] I have reviewed following [Resource Provider guidelines](https://aka.ms/rpguidelines), including [ARM resource provider contract](https://aka.ms/azurerpc) and [REST guidelines](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md).

## Summary

Add `acceleratorCapacities` subscription-level read-only resource type to the CognitiveServices ARM API for api-version `2026-03-15-preview`.

This resource exposes accelerator (GPU) capacity information per accelerator type and region, enabling clients to query available capacity for managed compute (MaaP) deployments.

### Changes
- **AcceleratorCapacity.tsp**: New subscription-level proxy resource with list operation
  - Query parameters: `offer` (required), `acceleratorType` (optional), `deploymentId` (optional)
- **models.tsp**: Added `AcceleratorCapacityProperties`, `DeploymentSizeCapacity`, and `AcceleratorCapacityListResult` models
- **main.tsp**: Added `v2026_03_15_preview` to Versions enum and imported new file
- **examples**: `ListAcceleratorCapacities.json`
- **Generated OpenAPI spec**: `2026-03-15-preview/cognitiveservices.json`

### Related PRs
- RP manifest PR: https://msazure.visualstudio.com/Cognitive%20Services/_git/Platform-ResourceProvider/pullrequest/15510090
