### PR TITLE
CP : Swagger changes for Circuit link failover APIs (#42555)

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/ExpressRouteCircuit.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/ExpressRouteCircuit.tsp
@@ -2,6 +2,7 @@ import "@azure-tools/typespec-azure-core";
 import "@azure-tools/typespec-azure-resource-manager";
 import "@typespec/openapi";
 import "@typespec/rest";
+import "@typespec/versioning";
 import "./models.tsp";
 import "../Common/main.tsp";
 
@@ -9,6 +10,7 @@ using TypeSpec.Rest;
 using Azure.ResourceManager;
 using TypeSpec.Http;
 using TypeSpec.OpenAPI;
+using TypeSpec.Versioning;
 using Common;
 
 namespace Microsoft.Network;
@@ -106,6 +108,126 @@ interface ExpressRouteCircuits {
     ExpressRouteCircuit,
     void,
     ArmResponse<ExpressRouteCircuitStats>,
+    Error = CloudError
+  >;
+
+  /**
+   * Retrieves the details of all the link failover tests performed on the express route circuit.
+   */
+  @tag("ExpressRouteCircuits")
+  @action("getCircuitLinkFailoverAllTestsDetails")
+  @added(Versions.v2025_07_01)
+  getCircuitLinkFailoverAllTestsDetails is ArmResourceActionAsync<
+    ExpressRouteCircuit,
+    void,
+    Response = {
+      #suppress "@azure-tools/typespec-azure-resource-manager/missing-x-ms-identifiers" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+      @body body: ExpressRouteLinkFailoverAllTestsDetailsList;
+    },
+    Parameters = {
+      /**
+       * The type of failover test.
+       */
+      @query("failoverTestType")
+      failoverTestType?: string;
+
+      /**
+       * Fetch only the latest tests.
+       */
+      @query("fetchLatest")
+      fetchLatest?: boolean;
+    },
+    LroHeaders = ArmLroLocationHeader<FinalResult = ExpressRouteLinkFailoverAllTestsDetailsList> &
+      Azure.Core.Foundations.RetryAfterHeader,
+    Error = CloudError
+  >;
+
+  /**
+   * Retrieves the details of a particular link failover test performed on the express route circuit.
+   */
+  @tag("ExpressRouteCircuits")
+  @action("getCircuitLinkFailoverSingleTestDetails")
+  @added(Versions.v2025_07_01)
+  getCircuitLinkFailoverSingleTestDetails is ArmResourceActionAsync<
+    ExpressRouteCircuit,
+    void,
+    Response = {
+      #suppress "@azure-tools/typespec-azure-resource-manager/missing-x-ms-identifiers" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+      @body body: ExpressRouteLinkFailoverSingleTestDetailsList;
+    },
+    Parameters = {
+      /**
+       * The link type.
+       */
+      @query("linkType")
+      linkType: string;
+
+      /**
+       * The circuit test category.
+       */
+      @query("circuitTestCategory")
+      circuitTestCategory: string;
+
+      /**
+       * The unique Guid value which identifies the test.
+       */
+      @query("failoverTestId")
+      failoverTestId: string;
+    },
+    LroHeaders = ArmLroLocationHeader<FinalResult = ExpressRouteLinkFailoverSingleTestDetailsList> &
+      Azure.Core.Foundations.RetryAfterHeader,
+    Error = CloudError
+  >;
+
+  /**
+   * Starts link failover simulation on the express route circuit for the specified link type and test category.
+   */
+  @tag("ExpressRouteCircuits")
+  @action("startCircuitLinkFailoverTest")
+  @added(Versions.v2025_07_01)
+  startCircuitLinkFailoverTest is ArmResourceActionAsync<
+    ExpressRouteCircuit,
+    void,
+    {
+      /** The result of the start circuit link failover test operation. */
+      @body body: stringApplicationJson;
+    },
+    Parameters = {
+      /**
+       * The link type.
+       */
+      @query("linkType")
+      linkType: string;
+
+      /**
+       * The circuit test category.
+       */
+      @query("circuitTestCategory")
+      circuitTestCategory: string;
+    },
+    LroHeaders = ArmLroLocationHeader<FinalResult = stringApplicationJson> &
+      Azure.Core.Foundations.RetryAfterHeader,
+    Error = CloudError
+  >;
+
+  /**
+   * Stops link failover simulation on the express route circuit.
+   */
+  @tag("ExpressRouteCircuits")
+  @action("stopCircuitLinkFailoverTest")
+  @added(Versions.v2025_07_01)
+  stopCircuitLinkFailoverTest is ArmResourceActionAsync<
+    ExpressRouteCircuit,
+    {
+      /** Parameters supplied to stop the link failover simulation on the express route circuit. */
+      @bodyRoot stopParameters: ExpressRouteLinkFailoverStopApiParameters;
+    },
+    {
+      /** The result of the stop circuit link failover test operation. */
+      @body body: stringApplicationJson;
+    },
+    LroHeaders = ArmLroLocationHeader<FinalResult = stringApplicationJson> &
+      Azure.Core.Foundations.RetryAfterHeader,
     Error = CloudError
   >;
 }

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/ExpressRouteCircuitGetCircuitLinkFailoverAllTestsDetails.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/ExpressRouteCircuitGetCircuitLinkFailoverAllTestsDetails.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2025-07-01",
+    "failoverTestType": "SingleSiteFailover",
+    "fetchLatest": true,
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "circuitName": "circuit1"
+  },
+  "responses": {
+    "200": {
+      "body": [
+        {
+          "status": "Completed",
+          "startTime": "2025-01-01T00:00:00Z",
+          "endTime": "2025-01-01T01:00:00Z",
+          "testGuid": "00000000-0000-0000-0000-000000000001",
+          "testType": "SingleSiteFailover",
+          "issues": [],
+          "wasSimulationSuccessful": true,
+          "circuitTestCategory": "BgpDisconnect",
+          "linkType": "Primary",
+          "bgpStatus": [
+            {
+              "type": "IPv4",
+              "link": "Primary",
+              "status": "Connected",
+              "checkTimeUtc": "2025-01-01T00:30:00Z"
+            }
+          ]
+        }
+      ]
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/locations/eastus/operations/00000000-0000-0000-0000-000000000000?api-version=2025-07-01"
+      }
+    }
+  },
+  "operationId": "ExpressRouteCircuits_GetCircuitLinkFailoverAllTestsDetails",
+  "title": "ExpressRouteCircuitGetCircuitLinkFailoverAllTestsDetails"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/ExpressRouteCircuitGetCircuitLinkFailoverSingleTestDetails.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/ExpressRouteCircuitGetCircuitLinkFailoverSingleTestDetails.json
@@ -1,0 +1,63 @@
+{
+  "parameters": {
+    "api-version": "2025-07-01",
+    "linkType": "Primary",
+    "circuitTestCategory": "BgpDisconnect",
+    "failoverTestId": "00000000-0000-0000-0000-000000000001",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "circuitName": "circuit1"
+  },
+  "responses": {
+    "200": {
+      "body": [
+        {
+          "startTimeUtc": "2025-01-01T00:00:00Z",
+          "endTimeUtc": "2025-01-01T01:00:00Z",
+          "status": "Completed",
+          "wasSimulationSuccessful": true,
+          "linkType": "Primary",
+          "circuitTestCategory": "BgpDisconnect",
+          "isSimulationVerified": true,
+          "redundantRoutes": {
+            "beforeSimulation": [
+              {
+                "route": "10.0.0.0/24",
+                "nextHop": "10.0.0.1",
+                "primaryASPath": "65000 65001",
+                "secondaryASPath": "65000 65002"
+              }
+            ],
+            "duringSimulation": [
+              {
+                "route": "10.0.0.0/24",
+                "nextHop": "10.0.0.2",
+                "primaryASPath": "65000 65001",
+                "secondaryASPath": "65000 65002"
+              }
+            ]
+          },
+          "nonRedundantRoutes": {
+            "beforeSimulation": [],
+            "duringSimulation": []
+          },
+          "bgpStatus": [
+            {
+              "type": "IPv4",
+              "link": "Primary",
+              "status": "Connected",
+              "checkTimeUtc": "2025-01-01T00:30:00Z"
+            }
+          ]
+        }
+      ]
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/locations/eastus/operations/00000000-0000-0000-0000-000000000000?api-version=2025-07-01"
+      }
+    }
+  },
+  "operationId": "ExpressRouteCircuits_GetCircuitLinkFailoverSingleTestDetails",
+  "title": "ExpressRouteCircuitGetCircuitLinkFailoverSingleTestDetails"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/ExpressRouteCircuitStartCircuitLinkFailoverTest.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/ExpressRouteCircuitStartCircuitLinkFailoverTest.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2025-07-01",
+    "linkType": "Primary",
+    "circuitTestCategory": "BgpDisconnect",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "circuitName": "circuit1"
+  },
+  "responses": {
+    "200": {
+      "body": ""
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/locations/eastus/operations/00000000-0000-0000-0000-000000000000?api-version=2025-07-01"
+      }
+    }
+  },
+  "operationId": "ExpressRouteCircuits_StartCircuitLinkFailoverTest",
+  "title": "ExpressRouteCircuitStartCircuitLinkFailoverTest"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/ExpressRouteCircuitStopCircuitLinkFailoverTest.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/ExpressRouteCircuitStopCircuitLinkFailoverTest.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2025-07-01",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "circuitName": "circuit1",
+    "stopParameters": {
+      "circuitTestCategory": "BgpDisconnect",
+      "linkType": "Primary",
+      "wasSimulationSuccessful": true,
+      "isVerified": true
+    }
+  },
+  "responses": {
+    "200": {
+      "body": ""
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/locations/eastus/operations/00000000-0000-0000-0000-000000000000?api-version=2025-07-01"
+      }
+    }
+  },
+  "operationId": "ExpressRouteCircuits_StopCircuitLinkFailoverTest",
+  "title": "ExpressRouteCircuitStopCircuitLinkFailoverTest"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
@@ -4648,6 +4648,91 @@ union FailoverTestStatusForSingleTest {
 }
 
 /**
+ * The link on which the failover test is being performed.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+@Azure.ResourceManager.Legacy.feature(Features.expressRoute)
+@added(Versions.v2025_07_01)
+union ExpressRouteFailoverLinkType {
+  string,
+
+  /**
+   * Primary link.
+   */
+  Primary: "Primary",
+
+  /**
+   * Secondary link.
+   */
+  Secondary: "Secondary",
+}
+
+/**
+ * The type of maintenance that can occur during an ExpressRoute failover test.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+@Azure.ResourceManager.Legacy.feature(Features.expressRoute)
+@added(Versions.v2025_07_01)
+union MaintenanceTestCategory {
+  string,
+
+  /**
+   * BGP disconnect test category.
+   */
+  BgpDisconnect: "BgpDisconnect",
+
+  /**
+   * AS path prepend test category.
+   */
+  ASPathPrepend: "ASPathPrepend",
+}
+
+/**
+ * The address family type for BGP status.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+@Azure.ResourceManager.Legacy.feature(Features.expressRoute)
+@added(Versions.v2025_07_01)
+union ExpressRouteFailoverBgpStatusAddressFamily {
+  string,
+
+  /**
+   * IPv4 address family.
+   */
+  IPv4: "IPv4",
+
+  /**
+   * IPv6 address family.
+   */
+  IPv6: "IPv6",
+}
+
+/**
+ * The BGP status of an ExpressRoute link failover.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+@Azure.ResourceManager.Legacy.feature(Features.expressRoute)
+@added(Versions.v2025_07_01)
+union ExpressRouteLinkFailoverBgpStatus {
+  string,
+
+  /**
+   * Undefined status.
+   */
+  Undefined: "Undefined",
+
+  /**
+   * Connected status.
+   */
+  Connected: "Connected",
+
+  /**
+   * Disconnected status.
+   */
+  Disconnected: "Disconnected",
+}
+
+/**
  * Gateway connection authentication type.
  */
 union ConnectionAuthenticationType {
@@ -21314,6 +21399,230 @@ model ExpressRouteFailoverStopApiParameters {
 }
 
 /**
+ * Represents a failover route for an ExpressRoute link.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+@Azure.ResourceManager.Legacy.feature(Features.expressRoute)
+@added(Versions.v2025_07_01)
+model ExpressRouteLinkFailoverRoute {
+  /**
+   * The route.
+   */
+  route?: string;
+
+  /**
+   * The next hop.
+   */
+  nextHop?: string;
+
+  /**
+   * The AS path for primary link.
+   */
+  #suppress "@azure-tools/typespec-azure-core/casing-style" "Property name must match C# model ExpressRouteLinkFailoverRoute.PrimaryASPath"
+  primaryASPath?: string;
+
+  /**
+   * The AS path for secondary link.
+   */
+  #suppress "@azure-tools/typespec-azure-core/casing-style" "Property name must match C# model ExpressRouteLinkFailoverRoute.SecondaryASPath"
+  secondaryASPath?: string;
+}
+
+/**
+ * Represents a list of failover routes for an ExpressRoute link.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+@Azure.ResourceManager.Legacy.feature(Features.expressRoute)
+@added(Versions.v2025_07_01)
+model ExpressRouteLinkFailoverRouteList {
+  /**
+   * The routes before the simulation.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/missing-x-ms-identifiers" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+  beforeSimulation?: ExpressRouteLinkFailoverRoute[];
+
+  /**
+   * The routes during the simulation.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/missing-x-ms-identifiers" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+  duringSimulation?: ExpressRouteLinkFailoverRoute[];
+}
+
+/**
+ * Represents the BGP status of an ExpressRoute link failover test.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+@Azure.ResourceManager.Legacy.feature(Features.expressRoute)
+@added(Versions.v2025_07_01)
+model ExpressRouteLinkFailoverTestBgpStatus {
+  /**
+   * The address family type.
+   */
+  type?: ExpressRouteFailoverBgpStatusAddressFamily;
+
+  /**
+   * The link type.
+   */
+  link?: ExpressRouteFailoverLinkType;
+
+  /**
+   * The BGP status.
+   */
+  status?: ExpressRouteLinkFailoverBgpStatus;
+
+  /**
+   * The check time in UTC.
+   */
+  checkTimeUtc?: string;
+}
+
+/**
+ * ExpressRoute circuit link failover test details for all tests.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+@Azure.ResourceManager.Legacy.feature(Features.expressRoute)
+@added(Versions.v2025_07_01)
+model ExpressRouteLinkFailoverAllTestsDetails {
+  /**
+   * The current status of the test.
+   */
+  status?: FailoverTestStatus;
+
+  /**
+   * Time when the test was started.
+   */
+  startTime?: string;
+
+  /**
+   * Time when the test was completed.
+   */
+  endTime?: string;
+
+  /**
+   * The unique GUID associated with the test.
+   */
+  testGuid?: string;
+
+  /**
+   * The type of failover test.
+   */
+  testType?: FailoverTestType;
+
+  /**
+   * A list of all issues with the test.
+   */
+  issues?: string[];
+
+  /**
+   * Whether the failover simulation was successful or not.
+   */
+  wasSimulationSuccessful?: boolean;
+
+  /**
+   * The maintenance test category.
+   */
+  circuitTestCategory?: MaintenanceTestCategory;
+
+  /**
+   * The link type.
+   */
+  linkType?: ExpressRouteFailoverLinkType;
+
+  /**
+   * The BGP status details.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/missing-x-ms-identifiers" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+  bgpStatus?: ExpressRouteLinkFailoverTestBgpStatus[];
+}
+
+/**
+ * ExpressRoute circuit link failover single test details.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+@Azure.ResourceManager.Legacy.feature(Features.expressRoute)
+@added(Versions.v2025_07_01)
+model ExpressRouteLinkFailoverSingleTestDetails {
+  /**
+   * Time when the test was started in UTC.
+   */
+  startTimeUtc?: string;
+
+  /**
+   * Time when the test was completed in UTC.
+   */
+  endTimeUtc?: string;
+
+  /**
+   * The current status of the test.
+   */
+  status?: FailoverTestStatus;
+
+  /**
+   * Whether the failover simulation was successful or not.
+   */
+  wasSimulationSuccessful?: boolean;
+
+  /**
+   * The link type.
+   */
+  linkType?: ExpressRouteFailoverLinkType;
+
+  /**
+   * The circuit test category.
+   */
+  circuitTestCategory?: MaintenanceTestCategory;
+
+  /**
+   * Whether the simulation was verified.
+   */
+  isSimulationVerified?: boolean;
+
+  /**
+   * The redundant routes for link failover tests.
+   */
+  redundantRoutes?: ExpressRouteLinkFailoverRouteList;
+
+  /**
+   * The non-redundant routes for link failover tests.
+   */
+  nonRedundantRoutes?: ExpressRouteLinkFailoverRouteList;
+
+  /**
+   * The BGP status details.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/missing-x-ms-identifiers" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+  bgpStatus?: ExpressRouteLinkFailoverTestBgpStatus[];
+}
+
+/**
+ * Parameters for stopping an ExpressRoute circuit link failover test.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+@Azure.ResourceManager.Legacy.feature(Features.expressRoute)
+@added(Versions.v2025_07_01)
+model ExpressRouteLinkFailoverStopApiParameters {
+  /**
+   * The category of the circuit test.
+   */
+  circuitTestCategory?: string;
+
+  /**
+   * The type of the link.
+   */
+  linkType?: string;
+
+  /**
+   * Whether the simulation was successful.
+   */
+  wasSimulationSuccessful?: boolean;
+
+  /**
+   * Whether the link is verified.
+   */
+  isVerified?: boolean;
+}
+
+/**
  * VirtualNetworkGatewayConnection properties.
  */
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
@@ -25639,6 +25948,16 @@ alias ExpressRouteFailoverAllTestDetails = ExpressRouteFailoverTestDetails[];
  * Gateway Failover Single Test Details Object
  */
 alias ExpressRouteFailoverSingleTestDetailsObject = ExpressRouteFailoverSingleTestDetails[];
