### PR TITLE
Connection policy changes

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/ConnectionPolicy.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/ConnectionPolicy.tsp
@@ -1,0 +1,91 @@
+import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-azure-resource-manager";
+import "@typespec/openapi";
+import "@typespec/rest";
+import "@typespec/versioning";
+import "./models.tsp";
+import "./VirtualHub.tsp";
+import "../Common/main.tsp";
+
+using TypeSpec.Rest;
+using Azure.ResourceManager;
+using TypeSpec.Http;
+using TypeSpec.OpenAPI;
+using TypeSpec.Versioning;
+using Common;
+
+namespace Microsoft.Network;
+/**
+ * ConnectionPolicy resource defined for VirtualHub.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy feature decorator required for Network RP VirtualWAN feature gating, consistent with all other VirtualWAN interface definitions"
+#suppress "@azure-tools/typespec-azure-core/no-private-usage" "Required for includeInapplicableMetadataInPayload which suppresses systemData in the response payload, consistent with all other VirtualWAN nested resources"
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-custom-resource-usage-discourage" "ConnectionPolicy uses the local Network RP ProxyResource base type consistent with all other VirtualWAN nested resources (e.g. AzureWebCategory, BgpConnection)"
+#suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "Extending the local Network RP ProxyResource is the established pattern for nested resources in this RP"
+@added(Versions.v2025_07_01)
+@Azure.ResourceManager.Legacy.feature(Features.virtualWAN)
+@parentResource(VirtualHub)
+@Http.Private.includeInapplicableMetadataInPayload(false)
+model ConnectionPolicy extends ProxyResource {
+  /**
+   * Properties of the ConnectionPolicy resource.
+   */
+  properties?: ConnectionPolicyProperties;
+
+  /**
+   * The name of the ConnectionPolicy that is unique within a VirtualHub. This name can be used to access the resource.
+   */
+  @visibility(Lifecycle.Read)
+  @path
+  @key("connectionPolicyName")
+  @segment("connectionPolicies")
+  @pattern("^(?![.-])[a-zA-Z0-9_.-]{1,128}$")
+  name: string;
+}
+
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy feature decorator required for Network RP VirtualWAN feature gating, consistent with all other VirtualWAN interface definitions"
+@added(Versions.v2025_07_01)
+@Azure.ResourceManager.Legacy.feature(Features.virtualWAN)
+@armResourceOperations(#{ omitTags: true })
+interface ConnectionPolicies {
+  /**
+   * Retrieves the details of a ConnectionPolicy.
+   */
+  get is ArmResourceRead<ConnectionPolicy, Error = CloudError>;
+
+  /**
+   * Creates a ConnectionPolicy if it doesn't exist else updates the existing one.
+   */
+  createOrUpdate is ArmResourceCreateOrReplaceAsync<
+    ConnectionPolicy,
+    Error = CloudError
+  >;
+
+  /**
+   * Deletes a ConnectionPolicy.
+   */
+  delete is ArmResourceDeleteWithoutOkAsync<
+    ConnectionPolicy,
+    Response = ArmDeleteAcceptedLroResponse | ArmDeletedNoContentResponse,
+    Error = CloudError
+  >;
+
+  /**
+   * Retrieves the details of all ConnectionPolicies.
+   */
+  list is ArmResourceListByParent<
+    ConnectionPolicy,
+    Response = ArmResponse<ListConnectionPoliciesResult>,
+    Error = CloudError
+  >;
+}
+
+@@doc(ConnectionPolicy.name,
+  "The name of the ConnectionPolicy that is unique within a VirtualHub. This name can be used to access the resource."
+);
+@@doc(ConnectionPolicy.properties,
+  "Properties of the ConnectionPolicy resource."
+);
+@@doc(ConnectionPolicies.createOrUpdate::parameters.resource,
+  "Parameters supplied to create or update a ConnectionPolicy."
+);

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/ConnectionPolicyDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/ConnectionPolicyDelete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "virtualHubName": "TestHub",
+    "connectionPolicyName": "testpolicy",
+    "api-version": "2025-07-01"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/operationResults/{operationId}?api-version={api-version}"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ConnectionPolicies_Delete",
+  "title": "ConnectionPolicyDelete"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/ConnectionPolicyGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/ConnectionPolicyGet.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "virtualHubName": "TestHub",
+    "connectionPolicyName": "testpolicy",
+    "api-version": "2025-07-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testpolicy",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/connectionPolicies/testpolicy",
+        "etag": "W/\"2b03e4fa-c9ed-403c-815f-d8bd6d40a37b\"",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "enableInternetSecurity": true,
+          "associatedConnections": [],
+          "routingConfiguration": {
+            "associatedRouteTable": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/hubRouteTables/defaultRouteTable"
+            },
+            "propagatedRouteTables": {
+              "labels": [
+                "default"
+              ],
+              "ids": []
+            }
+          }
+        },
+        "type": "Microsoft.Network/virtualHubs/connectionPolicies"
+      }
+    }
+  },
+  "operationId": "ConnectionPolicies_Get",
+  "title": "ConnectionPolicyGet"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/ConnectionPolicyList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/ConnectionPolicyList.json
@@ -1,0 +1,68 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "virtualHubName": "TestHub",
+    "api-version": "2025-07-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testpolicy",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/connectionPolicies/testpolicy",
+            "etag": "W/\"2b03e4fa-c9ed-403c-815f-d8bd6d40a37b\"",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "enableInternetSecurity": true,
+              "associatedConnections": [],
+              "routingConfiguration": {
+                "associatedRouteTable": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/hubRouteTables/defaultRouteTable"
+                },
+                "propagatedRouteTables": {
+                  "labels": [
+                    "default"
+                  ],
+                  "ids": []
+                }
+              }
+            },
+            "type": "Microsoft.Network/virtualHubs/connectionPolicies"
+          },
+          {
+            "name": "testpolicy2",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/connectionPolicies/testpolicy2",
+            "etag": "W/\"2b03e4fa-c9ed-403c-815f-d8bd6d40a37b\"",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "enableInternetSecurity": true,
+              "associatedConnections": [],
+              "routingConfiguration": {
+                "associatedRouteTable": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/hubRouteTables/defaultRouteTable"
+                },
+                "propagatedRouteTables": {
+                  "labels": [
+                    "default"
+                  ],
+                  "ids": []
+                },
+                "inboundRouteMap": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/routeMaps/TestRouteMap"
+                },
+                "outboundRouteMap": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/routeMaps/TestRouteMap"
+                }
+              }
+            },
+            "type": "Microsoft.Network/virtualHubs/connectionPolicies"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ConnectionPolicies_List",
+  "title": "ConnectionPolicyList"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/ConnectionPolicyPut.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/ConnectionPolicyPut.json
@@ -1,0 +1,94 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "virtualHubName": "TestHub",
+    "connectionPolicyName": "testpolicy2",
+    "api-version": "2025-07-01",
+    "resource": {
+      "properties": {
+        "routingConfiguration": {
+          "associatedRouteTable": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/hubRouteTables/defaultRouteTable"
+          },
+          "inboundRouteMap": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/routeMaps/TestRouteMap"
+          },
+          "outboundRouteMap": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/routeMaps/TestRouteMap"
+          },
+          "propagatedRouteTables": {
+            "labels": [
+              "default"
+            ]
+          }
+        },
+        "enableInternetSecurity": true
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testpolicy2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/connectionPolicies/testpolicy2",
+        "etag": "W/\"2b03e4fa-c9ed-403c-815f-d8bd6d40a37b\"",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "enableInternetSecurity": true,
+          "associatedConnections": [],
+          "routingConfiguration": {
+            "associatedRouteTable": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/hubRouteTables/defaultRouteTable"
+            },
+            "propagatedRouteTables": {
+              "labels": [
+                "default"
+              ],
+              "ids": []
+            },
+            "inboundRouteMap": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/routeMaps/TestRouteMap"
+            },
+            "outboundRouteMap": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/routeMaps/TestRouteMap"
+            }
+          }
+        },
+        "type": "Microsoft.Network/virtualHubs/connectionPolicies"
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testpolicy2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/connectionPolicies/testpolicy2",
+        "etag": "W/\"2b03e4fa-c9ed-403c-815f-d8bd6d40a37b\"",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "enableInternetSecurity": true,
+          "associatedConnections": [],
+          "routingConfiguration": {
+            "associatedRouteTable": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/hubRouteTables/defaultRouteTable"
+            },
+            "propagatedRouteTables": {
+              "labels": [
+                "default"
+              ],
+              "ids": []
+            },
+            "inboundRouteMap": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/routeMaps/TestRouteMap"
+            },
+            "outboundRouteMap": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/routeMaps/TestRouteMap"
+            }
+          }
+        },
+        "type": "Microsoft.Network/virtualHubs/connectionPolicies"
+      }
+    }
+  },
+  "operationId": "ConnectionPolicies_CreateOrUpdate",
+  "title": "ConnectionPolicyPut"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/main.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/main.tsp
@@ -130,6 +130,7 @@ import "./BgpConnection.tsp";
 import "./HubIpConfiguration.tsp";
 import "./HubRouteTable.tsp";
 import "./RoutingIntent.tsp";
