### PR TITLE
feat(ai-foundry): add TypeSpec for Foundry Routines

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/main.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/main.tsp
@@ -20,6 +20,7 @@ import "./src/openai-evaluations/routes.tsp";
 import "./src/openai-finetuning/routes.tsp";
 import "./src/openai-responses/routes.tsp";
 import "./src/red-teams/routes.tsp";
+import "./src/routines/routes.tsp";
 import "./src/schedules/routes.tsp";
 import "./src/skills/routes.tsp";
 import "./src/toolboxes/routes.tsp";

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -57,6 +57,9 @@
       "name": "Redteams"
     },
     {
+      "name": "Routines"
+    },
+    {
       "name": "Schedules"
     },
     {
@@ -8488,6 +8491,538 @@
         }
       }
     },
+    "/routines": {
+      "get": {
+        "operationId": "Routines_list",
+        "description": "List all routines.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "continuationToken",
+            "in": "query",
+            "required": false,
+            "description": "Continuation token from a previous list response.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Routines=V1Preview"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedRoutine"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "headers": {
+              "x-ms-error-code": {
+                "required": false,
+                "description": "String error code indicating what went wrong.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Routines"
+        ]
+      }
+    },
+    "/routines/{routine_name}": {
+      "put": {
+        "operationId": "Routines_createOrUpdate",
+        "description": "Create or update a routine.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "routine_name",
+            "in": "path",
+            "required": true,
+            "description": "Unique name of the routine within the workspace.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Routines=V1Preview"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Routine"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "The request has succeeded and a new resource has been created as a result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Routine"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "headers": {
+              "x-ms-error-code": {
+                "required": false,
+                "description": "String error code indicating what went wrong.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Routines"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Routine"
+              }
+            }
+          },
+          "description": "The routine to create or update."
+        }
+      },
+      "get": {
+        "operationId": "Routines_get",
+        "description": "Get a routine by name.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "routine_name",
+            "in": "path",
+            "required": true,
+            "description": "Unique name of the routine within the workspace.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Routines=V1Preview"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Routine"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "headers": {
+              "x-ms-error-code": {
+                "required": false,
+                "description": "String error code indicating what went wrong.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Routines"
+        ]
+      },
+      "delete": {
+        "operationId": "Routines_delete",
+        "description": "Delete a routine.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "routine_name",
+            "in": "path",
+            "required": true,
+            "description": "Unique name of the routine within the workspace.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Routines=V1Preview"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "headers": {
+              "x-ms-error-code": {
+                "required": false,
+                "description": "String error code indicating what went wrong.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Routines"
+        ]
+      }
+    },
+    "/routines/{routine_name}/runs": {
+      "get": {
+        "operationId": "Routines_listRuns",
+        "description": "List execution history for a routine.",
+        "parameters": [
+          {
+            "name": "routine_name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the routine.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "description": "OData-style filter expression.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "description": "One or more ordering expressions.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "maxResults",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return per page.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "explode": false
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "description": "Continuation token from a previous list response.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Routines=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoutineRunsResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Routines"
+        ]
+      }
+    },
+    "/routines/{routine_name}:dispatch": {
+      "post": {
+        "operationId": "Routines_dispatch",
+        "description": "Synchronously dispatch a routine. Returns after the downstream action completes.",
+        "parameters": [
+          {
+            "name": "routine_name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the routine to dispatch.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Routines=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DispatchRoutineResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Routines"
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DispatchRoutineRequest"
+              }
+            }
+          },
+          "description": "Optional dispatch request payload."
+        }
+      }
+    },
+    "/routines/{routine_name}:dispatchAsync": {
+      "post": {
+        "operationId": "Routines_dispatchAsync",
+        "description": "Asynchronously dispatch a routine. Returns immediately after enqueueing the action.",
+        "parameters": [
+          {
+            "name": "routine_name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the routine to dispatch.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Routines=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DispatchRoutineResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Routines"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DispatchRoutineRequest"
+              }
+            }
+          },
+          "description": "Dispatch request payload."
+        }
+      }
+    },
     "/schedules": {
       "get": {
         "operationId": "Schedules_list",
@@ -14139,6 +14674,34 @@
           }
         ]
       },
+      "DispatchRoutineRequest": {
+        "type": "object",
+        "properties": {
+          "payload": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RoutineDispatchPayload"
+              }
+            ],
+            "description": "Optional payload to override the action's default input."
+          }
+        },
+        "description": "Request body for manually dispatching a routine."
+      },
+      "DispatchRoutineResponse": {
+        "type": "object",
+        "properties": {
+          "dispatch_id": {
+            "type": "string",
+            "description": "Unique identifier for this dispatch event."
+          },
+          "action_correlation_id": {
+            "type": "string",
+            "description": "Correlation ID linking this dispatch to the resulting agent run."
+          }
+        },
+        "description": "Response returned by the dispatch and dispatchAsync operations."
+      },
       "EntraAuthorizationScheme": {
         "type": "object",
         "required": [
@@ -15735,6 +16298,45 @@
         },
         "description": "Evaluator Definition"
       },
+      "EventRoutineTrigger": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "github_issue"
+            ]
+          },
+          "connection_id": {
+            "type": "string",
+            "description": "ID of the workspace connection that owns the GitHub OAuth credentials."
+          },
+          "owner": {
+            "type": "string",
+            "description": "GitHub repository owner or organization. Example: `\"contoso\"`."
+          },
+          "repository": {
+            "type": "string",
+            "description": "GitHub repository name. Example: `\"contoso-app\"`."
+          },
+          "actions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "GitHub issue actions to match. Example: `[\"opened\", \"reopened\"]`. When omitted all actions are accepted."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RoutineTrigger"
+          }
+        ],
+        "description": "GitHub issue event trigger backed by a workspace connection."
+      },
       "FabricDataAgentToolCall": {
         "type": "object",
         "required": [
@@ -16781,6 +17383,119 @@
           }
         },
         "description": "Metadata about the insights."