+
+/**
+ * Circuit Link Failover All Test Details
+ */
+alias ExpressRouteLinkFailoverAllTestsDetailsList = ExpressRouteLinkFailoverAllTestsDetails[];
+
+/**
+ * Circuit Link Failover Single Test Details
+ */
+alias ExpressRouteLinkFailoverSingleTestDetailsList = ExpressRouteLinkFailoverSingleTestDetails[];
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @Azure.ResourceManager.Legacy.feature(Features.networkSecurityPerimeter)

--- a/specification/network/resource-manager/Microsoft.Network/Network/readme.md
+++ b/specification/network/resource-manager/Microsoft.Network/Network/readme.md
@@ -4618,6 +4618,9 @@ directive:
     from: virtualNetworkGateway.json
     reason: There are existing APIs in the file using the same format. Suppress it to avoid breaking change because it is referenced by all Virtual Network Gateway APIs.
   - suppress: ParametersInPost
+    from: expressRoute.json
+    reason: Backend APIs require these as query parameters for consistency with existing VirtualNetworkGateway failover APIs.
+  - suppress: ParametersInPost
     from: virtualWan.json
     reason: Backend APIs require these as query parameters for consistency with existing VirtualNetworkGateway failover and insights APIs.
   - suppress: AvoidAdditionalProperties
