### PR TITLE
rename DiscountType for go

### DIFF
--- a/specification/billingbenefits/BillingBenefits.Management/client.tsp
+++ b/specification/billingbenefits/BillingBenefits.Management/client.tsp
@@ -286,3 +286,4 @@ using Microsoft.BillingBenefits;
 
 // csharp: preserve original public property name after flatten/lift-to-nullable generator fix
 @@clientName(MaccModelProperties.entityType, "MaccEntityType", "csharp");
+@@clientName(DiscountType, "DiscountTypeEnum", "go");


### PR DESCRIPTION
 since there are many naming conflicts in generated go sdk billingbenefits about union DiscountType，so to rename it to DiscountTypeEnum for go
 