### PR TITLE
Fix GA scope: add modelWebSummarization to KnowledgeBaseActivityRecordType 

### DIFF
--- a/specification/search/data-plane/Search/models-knowledgebase.tsp
+++ b/specification/search/data-plane/Search/models-knowledgebase.tsp
@@ -316,6 +316,10 @@ union KnowledgeBaseActivityRecordType {
   @removed(Versions.v2026_04_01)
   modelAnswerSynthesis: "modelAnswerSynthesis",
 
+  /** LLM web summarization activity. */
+  @added(Versions.v2026_04_01)
+  modelWebSummarization: "modelWebSummarization",
+
   /** Agentic reasoning activity. */
   agenticReasoning: "agenticReasoning",
 }
@@ -517,6 +521,21 @@ model KnowledgeBaseModelAnswerSynthesisActivityRecord
   inputTokens?: int32;
 
   /** The number of output tokens for the LLM answer synthesis activity. */
+  outputTokens?: int32;
+}
+
+/** Represents an LLM web summarization activity record. */
+#suppress "@azure-tools/typespec-azure-core/no-multiple-discriminator" "Existing"
+@added(Versions.v2026_04_01)
+model KnowledgeBaseModelWebSummarizationActivityRecord
+  extends KnowledgeBaseActivityRecord {
+  /** The discriminator value. */
+  type: KnowledgeBaseActivityRecordType.modelWebSummarization;
+
+  /** The number of input tokens for the LLM web summarization activity. */
+  inputTokens?: int32;
+
+  /** The number of output tokens for the LLM web summarization activity. */
   outputTokens?: int32;
 }
 

--- a/specification/search/data-plane/Search/stable/2026-04-01/search.json
+++ b/specification/search/data-plane/Search/stable/2026-04-01/search.json
@@ -8757,6 +8757,7 @@
         "azureBlob",
         "indexedOneLake",
         "web",
+        "modelWebSummarization",
         "agenticReasoning"
       ],
       "x-ms-enum": {
@@ -8782,6 +8783,11 @@
             "name": "web",
             "value": "web",
             "description": "Web retrieval activity."
+          },
+          {
+            "name": "modelWebSummarization",
+            "value": "modelWebSummarization",
+            "description": "LLM web summarization activity."
           },
           {
             "name": "agenticReasoning",
@@ -9112,6 +9118,28 @@
           }
         ]
       }
+    },
+    "KnowledgeBaseModelWebSummarizationActivityRecord": {
+      "type": "object",
+      "description": "Represents an LLM web summarization activity record.",
+      "properties": {
+        "inputTokens": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of input tokens for the LLM web summarization activity."
+        },
+        "outputTokens": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of output tokens for the LLM web summarization activity."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/KnowledgeBaseActivityRecord"
+        }
+      ],
+      "x-ms-discriminator-value": "modelWebSummarization"
     },
     "KnowledgeBaseReference": {
       "type": "object",


### PR DESCRIPTION
This pull request introduces support for a new "LLM web summarization" activity type in the knowledge base activity records. The changes add a new discriminator value, update the relevant enum and documentation, and define a new model to represent this activity, including input and output token counts.

**Support for LLM Web Summarization Activity:**

* Added a new discriminator value `modelWebSummarization` to `KnowledgeBaseActivityRecordType` and updated its documentation to include LLM web summarization activity. [[1]](diffhunk://#diff-b096e838006db2e576ece1cf37df796689e515f8606cf058f8e0317612752259R319-R322) [[2]](diffhunk://#diff-1261feb705b3c86e5ca24fd2591bf7b72a7cc219b1ee6d25174acf82b585524fR8760) [[3]](diffhunk://#diff-1261feb705b3c86e5ca24fd2591bf7b72a7cc219b1ee6d25174acf82b585524fR8787-R8791)
* Introduced a new model `KnowledgeBaseModelWebSummarizationActivityRecord` with fields for `inputTokens` and `outputTokens`, extending `KnowledgeBaseActivityRecord`. [[1]](diffhunk://#diff-b096e838006db2e576ece1cf37df796689e515f8606cf058f8e0317612752259R527-R541) [[2]](diffhunk://#diff-1261feb705b3c86e5ca24fd2591bf7b72a7cc219b1ee6d25174acf82b585524fR9122-R9143)