@@ -4680,6 +4683,17 @@ directive:
     reason: name, id and type properties are inherited from the upper level
 
 suppressions:
+  - code: ResourceNameRestriction
+    from: expressRoute.json
+    reason: The resource name parameter 'circuitName' is not defined with a 'pattern' restriction. Suppress it for now to avoid breaking change because it is referenced by all ExpressRoute circuit link failover APIs.
+    where:
+      - $.paths.["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/getCircuitLinkFailoverAllTestsDetails"]
+      - $.paths.["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/getCircuitLinkFailoverSingleTestDetails"]
+      - $.paths.["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/startCircuitLinkFailoverTest"]
+      - $.paths.["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/stopCircuitLinkFailoverTest"]
+  - code: ParametersInPost
+    from: expressRoute.json
+    reason: Backend APIs require these as query parameters for consistency with existing VirtualNetworkGateway failover APIs.
   - code: ResourceNameRestriction
     from: virtualWan.json
     reason: The resource name parameter 'expressRouteGatewayName' is not defined with a 'pattern' restriction. Suppress it for now to avoid breaking change because it is referenced by all ExpressRoute gateway failover and insights APIs.

--- a/specification/network/resource-manager/Microsoft.Network/Network/sdk-suppressions.yaml
+++ b/specification/network/resource-manager/Microsoft.Network/Network/sdk-suppressions.yaml
@@ -1,0 +1,43 @@
+suppressions:
+  azure-sdk-for-go:
+    - package: sdk/resourcemanager/network/armnetwork
+      breaking-changes:
+        - Function `*IpamPoolsClient.Update` parameter(s) have been changed from `(ctx context.Context, resourceGroupName string, networkManagerName string, poolName string, options *IpamPoolsClientUpdateOptions)` to `(ctx context.Context, resourceGroupName string, networkManagerName string, poolName string, body IpamPoolUpdate, options *IpamPoolsClientUpdateOptions)`
+        - Function `*StaticCidrsClient.Create` parameter(s) have been changed from `(ctx context.Context, resourceGroupName string, networkManagerName string, poolName string, staticCidrName string, options *StaticCidrsClientCreateOptions)` to `(ctx context.Context, resourceGroupName string, networkManagerName string, poolName string, staticCidrName string, body StaticCidr, options *StaticCidrsClientCreateOptions)`
+        - Function `*VerifierWorkspacesClient.Update` parameter(s) have been changed from `(ctx context.Context, resourceGroupName string, networkManagerName string, workspaceName string, options *VerifierWorkspacesClientUpdateOptions)` to `(ctx context.Context, resourceGroupName string, networkManagerName string, workspaceName string, body VerifierWorkspaceUpdate, options *VerifierWorkspacesClientUpdateOptions)`
+        - Type of `EffectiveNetworkSecurityGroup.TagMap` has been changed from `*string` to `map[string][]*string`
+        - Type of `ManagedServiceIdentity.UserAssignedIdentities` has been changed from `map[string]*Components1Jq1T4ISchemasManagedserviceidentityPropertiesUserassignedidentitiesAdditionalproperties` to `map[string]*ManagedServiceIdentityUserAssignedIdentities`
+        - Type of `OperationStatusResult.PercentComplete` has been changed from `*float32` to `*float64`
+        - Type of `VirtualNetworkAppliancePropertiesFormat.BandwidthInGbps` has been changed from `*string` to `*float64`
+        - Enum `ConnectionMonitorSourceStatus` has been removed
+        - Enum `ConnectionState` has been removed
+        - Enum `EvaluationState` has been removed
+        - Enum `HubVirtualNetworkConnectionStatus` has been removed
+        - Enum `NetworkOperationStatus` has been removed
+        - Enum `TunnelConnectionStatus` has been removed
+        - Struct `AzureAsyncOperationResult` has been removed
+        - Struct `ChildResource` has been removed
+        - Struct `CommonErrorAdditionalInfo` has been removed
+        - Struct `CommonErrorDetail` has been removed
+        - Struct `CommonErrorResponse` has been removed
+        - Struct `CommonProxyResource` has been removed
+        - Struct `CommonResource` has been removed
+        - Struct `CommonTrackedResource` has been removed
+        - Struct `Components1Jq1T4ISchemasManagedserviceidentityPropertiesUserassignedidentitiesAdditionalproperties` has been removed
+        - Struct `ConnectionMonitorQueryResult` has been removed
+        - Struct `ConnectionStateSnapshot` has been removed
+        - Struct `Error` has been removed
+        - Struct `ErrorDetails` has been removed
+        - Struct `ErrorResponse` has been removed
+        - Struct `PatchRouteFilter` has been removed
+        - Struct `PatchRouteFilterRule` has been removed
+        - Struct `ProxyResource` has been removed
+        - Struct `Resource` has been removed
+        - Struct `ResourceSet` has been removed
+        - Struct `SecurityPerimeterProxyResource` has been removed
+        - Struct `SecurityPerimeterResource` has been removed
+        - Struct `TrackedResource` has been removed
+        - Struct `VPNSiteID` has been removed
+        - Field `Body` of struct `IpamPoolsClientUpdateOptions` has been removed
+        - Field `Body` of struct `StaticCidrsClientCreateOptions` has been removed
+        - Field `Body` of struct `VerifierWorkspacesClientUpdateOptions` has been removed

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/common.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/common.json
@@ -4536,6 +4536,54 @@
         ]
       }
     },
