### PR TITLE
Wire servicepatterns.tsp into sdk-service-agents-contracts profile

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/src/agents-containers/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-containers/routes.tsp
@@ -1,4 +1,5 @@
 import "../common/models.tsp";
+import "../servicepatterns.tsp";
 import "./models.tsp";
 
 using TypeSpec.Http;

--- a/specification/ai-foundry/data-plane/Foundry/src/memory-stores/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/memory-stores/routes.tsp
@@ -1,4 +1,5 @@
 import "../common/models.tsp";
+import "../servicepatterns.tsp";
 import "./models.tsp";
 
 using TypeSpec.Http;

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-service-agents-contracts/main.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-service-agents-contracts/main.tsp
@@ -1,3 +1,4 @@
+import "../servicepatterns.tsp";
 import "../agents/routes.tsp";
 import "../agents-containers/routes.tsp";
 import "../common/models.tsp";

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-service-agents-contracts/tspconfig.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-service-agents-contracts/tspconfig.yaml
@@ -6,6 +6,17 @@ options:
     package-name: Azure.AI.Agents.Contracts.V2
     api-version: "virtual-public-preview"
     unreferenced-types-handling: keepAll
+  "@azure-tools/typespec-client-generator-cli":
+    additionalDirectories:
+      - specification/ai-foundry/data-plane/Foundry/src/agents
+      - specification/ai-foundry/data-plane/Foundry/src/agents-containers
+      - specification/ai-foundry/data-plane/Foundry/src/common
+      - specification/ai-foundry/data-plane/Foundry/src/memory-stores
+      - specification/ai-foundry/data-plane/Foundry/src/skills
+      - specification/ai-foundry/data-plane/Foundry/src/openai-conversations
+      - specification/ai-foundry/data-plane/Foundry/src/openai-responses
+      - specification/ai-foundry/data-plane/Foundry/src/toolboxes
+      - specification/ai-foundry/data-plane/Foundry/src/servicepatterns.tsp
 imports:
   - "@azure-tools/typespec-azure-core"
   - "@azure-tools/typespec-azure-core/experimental"

--- a/specification/ai-foundry/data-plane/Foundry/src/skills/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/skills/routes.tsp
@@ -1,4 +1,5 @@
 import "../common/models.tsp";
+import "../servicepatterns.tsp";
 import "./models.tsp";
 
 using TypeSpec.Http;

--- a/specification/ai-foundry/data-plane/Foundry/src/toolboxes/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/toolboxes/routes.tsp
@@ -1,4 +1,5 @@
 import "../common/models.tsp";
+import "../servicepatterns.tsp";
 import "./models.tsp";
 
 using TypeSpec.Http;


### PR DESCRIPTION
## What

Wires the top-level `servicepatterns.tsp` file into the `sdk-service-agents-contracts` SDK profile.

**Required changes** (the actual bug fix):
- `sdk-service-agents-contracts/main.tsp` — adds `import "../servicepatterns.tsp";`
- `sdk-service-agents-contracts/tspconfig.yaml` — adds an `@azure-tools/typespec-client-generator-cli.additionalDirectories` block listing the sibling directories that `main.tsp` imports, plus `servicepatterns.tsp` as a single-file entry. Modeled on `sdk-projects-agents/tspconfig.yaml`.

**Hygiene**:
Adds an explicit `import "../servicepatterns.tsp";` to four sibling routes files that use servicepatterns symbols (`FoundryDataPlaneOperation`, `AgentDefinitionOptInKeys`) but only resolved them today via transitive load order:
- `agents-containers/routes.tsp`
- `memory-stores/routes.tsp`
- `skills/routes.tsp`
- `toolboxes/routes.tsp`

No model or operation surface changes. No OpenAPI emit changes.

## Why

`servicepatterns.tsp` was extracted as a top-level file under `Foundry/src/` and now defines symbols used across many sibling directories (`FoundryDataPlaneApiVersionParameter`, `FoundryDataPlaneAzureTraits`, `FoundryAzureOperations`, `FoundryDataPlaneOperation`, `AgentDefinitionOptInKeys`).

Two SDK profiles were updated to reference it correctly, but `sdk-service-agents-contracts` was missed:

| SDK profile | imports `../servicepatterns.tsp` in `main.tsp` | `additionalDirectories` lists `servicepatterns.tsp` |
|---|---|---|
| `sdk-extensions-openai` | yes | yes |
| `sdk-projects-agents` | no (transitive) | yes |
| `sdk-service-agents-contracts` | **no** | **no `typespec-client-generator-cli` block at all** |

When a downstream SDK repo runs `tsp-client` against `sdk-service-agents-contracts`, tsp-client copies only `directory` + `additionalDirectories`. Because neither references `servicepatterns.tsp`, the file is never synced — leaving the synced `main.tsp` with dangling references and forcing downstream consumers to fetch `servicepatterns.tsp` manually and inject the import.

This change retires that downstream workaround.

## Validation

- `azsdk_run_typespec_validation` on `sdk-service-agents-contracts` — passes.
- Pure import wiring; the operation/model surface is unchanged.


