### PR TITLE
Add federated authorization provider examples for 2025-09-01-preview

### DIFF
--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/ApiManagement/examples/2025-09-01-preview/ApiManagementCreateAuthorizationProviderAADFederatedAuthCode.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/ApiManagement/examples/2025-09-01-preview/ApiManagementCreateAuthorizationProviderAADFederatedAuthCode.json
@@ -1,0 +1,81 @@
+{
+  "parameters": {
+    "api-version": "2025-09-01-preview",
+    "authorizationProviderId": "aad-ev2-connection",
+    "parameters": {
+      "properties": {
+        "identityProvider": "aad",
+        "oauth2": {
+          "grantTypes": {
+            "authorizationCodeWithFederatedIdentityCredentials": {
+              "clientId": "3cb9ece2-xxxx-4bf4-xxxx-a98d0f209ce5",
+              "resourceUri": "https://ev2.deployment.com",
+              "tenantId": "72f988bf-xxxx-41af-91ab-xxxxxx"
+            }
+          }
+        }
+      }
+    },
+    "resourceGroupName": "rg1",
+    "serviceName": "apimService1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "aad-ev2-connection",
+        "type": "Microsoft.ApiManagement/service/authorizationProviders",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/authorizationProviders/aadwithclientcred",
+        "properties": {
+          "displayName": "aadwithclientcred",
+          "identityProvider": "aad",
+          "oauth2": {
+            "redirectUrl": "https://authorization-manager.consent.azure-apim.net/redirect/apim/apim-agent-library",
+            "grantTypes": {
+              "authorizationCodeWithFederatedIdentityCredentials": {
+                "clientId": "3cb9ece2-xxxx-4bf4-xxxx-a98d0f209ce5",
+                "clientAssertionType": "GenericFederatedIdentityCredential",
+                "resourceUri": "https://ev2.deployment.com",
+                "tenantId": "72f988bf-xxxx-41af-91ab-xxxxxx"
+              }
+            },
+            "federatedIdentityCredentialsProperties": {
+              "issuer": "https://login.microsoftonline.com/72f988bf-xxxx-41af-91ab-xxxxxx/v2.0",
+              "subject": "/eid1/c/pub/t/v4j5cvGGr0GRqy180BHbRw/a/XXXXXXX/cf-XXXXXXXX-apim-agent-library_apim-EV2-test-connection",
+              "audience": "api://AzureADTokenExchange"
+            }
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "aad-ev2-connection",
+        "type": "Microsoft.ApiManagement/service/authorizationProviders",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/authorizationProviders/aadwithclientcred",
+        "properties": {
+          "displayName": "aadwithclientcred",
+          "identityProvider": "aad",
+          "oauth2": {
+            "redirectUrl": "https://authorization-manager.consent.azure-apim.net/redirect/apim/apim-agent-library",
+            "grantTypes": {
+              "authorizationCodeWithFederatedIdentityCredentials": {
+                "clientId": "3cb9ece2-xxxx-4bf4-xxxx-a98d0f209ce5",
+                "clientAssertionType": "GenericFederatedIdentityCredential",
+                "resourceUri": "https://ev2.deployment.com",
+                "tenantId": "72f988bf-xxxx-41af-91ab-xxxxxx"
+              }
+            },
+            "federatedIdentityCredentialsProperties": {
+              "issuer": "https://login.microsoftonline.com/72f988bf-xxxx-41af-91ab-xxxxxx/v2.0",
+              "subject": "/eid1/c/pub/t/v4j5cvGGr0GRqy180BHbRw/a/XXXXXXX/cf-XXXXXXXX-apim-agent-library_apim-EV2-test-connection",
+              "audience": "api://AzureADTokenExchange"
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "AuthorizationProvider_CreateOrUpdate",
+  "title": "ApiManagementCreateAuthorizationProviderAADFederatedAuthCode"
+}

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/ApiManagement/examples/2025-09-01-preview/ApiManagementGetFederateAuthorizationProvider.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/ApiManagement/examples/2025-09-01-preview/ApiManagementGetFederateAuthorizationProvider.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2025-09-01-preview",
+    "authorizationProviderId": "apimfederatedidentitycredential",
+    "resourceGroupName": "rg1",
+    "serviceName": "apimService1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "apimfederatedidentitycredential",
+        "type": "Microsoft.ApiManagement/service/authorizationProviders",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/authorizationProviders/apimfederatedidentitycredential",
+        "properties": {
+          "displayName": "apimfederatedidentitycredential",
+          "identityProvider": "aad",
+          "oauth2": {
+            "redirectUrl": "https://authorization-manager.consent.azure-apim.net/redirect/apim/apim-xxxx-library",
+            "grantTypes": {
+              "authorizationCodeWithFederatedIdentityCredentials": {
+                "clientId": "3cb9ece2-xxx-4bf4-xxxx-xxxxxxxxx",
+                "clientAssertionType": "GenericFederatedIdentityCredential",
+                "resourceUri": "https://xxxxx.westus2.kusto.windows.net",
+                "tenantId": "72f988bf-xxxx-41af-91ab-xxxxxx"
+              }
+            },
+            "federatedIdentityCredentialsProperties": {
+              "issuer": "https://login.microsoftonline.com/72f988bf-xxxx-41af-91ab-xxxxxx/v2.0",
+              "subject": "/eid1/c/pub/t/v4jxxxxxx180BHbRw/a/kxxxxxxxfrNA/cf-xxxxxxxxd-apim-xxxx-library_apimfederatedidentitycredential",
+              "audience": "api://AzureADTokenExchange"
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "AuthorizationProvider_Get",
+  "title": "ApiManagementGetFederateAuthorizationProvider"
+}

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/ApiManagement/preview/2025-09-01-preview/examples/ApiManagementGetFederateAuthorizationProvider.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/ApiManagement/preview/2025-09-01-preview/examples/ApiManagementGetFederateAuthorizationProvider.json
@@ -11,7 +11,7 @@
       "body": {
         "name": "apimfederatedidentitycredential",
         "type": "Microsoft.ApiManagement/service/authorizationProviders",
-        "location": "West US 2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/authorizationProviders/apimfederatedidentitycredential",
         "properties": {
           "displayName": "apimfederatedidentitycredential",
           "identityProvider": "aad",

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/ApiManagement/preview/2025-09-01-preview/openapi.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/ApiManagement/preview/2025-09-01-preview/openapi.json
@@ -11416,11 +11416,11 @@
           "ApiManagementCreateAuthorizationProviderAADAuthCodeWithKeyVault": {
             "$ref": "./examples/ApiManagementCreateAuthorizationProviderAADAuthCodeWithKeyVault.json"
           },
-          "ApiManagementCreateAuthorizationProviderAADFederatedAuthCode": {
-            "$ref": "./examples/ApiManagementCreateAuthorizationProviderAADFederatedAuthCode.json"
-          },
           "ApiManagementCreateAuthorizationProviderAADClientCred": {
             "$ref": "./examples/ApiManagementCreateAuthorizationProviderAADClientCred.json"
+          },
+          "ApiManagementCreateAuthorizationProviderAADFederatedAuthCode": {
+            "$ref": "./examples/ApiManagementCreateAuthorizationProviderAADFederatedAuthCode.json"
           },
           "ApiManagementCreateAuthorizationProviderGenericOAuth2": {
             "$ref": "./examples/ApiManagementCreateAuthorizationProviderGenericOAuth2.json"

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/ApiManagement/preview/2025-09-01-preview/openapi.json
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/ApiManagement/preview/2025-09-01-preview/openapi.json
@@ -11313,6 +11313,9 @@
         "x-ms-examples": {
           "ApiManagementGetAuthorizationProvider": {
             "$ref": "./examples/ApiManagementGetAuthorizationProvider.json"
+          },
+          "ApiManagementGetFederateAuthorizationProvider": {
+            "$ref": "./examples/ApiManagementGetFederateAuthorizationProvider.json"
           }
         }
       },
@@ -11412,6 +11415,9 @@
           },
           "ApiManagementCreateAuthorizationProviderAADAuthCodeWithKeyVault": {
             "$ref": "./examples/ApiManagementCreateAuthorizationProviderAADAuthCodeWithKeyVault.json"
+          },
+          "ApiManagementCreateAuthorizationProviderAADFederatedAuthCode": {
+            "$ref": "./examples/ApiManagementCreateAuthorizationProviderAADFederatedAuthCode.json"
           },
           "ApiManagementCreateAuthorizationProviderAADClientCred": {
             "$ref": "./examples/ApiManagementCreateAuthorizationProviderAADClientCred.json"


### PR DESCRIPTION
## Summary
Add missing `x-ms-examples` references in API Management `2025-09-01-preview` so federated authorization provider examples are included in generated documentation.

## Changes
- Add `ApiManagementCreateAuthorizationProviderAADFederatedAuthCode` reference to `AuthorizationProvider_CreateOrUpdate`
- Add `ApiManagementGetFederateAuthorizationProvider` reference to `AuthorizationProvider_Get`

## Scope
- Only updates `specification/apimanagement/resource-manager/Microsoft.ApiManagement/ApiManagement/preview/2025-09-01-preview/openapi.json`