+    "ExpressRouteFailoverBgpStatusAddressFamily": {
+      "type": "string",
+      "description": "The address family type for BGP status.",
+      "enum": [
+        "IPv4",
+        "IPv6"
+      ],
+      "x-ms-enum": {
+        "name": "ExpressRouteFailoverBgpStatusAddressFamily",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "IPv4",
+            "value": "IPv4",
+            "description": "IPv4 address family."
+          },
+          {
+            "name": "IPv6",
+            "value": "IPv6",
+            "description": "IPv6 address family."
+          }
+        ]
+      }
+    },
+    "ExpressRouteFailoverLinkType": {
+      "type": "string",
+      "description": "The link on which the failover test is being performed.",
+      "enum": [
+        "Primary",
+        "Secondary"
+      ],
+      "x-ms-enum": {
+        "name": "ExpressRouteFailoverLinkType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Primary",
+            "value": "Primary",
+            "description": "Primary link."
+          },
+          {
+            "name": "Secondary",
+            "value": "Secondary",
+            "description": "Secondary link."
+          }
+        ]
+      }
+    },
     "ExpressRouteLinkAdminState": {
       "type": "string",
       "description": "Administrative state of the physical port.",
@@ -4580,6 +4628,36 @@
             "name": "SC",
             "value": "SC",
             "description": "SC"
+          }
+        ]
+      }
+    },
+    "ExpressRouteLinkFailoverBgpStatus": {
+      "type": "string",
+      "description": "The BGP status of an ExpressRoute link failover.",
+      "enum": [
+        "Undefined",
+        "Connected",
+        "Disconnected"
+      ],
+      "x-ms-enum": {
+        "name": "ExpressRouteLinkFailoverBgpStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Undefined",
+            "value": "Undefined",
+            "description": "Undefined status."
+          },
+          {
+            "name": "Connected",
+            "value": "Connected",
+            "description": "Connected status."
+          },
+          {
+            "name": "Disconnected",
+            "value": "Disconnected",
+            "description": "Disconnected status."
           }
         ]
       }
