### PR TITLE
Add managedComputeCapacities API for 2026-03-15-preview

### DIFF
--- a/specification/cognitiveservices/CognitiveServices.Management/ManagedComputeCapacity.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/ManagedComputeCapacity.tsp
@@ -14,32 +14,32 @@ using TypeSpec.Versioning;
 namespace Microsoft.CognitiveServices;
 
 /**
- * Accelerator capacity information for Cognitive Services managed compute deployments.
+ * Managed compute capacity information for Cognitive Services managed compute deployments.
  * Provides available accelerator capacity per type and region at the subscription level.
  */
 @added(Versions.v2026_03_15_preview)
 @subscriptionResource
-model AcceleratorCapacity
-  is Azure.ResourceManager.ProxyResource<AcceleratorCapacityProperties> {
+model ManagedComputeCapacity
+  is Azure.ResourceManager.ProxyResource<ManagedComputeCapacityProperties> {
   ...ResourceNameParameter<
-    Resource = AcceleratorCapacity,
-    KeyName = "acceleratorCapacityName",
-    SegmentName = "acceleratorCapacities",
+    Resource = ManagedComputeCapacity,
+    KeyName = "managedComputeCapacityName",
+    SegmentName = "managedComputeCapacities",
     NamePattern = ""
   >;
 }
 
-#suppress "@azure-tools/typespec-azure-resource-manager/no-resource-delete-operation" "'AcceleratorCapacities' is a read-only resource type that does not support delete operations"
+#suppress "@azure-tools/typespec-azure-resource-manager/no-resource-delete-operation" "'ManagedComputeCapacities' is a read-only resource type that does not support delete operations"
 @added(Versions.v2026_03_15_preview)
 @armResourceOperations(#{ omitTags: true })
-interface AcceleratorCapacities {
+interface ManagedComputeCapacities {
   /**
-   * Gets the accelerator capacities for a subscription. Returns available capacity
+   * Gets the managed compute capacities for a subscription. Returns available capacity
    * per accelerator type, including deployment size information.
    */
-  @tag("AcceleratorCapacities")
+  @tag("ManagedComputeCapacities")
   list is ArmResourceListByParent<
-    AcceleratorCapacity,
+    ManagedComputeCapacity,
     BaseParameters = Azure.ResourceManager.Foundations.SubscriptionBaseParameters,
     Parameters = {
       /**
@@ -61,13 +61,13 @@ interface AcceleratorCapacities {
       @query("deploymentId")
       deploymentId?: string;
     },
-    Response = AcceleratorCapacityListResult
+    Response = ManagedComputeCapacityListResult
   >;
 }
 
-@@doc(AcceleratorCapacity.name,
-  "The name of the accelerator capacity resource."
+@@doc(ManagedComputeCapacity.name,
+  "The name of the managed compute capacity resource."
 );
-@@doc(AcceleratorCapacity.properties,
-  "Properties of the accelerator capacity resource."
+@@doc(ManagedComputeCapacity.properties,
+  "Properties of the managed compute capacity resource."
 );

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-03-15-preview/ListManagedComputeCapacities.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-03-15-preview/ListManagedComputeCapacities.json
@@ -1,6 +1,6 @@
 {
-  "operationId": "AcceleratorCapacities_List",
-  "title": "List Accelerator Capacities",
+  "operationId": "ManagedComputeCapacities_List",
+  "title": "List Managed Compute Capacities",
   "parameters": {
     "subscriptionId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
     "api-version": "2026-03-15-preview",
@@ -11,9 +11,9 @@
       "body": {
         "value": [
           {
-            "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/providers/Microsoft.CognitiveServices/acceleratorCapacities/Azure.A100",
+            "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/providers/Microsoft.CognitiveServices/managedComputeCapacities/Azure.A100",
             "name": "Azure.A100",
-            "type": "Microsoft.CognitiveServices/acceleratorCapacities",
+            "type": "Microsoft.CognitiveServices/managedComputeCapacities",
             "properties": {
               "acceleratorType": "Azure.A100",
               "location": "eastus",
@@ -38,9 +38,9 @@
             }
           },
           {
-            "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/providers/Microsoft.CognitiveServices/acceleratorCapacities/Azure.H100",
+            "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/providers/Microsoft.CognitiveServices/managedComputeCapacities/Azure.H100",
             "name": "Azure.H100",
-            "type": "Microsoft.CognitiveServices/acceleratorCapacities",
+            "type": "Microsoft.CognitiveServices/managedComputeCapacities",
             "properties": {
               "acceleratorType": "Azure.H100",
               "location": "westus2",

--- a/specification/cognitiveservices/CognitiveServices.Management/main.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/main.tsp
@@ -41,7 +41,7 @@ import "./ManagedComputeDeployment.tsp";
 import "./ComputeOperation.tsp";
 import "./ManagedComputeUsages.tsp";
 import "./Compute.tsp";
-import "./AcceleratorCapacity.tsp";
+import "./ManagedComputeCapacity.tsp";
 import "./routes.tsp";
 
 using TypeSpec.Rest;

--- a/specification/cognitiveservices/CognitiveServices.Management/models.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/models.tsp
@@ -6346,11 +6346,11 @@ model PolicyExpressionEvaluationDetails {
 }
 
 /**
- * Properties of an accelerator capacity resource.
+ * Properties of a managed compute capacity resource.
  */
-#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" "AcceleratorCapacity is a read-only resource that does not have a provisioning state"
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" "ManagedComputeCapacity is a read-only resource that does not have a provisioning state"
 @added(Versions.v2026_03_15_preview)
-model AcceleratorCapacityProperties {
+model ManagedComputeCapacityProperties {
   /**
    * The type of accelerator (e.g., Azure.A100, Azure.H100).
    */
@@ -6402,21 +6402,21 @@ model DeploymentSizeCapacity {
 }
 
 /**
- * The list of accelerator capacities response.
+ * The list of managed compute capacities response.
  */
 @added(Versions.v2026_03_15_preview)
-model AcceleratorCapacityListResult {
+model ManagedComputeCapacityListResult {
   /**
-   * The link used to get the next page of accelerator capacities.
+   * The link used to get the next page of managed compute capacities.
    */
   @nextLink
   nextLink?: string;
 
   /**
-   * Gets the list of accelerator capacities.
+   * Gets the list of managed compute capacities.
    */
   @pageItems
   @visibility(Lifecycle.Read)
   @identifiers(#["id"])
-  value?: AcceleratorCapacity[];
+  value?: ManagedComputeCapacity[];
 }

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-03-15-preview/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-03-15-preview/cognitiveservices.json
@@ -133,7 +133,7 @@
       "name": "Computes"
     },
     {
-      "name": "AcceleratorCapacities"
+      "name": "ManagedComputeCapacities"
     },
     {
       "name": "Skus"
@@ -181,66 +181,6 @@
         "x-ms-examples": {
           "Get Operations": {
             "$ref": "./examples/GetOperations.json"
-          }
-        },
-        "x-ms-pageable": {
-          "nextLinkName": "nextLink"
-        }
-      }
-    },
-    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/acceleratorCapacities": {
-      "get": {
-        "operationId": "AcceleratorCapacities_List",
-        "tags": [
-          "AcceleratorCapacities"
-        ],
-        "description": "Gets the accelerator capacities for a subscription. Returns available capacity\nper accelerator type, including deployment size information.",
-        "parameters": [
-          {
-            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
-          },
-          {
-            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
-          },
-          {
-            "name": "offer",
-            "in": "query",
-            "description": "The offer name to query capacity for (required).",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "acceleratorType",
-            "in": "query",
-            "description": "Optional accelerator type filter to narrow results to a specific accelerator type.",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "name": "deploymentId",
-            "in": "query",
-            "description": "Optional deployment resource ID. When provided, returns capacity for the specific region\nwhere the deployment is hosted rather than the best available region.",
-            "required": false,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "The request has succeeded.",
-            "schema": {
-              "$ref": "#/definitions/AcceleratorCapacityListResult"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
-            }
-          }
-        },
-        "x-ms-examples": {
-          "List Accelerator Capacities": {
-            "$ref": "./examples/ListAcceleratorCapacities.json"
           }
         },
         "x-ms-pageable": {
@@ -1010,6 +950,66 @@
           },
           "Get Usages Global Scope": {
             "$ref": "./examples/ListUsagesGlobalScope.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/managedComputeCapacities": {
+      "get": {
+        "operationId": "ManagedComputeCapacities_List",
+        "tags": [
+          "ManagedComputeCapacities"
+        ],
+        "description": "Gets the managed compute capacities for a subscription. Returns available capacity\nper accelerator type, including deployment size information.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "offer",
+            "in": "query",
+            "description": "The offer name to query capacity for (required).",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "acceleratorType",
+            "in": "query",
+            "description": "Optional accelerator type filter to narrow results to a specific accelerator type.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "deploymentId",
+            "in": "query",
+            "description": "Optional deployment resource ID. When provided, returns capacity for the specific region\nwhere the deployment is hosted rather than the best available region.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ManagedComputeCapacityListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Managed Compute Capacities": {
+            "$ref": "./examples/ListManagedComputeCapacities.json"
           }
         },
         "x-ms-pageable": {
@@ -10669,73 +10669,6 @@
         ]
       }
     },
-    "AcceleratorCapacity": {
-      "type": "object",
-      "description": "Accelerator capacity information for Cognitive Services managed compute deployments.\nProvides available accelerator capacity per type and region at the subscription level.",
-      "properties": {
-        "properties": {
-          "$ref": "#/definitions/AcceleratorCapacityProperties",
-          "description": "Properties of the accelerator capacity resource."
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
-        }
-      ]
-    },
-    "AcceleratorCapacityListResult": {
-      "type": "object",
-      "description": "The list of accelerator capacities response.",
-      "properties": {
-        "nextLink": {
-          "type": "string",
-          "description": "The link used to get the next page of accelerator capacities."
-        },
-        "value": {
-          "type": "array",
-          "description": "Gets the list of accelerator capacities.",
-          "items": {
-            "$ref": "#/definitions/AcceleratorCapacity"
-          },
-          "readOnly": true,
-          "x-ms-identifiers": [
-            "id"
-          ]
-        }
-      }
-    },
-    "AcceleratorCapacityProperties": {
-      "type": "object",
-      "description": "Properties of an accelerator capacity resource.",
-      "properties": {
-        "acceleratorType": {
-          "type": "string",
-          "description": "The type of accelerator (e.g., Azure.A100, Azure.H100).",
-          "readOnly": true
-        },
-        "location": {
-          "type": "string",
-          "description": "The Azure region where the capacity is available.",
-          "readOnly": true
-        },
-        "availableAccelerators": {
-          "type": "integer",
-          "format": "int32",
-          "description": "The number of available accelerators in the region.",
-          "readOnly": true
-        },
-        "deploymentSizeCapacities": {
-          "type": "array",
-          "description": "Capacity information broken down by deployment size.",
-          "items": {
-            "$ref": "#/definitions/DeploymentSizeCapacity"
-          },
-          "readOnly": true,
-          "x-ms-identifiers": []
-        }
-      }
-    },
     "AccessKeyAuthTypeConnectionProperties": {
       "type": "object",
       "properties": {
@@ -15337,6 +15270,73 @@
         }
       ],
       "x-ms-discriminator-value": "Managed"
+    },
+    "ManagedComputeCapacity": {
+      "type": "object",
+      "description": "Managed compute capacity information for Cognitive Services managed compute deployments.\nProvides available accelerator capacity per type and region at the subscription level.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ManagedComputeCapacityProperties",
+          "description": "Properties of the managed compute capacity resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ManagedComputeCapacityListResult": {
+      "type": "object",
+      "description": "The list of managed compute capacities response.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of managed compute capacities."
+        },
+        "value": {
+          "type": "array",
+          "description": "Gets the list of managed compute capacities.",
+          "items": {
+            "$ref": "#/definitions/ManagedComputeCapacity"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "id"
+          ]
+        }
+      }
+    },
+    "ManagedComputeCapacityProperties": {
+      "type": "object",
+      "description": "Properties of a managed compute capacity resource.",
+      "properties": {
+        "acceleratorType": {
+          "type": "string",
+          "description": "The type of accelerator (e.g., Azure.A100, Azure.H100).",
+          "readOnly": true
+        },
+        "location": {
+          "type": "string",
+          "description": "The Azure region where the capacity is available.",
+          "readOnly": true
+        },
+        "availableAccelerators": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of available accelerators in the region.",
+          "readOnly": true
+        },
+        "deploymentSizeCapacities": {
+          "type": "array",
+          "description": "Capacity information broken down by deployment size.",
+          "items": {
+            "$ref": "#/definitions/DeploymentSizeCapacity"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": []
+        }
+      }
     },
     "ManagedComputeDeployment": {
       "type": "object",

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-03-15-preview/examples/ListManagedComputeCapacities.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-03-15-preview/examples/ListManagedComputeCapacities.json
@@ -1,6 +1,6 @@
 {
-  "operationId": "AcceleratorCapacities_List",
-  "title": "List Accelerator Capacities",
+  "operationId": "ManagedComputeCapacities_List",
+  "title": "List Managed Compute Capacities",
   "parameters": {
     "subscriptionId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
     "api-version": "2026-03-15-preview",
@@ -11,9 +11,9 @@
       "body": {
         "value": [
           {
-            "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/providers/Microsoft.CognitiveServices/acceleratorCapacities/Azure.A100",
+            "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/providers/Microsoft.CognitiveServices/managedComputeCapacities/Azure.A100",
             "name": "Azure.A100",
-            "type": "Microsoft.CognitiveServices/acceleratorCapacities",
+            "type": "Microsoft.CognitiveServices/managedComputeCapacities",
             "properties": {
               "acceleratorType": "Azure.A100",
               "location": "eastus",
@@ -38,9 +38,9 @@
             }
           },
           {
-            "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/providers/Microsoft.CognitiveServices/acceleratorCapacities/Azure.H100",
+            "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/providers/Microsoft.CognitiveServices/managedComputeCapacities/Azure.H100",
             "name": "Azure.H100",
-            "type": "Microsoft.CognitiveServices/acceleratorCapacities",
+            "type": "Microsoft.CognitiveServices/managedComputeCapacities",
             "properties": {
               "acceleratorType": "Azure.H100",
               "location": "westus2",


### PR DESCRIPTION
Adds the `managedComputeCapacities` subscription-level GET endpoint that returns available accelerator capacity filtered by offer.

## Context
This corresponds to the rename from `acceleratorCapacities` → `managedComputeCapacities` in Platform-ResourceProvider PR [#15582507](https://msazure.visualstudio.com/Cognitive%20Services/_git/Platform-ResourceProvider/pullrequest/15582507).

## Changes
- **ManagedComputeCapacities.tsp**: New operation interface at subscription scope
- **models.tsp**: `ManagedComputeCapacity`, `DeploymentSizeCapacity`, `ManagedComputeCapacityListResult`
- **client.tsp**: SDK client name mapping (`GetManagedComputeCapacities`)
- **Example**: `ListManagedComputeCapacities.json`

## API Shape
```
GET /subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/managedComputeCapacities?offer={offer}&acceleratorType={acceleratorType}&deploymentId={deploymentId}
```

Query parameters:
- `offer` (required): The offer name to query capacity for
- `acceleratorType` (optional): Filter by accelerator type
- `deploymentId` (optional): Scope to a specific deployment's region