+      },
+      "InvokeAgentInvocationsApiDispatchPayload": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "invoke_agent_invocations_api"
+            ],
+            "description": "Payload type discriminator."
+          },
+          "input": {
+            "type": "string",
+            "description": "Raw input content to send to the agent endpoint."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RoutineDispatchPayload"
+          }
+        ],
+        "description": "Manual dispatch payload for `invoke_agent_invocations_api` actions."
+      },
+      "InvokeAgentInvocationsApiRoutineAction": {
+        "type": "object",
+        "required": [
+          "type",
+          "agent_endpoint_id"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "invoke_agent_invocations_api"
+            ],
+            "description": "Action type discriminator."
+          },
+          "agent_endpoint_id": {
+            "type": "string",
+            "description": "Agent endpoint target for the endpoint invocations route."
+          },
+          "session_id": {
+            "type": "string",
+            "description": "Optional existing hosted-agent session to continue."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RoutineAction"
+          }
+        ],
+        "description": "Action that invokes a published agent via the endpoint invocations API."
+      },
+      "InvokeAgentResponsesApiDispatchPayload": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "invoke_agent_responses_api"
+            ],
+            "description": "Payload type discriminator."
+          },
+          "input": {
+            "type": "string",
+            "description": "User message content to send to the agent. Example: `\"Summarize today's build failures.\"`"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RoutineDispatchPayload"
+          }
+        ],
+        "description": "Manual dispatch payload for `invoke_agent_responses_api` actions."
+      },
+      "InvokeAgentResponsesApiRoutineAction": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "invoke_agent_responses_api"
+            ],
+            "description": "Action type discriminator."
+          },
+          "agent_id": {
+            "type": "string",
+            "description": "Project-scoped agent ID used with the workspace `/openai/responses` route. Exactly one of `agent_id` or `agent_endpoint_id` must be provided."
+          },
+          "agent_endpoint_id": {
+            "type": "string",
+            "description": "Agent endpoint target for endpoint-scoped protocol routes. Exactly one of `agent_id` or `agent_endpoint_id` must be provided."
+          },
+          "conversation_id": {
+            "type": "string",
+            "description": "Optional existing conversation ID to continue across scheduled fires."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RoutineAction"
+          }
+        ],
+        "description": "Action that invokes a published agent via the workspace responses API."
       },
       "IsolationKeySource": {
         "type": "object",
@@ -37870,6 +38585,27 @@
         },
         "description": "Paged collection of RedTeam items"
       },
+      "PagedRoutine": {
+        "type": "object",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Routine"
+            },
+            "description": "The Routine items on this page"
+          },
+          "nextLink": {
+            "type": "string",
+            "format": "uri",
+            "description": "The link to the next page of items"
+          }
+        },
+        "description": "Paged collection of Routine items"
+      },
       "PagedSchedule": {
         "type": "object",
         "required": [
@@ -38554,6 +39290,245 @@
         ],
         "description": "Risk category for the attack objective."
       },
+      "Routine": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Unique name of the routine within the workspace.",
+            "readOnly": true
+          },
+          "description": {
+            "type": "string",
+            "description": "Human-readable description of the routine."
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether the trigger schedule is active. Defaults to `true` on creation.",
+            "default": true
+          },
+          "triggers": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/RoutineTrigger"
+            },
+            "description": "Named trigger configurations for this routine. The key is a user-defined trigger identifier."
+          },
+          "action": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RoutineAction"
+              }
+            ],
+            "description": "Action to execute when a trigger fires."
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "UTC timestamp at which the routine was created.",
+            "readOnly": true
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "UTC timestamp at which the routine was last updated.",
+            "readOnly": true
+          }
+        },
+        "description": "A workspace-scoped resource that pairs named trigger(s) with a single action, defining when and how a Foundry agent is invoked."
+      },
+      "RoutineAction": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RoutineActionType"
+              }
+            ],
+            "description": "Action type discriminator."
+          }
+        },
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "invoke_agent_responses_api": "#/components/schemas/InvokeAgentResponsesApiRoutineAction",
+            "invoke_agent_invocations_api": "#/components/schemas/InvokeAgentInvocationsApiRoutineAction"
+          }
+        },
+        "description": "Base model for a Routine action. Discriminated by `type`."
+      },
+      "RoutineActionType": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "invoke_agent_responses_api",
+              "invoke_agent_invocations_api"
+            ]
+          }
+        ],
+        "description": "Discriminator values for RoutineAction.type."
+      },
+      "RoutineDispatchPayload": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RoutineActionType"
+              }
+            ],
+            "description": "Payload type discriminator, matching the routine's action type."
+          }
+        },
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "invoke_agent_responses_api": "#/components/schemas/InvokeAgentResponsesApiDispatchPayload",
+            "invoke_agent_invocations_api": "#/components/schemas/InvokeAgentInvocationsApiDispatchPayload"
+          }
+        },
+        "description": "Base class for a manual dispatch payload. Discriminated by `type`."
+      },
+      "RoutineRunDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "MLflow run identifier for this attempt."
+          },
+          "status": {
+            "type": "string",
+            "description": "Underlying MLflow run status. Example values: `RUNNING`, `FINISHED`, `FAILED`."
+          },
+          "phase": {
+            "type": "string",
+            "description": "AgentExtensions lifecycle phase. Example values: `queued`, `dispatching`, `completed`, `failed`."
+          },
+          "trigger_type": {
+            "type": "string",
+            "description": "Trigger type that produced the attempt. Example values: `schedule`, `timer`, `github_issue`."
+          },
+          "attempt_source": {
+            "type": "string",
+            "description": "Source path that created the attempt. Example values: `manual_dispatch`, `queued_dispatch`, `schedule_delivery`, `timer_delivery`."
+          },
+          "action_type": {
+            "type": "string",
+            "description": "Action type dispatched for the attempt."
+          },
+          "triggered_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Logical trigger time for the attempt."
+          },
+          "started_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Time the underlying MLflow run started."
+          },
+          "ended_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Time the underlying MLflow run reached a terminal state."
+          },
+          "dispatch_id": {
+            "type": "string",
+            "description": "Dispatch identifier for the attempt."
+          },
+          "action_correlation_id": {
+            "type": "string",
+            "description": "Downstream action correlation identifier."
+          },
+          "response_id": {
+            "type": "string",
+            "description": "Downstream response or invocation identifier, if available."
+          },
+          "error_type": {
+            "type": "string",
+            "description": "Fully-qualified error type for a failed attempt, if available."
+          },
+          "error_message": {
+            "type": "string",
+            "description": "Truncated failure message for a failed attempt, if available."
+          }
+        },
+        "description": "Compact record of a single routine trigger attempt."
+      },
+      "RoutineRunsResponse": {
+        "type": "object",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RoutineRunDto"
+            },
+            "description": "Current page of routine runs."
+          },
+          "next_page_token": {
+            "type": "string",
+            "description": "Continuation token for the next page. Omitted when there are no additional results."
+          }
+        },
+        "description": "Paged response for routine run history."
+      },
+      "RoutineTrigger": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RoutineTriggerType"
+              }
+            ],
+            "description": "Trigger type discriminator."
+          }
+        },
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "schedule": "#/components/schemas/ScheduleRoutineTrigger",
+            "timer": "#/components/schemas/TimerRoutineTrigger",
+            "github_issue": "#/components/schemas/EventRoutineTrigger"
+          }
+        },
+        "description": "Base model for a Routine trigger. Discriminated by `type`."
+      },
+      "RoutineTriggerType": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "schedule",
+              "timer",
+              "github_issue"
+            ]
+          }
+        ],
+        "description": "Discriminator values for RoutineTrigger.type."
+      },
       "SASCredentials": {
         "type": "object",
         "required": [
@@ -38712,6 +39687,35 @@
           }
         ],
         "description": "Schedule provisioning status."