@@ -6068,6 +6146,30 @@
             "name": "Platform",
             "value": "Platform",
             "description": "Platform"
+          }
+        ]
+      }
+    },
+    "MaintenanceTestCategory": {
+      "type": "string",
+      "description": "The type of maintenance that can occur during an ExpressRoute failover test.",
+      "enum": [
+        "BgpDisconnect",
+        "ASPathPrepend"
+      ],
+      "x-ms-enum": {
+        "name": "MaintenanceTestCategory",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "BgpDisconnect",
+            "value": "BgpDisconnect",
+            "description": "BGP disconnect test category."
+          },
+          {
+            "name": "ASPathPrepend",
+            "value": "ASPathPrepend",
+            "description": "AS path prepend test category."
           }
         ]
       }

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/ExpressRouteCircuitGetCircuitLinkFailoverAllTestsDetails.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/ExpressRouteCircuitGetCircuitLinkFailoverAllTestsDetails.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2025-07-01",
+    "failoverTestType": "SingleSiteFailover",
+    "fetchLatest": true,
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "circuitName": "circuit1"
+  },
+  "responses": {
+    "200": {
+      "body": [
+        {
+          "status": "Completed",
+          "startTime": "2025-01-01T00:00:00Z",
+          "endTime": "2025-01-01T01:00:00Z",
+          "testGuid": "00000000-0000-0000-0000-000000000001",
+          "testType": "SingleSiteFailover",
+          "issues": [],
+          "wasSimulationSuccessful": true,
+          "circuitTestCategory": "BgpDisconnect",
+          "linkType": "Primary",
+          "bgpStatus": [
+            {
+              "type": "IPv4",
+              "link": "Primary",
+              "status": "Connected",
+              "checkTimeUtc": "2025-01-01T00:30:00Z"
+            }
+          ]
+        }
+      ]
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/locations/eastus/operations/00000000-0000-0000-0000-000000000000?api-version=2025-07-01"
+      }
+    }
+  },
+  "operationId": "ExpressRouteCircuits_GetCircuitLinkFailoverAllTestsDetails",
+  "title": "ExpressRouteCircuitGetCircuitLinkFailoverAllTestsDetails"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/ExpressRouteCircuitGetCircuitLinkFailoverSingleTestDetails.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/ExpressRouteCircuitGetCircuitLinkFailoverSingleTestDetails.json
@@ -1,0 +1,63 @@
+{
+  "parameters": {
+    "api-version": "2025-07-01",
+    "linkType": "Primary",
+    "circuitTestCategory": "BgpDisconnect",
+    "failoverTestId": "00000000-0000-0000-0000-000000000001",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "circuitName": "circuit1"
+  },
+  "responses": {
+    "200": {
+      "body": [
+        {
+          "startTimeUtc": "2025-01-01T00:00:00Z",
+          "endTimeUtc": "2025-01-01T01:00:00Z",
+          "status": "Completed",
+          "wasSimulationSuccessful": true,
+          "linkType": "Primary",
+          "circuitTestCategory": "BgpDisconnect",
+          "isSimulationVerified": true,
+          "redundantRoutes": {
+            "beforeSimulation": [
+              {
+                "route": "10.0.0.0/24",
+                "nextHop": "10.0.0.1",
+                "primaryASPath": "65000 65001",
+                "secondaryASPath": "65000 65002"
+              }
+            ],
+            "duringSimulation": [
+              {
+                "route": "10.0.0.0/24",
+                "nextHop": "10.0.0.2",
+                "primaryASPath": "65000 65001",
+                "secondaryASPath": "65000 65002"
+              }
+            ]
+          },
+          "nonRedundantRoutes": {
+            "beforeSimulation": [],
+            "duringSimulation": []
+          },
+          "bgpStatus": [
+            {
+              "type": "IPv4",
+              "link": "Primary",
+              "status": "Connected",
+              "checkTimeUtc": "2025-01-01T00:30:00Z"
+            }
+          ]
+        }
+      ]
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/locations/eastus/operations/00000000-0000-0000-0000-000000000000?api-version=2025-07-01"
+      }
+    }
+  },
+  "operationId": "ExpressRouteCircuits_GetCircuitLinkFailoverSingleTestDetails",
+  "title": "ExpressRouteCircuitGetCircuitLinkFailoverSingleTestDetails"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/ExpressRouteCircuitStartCircuitLinkFailoverTest.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/ExpressRouteCircuitStartCircuitLinkFailoverTest.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2025-07-01",
+    "linkType": "Primary",
+    "circuitTestCategory": "BgpDisconnect",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "circuitName": "circuit1"
+  },
+  "responses": {
+    "200": {
+      "body": ""
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/locations/eastus/operations/00000000-0000-0000-0000-000000000000?api-version=2025-07-01"
+      }
+    }
+  },
+  "operationId": "ExpressRouteCircuits_StartCircuitLinkFailoverTest",
+  "title": "ExpressRouteCircuitStartCircuitLinkFailoverTest"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/ExpressRouteCircuitStopCircuitLinkFailoverTest.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/ExpressRouteCircuitStopCircuitLinkFailoverTest.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2025-07-01",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "circuitName": "circuit1",
+    "stopParameters": {
+      "circuitTestCategory": "BgpDisconnect",
+      "linkType": "Primary",
+      "wasSimulationSuccessful": true,
+      "isVerified": true
+    }
+  },
+  "responses": {
+    "200": {
+      "body": ""
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/locations/eastus/operations/00000000-0000-0000-0000-000000000000?api-version=2025-07-01"
+      }
+    }
+  },
+  "operationId": "ExpressRouteCircuits_StopCircuitLinkFailoverTest",
+  "title": "ExpressRouteCircuitStopCircuitLinkFailoverTest"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/expressRoute.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/expressRoute.json
@@ -1544,6 +1544,177 @@
         "x-ms-long-running-operation": true
       }
     },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/getCircuitLinkFailoverAllTestsDetails": {
