### PR TITLE
fix(adaptive-evals): align with Johan's feedback on data-gen PR #41606

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -16146,10 +16146,6 @@
               }
             ],
             "description": "The type of source."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional description of what this source represents — helps the pipeline interpret its content (e.g., 'Company refund policy document' or 'Describes the agent's core capabilities')."
           }
         },
         "discriminator": {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -18815,10 +18815,6 @@
               }
             ],
             "description": "The type of source."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional description of what this source represents — helps the pipeline interpret its content (e.g., 'Company refund policy document' or 'Describes the agent's core capabilities')."
           }
         },
         "discriminator": {

--- a/specification/ai-foundry/data-plane/Foundry/src/common/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/common/models.tsp
@@ -111,11 +111,15 @@ alias SseResponseOf<T> = {
 // duplication across job-specific model files.
 // ============================================================================
 
-@doc("Common properties shared across all job source types. Spread into per-context source variants alongside a context-specific discriminated base (e.g., `EvaluatorGenerationJobSource`).")
-model JobSourceDescription {
+// Common properties shared across all job source types. Spread into per-context
+// source variants alongside a context-specific discriminated base (e.g.,
+// `EvaluatorGenerationJobSource`). Modeled as an `alias` (not a `model`) since
+// it is a single-property fragment used purely for spreading — declaring a
+// named model adds no value over inlining the property.
+alias JobSourceDescription = {
   @doc("Optional description of what this source represents — helps the pipeline interpret its content (e.g., 'Company refund policy document' or 'Describes the agent's core capabilities').")
   description?: string;
-}
+};
 
 @doc("Prompt source — inline text provided by the user. Reusable shape spread into per-context discriminated subtypes.")
 model PromptJobSource {

--- a/specification/ai-foundry/data-plane/Foundry/src/evaluators/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/evaluators/models.tsp
@@ -193,9 +193,11 @@ union EvaluatorGenerationJobSourceType {
 model EvaluatorGenerationJobSource {
   @doc("The type of source.")
   type: EvaluatorGenerationJobSourceType;
-
-  ...JobSourceDescription;
 }
+// Note: `JobSourceDescription` is intentionally NOT spread here. Each
+// concrete subtype already spreads its `XxxJobSource` shape from common/, and
+// each of those already spreads `JobSourceDescription`. Spreading it again on
+// the discriminated base would emit `description` twice in the union.
 
 @doc("Prompt source for evaluator generation jobs — inline text provided by the user.")
 model PromptEvaluatorGenerationJobSource


### PR DESCRIPTION
Applies @johanste's review feedback patterns from #41606 to the adaptive-evals models reapplied in #42764.

## Changes

1. **JobSourceDescription: `model` → `alias`** in common/models.tsp. Per Johan's [comment on #41606](https://github.com/Azure/azure-rest-api-specs/pull/41606), single-property fragments used purely for spreading should be aliases — declaring a named model adds no value over inlining.

2. **Remove redundant `...JobSourceDescription` spread from `EvaluatorGenerationJobSource` discriminated base** in valuators/models.tsp. Each concrete subtype (`PromptEvaluatorGenerationJobSource`, `AgentEvaluatorGenerationJobSource`, `TracesEvaluatorGenerationJobSource`, `DatasetEvaluatorGenerationJobSource`) already spreads its `XxxJobSource` shape from `common/`, and each of those already spreads `JobSourceDescription`. The redundant spread on the base was emitting `description` twice in the union.

3. **Regenerate `openapi3` for v1 + virtual-public-preview.** Net schema delta: 4 lines removed per file (the redundant `description` property on the discriminated base). All concrete leaf types still expose `description` via the spread chain — verified in the regenerated JSON.

## Why we kept some things as-is

- **`XxxJobSource` shapes stay as `model` (not `alias`)** because each is spread into multiple per-context discriminated subtypes — one in valuators/models.tsp (this PR) and one in data_generation/models.tsp (once @sakoll's #41606 rebases on the shared `common/` shapes). Two-or-more consumers justifies a named model.
- **`common/` placement of the source shapes** is now genuinely cross-cutting: this PR + #41606 both consume them. Happy to revisit once #41606 lands.
- **`agent_name` / `agent_version` duplication between `AgentJobSource` and `TracesJobSource`** was *not* extracted into a shared alias because the `agent_version?` docstrings differ semantically (`AgentJobSource`: "If not specified, the latest version is used"; `TracesJobSource`: "If not specified, traces for ALL versions of the agent are included within the time window"). Folding them into a shared alias would lose per-context meaning.

## Coordination

- @sakoll — PR #41606 will need a small rebase once this lands so its shared `common/` consumption matches the new `alias` form. Happy to coordinate ordering.
- @johanste — would appreciate your signoff so the parent PR (#42764) can merge.