+import "./ConnectionPolicy.tsp";
 import "./WebApplicationFirewallPolicy.tsp";
 import "./routes.tsp";
 import "./VirtualNetworkAppliance.tsp";

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
@@ -23042,6 +23042,12 @@ model HubVirtualNetworkConnectionProperties {
   allowRemoteVnetToUseHubVnetGateways?: boolean;
 
   /**
+   * The resource id of the ConnectionPolicy associated with this HubVirtualNetworkConnection.
+   */
+  @added(Versions.v2025_07_01)
+  connectionPolicy?: SubResource;
+
+  /**
    * Enable internet security.
    */
   enableInternetSecurity?: boolean;
@@ -24313,6 +24319,44 @@ model RoutingPolicy {
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @Azure.ResourceManager.Legacy.feature(Features.virtualWAN)
 model ListRoutingIntentResult is Azure.Core.Page<RoutingIntent>;
+
+/**
+ * Properties of the ConnectionPolicy resource.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy feature decorator required for Network RP VirtualWAN feature gating, consistent with all other VirtualWAN model definitions"
+@added(Versions.v2025_07_01)
+@Azure.ResourceManager.Legacy.feature(Features.virtualWAN)
+model ConnectionPolicyProperties {
+  /**
+   * Enable internet security.
+   */
+  enableInternetSecurity?: boolean;
+
+  /**
+   * The Routing Configuration indicating the associated and propagated route tables on this connection.
+   */
+  routingConfiguration?: RoutingConfiguration;
+
+  /**
+   * The provisioning state of the ConnectionPolicy resource.
+   */
+  @visibility(Lifecycle.Read)
+  provisioningState?: ProvisioningState;
+
+  /**
+   * List of connection names (e.g. VpnConnection, HubVirtualNetworkConnection) associated with this ConnectionPolicy. These are resource names, not Azure resource IDs, consistent with the established VirtualWAN pattern used by HubRouteTable.associatedConnections.
+   */
+  @visibility(Lifecycle.Read)
+  associatedConnections?: string[];
+}
+
+/**
+ * List of ConnectionPolicies and a URL nextLink to get the next set of results.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy feature decorator required for Network RP VirtualWAN feature gating, consistent with all other VirtualWAN list result model definitions"
+@added(Versions.v2025_07_01)
+@Azure.ResourceManager.Legacy.feature(Features.virtualWAN)
+model ListConnectionPoliciesResult is Azure.Core.Page<ConnectionPolicy>;
 
 /**
  * Defines web application firewall policy properties.

--- a/specification/network/resource-manager/Microsoft.Network/Network/readme.md
+++ b/specification/network/resource-manager/Microsoft.Network/Network/readme.md
@@ -4352,6 +4352,12 @@ input-file:
 
 ```yaml
 directive:
+  - suppress: ResourceNameRestriction
+    from: virtualWan.json
+    reason: virtualHubName is an existing parent resource path parameter established in prior API versions. Adding a pattern constraint would be a breaking change to 2025-05-01 and earlier versions.
+  - suppress: ProvisioningStateMustBeReadOnly
+    from: virtualWan.json
+    reason: The Common.ProvisioningState type is marked readOnly in TypeSpec via @visibility(Lifecycle.Read), but the autorest emitter places readOnly as a sibling of $ref rather than in the type definition itself. The linter does not follow $ref siblings per OpenAPI 2.0 spec. Known issue https://github.com/Azure/azure-openapi-validator/issues/637
   - suppress: PutRequestResponseSchemeArm
     from: virtualNetworkAppliance.json
     reason: Known issue. Github link https://github.com/Azure/azure-openapi-validator/issues/752

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/ConnectionPolicyDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/ConnectionPolicyDelete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "virtualHubName": "TestHub",
+    "connectionPolicyName": "testpolicy",
+    "api-version": "2025-07-01"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/operationResults/{operationId}?api-version={api-version}"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ConnectionPolicies_Delete",
+  "title": "ConnectionPolicyDelete"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/ConnectionPolicyGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/ConnectionPolicyGet.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "virtualHubName": "TestHub",
+    "connectionPolicyName": "testpolicy",
+    "api-version": "2025-07-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testpolicy",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/connectionPolicies/testpolicy",
+        "etag": "W/\"2b03e4fa-c9ed-403c-815f-d8bd6d40a37b\"",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "enableInternetSecurity": true,
+          "associatedConnections": [],
+          "routingConfiguration": {
+            "associatedRouteTable": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/hubRouteTables/defaultRouteTable"
+            },
+            "propagatedRouteTables": {
+              "labels": [
+                "default"
+              ],
+              "ids": []
+            }
+          }
+        },
+        "type": "Microsoft.Network/virtualHubs/connectionPolicies"
+      }
+    }
+  },
+  "operationId": "ConnectionPolicies_Get",
+  "title": "ConnectionPolicyGet"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/ConnectionPolicyList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/ConnectionPolicyList.json
@@ -1,0 +1,68 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "virtualHubName": "TestHub",
+    "api-version": "2025-07-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testpolicy",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/connectionPolicies/testpolicy",
+            "etag": "W/\"2b03e4fa-c9ed-403c-815f-d8bd6d40a37b\"",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "enableInternetSecurity": true,
+              "associatedConnections": [],
+              "routingConfiguration": {
+                "associatedRouteTable": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/hubRouteTables/defaultRouteTable"
+                },
+                "propagatedRouteTables": {
+                  "labels": [
+                    "default"
+                  ],
+                  "ids": []
+                }
+              }
+            },
+            "type": "Microsoft.Network/virtualHubs/connectionPolicies"
+          },
+          {
+            "name": "testpolicy2",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/connectionPolicies/testpolicy2",
+            "etag": "W/\"2b03e4fa-c9ed-403c-815f-d8bd6d40a37b\"",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "enableInternetSecurity": true,
+              "associatedConnections": [],
+              "routingConfiguration": {
+                "associatedRouteTable": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/hubRouteTables/defaultRouteTable"
+                },
+                "propagatedRouteTables": {
+                  "labels": [
+                    "default"
+                  ],
+                  "ids": []
+                },
+                "inboundRouteMap": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/routeMaps/TestRouteMap"
+                },
+                "outboundRouteMap": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/routeMaps/TestRouteMap"
+                }
+              }
+            },
+            "type": "Microsoft.Network/virtualHubs/connectionPolicies"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ConnectionPolicies_List",
+  "title": "ConnectionPolicyList"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/ConnectionPolicyPut.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/ConnectionPolicyPut.json
@@ -1,0 +1,94 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "virtualHubName": "TestHub",
+    "connectionPolicyName": "testpolicy2",
+    "api-version": "2025-07-01",
+    "resource": {
+      "properties": {
+        "routingConfiguration": {
+          "associatedRouteTable": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/hubRouteTables/defaultRouteTable"
+          },
+          "inboundRouteMap": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/routeMaps/TestRouteMap"
+          },
+          "outboundRouteMap": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/routeMaps/TestRouteMap"
+          },
+          "propagatedRouteTables": {
+            "labels": [
+              "default"
+            ]
+          }
+        },
+        "enableInternetSecurity": true
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testpolicy2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/connectionPolicies/testpolicy2",
+        "etag": "W/\"2b03e4fa-c9ed-403c-815f-d8bd6d40a37b\"",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "enableInternetSecurity": true,
+          "associatedConnections": [],
+          "routingConfiguration": {
+            "associatedRouteTable": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/hubRouteTables/defaultRouteTable"
+            },
+            "propagatedRouteTables": {
+              "labels": [
+                "default"
+              ],
+              "ids": []
+            },
+            "inboundRouteMap": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/routeMaps/TestRouteMap"
+            },
+            "outboundRouteMap": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/routeMaps/TestRouteMap"
+            }
+          }
+        },
+        "type": "Microsoft.Network/virtualHubs/connectionPolicies"
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testpolicy2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/connectionPolicies/testpolicy2",
+        "etag": "W/\"2b03e4fa-c9ed-403c-815f-d8bd6d40a37b\"",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "enableInternetSecurity": true,
+          "associatedConnections": [],
+          "routingConfiguration": {
+            "associatedRouteTable": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/hubRouteTables/defaultRouteTable"
+            },
+            "propagatedRouteTables": {
+              "labels": [
+                "default"
+              ],
+              "ids": []
+            },
+            "inboundRouteMap": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/routeMaps/TestRouteMap"
+            },
+            "outboundRouteMap": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/TestHub/routeMaps/TestRouteMap"
+            }
+          }
+        },
+        "type": "Microsoft.Network/virtualHubs/connectionPolicies"
+      }
+    }
+  },
+  "operationId": "ConnectionPolicies_CreateOrUpdate",
+  "title": "ConnectionPolicyPut"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/virtualWan.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/virtualWan.json
@@ -2838,6 +2838,247 @@
         "x-ms-long-running-operation": true
       }
     },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/connectionPolicies": {
+      "get": {
+        "operationId": "ConnectionPolicies_List",
+        "description": "Retrieves the details of all ConnectionPolicies.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListConnectionPoliciesResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Common.CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ConnectionPolicyList": {
+            "$ref": "./examples/ConnectionPolicyList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/connectionPolicies/{connectionPolicyName}": {
+      "get": {
+        "operationId": "ConnectionPolicies_Get",
+        "description": "Retrieves the details of a ConnectionPolicy.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionPolicyName",
+            "in": "path",
+            "description": "The name of the ConnectionPolicy that is unique within a VirtualHub. This name can be used to access the resource.",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?![.-])[a-zA-Z0-9_.-]{1,128}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectionPolicy"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Common.CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ConnectionPolicyGet": {
+            "$ref": "./examples/ConnectionPolicyGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "ConnectionPolicies_CreateOrUpdate",
+        "description": "Creates a ConnectionPolicy if it doesn't exist else updates the existing one.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionPolicyName",
+            "in": "path",
+            "description": "The name of the ConnectionPolicy that is unique within a VirtualHub. This name can be used to access the resource.",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?![.-])[a-zA-Z0-9_.-]{1,128}$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Parameters supplied to create or update a ConnectionPolicy.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ConnectionPolicy"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ConnectionPolicy' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ConnectionPolicy"
+            }
+          },
+          "201": {
+            "description": "Resource 'ConnectionPolicy' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ConnectionPolicy"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Common.CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ConnectionPolicyPut": {
+            "$ref": "./examples/ConnectionPolicyPut.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ConnectionPolicy"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "ConnectionPolicies_Delete",
+        "description": "Deletes a ConnectionPolicy.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionPolicyName",
+            "in": "path",
+            "description": "The name of the ConnectionPolicy that is unique within a VirtualHub. This name can be used to access the resource.",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?![.-])[a-zA-Z0-9_.-]{1,128}$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Common.CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ConnectionPolicyDelete": {
+            "$ref": "./examples/ConnectionPolicyDelete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/effectiveRoutes": {
       "post": {
         "operationId": "VirtualHubs_GetEffectiveVirtualHubRoutes",
@@ -7685,6 +7926,48 @@
         }
       }
     },
+    "ConnectionPolicy": {
+      "type": "object",
+      "description": "ConnectionPolicy resource defined for VirtualHub.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ConnectionPolicyProperties",
+          "description": "Properties of the ConnectionPolicy resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ConnectionPolicyProperties": {
+      "type": "object",
+      "description": "Properties of the ConnectionPolicy resource.",
+      "properties": {
+        "enableInternetSecurity": {
+          "type": "boolean",
+          "description": "Enable internet security."
+        },
+        "routingConfiguration": {
+          "$ref": "#/definitions/RoutingConfiguration",
+          "description": "The Routing Configuration indicating the associated and propagated route tables on this connection."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/Common.ProvisioningState",
+          "description": "The provisioning state of the ConnectionPolicy resource.",
+          "readOnly": true
+        },
+        "associatedConnections": {
+          "type": "array",
+          "description": "List of connection names (e.g. VpnConnection, HubVirtualNetworkConnection) associated with this ConnectionPolicy. These are resource names, not Azure resource IDs, consistent with the established VirtualWAN pattern used by HubRouteTable.associatedConnections.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        }
+      }
+    },
     "ConnectionSharedKeyResult": {
       "type": "object",
       "description": "SharedKey Resource .",
@@ -8245,6 +8528,10 @@
           "type": "boolean",
           "description": "Deprecated: Allow RemoteVnet to use Virtual Hub's gateways."
         },
+        "connectionPolicy": {
+          "$ref": "./common.json#/definitions/Common.SubResource",
+          "description": "The resource id of the ConnectionPolicy associated with this HubVirtualNetworkConnection."
+        },
         "enableInternetSecurity": {
           "type": "boolean",
           "description": "Enable internet security."
@@ -8259,6 +8546,27 @@
           "readOnly": true
         }
       }
+    },
+    "ListConnectionPoliciesResult": {
+      "type": "object",
+      "description": "List of ConnectionPolicies and a URL nextLink to get the next set of results.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ConnectionPolicy items on this page",
+          "items": {
+            "$ref": "#/definitions/ConnectionPolicy"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
     },
     "ListHubRouteTablesResult": {
       "type": "object",


### PR DESCRIPTION
## Description
- Added **Connection policy** CRUD operations (*Get, Put, Delete, List*).

### New example files
- `ConnectionPolicyGet.json`
- `ConnectionPolicyPut.json`
- `ConnectionPolicyDelete.json`
- `ConnectionPolicyList.json`

## Validation
Prettier and TypeSpec

## Note
- ProvisioningStateMustBeReadOnly suppression: This is a known validator bug tracked at [azure-openapi-validator#637](https://github.com/Azure/azure-openapi-validator/issues/637), the rule ignores `readOnly` placed as a `$ref` sibling per OpenAPI 2.0. The suppression is the documented workaround; using `use-read-only-status-schema: true` instead would add `readOnly: true` to already-published `2025-05-01/common.json` definitions, triggering a `ReadonlyPropertyChanged` OAD breaking change error. Multiple other teams in this repo have cited the same issue for the same reason.
- This PR is based on an already approved PR: https://github.com/Azure/azure-rest-api-specs/pull/42420