+      "post": {
+        "operationId": "ExpressRouteCircuits_GetCircuitLinkFailoverAllTestsDetails",
+        "tags": [
+          "ExpressRouteCircuits"
+        ],
+        "description": "Retrieves the details of all the link failover tests performed on the express route circuit.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "description": "The name of express route circuit.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "failoverTestType",
+            "in": "query",
+            "description": "The type of failover test.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "fetchLatest",
+            "in": "query",
+            "description": "Fetch only the latest tests.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ExpressRouteLinkFailoverAllTestsDetails"
+              }
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Common.CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ExpressRouteCircuitGetCircuitLinkFailoverAllTestsDetails": {
+            "$ref": "./examples/ExpressRouteCircuitGetCircuitLinkFailoverAllTestsDetails.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ExpressRouteLinkFailoverAllTestsDetailsArray"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/getCircuitLinkFailoverSingleTestDetails": {
+      "post": {
+        "operationId": "ExpressRouteCircuits_GetCircuitLinkFailoverSingleTestDetails",
+        "tags": [
+          "ExpressRouteCircuits"
+        ],
+        "description": "Retrieves the details of a particular link failover test performed on the express route circuit.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "description": "The name of express route circuit.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "linkType",
+            "in": "query",
+            "description": "The link type.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "circuitTestCategory",
+            "in": "query",
+            "description": "The circuit test category.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "failoverTestId",
+            "in": "query",
+            "description": "The unique Guid value which identifies the test.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ExpressRouteLinkFailoverSingleTestDetails"
+              }
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Common.CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ExpressRouteCircuitGetCircuitLinkFailoverSingleTestDetails": {
+            "$ref": "./examples/ExpressRouteCircuitGetCircuitLinkFailoverSingleTestDetails.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ExpressRouteLinkFailoverSingleTestDetailsArray"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings": {
       "get": {
         "operationId": "ExpressRouteCircuitPeerings_List",
@@ -2484,6 +2655,85 @@
         }
       }
     },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/startCircuitLinkFailoverTest": {