+      },
+      "ScheduleRoutineTrigger": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "schedule"
+            ],
+            "description": "Trigger type discriminator."
+          },
+          "cron_expression": {
+            "type": "string",
+            "description": "Standard cron expression for the recurring schedule. Example: `\"0 8 * * *\"` for daily at 08:00."
+          },
+          "time_zone": {
+            "type": "string",
+            "description": "IANA/Windows time zone identifier. Example: `\"UTC\"` or `\"America/Los_Angeles\"`."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RoutineTrigger"
+          }
+        ],
+        "description": "Cron-based recurring schedule trigger."
       },
       "ScheduleRun": {
         "type": "object",
@@ -39708,6 +40712,35 @@
           }
         },
         "title": "AzureAIEvaluatorGrader"
+      },
+      "TimerRoutineTrigger": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "timer"
+            ],
+            "description": "Trigger type discriminator."
+          },
+          "at": {
+            "type": "string",
+            "description": "One-shot fire time in ISO 8601 format. Example: `\"2030-01-02T03:04:05Z\"`."
+          },
+          "time_zone": {
+            "type": "string",
+            "description": "IANA/Windows time zone identifier. Example: `\"UTC\"` or `\"America/Los_Angeles\"`."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RoutineTrigger"
+          }
+        ],
+        "description": "One-shot timer trigger. Fires once at the configured time."
       },
       "ToolCallOutputContent": {
         "anyOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -60,6 +60,9 @@
       "name": "Redteams"
     },
     {
+      "name": "Routines"
+    },
+    {
       "name": "Schedules"
     },
     {
@@ -10299,6 +10302,538 @@
         }
       }
     },
+    "/routines": {
+      "get": {
+        "operationId": "Routines_list",
+        "description": "List all routines.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "continuationToken",
+            "in": "query",
+            "required": false,
+            "description": "Continuation token from a previous list response.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Routines=V1Preview"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedRoutine"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "headers": {
+              "x-ms-error-code": {
+                "required": false,
+                "description": "String error code indicating what went wrong.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Routines"
+        ]
+      }
+    },
+    "/routines/{routine_name}": {
+      "put": {
+        "operationId": "Routines_createOrUpdate",
+        "description": "Create or update a routine.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "routine_name",
+            "in": "path",
+            "required": true,
+            "description": "Unique name of the routine within the workspace.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Routines=V1Preview"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Routine"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "The request has succeeded and a new resource has been created as a result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Routine"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "headers": {
+              "x-ms-error-code": {
+                "required": false,
+                "description": "String error code indicating what went wrong.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Routines"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Routine"
+              }
+            }
+          },
+          "description": "The routine to create or update."
+        }
+      },
+      "get": {
+        "operationId": "Routines_get",
+        "description": "Get a routine by name.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "routine_name",
+            "in": "path",
+            "required": true,
+            "description": "Unique name of the routine within the workspace.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Routines=V1Preview"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Routine"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "headers": {
+              "x-ms-error-code": {
+                "required": false,
+                "description": "String error code indicating what went wrong.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Routines"
+        ]
+      },
+      "delete": {
+        "operationId": "Routines_delete",
+        "description": "Delete a routine.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "routine_name",
+            "in": "path",
+            "required": true,
+            "description": "Unique name of the routine within the workspace.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Routines=V1Preview"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "headers": {
+              "x-ms-error-code": {
+                "required": false,
+                "description": "String error code indicating what went wrong.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Routines"
+        ]
+      }
+    },
+    "/routines/{routine_name}/runs": {
+      "get": {
+        "operationId": "Routines_listRuns",
+        "description": "List execution history for a routine.",
+        "parameters": [
+          {
+            "name": "routine_name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the routine.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "description": "OData-style filter expression.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "description": "One or more ordering expressions.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "maxResults",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return per page.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "explode": false
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "description": "Continuation token from a previous list response.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Routines=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoutineRunsResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Routines"
+        ]
+      }
+    },
+    "/routines/{routine_name}:dispatch": {
+      "post": {
+        "operationId": "Routines_dispatch",
+        "description": "Synchronously dispatch a routine. Returns after the downstream action completes.",
+        "parameters": [
+          {
+            "name": "routine_name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the routine to dispatch.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Routines=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DispatchRoutineResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Routines"
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DispatchRoutineRequest"
+              }
+            }
+          },
+          "description": "Optional dispatch request payload."
+        }
+      }
+    },
+    "/routines/{routine_name}:dispatchAsync": {
+      "post": {
+        "operationId": "Routines_dispatchAsync",
+        "description": "Asynchronously dispatch a routine. Returns immediately after enqueueing the action.",
+        "parameters": [
+          {
+            "name": "routine_name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the routine to dispatch.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Routines=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DispatchRoutineResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Routines"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DispatchRoutineRequest"
+              }
+            }
+          },
+          "description": "Dispatch request payload."
+        }
+      }
+    },
     "/schedules": {
       "get": {
         "operationId": "Schedules_list",
@@ -16659,6 +17194,34 @@
         ],
         "description": "A message authored by a developer to guide the model during evaluation."
       },
