### PR TITLE
Fix 404 URLs in api-version-evolution.md

### DIFF
--- a/.github/skills/azure-typespec-author/references/api-version-evolution.md
+++ b/.github/skills/azure-typespec-author/references/api-version-evolution.md
@@ -12,13 +12,13 @@ Search using [agentic search](agentic-search.md) in below documents to determine
 - MUST use a user friendly way to collect information.
   e.g. you MUST List features from latest version and let user select which to carry over vs exclude, rather than assume user wants to carry over all features.
 
-  | Doc                      | Guide URL                                                                                     |
-  | ------------------------ | --------------------------------------------------------------------------------------------- |
-  | Preview version overview | `https://azure.github.io/typespec-azure/docs/howtos/versioning/01-preview-version`            |
-  | preview > preview        | `https://azure.github.io/typespec-azure/docs/howtos/versioning/arm/02-preview-after-preview/` |
-  | preview > stable         | `https://azure.github.io/typespec-azure/docs/howtos/versioning/arm/03-stable-after-preview/`  |
-  | stable > preview         | `https://azure.github.io/typespec-azure/docs/howtos/versioning/arm/04-preview-after-stable/`  |
-  | stable > stable          | `https://azure.github.io/typespec-azure/docs/howtos/versioning/arm/05-stable-after-stable/`   |
+  | Doc                      | Guide URL                                                                                       |
+  | ------------------------ | ----------------------------------------------------------------------------------------------- |
+  | Preview version overview | `https://azure.github.io/typespec-azure/docs/howtos/versioning/01-about-versioning/`            |
+  | preview > preview        | `https://azure.github.io/typespec-azure/docs/howtos/versioning/02-preview-after-preview/`       |
+  | preview > stable         | `https://azure.github.io/typespec-azure/docs/howtos/versioning/03-stable-after-preview/`        |
+  | stable > preview         | `https://azure.github.io/typespec-azure/docs/howtos/versioning/04-preview-after-stable/`        |
+  | stable > stable          | `https://azure.github.io/typespec-azure/docs/howtos/versioning/05-stable-after-stable/`         |
 
 ---
 

--- a/.github/skills/azure-typespec-author/references/api-version-evolution.md
+++ b/.github/skills/azure-typespec-author/references/api-version-evolution.md
@@ -12,13 +12,13 @@ Search using [agentic search](agentic-search.md) in below documents to determine
 - MUST use a user friendly way to collect information.
   e.g. you MUST List features from latest version and let user select which to carry over vs exclude, rather than assume user wants to carry over all features.
 
-  | Doc                      | Guide URL                                                                                       |
-  | ------------------------ | ----------------------------------------------------------------------------------------------- |
-  | Preview version overview | `https://azure.github.io/typespec-azure/docs/howtos/versioning/01-about-versioning/`            |
-  | preview > preview        | `https://azure.github.io/typespec-azure/docs/howtos/versioning/02-preview-after-preview/`       |
-  | preview > stable         | `https://azure.github.io/typespec-azure/docs/howtos/versioning/03-stable-after-preview/`        |
-  | stable > preview         | `https://azure.github.io/typespec-azure/docs/howtos/versioning/04-preview-after-stable/`        |
-  | stable > stable          | `https://azure.github.io/typespec-azure/docs/howtos/versioning/05-stable-after-stable/`         |
+  | Doc                      | Guide URL                                                                                 |
+  | ------------------------ | ----------------------------------------------------------------------------------------- |
+  | Preview version overview | `https://azure.github.io/typespec-azure/docs/howtos/versioning/01-about-versioning/`      |
+  | preview > preview        | `https://azure.github.io/typespec-azure/docs/howtos/versioning/02-preview-after-preview/` |
+  | preview > stable         | `https://azure.github.io/typespec-azure/docs/howtos/versioning/03-stable-after-preview/`  |
+  | stable > preview         | `https://azure.github.io/typespec-azure/docs/howtos/versioning/04-preview-after-stable/`  |
+  | stable > stable          | `https://azure.github.io/typespec-azure/docs/howtos/versioning/05-stable-after-stable/`   |
 
 ---
 


### PR DESCRIPTION
## Summary

Updates broken documentation URLs in \.github/skills/azure-typespec-author/references/api-version-evolution.md\.

The TypeSpec Azure versioning docs were restructured and the old URLs now return 404. This PR updates all 5 URLs to point to the new locations:

| Old URL (404) | New URL |
|---|---|
| \.../versioning/01-preview-version\ | \.../versioning/01-about-versioning/\ |
| \.../versioning/arm/02-preview-after-preview/\ | \.../versioning/02-preview-after-preview/\ |
| \.../versioning/arm/03-stable-after-preview/\ | \.../versioning/03-stable-after-preview/\ |
| \.../versioning/arm/04-preview-after-stable/\ | \.../versioning/04-preview-after-stable/\ |
| \.../versioning/arm/05-stable-after-stable/\ | \.../versioning/05-stable-after-stable/\ |

Key changes:
- \