+      "post": {
+        "operationId": "ExpressRouteCircuits_StartCircuitLinkFailoverTest",
+        "tags": [
+          "ExpressRouteCircuits"
+        ],
+        "description": "Starts link failover simulation on the express route circuit for the specified link type and test category.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "description": "The name of express route circuit.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "linkType",
+            "in": "query",
+            "description": "The link type.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "circuitTestCategory",
+            "in": "query",
+            "description": "The circuit test category.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "./common.json#/definitions/stringApplicationJson"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Common.CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ExpressRouteCircuitStartCircuitLinkFailoverTest": {
+            "$ref": "./examples/ExpressRouteCircuitStartCircuitLinkFailoverTest.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "./common.json#/definitions/stringApplicationJson"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/stats": {
       "get": {
         "operationId": "ExpressRouteCircuits_GetStats",
@@ -2528,6 +2778,80 @@
             "$ref": "./examples/ExpressRouteCircuitStats.json"
           }
         }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/stopCircuitLinkFailoverTest": {
+      "post": {
+        "operationId": "ExpressRouteCircuits_StopCircuitLinkFailoverTest",
+        "tags": [
+          "ExpressRouteCircuits"
+        ],
+        "description": "Stops link failover simulation on the express route circuit.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "description": "The name of express route circuit.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "stopParameters",
+            "in": "body",
+            "description": "Parameters supplied to stop the link failover simulation on the express route circuit.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteLinkFailoverStopApiParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "./common.json#/definitions/stringApplicationJson"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Common.CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ExpressRouteCircuitStopCircuitLinkFailoverTest": {
+            "$ref": "./examples/ExpressRouteCircuitStopCircuitLinkFailoverTest.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "./common.json#/definitions/stringApplicationJson"
+        },
+        "x-ms-long-running-operation": true
       }
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections": {
@@ -5768,6 +6092,205 @@
           "$ref": "./common.json#/definitions/Common.SubResource"
         }
       ]
