### PR TITLE
Update folder-structure rule error URL to aka.ms short link

### DIFF
--- a/eng/tools/typespec-validation/src/rules/folder-structure.ts
+++ b/eng/tools/typespec-validation/src/rules/folder-structure.ts
@@ -47,7 +47,7 @@ export class FolderStructureRule implements Rule {
         return {
           success: false,
           stdOutput: stdOutput,
-          errorOutput: `Folder '${folder}' must use "folder structure v2". See https://github.com/Azure/azure-rest-api-specs/wiki/Folder-Structure \n`,
+          errorOutput: `Folder '${folder}' must use "folder structure v2". See https://aka.ms/azsdk/spec-dirs \n`,
         };
       }
     }


### PR DESCRIPTION
## Description

Updates the error message URL in the `FolderStructureRule` from the GitHub wiki link to the shorter `aka.ms` redirect:

- Before: `https://github.com/Azure/azure-rest-api-specs/wiki/Folder-Structure`
- After: `https://aka.ms/azsdk/spec-dirs`

This makes the URL easier to maintain and provides a stable short link for the folder structure documentation.