+      "DispatchRoutineRequest": {
+        "type": "object",
+        "properties": {
+          "payload": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RoutineDispatchPayload"
+              }
+            ],
+            "description": "Optional payload to override the action's default input."
+          }
+        },
+        "description": "Request body for manually dispatching a routine."
+      },
+      "DispatchRoutineResponse": {
+        "type": "object",
+        "properties": {
+          "dispatch_id": {
+            "type": "string",
+            "description": "Unique identifier for this dispatch event."
+          },
+          "action_correlation_id": {
+            "type": "string",
+            "description": "Correlation ID linking this dispatch to the resulting agent run."
+          }
+        },
+        "description": "Response returned by the dispatch and dispatchAsync operations."
+      },
       "EntraAuthorizationScheme": {
         "type": "object",
         "required": [
@@ -18404,6 +18967,45 @@
         },
         "description": "Evaluator Definition"
       },
+      "EventRoutineTrigger": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "github_issue"
+            ]
+          },
+          "connection_id": {
+            "type": "string",
+            "description": "ID of the workspace connection that owns the GitHub OAuth credentials."
+          },
+          "owner": {
+            "type": "string",
+            "description": "GitHub repository owner or organization. Example: `\"contoso\"`."
+          },
+          "repository": {
+            "type": "string",
+            "description": "GitHub repository name. Example: `\"contoso-app\"`."
+          },
+          "actions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "GitHub issue actions to match. Example: `[\"opened\", \"reopened\"]`. When omitted all actions are accepted."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RoutineTrigger"
+          }
+        ],
+        "description": "GitHub issue event trigger backed by a workspace connection."
+      },
       "FabricDataAgentToolCall": {
         "type": "object",
         "required": [
@@ -19523,6 +20125,119 @@
           }
         },
         "description": "Metadata about the insights."
+      },
+      "InvokeAgentInvocationsApiDispatchPayload": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "invoke_agent_invocations_api"
+            ],
+            "description": "Payload type discriminator."
+          },
+          "input": {
+            "type": "string",
+            "description": "Raw input content to send to the agent endpoint."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RoutineDispatchPayload"
+          }
+        ],
+        "description": "Manual dispatch payload for `invoke_agent_invocations_api` actions."
+      },
+      "InvokeAgentInvocationsApiRoutineAction": {
+        "type": "object",
+        "required": [
+          "type",
+          "agent_endpoint_id"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "invoke_agent_invocations_api"
+            ],
+            "description": "Action type discriminator."
+          },
+          "agent_endpoint_id": {
+            "type": "string",
+            "description": "Agent endpoint target for the endpoint invocations route."
+          },
+          "session_id": {
+            "type": "string",
+            "description": "Optional existing hosted-agent session to continue."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RoutineAction"
+          }
+        ],
+        "description": "Action that invokes a published agent via the endpoint invocations API."
+      },
+      "InvokeAgentResponsesApiDispatchPayload": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "invoke_agent_responses_api"
+            ],
+            "description": "Payload type discriminator."
+          },
+          "input": {
+            "type": "string",
+            "description": "User message content to send to the agent. Example: `\"Summarize today's build failures.\"`"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RoutineDispatchPayload"
+          }
+        ],
+        "description": "Manual dispatch payload for `invoke_agent_responses_api` actions."
+      },
+      "InvokeAgentResponsesApiRoutineAction": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "invoke_agent_responses_api"
+            ],
+            "description": "Action type discriminator."
+          },
+          "agent_id": {
+            "type": "string",
+            "description": "Project-scoped agent ID used with the workspace `/openai/responses` route. Exactly one of `agent_id` or `agent_endpoint_id` must be provided."
+          },
+          "agent_endpoint_id": {
+            "type": "string",
+            "description": "Agent endpoint target for endpoint-scoped protocol routes. Exactly one of `agent_id` or `agent_endpoint_id` must be provided."
+          },
+          "conversation_id": {
+            "type": "string",
+            "description": "Optional existing conversation ID to continue across scheduled fires."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RoutineAction"
+          }
+        ],
+        "description": "Action that invokes a published agent via the workspace responses API."
       },
       "IsolationKeySource": {
         "type": "object",
@@ -40779,6 +41494,27 @@
         },
         "description": "Paged collection of RedTeam items"
       },
+      "PagedRoutine": {
+        "type": "object",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Routine"
+            },
+            "description": "The Routine items on this page"
+          },
+          "nextLink": {
+            "type": "string",
+            "format": "uri",
+            "description": "The link to the next page of items"
+          }
+        },
+        "description": "Paged collection of Routine items"
+      },
       "PagedSchedule": {
         "type": "object",
         "required": [
@@ -41463,6 +42199,245 @@
         ],
         "description": "Risk category for the attack objective."
       },
