### PR TITLE
remove  resourceSku=>SKU clientName config

### DIFF
--- a/specification/billingbenefits/BillingBenefits.Management/client.tsp
+++ b/specification/billingbenefits/BillingBenefits.Management/client.tsp
@@ -6,7 +6,6 @@ using Microsoft.BillingBenefits;
 
 // go
 @@clientLocation(BenefitOperationGroup.validate, "RP", "go");
-@@clientName(Microsoft.BillingBenefits.ResourceSku, "SKU", "go");
 @@clientName(Microsoft.BillingBenefits.ManagedServiceIdentity,
   "ServiceManagedIdentity",
   "go"

--- a/specification/billingbenefits/BillingBenefits.Management/client.tsp
+++ b/specification/billingbenefits/BillingBenefits.Management/client.tsp
@@ -286,3 +286,4 @@ using Microsoft.BillingBenefits;
 
 // csharp: preserve original public property name after flatten/lift-to-nullable generator fix
 @@clientName(MaccModelProperties.entityType, "MaccEntityType", "csharp");
+@@clientName(DiscountType, "DiscountTypeEnum", "go");


### PR DESCRIPTION
since `SKU` definition has exist, now remove resourceSku=>SKU config to avoid name conflicts