+    },
+    "ExpressRouteLinkFailoverAllTestsDetails": {
+      "type": "object",
+      "description": "ExpressRoute circuit link failover test details for all tests.",
+      "properties": {
+        "status": {
+          "$ref": "./common.json#/definitions/FailoverTestStatus",
+          "description": "The current status of the test."
+        },
+        "startTime": {
+          "type": "string",
+          "description": "Time when the test was started."
+        },
+        "endTime": {
+          "type": "string",
+          "description": "Time when the test was completed."
+        },
+        "testGuid": {
+          "type": "string",
+          "description": "The unique GUID associated with the test."
+        },
+        "testType": {
+          "$ref": "./common.json#/definitions/FailoverTestType",
+          "description": "The type of failover test."
+        },
+        "issues": {
+          "type": "array",
+          "description": "A list of all issues with the test.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "wasSimulationSuccessful": {
+          "type": "boolean",
+          "description": "Whether the failover simulation was successful or not."
+        },
+        "circuitTestCategory": {
+          "$ref": "./common.json#/definitions/MaintenanceTestCategory",
+          "description": "The maintenance test category."
+        },
+        "linkType": {
+          "$ref": "./common.json#/definitions/ExpressRouteFailoverLinkType",
+          "description": "The link type."
+        },
+        "bgpStatus": {
+          "type": "array",
+          "description": "The BGP status details.",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteLinkFailoverTestBgpStatus"
+          }
+        }
+      }
+    },
+    "ExpressRouteLinkFailoverAllTestsDetailsArray": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ExpressRouteLinkFailoverAllTestsDetails"
+      }
+    },
+    "ExpressRouteLinkFailoverRoute": {
+      "type": "object",
+      "description": "Represents a failover route for an ExpressRoute link.",
+      "properties": {
+        "route": {
+          "type": "string",
+          "description": "The route."
+        },
+        "nextHop": {
+          "type": "string",
+          "description": "The next hop."
+        },
+        "primaryASPath": {
+          "type": "string",
+          "description": "The AS path for primary link."
+        },
+        "secondaryASPath": {
+          "type": "string",
+          "description": "The AS path for secondary link."
+        }
+      }
+    },
+    "ExpressRouteLinkFailoverRouteList": {
+      "type": "object",
+      "description": "Represents a list of failover routes for an ExpressRoute link.",
+      "properties": {
+        "beforeSimulation": {
+          "type": "array",
+          "description": "The routes before the simulation.",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteLinkFailoverRoute"
+          }
+        },
+        "duringSimulation": {
+          "type": "array",
+          "description": "The routes during the simulation.",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteLinkFailoverRoute"
+          }
+        }
+      }
+    },
+    "ExpressRouteLinkFailoverSingleTestDetails": {
+      "type": "object",
+      "description": "ExpressRoute circuit link failover single test details.",
+      "properties": {
+        "startTimeUtc": {
+          "type": "string",
+          "description": "Time when the test was started in UTC."
+        },
+        "endTimeUtc": {
+          "type": "string",
+          "description": "Time when the test was completed in UTC."
+        },
+        "status": {
+          "$ref": "./common.json#/definitions/FailoverTestStatus",
+          "description": "The current status of the test."
+        },
+        "wasSimulationSuccessful": {
+          "type": "boolean",
+          "description": "Whether the failover simulation was successful or not."
+        },
+        "linkType": {
+          "$ref": "./common.json#/definitions/ExpressRouteFailoverLinkType",
+          "description": "The link type."
+        },
+        "circuitTestCategory": {
+          "$ref": "./common.json#/definitions/MaintenanceTestCategory",
+          "description": "The circuit test category."
+        },
+        "isSimulationVerified": {
+          "type": "boolean",
+          "description": "Whether the simulation was verified."
+        },
+        "redundantRoutes": {
+          "$ref": "#/definitions/ExpressRouteLinkFailoverRouteList",
+          "description": "The redundant routes for link failover tests."
+        },
+        "nonRedundantRoutes": {
+          "$ref": "#/definitions/ExpressRouteLinkFailoverRouteList",
+          "description": "The non-redundant routes for link failover tests."
+        },
+        "bgpStatus": {
+          "type": "array",
+          "description": "The BGP status details.",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteLinkFailoverTestBgpStatus"
+          }
+        }
+      }
+    },
+    "ExpressRouteLinkFailoverSingleTestDetailsArray": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ExpressRouteLinkFailoverSingleTestDetails"
+      }
+    },
+    "ExpressRouteLinkFailoverStopApiParameters": {
+      "type": "object",
+      "description": "Parameters for stopping an ExpressRoute circuit link failover test.",
+      "properties": {
+        "circuitTestCategory": {
+          "type": "string",
+          "description": "The category of the circuit test."
+        },
+        "linkType": {
+          "type": "string",
+          "description": "The type of the link."
+        },
+        "wasSimulationSuccessful": {
+          "type": "boolean",
+          "description": "Whether the simulation was successful."
+        },
+        "isVerified": {
+          "type": "boolean",
+          "description": "Whether the link is verified."
+        }
+      }
+    },
+    "ExpressRouteLinkFailoverTestBgpStatus": {
+      "type": "object",
+      "description": "Represents the BGP status of an ExpressRoute link failover test.",
+      "properties": {
+        "type": {
+          "$ref": "./common.json#/definitions/ExpressRouteFailoverBgpStatusAddressFamily",
+          "description": "The address family type."
+        },
+        "link": {
+          "$ref": "./common.json#/definitions/ExpressRouteFailoverLinkType",
+          "description": "The link type."
+        },
+        "status": {
+          "$ref": "./common.json#/definitions/ExpressRouteLinkFailoverBgpStatus",
+          "description": "The BGP status."
+        },
+        "checkTimeUtc": {
+          "type": "string",
+          "description": "The check time in UTC."
+        }
+      }
     },
     "ExpressRouteLinkListResult": {
       "type": "object",


### PR DESCRIPTION
* link fialover swagger

* fixed errors

* added in readme

* add suppression

* update suppression

* updated doc

* reverted back-compatible changes

* Merging Circuit link failover final cp 2 branch with latest pull (#42690)

* Make propagateStaticRoutes read/write (#42616)



* Swagger changes for Vwan Express Route Gateway Failover and Insights (#42560)

* swagger changes for vwan express route gateway apis

* fixed errros

* fixed errros

* fixed errros

* fixed errros

* add suppression

* Delete specification/network/resource-manager/Microsoft.Network/Network/sdk-suppressions.yaml

* reverted back compatible.tsp

---------






---------








* resolved merged conflicts:1 (#42715)



---------

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
