### PR TITLE
[StorageBlob] JS SDK: opt out of clientNamespace

### DIFF
--- a/specification/storage/Microsoft.BlobStorage/client.tsp
+++ b/specification/storage/Microsoft.BlobStorage/client.tsp
@@ -123,23 +123,23 @@ interface PageBlobClient extends Storage.Blob.PageBlob {}
   "rust"
 );
 
-@@clientNamespace(Storage.Blob, "Azure.Storage.Blobs", "!csharp, !python, !javascript");
+@@clientNamespace(Storage.Blob, "Azure.Storage.Blobs", "rust,go");
 @@clientNamespace(Storage.Blob.Container,
   "Azure.Storage.Blobs",
-  "!csharp, !python, !javascript"
+  "rust,go"
 );
-@@clientNamespace(Storage.Blob.Blob, "Azure.Storage.Blobs", "!csharp, !python, !javascript");
+@@clientNamespace(Storage.Blob.Blob, "Azure.Storage.Blobs", "rust,go");
 @@clientNamespace(Storage.Blob.AppendBlob,
   "Azure.Storage.Blobs",
-  "!csharp, !python, !javascript"
+  "rust,go"
 );
 @@clientNamespace(Storage.Blob.BlockBlob,
   "Azure.Storage.Blobs",
-  "!csharp, !python, !javascript"
+  "rust,go"
 );
 @@clientNamespace(Storage.Blob.PageBlob,
   "Azure.Storage.Blobs",
-  "!csharp, !python, !javascript"
+  "rust,go"
 );
 
 @@clientName(Storage.Blob.BlockBlob.upload, "upload_internal", "rust");

--- a/specification/storage/Microsoft.BlobStorage/client.tsp
+++ b/specification/storage/Microsoft.BlobStorage/client.tsp
@@ -124,23 +124,11 @@ interface PageBlobClient extends Storage.Blob.PageBlob {}
 );
 
 @@clientNamespace(Storage.Blob, "Azure.Storage.Blobs", "rust,go");
-@@clientNamespace(Storage.Blob.Container,
-  "Azure.Storage.Blobs",
-  "rust,go"
-);
+@@clientNamespace(Storage.Blob.Container, "Azure.Storage.Blobs", "rust,go");
 @@clientNamespace(Storage.Blob.Blob, "Azure.Storage.Blobs", "rust,go");
-@@clientNamespace(Storage.Blob.AppendBlob,
-  "Azure.Storage.Blobs",
-  "rust,go"
-);
-@@clientNamespace(Storage.Blob.BlockBlob,
-  "Azure.Storage.Blobs",
-  "rust,go"
-);
-@@clientNamespace(Storage.Blob.PageBlob,
-  "Azure.Storage.Blobs",
-  "rust,go"
-);
+@@clientNamespace(Storage.Blob.AppendBlob, "Azure.Storage.Blobs", "rust,go");
+@@clientNamespace(Storage.Blob.BlockBlob, "Azure.Storage.Blobs", "rust,go");
+@@clientNamespace(Storage.Blob.PageBlob, "Azure.Storage.Blobs", "rust,go");
 
 @@clientName(Storage.Blob.BlockBlob.upload, "upload_internal", "rust");
 @@clientName(Storage.Blob.Blob.download, "download_internal", "rust");

--- a/specification/storage/Microsoft.BlobStorage/client.tsp
+++ b/specification/storage/Microsoft.BlobStorage/client.tsp
@@ -123,23 +123,23 @@ interface PageBlobClient extends Storage.Blob.PageBlob {}
   "rust"
 );
 
-@@clientNamespace(Storage.Blob, "Azure.Storage.Blobs", "!csharp, !python");
+@@clientNamespace(Storage.Blob, "Azure.Storage.Blobs", "!csharp, !python, !javascript");
 @@clientNamespace(Storage.Blob.Container,
   "Azure.Storage.Blobs",
-  "!csharp, !python"
+  "!csharp, !python, !javascript"
 );
-@@clientNamespace(Storage.Blob.Blob, "Azure.Storage.Blobs", "!csharp, !python");
+@@clientNamespace(Storage.Blob.Blob, "Azure.Storage.Blobs", "!csharp, !python, !javascript");
 @@clientNamespace(Storage.Blob.AppendBlob,
   "Azure.Storage.Blobs",
-  "!csharp, !python"
+  "!csharp, !python, !javascript"
 );
 @@clientNamespace(Storage.Blob.BlockBlob,
   "Azure.Storage.Blobs",
-  "!csharp, !python"
+  "!csharp, !python, !javascript"
 );
 @@clientNamespace(Storage.Blob.PageBlob,
   "Azure.Storage.Blobs",
-  "!csharp, !python"
+  "!csharp, !python, !javascript"
 );
 
 @@clientName(Storage.Blob.BlockBlob.upload, "upload_internal", "rust");

--- a/specification/storage/Microsoft.BlobStorage/tspconfig.yaml
+++ b/specification/storage/Microsoft.BlobStorage/tspconfig.yaml
@@ -29,7 +29,7 @@ options:
     include-headers-in-response: true
     enable-storage-compat: true
     package-details:
-      name: "@azure-rest/storage-blob"
+      name: "@azure/storage-blob"
       description: "Azure.Storage.Blob Service"
     flavor: azure
   # "@azure-tools/typespec-java":


### PR DESCRIPTION
and update package name

# SDK configuration pull request

## Purpose of this PR

- [x] Make changes to the SDK configuration only when there are no modifications to the API specification, eliminating the need for an ARM or Stewardship Board API review.

## Due diligence checklist

To merge this PR, you **must** go through the following checklist and confirm you understood
and followed the instructions by checking all the boxes:

- [x] I confirm this PR is modifying only SDK configurations, and not API related specifications.
- [x] I have reviewed and used the respective `tspconfig.yaml` templates:
  - [ARM tspconfig template](https://aka.ms/azsdk/tspconfig-sample-mpg)
  - [Data plane tspconfig template](https://aka.ms/azsdk/tspconfig-sample-dpg)

## Getting help

- First, carefully read through this PR description, from top to bottom. Fill out the `Purpose of this PR` and `Due diligence checklist`.
- If you don't have permissions to remove or add labels to the PR, request `write access` per [aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories](https://aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories)
- To understand what you must do next to merge this PR, see the `Next Steps to Merge` comment. It will appear within few minutes of submitting this PR and will continue to be up-to-date with current PR state.
- For guidance on fixing this PR CI check failures, see the hyperlinks provided in given failure and https://aka.ms/ci-fix.
- If the PR CI checks appear to be stuck in `queued` state, please add a comment with contents `/azp run`.
  This should result in a new comment denoting a `PR validation pipeline` has started and the checks should be updated after few minutes.
- If the help provided by the previous points is not enough, post to https://aka.ms/azsdk/support/specreview-channel and link to this PR.
