### PR TITLE
Add @secret to migrationToken and qnaAzureSearchEndpointKey in CognitiveServices

### DIFF
--- a/specification/cognitiveservices/CognitiveServices.Management/models.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/models.tsp
@@ -1504,7 +1504,7 @@ model AccountProperties {
   /**
    * Resource migration token.
    */
-  #suppress "@azure-tools/typespec-azure-resource-manager/secret-prop" "'migrationToken' is correctly marked as secret matching service-side security handling"
+  @secret
   migrationToken?: string;
 
   /**
@@ -1906,7 +1906,7 @@ model ApiProperties {
   /**
    * (QnAMaker Only) The Azure Search endpoint key of QnAMaker.
    */
-  #suppress "@azure-tools/typespec-azure-resource-manager/secret-prop" "'qnaAzureSearchEndpointKey' is correctly marked as secret matching service-side security handling"
+  @secret
   qnaAzureSearchEndpointKey?: string;
 
   /**

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2025-10-01-preview/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2025-10-01-preview/cognitiveservices.json
@@ -9633,7 +9633,9 @@
         },
         "migrationToken": {
           "type": "string",
-          "description": "Resource migration token."
+          "format": "password",
+          "description": "Resource migration token.",
+          "x-ms-secret": true
         },
         "skuChangeInfo": {
           "$ref": "#/definitions/SkuChangeInfo",
@@ -10408,7 +10410,9 @@
         },
         "qnaAzureSearchEndpointKey": {
           "type": "string",
-          "description": "(QnAMaker Only) The Azure Search endpoint key of QnAMaker."
+          "format": "password",
+          "description": "(QnAMaker Only) The Azure Search endpoint key of QnAMaker.",
+          "x-ms-secret": true
         },
         "qnaAzureSearchEndpointId": {
           "type": "string",

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-01-15-preview/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-01-15-preview/cognitiveservices.json
@@ -9789,7 +9789,9 @@
         },
         "migrationToken": {
           "type": "string",
-          "description": "Resource migration token."
+          "format": "password",
+          "description": "Resource migration token.",
+          "x-ms-secret": true
         },
         "skuChangeInfo": {
           "$ref": "#/definitions/SkuChangeInfo",
@@ -10568,7 +10570,9 @@
         },
         "qnaAzureSearchEndpointKey": {
           "type": "string",
-          "description": "(QnAMaker Only) The Azure Search endpoint key of QnAMaker."
+          "format": "password",
+          "description": "(QnAMaker Only) The Azure Search endpoint key of QnAMaker.",
+          "x-ms-secret": true
         },
         "qnaAzureSearchEndpointId": {
           "type": "string",

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2025-12-01/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2025-12-01/cognitiveservices.json
@@ -9633,7 +9633,9 @@
         },
         "migrationToken": {
           "type": "string",
-          "description": "Resource migration token."
+          "format": "password",
+          "description": "Resource migration token.",
+          "x-ms-secret": true
         },
         "skuChangeInfo": {
           "$ref": "#/definitions/SkuChangeInfo",
@@ -10408,7 +10410,9 @@
         },
         "qnaAzureSearchEndpointKey": {
           "type": "string",
-          "description": "(QnAMaker Only) The Azure Search endpoint key of QnAMaker."
+          "format": "password",
+          "description": "(QnAMaker Only) The Azure Search endpoint key of QnAMaker.",
+          "x-ms-secret": true
         },
         "qnaAzureSearchEndpointId": {
           "type": "string",

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-03-01/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-03-01/cognitiveservices.json
@@ -9633,7 +9633,9 @@
         },
         "migrationToken": {
           "type": "string",
-          "description": "Resource migration token."
+          "format": "password",
+          "description": "Resource migration token.",
+          "x-ms-secret": true
         },
         "skuChangeInfo": {
           "$ref": "#/definitions/SkuChangeInfo",
@@ -10408,7 +10410,9 @@
         },
         "qnaAzureSearchEndpointKey": {
           "type": "string",
-          "description": "(QnAMaker Only) The Azure Search endpoint key of QnAMaker."
+          "format": "password",
+          "description": "(QnAMaker Only) The Azure Search endpoint key of QnAMaker.",
+          "x-ms-secret": true
         },
         "qnaAzureSearchEndpointId": {
           "type": "string",


### PR DESCRIPTION
## Purpose

- [x] Update existing version to fix OpenAPI spec quality issues in S360.

## Changes

Replace `#suppress` directives with `@secret` decorator on:
- `AccountProperties.migrationToken` (models.tsp:1508)
- `ApiProperties.qnaAzureSearchEndpointKey` (models.tsp:1913)

This emits `x-ms-secret: true` and `format: password` in the generated swagger, resolving **XMSSecretInResponse** (RPC-Put-V1-13) lint violations flagged by ARM review on PR #41922.

These properties are pre-existing on `main` — this PR fixes the lint violation at the source rather than suppressing it.

## Due diligence checklist

- [x] I confirm this PR is modifying Azure Resource Manager (ARM) related specifications.
- [x] I have reviewed the Resource Provider guidelines.
- [x] A release plan has been created.