+      "Routine": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Unique name of the routine within the workspace.",
+            "readOnly": true
+          },
+          "description": {
+            "type": "string",
+            "description": "Human-readable description of the routine."
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether the trigger schedule is active. Defaults to `true` on creation.",
+            "default": true
+          },
+          "triggers": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/RoutineTrigger"
+            },
+            "description": "Named trigger configurations for this routine. The key is a user-defined trigger identifier."
+          },
+          "action": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RoutineAction"
+              }
+            ],
+            "description": "Action to execute when a trigger fires."
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "UTC timestamp at which the routine was created.",
+            "readOnly": true
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "UTC timestamp at which the routine was last updated.",
+            "readOnly": true
+          }
+        },
+        "description": "A workspace-scoped resource that pairs named trigger(s) with a single action, defining when and how a Foundry agent is invoked."
+      },
+      "RoutineAction": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RoutineActionType"
+              }
+            ],
+            "description": "Action type discriminator."
+          }
+        },
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "invoke_agent_responses_api": "#/components/schemas/InvokeAgentResponsesApiRoutineAction",
+            "invoke_agent_invocations_api": "#/components/schemas/InvokeAgentInvocationsApiRoutineAction"
+          }
+        },
+        "description": "Base model for a Routine action. Discriminated by `type`."
+      },
+      "RoutineActionType": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "invoke_agent_responses_api",
+              "invoke_agent_invocations_api"
+            ]
+          }
+        ],
+        "description": "Discriminator values for RoutineAction.type."
+      },
+      "RoutineDispatchPayload": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RoutineActionType"
+              }
+            ],
+            "description": "Payload type discriminator, matching the routine's action type."
+          }
+        },
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "invoke_agent_responses_api": "#/components/schemas/InvokeAgentResponsesApiDispatchPayload",
+            "invoke_agent_invocations_api": "#/components/schemas/InvokeAgentInvocationsApiDispatchPayload"
+          }
+        },
+        "description": "Base class for a manual dispatch payload. Discriminated by `type`."
+      },
+      "RoutineRunDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "MLflow run identifier for this attempt."
+          },
+          "status": {
+            "type": "string",
+            "description": "Underlying MLflow run status. Example values: `RUNNING`, `FINISHED`, `FAILED`."
+          },
+          "phase": {
+            "type": "string",
+            "description": "AgentExtensions lifecycle phase. Example values: `queued`, `dispatching`, `completed`, `failed`."
+          },
+          "trigger_type": {
+            "type": "string",
+            "description": "Trigger type that produced the attempt. Example values: `schedule`, `timer`, `github_issue`."
+          },
+          "attempt_source": {
+            "type": "string",
+            "description": "Source path that created the attempt. Example values: `manual_dispatch`, `queued_dispatch`, `schedule_delivery`, `timer_delivery`."
+          },
+          "action_type": {
+            "type": "string",
+            "description": "Action type dispatched for the attempt."
+          },
+          "triggered_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Logical trigger time for the attempt."
+          },
+          "started_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Time the underlying MLflow run started."
+          },
+          "ended_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Time the underlying MLflow run reached a terminal state."
+          },
+          "dispatch_id": {
+            "type": "string",
+            "description": "Dispatch identifier for the attempt."
+          },
+          "action_correlation_id": {
+            "type": "string",
+            "description": "Downstream action correlation identifier."
+          },
+          "response_id": {
+            "type": "string",
+            "description": "Downstream response or invocation identifier, if available."
+          },
+          "error_type": {
+            "type": "string",
+            "description": "Fully-qualified error type for a failed attempt, if available."
+          },
+          "error_message": {
+            "type": "string",
+            "description": "Truncated failure message for a failed attempt, if available."
+          }
+        },
+        "description": "Compact record of a single routine trigger attempt."
+      },
+      "RoutineRunsResponse": {
+        "type": "object",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RoutineRunDto"
+            },
+            "description": "Current page of routine runs."
+          },
+          "next_page_token": {
+            "type": "string",
+            "description": "Continuation token for the next page. Omitted when there are no additional results."
+          }
+        },
+        "description": "Paged response for routine run history."
+      },
+      "RoutineTrigger": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RoutineTriggerType"
+              }
+            ],
+            "description": "Trigger type discriminator."
+          }
+        },
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "schedule": "#/components/schemas/ScheduleRoutineTrigger",
+            "timer": "#/components/schemas/TimerRoutineTrigger",
+            "github_issue": "#/components/schemas/EventRoutineTrigger"
+          }
+        },
+        "description": "Base model for a Routine trigger. Discriminated by `type`."
+      },
+      "RoutineTriggerType": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "schedule",
+              "timer",
+              "github_issue"
+            ]
+          }
+        ],
+        "description": "Discriminator values for RoutineTrigger.type."
+      },
       "SASCredentials": {
         "type": "object",
         "required": [
@@ -41621,6 +42596,35 @@
           }
         ],
         "description": "Schedule provisioning status."
+      },
+      "ScheduleRoutineTrigger": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "schedule"
+            ],
+            "description": "Trigger type discriminator."
+          },
+          "cron_expression": {
+            "type": "string",
+            "description": "Standard cron expression for the recurring schedule. Example: `\"0 8 * * *\"` for daily at 08:00."
+          },
+          "time_zone": {
+            "type": "string",
+            "description": "IANA/Windows time zone identifier. Example: `\"UTC\"` or `\"America/Los_Angeles\"`."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RoutineTrigger"
+          }
+        ],
+        "description": "Cron-based recurring schedule trigger."
       },
       "ScheduleRun": {
         "type": "object",
@@ -42643,6 +43647,35 @@
           }
         },
         "title": "AzureAIEvaluatorGrader"
