### PR TITLE
Mitigate Java SDK breaking changes for NetworkCloud

### DIFF
--- a/specification/networkcloud/NetworkCloud.Management/client.tsp
+++ b/specification/networkcloud/NetworkCloud.Management/client.tsp
@@ -571,3 +571,7 @@ using Microsoft.NetworkCloud;
 // --- java ---
 @@clientName(KeySetUser.azureUserName, "azureUsername", "java");
 @@clientName(KeySetUserStatus.azureUserName, "azureUsername", "java");
+@@clientName(VirtualMachineIPAllocationMethod,
+  "VirtualMachineIpAllocationMethod",
+  "java"
+);

--- a/specification/networkcloud/NetworkCloud.Management/client.tsp
+++ b/specification/networkcloud/NetworkCloud.Management/client.tsp
@@ -567,3 +567,7 @@ using Microsoft.NetworkCloud;
   "NetworkCloudAccessBridgeSecurityRule",
   "csharp"
 );
+
+// --- java ---
+@@clientName(KeySetUser.azureUserName, "azureUsername", "java");
+@@clientName(KeySetUserStatus.azureUserName, "azureUsername", "java");

--- a/specification/networkcloud/NetworkCloud.Management/storageappliances/StorageAppliance_models.tsp
+++ b/specification/networkcloud/NetworkCloud.Management/storageappliances/StorageAppliance_models.tsp
@@ -130,16 +130,16 @@ model StorageApplianceProperties {
  */
 model StorageApplianceSpec {
   /**
+   * The credentials of the administrative interface on this storage appliance.
+   */
+  @visibility(Lifecycle.Read, Lifecycle.Create)
+  administratorCredentials: AdministrativeCredentials;
+
+  /**
    * The resource ID of the rack where this storage appliance resides.
    */
   @visibility(Lifecycle.Read, Lifecycle.Create)
   rackId: Azure.Core.armResourceIdentifier;
-
-  /**
-   * The SKU for the storage appliance.
-   */
-  @visibility(Lifecycle.Read, Lifecycle.Create)
-  storageApplianceSkuId: string;
 
   /**
    * The slot the storage appliance is in the rack based on the BOM configuration.
@@ -155,10 +155,10 @@ model StorageApplianceSpec {
   serialNumber: string;
 
   /**
-   * The credentials of the administrative interface on this storage appliance.
+   * The SKU for the storage appliance.
    */
   @visibility(Lifecycle.Read, Lifecycle.Create)
-  administratorCredentials: AdministrativeCredentials;
+  storageApplianceSkuId: string;
 }
 
 /**

--- a/specification/networkcloud/resource-manager/Microsoft.NetworkCloud/preview/2026-01-01-preview/networkcloud.json
+++ b/specification/networkcloud/resource-manager/Microsoft.NetworkCloud/preview/2026-01-01-preview/networkcloud.json
@@ -18225,18 +18225,18 @@
       "type": "object",
       "description": "StorageApplianceProperties represents the properties of the storage appliance.",
       "properties": {
-        "rackId": {
-          "type": "string",
-          "format": "arm-id",
-          "description": "The resource ID of the rack where this storage appliance resides.",
+        "administratorCredentials": {
+          "$ref": "#/definitions/AdministrativeCredentials",
+          "description": "The credentials of the administrative interface on this storage appliance.",
           "x-ms-mutability": [
             "read",
             "create"
           ]
         },
-        "storageApplianceSkuId": {
+        "rackId": {
           "type": "string",
-          "description": "The SKU for the storage appliance.",
+          "format": "arm-id",
+          "description": "The resource ID of the rack where this storage appliance resides.",
           "x-ms-mutability": [
             "read",
             "create"
@@ -18257,9 +18257,9 @@
           "type": "string",
           "description": "The serial number for the storage appliance."
         },
-        "administratorCredentials": {
-          "$ref": "#/definitions/AdministrativeCredentials",
-          "description": "The credentials of the administrative interface on this storage appliance.",
+        "storageApplianceSkuId": {
+          "type": "string",
+          "description": "The SKU for the storage appliance.",
           "x-ms-mutability": [
             "read",
             "create"
@@ -18355,11 +18355,11 @@
         }
       },
       "required": [
+        "administratorCredentials",
         "rackId",
-        "storageApplianceSkuId",
         "rackSlot",
         "serialNumber",
-        "administratorCredentials"
+        "storageApplianceSkuId"
       ]
     },
     "StorageApplianceProvisioningState": {

--- a/specification/networkcloud/resource-manager/Microsoft.NetworkCloud/stable/2025-09-01/networkcloud.json
+++ b/specification/networkcloud/resource-manager/Microsoft.NetworkCloud/stable/2025-09-01/networkcloud.json
@@ -16434,18 +16434,18 @@
       "type": "object",
       "description": "StorageApplianceProperties represents the properties of the storage appliance.",
       "properties": {
-        "rackId": {
-          "type": "string",
-          "format": "arm-id",
-          "description": "The resource ID of the rack where this storage appliance resides.",
+        "administratorCredentials": {
+          "$ref": "#/definitions/AdministrativeCredentials",
+          "description": "The credentials of the administrative interface on this storage appliance.",
           "x-ms-mutability": [
             "read",
             "create"
           ]
         },
-        "storageApplianceSkuId": {
+        "rackId": {
           "type": "string",
-          "description": "The SKU for the storage appliance.",
+          "format": "arm-id",
+          "description": "The resource ID of the rack where this storage appliance resides.",
           "x-ms-mutability": [
             "read",
             "create"
@@ -16466,9 +16466,9 @@
           "type": "string",
           "description": "The serial number for the storage appliance."
         },
-        "administratorCredentials": {
-          "$ref": "#/definitions/AdministrativeCredentials",
-          "description": "The credentials of the administrative interface on this storage appliance.",
+        "storageApplianceSkuId": {
+          "type": "string",
+          "description": "The SKU for the storage appliance.",
           "x-ms-mutability": [
             "read",
             "create"
@@ -16555,11 +16555,11 @@
         }
       },
       "required": [
+        "administratorCredentials",
         "rackId",
-        "storageApplianceSkuId",
         "rackSlot",
         "serialNumber",
-        "administratorCredentials"
+        "storageApplianceSkuId"
       ]
     },
     "StorageApplianceProvisioningState": {


### PR DESCRIPTION
Mitigate Java SDK breaking changes for networkcloud TypeSpec migration.

### Changes
- Rename \zureUserName\ back to \zureUsername\ for \KeySetUser\ and \KeySetUserStatus\ models in Java SDK

### Remaining acceptable breaks
- \Float\ → \Double\ for \percentComplete()\ in \OperationStatusResult\
- \alidate()\ removed from many models (expected for TypeSpec)
- \List\ model removals (expected for TypeSpec)
- \ClusterCapacity\ setters removed (read-only properties)
- \serviceClient()\ return type change (expected)