### PR TITLE
Add endpoint property to Chaos Studio Workspace

### DIFF
--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-05-01-preview/openapi.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-05-01-preview/openapi.json
@@ -7930,6 +7930,11 @@
           "description": "Most recent provisioning state for the given Workspace resource.",
           "readOnly": true
         },
+        "endpoint": {
+          "type": "string",
+          "description": "The endpoint of the workspace used by Chaos agents to connect and communicate with the service.",
+          "readOnly": true
+        },
         "scopes": {
           "type": "array",
           "description": "The intended workspace-level resource scope to be used by child scenarios.",

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/workspace.models.tsp
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/workspace.models.tsp
@@ -61,6 +61,12 @@ model WorkspaceProperties {
   provisioningState?: ProvisioningState;
 
   /**
+   * The endpoint of the workspace used by Chaos agents to connect and communicate with the service.
+   */
+  @visibility(Lifecycle.Read)
+  endpoint?: string;
+
+  /**
    * The intended workspace-level resource scope to be used by child scenarios.
    */
   scopes: Azure.Core.armResourceIdentifier[];


### PR DESCRIPTION
Adds a read-only `endpoint` property to `WorkspaceProperties` in the Chaos Studio 2026-05-01-preview API. This is the base URL that Chaos agents connect to and communicate with for a given workspace.

## Context

Chaos Studio is introducing **Chaos Agents** — lightweight components that run fault injection on target resources. Agents need to know where their Workspace lives so they can connect to it. The `endpoint` property serves as the connection URL for the Workspace. In the current workflow, workspace owners use this endpoint to **manually install or connect Chaos Agents** to their Workspace.

For further background on the Agents-in-Workspaces design, see the [research docs](https://dev.azure.com/msazure/Squall/_git/Chaos?path=/docs/research/agents-in-workspaces).

## Changes

- **workspace.models.tsp** — Added `endpoint?: string` with `@visibility(Lifecycle.Read)` to `WorkspaceProperties`
- **preview/2026-05-01-preview/openapi.json** — Regenerated to include the new property

## Property Details

```typescript
/**
 * The endpoint of the workspace used by Chaos agents to connect and communicate with the service.
 */
@visibility(Lifecycle.Read)
endpoint?: string;
```

- **Read-only**: Service-computed, not user-settable
- **Optional**: May not be populated until provisioning completes
- **Type**: `string` (consistent with ARM conventions)

## Naming Research

The name `endpoint` follows the Cognitive Services convention for a base URL that clients build upon. Research across Azure RPs shows two distinct naming patterns:

| Name Pattern | Implies | Example RPs |
|---|---|---|
| `{resource}Uri` (e.g. `vaultUri`) | A complete URL used directly as-is | Key Vault |
| `{purpose}Endpoint` or `endpoint` | A base URL that clients append paths to | Cognitive Services, Monitor DCE |

Since Chaos agents will use this as a **base URL** and append further paths for communication, `endpoint` is the correct choice — matching the Cognitive Services pattern.

## Cross-RP Endpoint Property Comparison

| Resource Provider | Property Name | Type | Read-Only | Model | What It Represents |
|---|---|---|---|---|---|
| **Key Vault** | `vaultUri` | string | ✅ | VaultProperties | Complete vault URL for key/secret operations |
| **Cosmos DB** | `documentEndpoint` | string | ✅ | DatabaseAccountGetProperties | Base URL for document CRUD and queries |
| **Container Registry** | `loginServer` | string | ✅ | RegistryProperties | Hostname for docker login and image push/pull |
| **Communication** | `hostName` | string | ✅ | CommunicationServiceProperties | FQDN for SMS, voice, video, chat APIs |
| **Cognitive Services** | `endpoint` | string | ✅ | AccountProperties | Base URL for AI inference API calls |
| **Azure Monitor** | `prometheusQueryEndpoint` | string | ✅ | Metrics | URL for PromQL metric queries |
| **Monitor DCE** | `endpoint` | string | ✅ | ConfigurationAccessEndpointSpec | URL for data collection rule retrieval |
| **Storage** | `primaryEndpoints` (nested) | Endpoints | ✅ | StorageAccountProperties | Per-service URLs (blob, queue, table, file, web, dfs) |
| **Chaos Studio** | `endpoint` | string | ✅ | WorkspaceProperties | Base URL for Chaos agent communication |

All endpoint properties across Azure RPs are **read-only** and **service-computed**. Authentication keys/secrets are never returned alongside the endpoint in the properties model — they are provided via separate `listKeys`/`listCredentials` POST operations or via managed identity.
