### PR TITLE
Fix broken typespec validation in main

### DIFF
--- a/specification/networkcloud/resource-manager/Microsoft.NetworkCloud/preview/2026-05-01-preview/networkcloud.json
+++ b/specification/networkcloud/resource-manager/Microsoft.NetworkCloud/preview/2026-05-01-preview/networkcloud.json
@@ -18576,18 +18576,18 @@
       "type": "object",
       "description": "StorageApplianceProperties represents the properties of the storage appliance.",
       "properties": {
-        "rackId": {
-          "type": "string",
-          "format": "arm-id",
-          "description": "The resource ID of the rack where this storage appliance resides.",
+        "administratorCredentials": {
+          "$ref": "#/definitions/AdministrativeCredentials",
+          "description": "The credentials of the administrative interface on this storage appliance.",
           "x-ms-mutability": [
             "read",
             "create"
           ]
         },
-        "storageApplianceSkuId": {
+        "rackId": {
           "type": "string",
-          "description": "The SKU for the storage appliance.",
+          "format": "arm-id",
+          "description": "The resource ID of the rack where this storage appliance resides.",
           "x-ms-mutability": [
             "read",
             "create"
@@ -18608,9 +18608,9 @@
           "type": "string",
           "description": "The serial number for the storage appliance."
         },
-        "administratorCredentials": {
-          "$ref": "#/definitions/AdministrativeCredentials",
-          "description": "The credentials of the administrative interface on this storage appliance.",
+        "storageApplianceSkuId": {
+          "type": "string",
+          "description": "The SKU for the storage appliance.",
           "x-ms-mutability": [
             "read",
             "create"
@@ -18711,11 +18711,11 @@
         }
       },
       "required": [
+        "administratorCredentials",
         "rackId",
-        "storageApplianceSkuId",
         "rackSlot",
         "serialNumber",
-        "administratorCredentials"
+        "storageApplianceSkuId"
       ]
     },
     "StorageApplianceProvisioningState": {


### PR DESCRIPTION
Introduced after merge of pr #42234 which didn't regen including the changes from https://github.com/Azure/azure-rest-api-specs/pull/42792

The change only seems to be a reordering of properties