### PR TITLE
Rename SettingUp to Preparing in ScenarioRunState

### DIFF
--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-05-01-preview/openapi.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-05-01-preview/openapi.json
@@ -7091,7 +7091,7 @@
         "Validating",
         "ValidationSucceeded",
         "Starting",
-        "SettingUp",
+        "Preparing",
         "Running",
         "CleaningUp",
         "Canceling",
@@ -7134,9 +7134,9 @@
             "description": "The scenario run is in the process of being started."
           },
           {
-            "name": "SettingUp",
-            "value": "SettingUp",
-            "description": "The scenario run is in the process of being setup."
+            "name": "Preparing",
+            "value": "Preparing",
+            "description": "The scenario run is in the process of being prepared."
           },
           {
             "name": "Running",

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/scenarioRun.models.tsp
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/scenarioRun.models.tsp
@@ -344,9 +344,9 @@ union ScenarioRunState {
   Starting: "Starting",
 
   /**
-   * The scenario run is in the process of being setup.
+   * The scenario run is in the process of being prepared.
    */
-  SettingUp: "SettingUp",
+  Preparing: "Preparing",
 
   /**
    * The scenario run is in the process of running.


### PR DESCRIPTION
Renames the `SettingUp` enum value to `Preparing` in the `ScenarioRunState` union for a more generalized lifecycle phase name.

## Changes

- `scenarioRun.models.tsp` — Renamed `SettingUp` member to `Preparing` in the `ScenarioRunState` union and updated doc comment
- `preview/2026-05-01-preview/openapi.json` — Regenerated to reflect the rename

## Updated Scenario Run Lifecycle

`Queued → Resolving → Generating → Validating → ValidationSucceeded → Starting → Preparing → Running → CleaningUp → Canceling → Canceled/Succeeded/Failed`