### PR TITLE
Add AcceleratorCapacity resource type for CognitiveServices 2026-03-15-preview

### DIFF
--- a/specification/cognitiveservices/CognitiveServices.Management/AcceleratorCapacity.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/AcceleratorCapacity.tsp
@@ -1,0 +1,73 @@
+import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-azure-resource-manager";
+import "@typespec/openapi";
+import "@typespec/rest";
+import "@typespec/versioning";
+import "./models.tsp";
+
+using TypeSpec.Rest;
+using Azure.ResourceManager;
+using TypeSpec.Http;
+using TypeSpec.OpenAPI;
+using TypeSpec.Versioning;
+
+namespace Microsoft.CognitiveServices;
+
+/**
+ * Accelerator capacity information for Cognitive Services managed compute deployments.
+ * Provides available accelerator capacity per type and region at the subscription level.
+ */
+@added(Versions.v2026_03_15_preview)
+@subscriptionResource
+model AcceleratorCapacity
+  is Azure.ResourceManager.ProxyResource<AcceleratorCapacityProperties> {
+  ...ResourceNameParameter<
+    Resource = AcceleratorCapacity,
+    KeyName = "acceleratorCapacityName",
+    SegmentName = "acceleratorCapacities",
+    NamePattern = ""
+  >;
+}
+
+#suppress "@azure-tools/typespec-azure-resource-manager/no-resource-delete-operation" "'AcceleratorCapacities' is a read-only resource type that does not support delete operations"
+@added(Versions.v2026_03_15_preview)
+@armResourceOperations(#{ omitTags: true })
+interface AcceleratorCapacities {
+  /**
+   * Gets the accelerator capacities for a subscription. Returns available capacity
+   * per accelerator type, including deployment size information.
+   */
+  @tag("AcceleratorCapacities")
+  list is ArmResourceListByParent<
+    AcceleratorCapacity,
+    BaseParameters = Azure.ResourceManager.Foundations.SubscriptionBaseParameters,
+    Parameters = {
+      /**
+       * The offer name to query capacity for (required).
+       */
+      @query("offer")
+      offer: string;
+
+      /**
+       * Optional accelerator type filter to narrow results to a specific accelerator type.
+       */
+      @query("acceleratorType")
+      acceleratorType?: string;
+
+      /**
+       * Optional deployment resource ID. When provided, returns capacity for the specific region
+       * where the deployment is hosted rather than the best available region.
+       */
+      @query("deploymentId")
+      deploymentId?: string;
+    },
+    Response = AcceleratorCapacityListResult
+  >;
+}
+
+@@doc(AcceleratorCapacity.name,
+  "The name of the accelerator capacity resource."
+);
+@@doc(AcceleratorCapacity.properties,
+  "Properties of the accelerator capacity resource."
+);

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-03-15-preview/ListAcceleratorCapacities.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-03-15-preview/ListAcceleratorCapacities.json
@@ -1,0 +1,66 @@
+{
+  "operationId": "AcceleratorCapacities_List",
+  "title": "List Accelerator Capacities",
+  "parameters": {
+    "subscriptionId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "api-version": "2026-03-15-preview",
+    "offer": "MaaP"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/providers/Microsoft.CognitiveServices/acceleratorCapacities/Azure.A100",
+            "name": "Azure.A100",
+            "type": "Microsoft.CognitiveServices/acceleratorCapacities",
+            "properties": {
+              "acceleratorType": "Azure.A100",
+              "location": "eastus",
+              "availableAccelerators": 16,
+              "deploymentSizeCapacities": [
+                {
+                  "modelInstanceAcceleratorCount": 1,
+                  "totalAvailableCapacity": 16,
+                  "largestDeploymentCapacity": 8
+                },
+                {
+                  "modelInstanceAcceleratorCount": 2,
+                  "totalAvailableCapacity": 8,
+                  "largestDeploymentCapacity": 4
+                },
+                {
+                  "modelInstanceAcceleratorCount": 4,
+                  "totalAvailableCapacity": 4,
+                  "largestDeploymentCapacity": 2
+                }
+              ]
+            }
+          },
+          {
+            "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/providers/Microsoft.CognitiveServices/acceleratorCapacities/Azure.H100",
+            "name": "Azure.H100",
+            "type": "Microsoft.CognitiveServices/acceleratorCapacities",
+            "properties": {
+              "acceleratorType": "Azure.H100",
+              "location": "westus2",
+              "availableAccelerators": 32,
+              "deploymentSizeCapacities": [
+                {
+                  "modelInstanceAcceleratorCount": 1,
+                  "totalAvailableCapacity": 32,
+                  "largestDeploymentCapacity": 16
+                },
+                {
+                  "modelInstanceAcceleratorCount": 8,
+                  "totalAvailableCapacity": 4,
+                  "largestDeploymentCapacity": 2
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/main.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/main.tsp
@@ -40,6 +40,7 @@ import "./AgentDeploymentResource.tsp";
 import "./ManagedComputeDeployment.tsp";
 import "./ComputeOperation.tsp";
 import "./ManagedComputeUsages.tsp";
+import "./AcceleratorCapacity.tsp";
 import "./routes.tsp";
 
 using TypeSpec.Rest;

--- a/specification/cognitiveservices/CognitiveServices.Management/models.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/models.tsp
@@ -6108,3 +6108,79 @@ model PolicyExpressionEvaluationDetails {
    */
   expressionValue?: string;
 }
+
+/**
+ * Properties of an accelerator capacity resource.
+ */
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" "AcceleratorCapacity is a read-only resource that does not have a provisioning state"
+@added(Versions.v2026_03_15_preview)
+model AcceleratorCapacityProperties {
+  /**
+   * The type of accelerator (e.g., Azure.A100, Azure.H100).
+   */
+  @visibility(Lifecycle.Read)
+  acceleratorType?: string;
+
+  /**
+   * The Azure region where the capacity is available.
+   */
+  @visibility(Lifecycle.Read)
+  location?: string;
+
+  /**
+   * The number of available accelerators in the region.
+   */
+  @visibility(Lifecycle.Read)
+  availableAccelerators?: int32;
+
+  /**
+   * Capacity information broken down by deployment size.
+   */
+  @visibility(Lifecycle.Read)
+  @identifiers(#[])
+  deploymentSizeCapacities?: DeploymentSizeCapacity[];
+}
+
+/**
+ * Capacity information for a specific deployment size.
+ */
+@added(Versions.v2026_03_15_preview)
+model DeploymentSizeCapacity {
+  /**
+   * The number of accelerators required per model instance.
+   */
+  @visibility(Lifecycle.Read)
+  modelInstanceAcceleratorCount?: int32;
+
+  /**
+   * The total available capacity for this deployment size.
+   */
+  @visibility(Lifecycle.Read)
+  totalAvailableCapacity?: int32;
+
+  /**
+   * The largest contiguous deployment capacity available for this deployment size.
+   */
+  @visibility(Lifecycle.Read)
+  largestDeploymentCapacity?: int32;
+}
+
+/**
+ * The list of accelerator capacities response.
+ */
+@added(Versions.v2026_03_15_preview)
+model AcceleratorCapacityListResult {
+  /**
+   * The link used to get the next page of accelerator capacities.
+   */
+  @nextLink
+  nextLink?: string;
+
+  /**
+   * Gets the list of accelerator capacities.
+   */
+  @pageItems
+  @visibility(Lifecycle.Read)
+  @identifiers(#["id"])
+  value?: AcceleratorCapacity[];
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-03-15-preview/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-03-15-preview/cognitiveservices.json
@@ -130,6 +130,9 @@
       "name": "ManagedComputeUsages"
     },
     {
+      "name": "AcceleratorCapacities"
+    },
+    {
       "name": "Skus"
     },
     {
@@ -175,6 +178,66 @@
         "x-ms-examples": {
           "Get Operations": {
             "$ref": "./examples/GetOperations.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/acceleratorCapacities": {
+      "get": {
+        "operationId": "AcceleratorCapacities_List",
+        "tags": [
+          "AcceleratorCapacities"
+        ],
+        "description": "Gets the accelerator capacities for a subscription. Returns available capacity\nper accelerator type, including deployment size information.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "offer",
+            "in": "query",
+            "description": "The offer name to query capacity for (required).",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "acceleratorType",
+            "in": "query",
+            "description": "Optional accelerator type filter to narrow results to a specific accelerator type.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "deploymentId",
+            "in": "query",
+            "description": "Optional deployment resource ID. When provided, returns capacity for the specific region\nwhere the deployment is hosted rather than the best available region.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/AcceleratorCapacityListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Accelerator Capacities": {
+            "$ref": "./examples/ListAcceleratorCapacities.json"
           }
         },
         "x-ms-pageable": {
@@ -10019,6 +10082,73 @@
         ]
       }
     },
+    "AcceleratorCapacity": {
+      "type": "object",
+      "description": "Accelerator capacity information for Cognitive Services managed compute deployments.\nProvides available accelerator capacity per type and region at the subscription level.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AcceleratorCapacityProperties",
+          "description": "Properties of the accelerator capacity resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "AcceleratorCapacityListResult": {
+      "type": "object",
+      "description": "The list of accelerator capacities response.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of accelerator capacities."
+        },
+        "value": {
+          "type": "array",
+          "description": "Gets the list of accelerator capacities.",
+          "items": {
+            "$ref": "#/definitions/AcceleratorCapacity"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "id"
+          ]
+        }
+      }
+    },
+    "AcceleratorCapacityProperties": {
+      "type": "object",
+      "description": "Properties of an accelerator capacity resource.",
+      "properties": {
+        "acceleratorType": {
+          "type": "string",
+          "description": "The type of accelerator (e.g., Azure.A100, Azure.H100).",
+          "readOnly": true
+        },
+        "location": {
+          "type": "string",
+          "description": "The Azure region where the capacity is available.",
+          "readOnly": true
+        },
+        "availableAccelerators": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of available accelerators in the region.",
+          "readOnly": true
+        },
+        "deploymentSizeCapacities": {
+          "type": "array",
+          "description": "Capacity information broken down by deployment size.",
+          "items": {
+            "$ref": "#/definitions/DeploymentSizeCapacity"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": []
+        }
+      }
+    },
     "AccessKeyAuthTypeConnectionProperties": {
       "type": "object",
       "properties": {
@@ -13593,6 +13723,30 @@
         ]
       }
     },
+    "DeploymentSizeCapacity": {
+      "type": "object",
+      "description": "Capacity information for a specific deployment size.",
+      "properties": {
+        "modelInstanceAcceleratorCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of accelerators required per model instance.",
+          "readOnly": true
+        },
+        "totalAvailableCapacity": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The total available capacity for this deployment size.",
+          "readOnly": true
+        },
+        "largestDeploymentCapacity": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The largest contiguous deployment capacity available for this deployment size.",
+          "readOnly": true
+        }
+      }
+    },
     "DeploymentSkuListResult": {
       "type": "object",
       "description": "The list of cognitive services accounts operation response.",
@@ -14327,12 +14481,12 @@
           "description": "Properties of the Cognitive Services managed compute deployment."
         },
         "sku": {
-          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/Sku",
-          "description": "The SKU (Stock Keeping Unit) assigned to this resource."
+          "$ref": "#/definitions/Sku",
+          "description": "The resource model definition representing SKU"
         },
-        "eTag": {
+        "etag": {
           "type": "string",
-          "description": "If eTag is provided in the response body, it may also be provided as a header per the normal etag convention.  Entity tags are used for comparing two or more entities from the same requested resource. HTTP/1.1 uses entity tags in the etag (section 14.19), If-Match (section 14.24), If-None-Match (section 14.26), and If-Range (section 14.27) header fields.",
+          "description": "Resource Etag.",
           "readOnly": true
         }
       },

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-03-15-preview/examples/ListAcceleratorCapacities.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-03-15-preview/examples/ListAcceleratorCapacities.json
@@ -1,0 +1,66 @@
+{
+  "operationId": "AcceleratorCapacities_List",
+  "title": "List Accelerator Capacities",
+  "parameters": {
+    "subscriptionId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "api-version": "2026-03-15-preview",
+    "offer": "MaaP"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/providers/Microsoft.CognitiveServices/acceleratorCapacities/Azure.A100",
+            "name": "Azure.A100",
+            "type": "Microsoft.CognitiveServices/acceleratorCapacities",
+            "properties": {
+              "acceleratorType": "Azure.A100",
+              "location": "eastus",
+              "availableAccelerators": 16,
+              "deploymentSizeCapacities": [
+                {
+                  "modelInstanceAcceleratorCount": 1,
+                  "totalAvailableCapacity": 16,
+                  "largestDeploymentCapacity": 8
+                },
+                {
+                  "modelInstanceAcceleratorCount": 2,
+                  "totalAvailableCapacity": 8,
+                  "largestDeploymentCapacity": 4
+                },
+                {
+                  "modelInstanceAcceleratorCount": 4,
+                  "totalAvailableCapacity": 4,
+                  "largestDeploymentCapacity": 2
+                }
+              ]
+            }
+          },
+          {
+            "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/providers/Microsoft.CognitiveServices/acceleratorCapacities/Azure.H100",
+            "name": "Azure.H100",
+            "type": "Microsoft.CognitiveServices/acceleratorCapacities",
+            "properties": {
+              "acceleratorType": "Azure.H100",
+              "location": "westus2",
+              "availableAccelerators": 32,
+              "deploymentSizeCapacities": [
+                {
+                  "modelInstanceAcceleratorCount": 1,
+                  "totalAvailableCapacity": 32,
+                  "largestDeploymentCapacity": 16
+                },
+                {
+                  "modelInstanceAcceleratorCount": 8,
+                  "totalAvailableCapacity": 4,
+                  "largestDeploymentCapacity": 2
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add subscription-level AcceleratorCapacity proxy resource with list operation for querying accelerator capacity information.

### Changes
- New \AcceleratorCapacity.tsp\ - subscription-level proxy resource with list operation and query parameters (offer, acceleratorType, deploymentId)
- New models: \AcceleratorCapacityProperties\, \DeploymentSizeCapacity\, \AcceleratorCapacityListResult\
- Updated \main.tsp\ with import
- Updated \models.tsp\ with new model definitions
- Generated OpenAPI spec and example JSON

### Related PRs
- ARM manifest: https://msazure.visualstudio.com/Cognitive%20Services/_git/Platform-ResourceProvider/pullrequest/15512084
- Private spec repo: https://github.com/Azure/azure-rest-api-specs-pr/pull/28139