+      },
+      "TimerRoutineTrigger": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "timer"
+            ],
+            "description": "Trigger type discriminator."
+          },
+          "at": {
+            "type": "string",
+            "description": "One-shot fire time in ISO 8601 format. Example: `\"2030-01-02T03:04:05Z\"`."
+          },
+          "time_zone": {
+            "type": "string",
+            "description": "IANA/Windows time zone identifier. Example: `\"UTC\"` or `\"America/Los_Angeles\"`."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RoutineTrigger"
+          }
+        ],
+        "description": "One-shot timer trigger. Fires once at the configured time."
       },
       "ToolCallOutputContent": {
         "anyOf": [

--- a/specification/ai-foundry/data-plane/Foundry/src/routines/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/routines/models.tsp
@@ -1,0 +1,266 @@
+import "../common/models.tsp";
+import "../servicepatterns.tsp";
+
+using TypeSpec.Rest;
+
+namespace Azure.AI.Projects;
+
+// ─────────────────────────────────────────────
+// Trigger types
+// ─────────────────────────────────────────────
+
+@doc("Discriminator values for RoutineTrigger.type.")
+union RoutineTriggerType {
+  string,
+
+  @doc("Cron-based recurring schedule trigger.")
+  Schedule: "schedule",
+
+  @doc("One-shot timer trigger.")
+  Timer: "timer",
+
+  @doc("GitHub issue event trigger.")
+  GitHubIssue: "github_issue",
+}
+
+
+@doc("Base model for a Routine trigger. Discriminated by `type`.")
+@discriminator("type")
+model RoutineTrigger {
+  @doc("Trigger type discriminator.")
+  type: RoutineTriggerType;
+}
+
+@doc("Cron-based recurring schedule trigger.")
+model ScheduleRoutineTrigger extends RoutineTrigger {
+  @doc("Trigger type discriminator.")
+  type: RoutineTriggerType.Schedule;
+
+  @doc("Standard cron expression for the recurring schedule. Example: `\"0 8 * * *\"` for daily at 08:00.")
+  cron_expression?: string;
+
+  @doc("IANA/Windows time zone identifier. Example: `\"UTC\"` or `\"America/Los_Angeles\"`.")
+  time_zone?: string;
+}
+
+@doc("One-shot timer trigger. Fires once at the configured time.")
+model TimerRoutineTrigger extends RoutineTrigger {
+  @doc("Trigger type discriminator.")
+  type: RoutineTriggerType.Timer;
+
+  @doc("One-shot fire time in ISO 8601 format. Example: `\"2030-01-02T03:04:05Z\"`.")
+  at?: string;
+
+  @doc("IANA/Windows time zone identifier. Example: `\"UTC\"` or `\"America/Los_Angeles\"`.")
+  time_zone?: string;
+}
+
+@doc("GitHub issue event trigger backed by a workspace connection.")
+model EventRoutineTrigger extends RoutineTrigger {
+  type: RoutineTriggerType.GitHubIssue;
+
+  @doc("ID of the workspace connection that owns the GitHub OAuth credentials.")
+  connection_id?: string;
+
+  @doc("GitHub repository owner or organization. Example: `\"contoso\"`.")
+  owner?: string;
+
+  @doc("GitHub repository name. Example: `\"contoso-app\"`.")
+  repository?: string;
+
+  @doc("GitHub issue actions to match. Example: `[\"opened\", \"reopened\"]`. When omitted all actions are accepted.")
+  actions?: string[];
+}
+
+// ─────────────────────────────────────────────
+// Action models
+// ─────────────────────────────────────────────
+
+@doc("Discriminator values for RoutineAction.type.")
+union RoutineActionType {
+  string,
+
+  @doc("Invoke a published agent via the workspace responses API.")
+  InvokeAgentResponsesApi: "invoke_agent_responses_api",
+
+  @doc("Invoke a published agent via the endpoint invocations API.")
+  InvokeAgentInvocationsApi: "invoke_agent_invocations_api",
+}
+
+@doc("Base model for a Routine action. Discriminated by `type`.")
+@discriminator("type")
+model RoutineAction {
+  @doc("Action type discriminator.")
+  type: RoutineActionType;
+}
+
+@doc("Action that invokes a published agent via the workspace responses API.")
+model InvokeAgentResponsesApiRoutineAction extends RoutineAction {
+  @doc("Action type discriminator.")
+  type: RoutineActionType.InvokeAgentResponsesApi;
+
+  @doc("Project-scoped agent ID used with the workspace `/openai/responses` route. Exactly one of `agent_id` or `agent_endpoint_id` must be provided.")
+  agent_id?: string;
+
+  @doc("Agent endpoint target for endpoint-scoped protocol routes. Exactly one of `agent_id` or `agent_endpoint_id` must be provided.")
+  agent_endpoint_id?: string;
+
+  @doc("Optional existing conversation ID to continue across scheduled fires.")
+  conversation_id?: string;
+}
+
+@doc("Action that invokes a published agent via the endpoint invocations API.")
+model InvokeAgentInvocationsApiRoutineAction extends RoutineAction {
+  @doc("Action type discriminator.")
+  type: RoutineActionType.InvokeAgentInvocationsApi;
+
+  @doc("Agent endpoint target for the endpoint invocations route.")
+  agent_endpoint_id: string;
+
+  @doc("Optional existing hosted-agent session to continue.")
+  session_id?: string;
+}
+
+// ─────────────────────────────────────────────
+// Routine resource
+// ─────────────────────────────────────────────
+
+@doc("A workspace-scoped resource that pairs named trigger(s) with a single action, defining when and how a Foundry agent is invoked.")
+@resource("routines")
+model Routine {
+  @doc("Unique name of the routine within the workspace.")
+  @key("routine_name")
+  @visibility(Lifecycle.Read)
+  name: string;
+
+  @doc("Human-readable description of the routine.")
+  description?: string;
+
+  @doc("Whether the trigger schedule is active. Defaults to `true` on creation.")
+  enabled?: boolean = true;
+
+  @doc("Named trigger configurations for this routine. The key is a user-defined trigger identifier.")
+  triggers?: Record<RoutineTrigger>;
+
+  @doc("Action to execute when a trigger fires.")
+  action?: RoutineAction;
+
+  @doc("UTC timestamp at which the routine was created.")
+  @visibility(Lifecycle.Read)
+  created_at?: utcDateTime;
+
+  @doc("UTC timestamp at which the routine was last updated.")
+  @visibility(Lifecycle.Read)
+  updated_at?: utcDateTime;
+}
+
+@doc("Paginated list of routines.")
+model RoutineListResult {
+  @doc("Current page of routines.")
+  value: Routine[];
+
+  @doc("Continuation token for the next page. Omitted when there are no additional results.")
+  continuation_token?: string;
+}
+
+// ─────────────────────────────────────────────
+// Dispatch models
+// ─────────────────────────────────────────────
+
+@doc("Base class for a manual dispatch payload. Discriminated by `type`.")
+@discriminator("type")
+model RoutineDispatchPayload {
+  @doc("Payload type discriminator, matching the routine's action type.")
+  type: RoutineActionType;
+}
+
+@doc("Manual dispatch payload for `invoke_agent_responses_api` actions.")
+model InvokeAgentResponsesApiDispatchPayload extends RoutineDispatchPayload {
+  @doc("Payload type discriminator.")
+  type: RoutineActionType.InvokeAgentResponsesApi;
+
+  @doc("User message content to send to the agent. Example: `\"Summarize today's build failures.\"`")
+  input?: string;
+}
+
+@doc("Manual dispatch payload for `invoke_agent_invocations_api` actions.")
+model InvokeAgentInvocationsApiDispatchPayload extends RoutineDispatchPayload {
+  @doc("Payload type discriminator.")
+  type: RoutineActionType.InvokeAgentInvocationsApi;
+
+  @doc("Raw input content to send to the agent endpoint.")
+  input?: string;
+}
+
+@doc("Request body for manually dispatching a routine.")
+model DispatchRoutineRequest {
+  @doc("Optional payload to override the action's default input.")
+  payload?: RoutineDispatchPayload;
+}
+
+@doc("Response returned by the dispatch and dispatchAsync operations.")
+model DispatchRoutineResponse {
+  @doc("Unique identifier for this dispatch event.")
+  dispatch_id?: string;
+
+  @doc("Correlation ID linking this dispatch to the resulting agent run.")
+  action_correlation_id?: string;
+}
+
+// ─────────────────────────────────────────────
+// Routine run models
+// ─────────────────────────────────────────────
+
+@doc("Compact record of a single routine trigger attempt.")
+model RoutineRunDto {
+  @doc("MLflow run identifier for this attempt.")
+  id?: string;
+
+  @doc("Underlying MLflow run status. Example values: `RUNNING`, `FINISHED`, `FAILED`.")
+  status?: string;
+
+  @doc("AgentExtensions lifecycle phase. Example values: `queued`, `dispatching`, `completed`, `failed`.")
+  phase?: string;
+
+  @doc("Trigger type that produced the attempt. Example values: `schedule`, `timer`, `github_issue`.")
+  trigger_type?: string;
+
+  @doc("Source path that created the attempt. Example values: `manual_dispatch`, `queued_dispatch`, `schedule_delivery`, `timer_delivery`.")
+  attempt_source?: string;
+
+  @doc("Action type dispatched for the attempt.")
+  action_type?: string;
+
+  @doc("Logical trigger time for the attempt.")
+  triggered_at?: utcDateTime;
+
+  @doc("Time the underlying MLflow run started.")
+  started_at?: utcDateTime;
+
+  @doc("Time the underlying MLflow run reached a terminal state.")
+  ended_at?: utcDateTime;
+
+  @doc("Dispatch identifier for the attempt.")
+  dispatch_id?: string;
+
+  @doc("Downstream action correlation identifier.")
+  action_correlation_id?: string;
+
+  @doc("Downstream response or invocation identifier, if available.")
+  response_id?: string;
+
+  @doc("Fully-qualified error type for a failed attempt, if available.")
+  error_type?: string;
+
+  @doc("Truncated failure message for a failed attempt, if available.")
+  error_message?: string;
+}
+
+@doc("Paged response for routine run history.")
+model RoutineRunsResponse {
+  @doc("Current page of routine runs.")
+  value: RoutineRunDto[];
+
+  @doc("Continuation token for the next page. Omitted when there are no additional results.")
+  next_page_token?: string;
+}

--- a/specification/ai-foundry/data-plane/Foundry/src/routines/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/routines/models.tsp
@@ -48,7 +48,7 @@ model TimerRoutineTrigger extends RoutineTrigger {
   @doc("Trigger type discriminator.")
   type: RoutineTriggerType.Timer;
 
-  @doc("One-shot fire time in ISO 8601 format. Example: `\"2030-01-02T03:04:05Z\"`.")
+  @doc("One-shot fire time or delay. Supported values: ISO-8601 timestamp with explicit offset (e.g., `\"2030-01-02T03:04:05Z\"`), a local timestamp paired with `time_zone`, or a positive duration from now (e.g., `\"30m\"`, `\"2h\"`). The built-in `reminder` agent tool writes this field as `\"{minutes}m\"`.")
   at?: string;
 
   @doc("IANA/Windows time zone identifier. Example: `\"UTC\"` or `\"America/Los_Angeles\"`.")
@@ -105,8 +105,8 @@ model InvokeAgentResponsesApiRoutineAction extends RoutineAction {
   @doc("Agent endpoint target for endpoint-scoped protocol routes. Exactly one of `agent_id` or `agent_endpoint_id` must be provided.")
   agent_endpoint_id?: string;
 
-  @doc("Optional existing conversation ID to continue across scheduled fires.")
-  conversation_id?: string;
+  @doc("Optional existing conversation ID to continue across scheduled fires. Wire-format field name is `conversation`.")
+  conversation?: string;
 }
 
 @doc("Action that invokes a published agent via the endpoint invocations API.")

--- a/specification/ai-foundry/data-plane/Foundry/src/routines/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/routines/routes.tsp
@@ -1,0 +1,132 @@
+import "../common/models.tsp";
+import "../servicepatterns.tsp";
+import "./models.tsp";
+
+using TypeSpec.Http;
+using TypeSpec.Rest;
+
+namespace Azure.AI.Projects;
+
+alias RoutinesPreviewHeader = WithRequiredFoundryPreviewHeader<FoundryFeaturesOptInKeys.routines_v1_preview>;
+
+@tag("Routines")
+interface Routines {
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "We need explicit definition for header support"
+  @doc("Create or update a routine.")
+  @Http.put
+  createOrUpdate is Azure.Core.Foundations.ResourceOperation<
+    Routine,
+    {
+      ...RoutinesPreviewHeader;
+
+      @doc("The routine to create or update.")
+      @Http.bodyRoot
+      @TypeSpec.OpenAPI.extension("x-ms-client-name", "resource")
+      resource: Routine;
+    },
+    Azure.Core.Foundations.ResourceCreatedOrOkResponse<Routine>
+  >;
+
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "We need explicit definition for header support"
+  @doc("Get a routine by name.")
+  get is Azure.Core.Foundations.ResourceOperation<
+    Routine,
+    {
+      ...RoutinesPreviewHeader;
+    },
+    Azure.Core.Foundations.ResourceOkResponse<Routine>
+  >;
+
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "We need explicit definition for header support"
+  @doc("List all routines.")
+  @Rest.listsResource(Routine)
+  list is Azure.Core.Foundations.ResourceList<
+    Routine,
+    {
+      @query("continuationToken")
+      @doc("Continuation token from a previous list response.")
+      continuationToken?: string;
+    } & RoutinesPreviewHeader,
+    Azure.Core.Page<Routine>
+  >;
+
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "We need explicit definition for header support"
+  @doc("Delete a routine.")
+  @Http.delete
+  delete is Azure.Core.Foundations.ResourceOperation<
+    Routine,
+    {
+      ...RoutinesPreviewHeader;
+    },
+    Http.NoContentResponse
+  >;
+
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "We need explicit definition for header support"
+  @doc("Synchronously dispatch a routine. Returns after the downstream action completes.")
+  @route("routines/{routine_name}:dispatch")
+  @post
+  dispatch is FoundryDataPlaneOperation<
+    {
+      @path
+      @doc("The name of the routine to dispatch.")
+      routine_name: string;
+
+      ...RoutinesPreviewHeader;
+
+      @Http.bodyRoot
+      @doc("Optional dispatch request payload.")
+      body?: DispatchRoutineRequest;
+    },
+    DispatchRoutineResponse
+  >;
+
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "We need explicit definition for header support"
+  @doc("Asynchronously dispatch a routine. Returns immediately after enqueueing the action.")
+  @route("routines/{routine_name}:dispatchAsync")
+  @post
+  dispatchAsync is FoundryDataPlaneOperation<
+    {
+      @path
+      @doc("The name of the routine to dispatch.")
+      routine_name: string;
+
+      ...RoutinesPreviewHeader;
+
+      @Http.bodyRoot
+      @doc("Dispatch request payload.")
+      body: DispatchRoutineRequest;
+    },
+    DispatchRoutineResponse
+  >;
+
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "We need explicit definition for header support"
+  @doc("List execution history for a routine.")
+  @route("routines/{routine_name}/runs")
+  @get
+  listRuns is FoundryDataPlaneOperation<
+    {
+      @path
+      @doc("The name of the routine.")
+      routine_name: string;
+
+      @query("filter")
+      @doc("OData-style filter expression.")
+      filter?: string;
+
+      @query(#{ name: "orderBy", explode: true })
+      @doc("One or more ordering expressions.")
+      orderBy?: string[];
+
+      @query("maxResults")
+      @doc("Maximum number of results to return per page.")
+      maxResults?: int32;
+
+      @query("pageToken")
+      @doc("Continuation token from a previous list response.")
+      pageToken?: string;
+
+      ...RoutinesPreviewHeader;
+    },
+    RoutineRunsResponse
+  >;
+}

--- a/specification/ai-foundry/data-plane/Foundry/src/servicepatterns.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/servicepatterns.tsp
@@ -53,6 +53,7 @@ union FoundryFeaturesOptInKeys {
   insights_v1_preview: "Insights=V1Preview",
   memory_stores_v1_preview: "MemoryStores=V1Preview",
   toolboxes_v1_preview: "Toolboxes=V1Preview",
+  routines_v1_preview: "Routines=V1Preview",
 }
 
 alias WithRequiredFoundryPreviewHeader<RequiredPreviewOptInHeader extends FoundryFeaturesOptInKeys | AgentDefinitionOptInKeys> = {


### PR DESCRIPTION
## Summary

Adds TypeSpec models and routes for the Foundry **Routines** feature, based on the C# service contracts in Vienna.

### New files
- `src/routines/models.tsp` — all Routines domain models
- `src/routines/routes.tsp` — 7 REST operations

### Modified files
- `src/common/models.tsp` — adds `routines_v1_preview: "Routines=V1Preview"` to `FoundryFeaturesOptInKeys`
- `main.tsp` — imports `src/routines/routes.tsp`
- `openapi3/` — regenerated OpenAPI output

### Routes

| Method | Path | Description |
|--------|------|-------------|
| PUT | `/routines/{routineName}` | Create or update a routine |
| GET | `/routines/{routineName}` | Get a routine |
| GET | `/routines` | List all routines |
| DELETE | `/routines/{routineName}` | Delete a routine |
| POST | `/routines/{routineName}:dispatch` | Synchronous dispatch |
| POST | `/routines/{routineName}:dispatchAsync` | Asynchronous dispatch |
| GET | `/routines/{routineName}/runs` | List routine run history |

### Key model design

- `RoutineTrigger` discriminated on `type`: `"schedule"`, `"timer"`, `"github_issue"`
- `RoutineAction` discriminated on `type`: `"invoke_agent_responses_api"`, `"invoke_agent_invocations_api"`
- `Routine.triggers` is `Record<RoutineTrigger>` (named dict, matching C# `Dictionary<string, RoutineTrigger>`)
- `RoutineDispatchPayload` discriminated on `type` matching `RoutineActionType`
- All routes require `Foundry-Features: Routines=V1Preview` header