### PR TITLE
[AKS] Add ArtifactStreamingProfile to v2026-03-01 GA API

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
@@ -373,7 +373,7 @@ model ManagedClusterAgentPoolProfileProperties {
   /**
    * Configuration for using artifact streaming on AKS.
    */
-  @added(Versions.v2026_03_02_preview)
+  @added(Versions.v2026_03_01)
   artifactStreamingProfile?: AgentPoolArtifactStreamingProfile;
 
   /**
@@ -917,7 +917,7 @@ model AgentPoolGatewayProfile {
 }
 
 /** Artifact streaming profile for the agent pool. */
-@added(Versions.v2026_03_02_preview)
+@added(Versions.v2026_03_01)
 model AgentPoolArtifactStreamingProfile {
   /**
    * Artifact streaming speeds up the cold-start of containers on a node through on-demand image loading. To use this feature, container images must also enable artifact streaming on ACR. If not specified, the default is false.

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-03-01/managedClusters.json
@@ -4456,6 +4456,16 @@
         }
       ]
     },
+    "AgentPoolArtifactStreamingProfile": {
+      "type": "object",
+      "description": "Artifact streaming profile for the agent pool.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Artifact streaming speeds up the cold-start of containers on a node through on-demand image loading. To use this feature, container images must also enable artifact streaming on ACR. If not specified, the default is false."
+        }
+      }
+    },
     "AgentPoolAvailableVersions": {
       "type": "object",
       "description": "The list of available versions for an agent pool.",
@@ -6960,6 +6970,10 @@
         "gatewayProfile": {
           "$ref": "#/definitions/AgentPoolGatewayProfile",
           "description": "Profile specific to a managed agent pool in Gateway mode. This field cannot be set if agent pool mode is not Gateway."
+        },
+        "artifactStreamingProfile": {
+          "$ref": "#/definitions/AgentPoolArtifactStreamingProfile",
+          "description": "Configuration for using artifact streaming on AKS."
         },
         "virtualMachinesProfile": {
           "$ref": "#/definitions/VirtualMachinesProfile",


### PR DESCRIPTION
## Summary
Promote `artifactStreamingProfile` from `v2026-03-02-preview` to GA in `v2026-03-01`. Mirrors #40808 (which does the equivalent for `v2026-02-01`).

## Changes
- `AgentPoolModels.tsp`: bump `@added` decorator on the property and on the `AgentPoolArtifactStreamingProfile` model from `v2026_03_02_preview` → `v2026_03_01` (2 lines).
- `stable/2026-03-01/managedClusters.json`: add the `AgentPoolArtifactStreamingProfile` definition and the `artifactStreamingProfile` `$ref` under agent pool properties (14 lines).

Total: 2 files, +16 / -2.

## Context
Per Fuming's guidance in the AKS API Teams channel, GA support for artifact streaming requires the same TypeSpec + JSON change pattern as #40808, just targeted at the March dev branch.

## Test plan
- [ ] TypeSpec compiles cleanly
- [ ] Swagger lint / breaking-change checks pass
- [ ] Reviewer (Fuming Zhang) sign-off