### PR TITLE
[SDK Validation] Add TriggerSource parameter to mark SDK PRs as ready for review

### DIFF
--- a/eng/pipelines/spec-gen-sdk.yml
+++ b/eng/pipelines/spec-gen-sdk.yml
@@ -37,6 +37,10 @@ parameters:
     type: number
     default: 0
     displayName: 'Release plan work item id'
+  - name: TriggerSource
+    type: string
+    default: 'unspecified'
+    displayName: 'Trigger source'
 
 trigger: none
 
@@ -53,3 +57,4 @@ extends:
     CreatePullRequest: ${{ parameters.CreatePullRequest }}
     ForceCreateEvenWithFailures: ${{ parameters.ForceCreateEvenWithFailures }}
     ReleasePlanWorkItemId: ${{ parameters.ReleasePlanWorkItemId }}
+    TriggerSource: ${{ parameters.TriggerSource }}

--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -34,6 +34,9 @@ parameters:
   - name: ReleasePlanWorkItemId
     type: number
     default: 0
+  - name: TriggerSource
+    type: string
+    default: 'unspecified'
 
 stages:
 - stage: ${{ iif(eq(parameters.SpecBatchTypes, ''), 'Build', format('Build_{0}', replace(parameters.SpecBatchTypes, '-', '_'))) }}
@@ -339,7 +342,7 @@ stages:
               -AuthToken "$(azuresdk-github-pat)"
               -PRTitle "$(PrTitle)-generated-from-$(Build.DefinitionName)-$(Build.BuildId)"
               -PRBody "$(GeneratedSDKInformation)  $(ReleasePlanInfo)"
-              -OpenAsDraft $true
+              -OpenAsDraft $${{ ne(parameters.TriggerSource, 'release-plan-app') }}
         
 
         - ${{ if ne(parameters.ReleasePlanWorkItemId, 0) }}:
@@ -347,7 +350,7 @@ stages:
               $prUrl = "https://github.com/Azure/$(SdkRepoName)/pull/$(Submitted.PullRequest.Number)"
               Write-Host "Pull request created: $prUrl"
               Write-Host "##vso[task.setvariable variable=PullRequestUrl]$prUrl"
-              $prStatus = "draft"
+              $prStatus = "${{ iif(eq(parameters.TriggerSource, 'release-plan-app'), 'ready for review', 'draft') }}"
               Write-Host "##vso[task.setvariable variable=SdkPrStatus]$prStatus"
             condition: and(succeeded(), eq(variables['HasChanges'], 'true'), ne(variables['Build.Reason'], 'PullRequest'), not(endsWith(variables['SdkRepoName'], '-pr')))
             displayName: "Set pull request URL variable"

--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -342,7 +342,7 @@ stages:
               -AuthToken "$(azuresdk-github-pat)"
               -PRTitle "$(PrTitle)-generated-from-$(Build.DefinitionName)-$(Build.BuildId)"
               -PRBody "$(GeneratedSDKInformation)  $(ReleasePlanInfo)"
-              -OpenAsDraft $${{ ne(parameters.TriggerSource, 'release-plan-app') }}
+              -OpenAsDraft $${{ not(endsWith(parameters.TriggerSource, '-release')) }}
         
 
         - ${{ if ne(parameters.ReleasePlanWorkItemId, 0) }}:
@@ -350,7 +350,7 @@ stages:
               $prUrl = "https://github.com/Azure/$(SdkRepoName)/pull/$(Submitted.PullRequest.Number)"
               Write-Host "Pull request created: $prUrl"
               Write-Host "##vso[task.setvariable variable=PullRequestUrl]$prUrl"
-              $prStatus = "${{ iif(eq(parameters.TriggerSource, 'release-plan-app'), 'ready for review', 'draft') }}"
+              $prStatus = "${{ iif(endsWith(parameters.TriggerSource, '-release'), 'ready for review', 'draft') }}"
               Write-Host "##vso[task.setvariable variable=SdkPrStatus]$prStatus"
             condition: and(succeeded(), eq(variables['HasChanges'], 'true'), ne(variables['Build.Reason'], 'PullRequest'), not(endsWith(variables['SdkRepoName'], '-pr')))
             displayName: "Set pull request URL variable"


### PR DESCRIPTION
When spec-gen-sdk pipeline is triggered by the MCP tool, create the SDK pull request in 'ready for review' state instead of draft.

A new 'TriggerSource' parameter (default: 'unspecified') is added to differentiate callers.

Related: https://github.com/Azure/azure-sdk-tools/issues/15209
Related: https://github.com/Azure/azure-sdk-tools/issues/15294

Test Run:
https://github.com/Azure/azure-sdk-for-go/pull/26675