### PR TITLE
Add DPS GA API version 2026-10-01 with disableLocalAuth property

### DIFF
--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DpsCreate_DisableLocalAuthFalse.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DpsCreate_DisableLocalAuthFalse.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "myResourceGroup",
+    "provisioningServiceName": "myProvisioningService",
+    "api-version": "2026-10-01",
+    "iotDpsDescription": {
+      "location": "East US",
+      "sku": {
+        "name": "S1",
+        "capacity": 1
+      },
+      "tags": {
+        "key1": "value1"
+      },
+      "properties": {
+        "publicNetworkAccess": "Enabled",
+        "disableLocalAuth": false
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.Devices/provisioningServices/myProvisioningService",
+        "name": "myProvisioningService",
+        "type": "Microsoft.Devices/provisioningServices",
+        "location": "East US",
+        "tags": {
+          "key1": "value1"
+        },
+        "sku": {
+          "name": "S1",
+          "capacity": 1
+        },
+        "properties": {
+          "state": "Active",
+          "publicNetworkAccess": "Enabled",
+          "provisioningState": "Succeeded",
+          "serviceOperationsHostName": "myProvisioningService.azure-devices-provisioning.net",
+          "deviceProvisioningHostName": "global.azure-devices-provisioning.net",
+          "idScope": "0ne00000001",
+          "allocationPolicy": "Hashed",
+          "disableLocalAuth": false
+        }
+      }
+    }
+  }
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DpsCreate_DisableLocalAuthTrue.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DpsCreate_DisableLocalAuthTrue.json
@@ -1,0 +1,77 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "myResourceGroup",
+    "provisioningServiceName": "myFirstProvisioningService",
+    "api-version": "2026-10-01",
+    "iotDpsDescription": {
+      "location": "East US",
+      "sku": {
+        "name": "S1",
+        "capacity": 1
+      },
+      "tags": {
+        "key1": "value1",
+        "key2": "value2"
+      },
+      "properties": {
+        "publicNetworkAccess": "Enabled",
+        "disableLocalAuth": true
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.Devices/provisioningServices/myFirstProvisioningService",
+        "name": "myFirstProvisioningService",
+        "type": "Microsoft.Devices/provisioningServices",
+        "location": "East US",
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        },
+        "sku": {
+          "name": "S1",
+          "capacity": 1
+        },
+        "properties": {
+          "state": "Active",
+          "publicNetworkAccess": "Enabled",
+          "provisioningState": "Succeeded",
+          "serviceOperationsHostName": "myFirstProvisioningService.azure-devices-provisioning.net",
+          "deviceProvisioningHostName": "global.azure-devices-provisioning.net",
+          "idScope": "0ne00000000",
+          "allocationPolicy": "Hashed",
+          "disableLocalAuth": true
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.Devices/provisioningServices/myFirstProvisioningService",
+        "name": "myFirstProvisioningService",
+        "type": "Microsoft.Devices/provisioningServices",
+        "location": "East US",
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        },
+        "sku": {
+          "name": "S1",
+          "capacity": 1
+        },
+        "properties": {
+          "state": "Active",
+          "publicNetworkAccess": "Enabled",
+          "provisioningState": "Succeeded",
+          "serviceOperationsHostName": "myFirstProvisioningService.azure-devices-provisioning.net",
+          "deviceProvisioningHostName": "global.azure-devices-provisioning.net",
+          "idScope": "0ne00000000",
+          "allocationPolicy": "Hashed",
+          "disableLocalAuth": true
+        }
+      }
+    }
+  }
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DpsGet.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DpsGet.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "myResourceGroup",
+    "provisioningServiceName": "myProvisioningService",
+    "api-version": "2026-10-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.Devices/provisioningServices/myProvisioningService",
+        "name": "myProvisioningService",
+        "type": "Microsoft.Devices/provisioningServices",
+        "location": "East US",
+        "tags": {
+          "key1": "value1"
+        },
+        "sku": {
+          "name": "S1",
+          "capacity": 1
+        },
+        "properties": {
+          "state": "Active",
+          "publicNetworkAccess": "Enabled",
+          "provisioningState": "Succeeded",
+          "serviceOperationsHostName": "myProvisioningService.azure-devices-provisioning.net",
+          "deviceProvisioningHostName": "global.azure-devices-provisioning.net",
+          "idScope": "0ne00000001",
+          "allocationPolicy": "Hashed",
+          "disableLocalAuth": true
+        }
+      }
+    }
+  }
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DpsPatch_DisableLocalAuth.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/examples/2026-10-01/DpsPatch_DisableLocalAuth.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "myResourceGroup",
+    "provisioningServiceName": "myProvisioningService",
+    "api-version": "2026-10-01",
+    "iotDpsDescription": {
+      "tags": {
+        "key1": "value1"
+      },
+      "properties": {
+        "disableLocalAuth": true
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.Devices/provisioningServices/myProvisioningService",
+        "name": "myProvisioningService",
+        "type": "Microsoft.Devices/provisioningServices",
+        "location": "East US",
+        "tags": {
+          "key1": "value1"
+        },
+        "sku": {
+          "name": "S1",
+          "capacity": 1
+        },
+        "properties": {
+          "state": "Active",
+          "publicNetworkAccess": "Enabled",
+          "provisioningState": "Succeeded",
+          "serviceOperationsHostName": "myProvisioningService.azure-devices-provisioning.net",
+          "deviceProvisioningHostName": "global.azure-devices-provisioning.net",
+          "idScope": "0ne00000001",
+          "allocationPolicy": "Hashed",
+          "disableLocalAuth": true
+        }
+      }
+    }
+  }
+}

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/main.tsp
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/main.tsp
@@ -41,6 +41,11 @@ namespace Microsoft.Devices;
  */
 enum Versions {
   /**
+   * The 2026-10-01 API version.
+   */
+  v2026_10_01: "2026-10-01",
+
+  /**
    * The 2025-02-01-preview API version.
    */
   v2025_02_01_preview: "2025-02-01-preview",

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/models.tsp
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/models.tsp
@@ -1,9 +1,11 @@
 import "@typespec/rest";
 import "@typespec/http";
+import "@typespec/versioning";
 import "@azure-tools/typespec-azure-core";
 import "@azure-tools/typespec-azure-resource-manager";
 
 using Azure.ResourceManager.Foundations;
+using TypeSpec.Versioning;
 
 namespace Microsoft.Devices;
 
@@ -394,6 +396,12 @@ model IotDpsPropertiesDescription {
    * Portal endpoint to enable CORS for this provisioning service.
    */
   portalOperationsHostName?: string;
+
+  /**
+   * Disables all authentication methods other than Azure RBAC
+   */
+  @added(Versions.v2026_10_01)
+  disableLocalAuth?: boolean;
 }
 
 /**

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/readme.md
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/readme.md
@@ -27,9 +27,18 @@ These are the global settings for the API.
 ``` yaml
 openapi-type: arm
 azure-arm: true
-tag: package-preview-2025-02
+tag: package-2026-10
 ```
 
+
+### Tag: package-2026-10
+
+These settings apply only when `--tag=package-2026-10` is specified on the command line.
+
+``` yaml $(tag) == 'package-2026-10'
+input-file:
+  - stable/2026-10-01/iotdps.json
+```
 
 ### Tag: package-preview-2025-02
 

--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/iotdps.json
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/stable/2026-10-01/iotdps.json
@@ -1,0 +1,2588 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "iotDpsClient",
+    "version": "2026-10-01",
+    "description": "API for using the Azure IoT Hub Device Provisioning Service features.",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Operations"
+    },
+    {
+      "name": "CertificateResponses"
+    },
+    {
+      "name": "ProvisioningServiceDescriptions"
+    },
+    {
+      "name": "GroupIdInformations"
+    },
+    {
+      "name": "PrivateEndpointConnections"
+    }
+  ],
+  "paths": {
+    "/providers/Microsoft.Devices/operations": {
+      "get": {
+        "operationId": "Operations_List",
+        "tags": [
+          "Operations"
+        ],
+        "description": "List the operations for the provider",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/OperationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Devices/checkProvisioningServiceNameAvailability": {
+      "post": {
+        "operationId": "IotDpsResource_CheckProvisioningServiceNameAvailability",
+        "summary": "Check if a provisioning service name is available.",
+        "description": "Check if a provisioning service name is available. This will validate if the name is syntactically valid and if the name is usable",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "arguments",
+            "in": "body",
+            "description": "The request body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OperationInputs"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/NameAvailabilityInfo"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Devices/provisioningServices": {
+      "get": {
+        "operationId": "IotDpsResource_ListBySubscription",
+        "tags": [
+          "ProvisioningServiceDescriptions"
+        ],
+        "description": "List all the provisioning services for a given subscription id.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ProvisioningServiceDescriptionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/provisioningServices": {
+      "get": {
+        "operationId": "IotDpsResource_ListByResourceGroup",
+        "tags": [
+          "ProvisioningServiceDescriptions"
+        ],
+        "description": "Get a list of all provisioning services in the given resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ProvisioningServiceDescriptionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/provisioningServices/{provisioningServiceName}": {
+      "get": {
+        "operationId": "IotDpsResource_Get",
+        "tags": [
+          "ProvisioningServiceDescriptions"
+        ],
+        "description": "Get the metadata of the provisioning service without SAS keys.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "provisioningServiceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ProvisioningServiceDescription"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "IotDpsResource_CreateOrUpdate",
+        "tags": [
+          "ProvisioningServiceDescriptions"
+        ],
+        "description": "Create or update the metadata of the provisioning service. The usual pattern to modify a property is to retrieve the provisioning service metadata and security metadata, and then combine them with the modified values in a new body to update the provisioning service.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "provisioningServiceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "iotDpsDescription",
+            "in": "body",
+            "description": "Description of the provisioning service to create or update.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ProvisioningServiceDescription"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ProvisioningServiceDescription' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ProvisioningServiceDescription"
+            }
+          },
+          "201": {
+            "description": "Resource 'ProvisioningServiceDescription' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ProvisioningServiceDescription"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "IotDpsResource_Update",
+        "tags": [
+          "ProvisioningServiceDescriptions"
+        ],
+        "description": "Update an existing provisioning service's tags. to update other fields use the CreateOrUpdate method",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "provisioningServiceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ProvisioningServiceTags",
+            "in": "body",
+            "description": "Updated tag information to set into the provisioning service instance.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/TagsResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ProvisioningServiceDescription"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "IotDpsResource_Delete",
+        "tags": [
+          "ProvisioningServiceDescriptions"
+        ],
+        "description": "Deletes the Provisioning Service.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "provisioningServiceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "404": {
+            "description": "The Azure resource is not found"
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/provisioningServices/{provisioningServiceName}/certificates": {
+      "get": {
+        "operationId": "DpsCertificate_List",
+        "tags": [
+          "CertificateResponses"
+        ],
+        "description": "Get all the certificates tied to the provisioning service.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "provisioningServiceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CertificateListDescription"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/provisioningServices/{provisioningServiceName}/certificates/{certificateName}": {
+      "get": {
+        "operationId": "DpsCertificate_Get",
+        "tags": [
+          "CertificateResponses"
+        ],
+        "description": "Get the certificate from the provisioning service.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "provisioningServiceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "certificateName",
+            "in": "path",
+            "description": "Name of the certificate to retrieve.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag of the certificate.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "ifMatch"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CertificateResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "DpsCertificate_CreateOrUpdate",
+        "tags": [
+          "CertificateResponses"
+        ],
+        "description": "Add new certificate or update an existing certificate.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "provisioningServiceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "certificateName",
+            "in": "path",
+            "description": "Name of the certificate to retrieve.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag of the certificate. This is required to update an existing certificate, and ignored while creating a brand new certificate.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "ifMatch"
+          },
+          {
+            "name": "certificateDescription",
+            "in": "body",
+            "description": "The certificate body.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CertificateResponse"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'CertificateResponse' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/CertificateResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "DpsCertificate_Delete",
+        "tags": [
+          "CertificateResponses"
+        ],
+        "description": "Deletes the specified certificate associated with the Provisioning Service",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "provisioningServiceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "certificateName",
+            "in": "path",
+            "description": "Name of the certificate to retrieve.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag of the certificate",
+            "required": true,
+            "type": "string",
+            "x-ms-client-name": "ifMatch"
+          },
+          {
+            "name": "certificate.name",
+            "in": "query",
+            "description": "This is optional, and it is the Common Name of the certificate.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "certificate.rawBytes",
+            "in": "query",
+            "description": "Raw data within the certificate.",
+            "required": false,
+            "type": "string",
+            "format": "byte",
+            "x-ms-client-name": "certificateRawBytes"
+          },
+          {
+            "name": "certificate.isVerified",
+            "in": "query",
+            "description": "Indicates if certificate has been verified by owner of the private key.",
+            "required": false,
+            "type": "boolean",
+            "x-ms-client-name": "certificateIsVerified"
+          },
+          {
+            "name": "certificate.purpose",
+            "in": "query",
+            "description": "A description that mentions the purpose of the certificate.",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "clientAuthentication",
+              "serverAuthentication"
+            ],
+            "x-ms-enum": {
+              "name": "CertificatePurpose",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "clientAuthentication",
+                  "value": "clientAuthentication"
+                },
+                {
+                  "name": "serverAuthentication",
+                  "value": "serverAuthentication"
+                }
+              ]
+            },
+            "x-ms-client-name": "certificatePurpose"
+          },
+          {
+            "name": "certificate.created",
+            "in": "query",
+            "description": "Time the certificate is created.",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "x-ms-client-name": "certificateCreated"
+          },
+          {
+            "name": "certificate.lastUpdated",
+            "in": "query",
+            "description": "Certificate last updated time.",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "x-ms-client-name": "certificateLastUpdated"
+          },
+          {
+            "name": "certificate.hasPrivateKey",
+            "in": "query",
+            "description": "Indicates if the certificate contains a private key.",
+            "required": false,
+            "type": "boolean",
+            "x-ms-client-name": "certificateHasPrivateKey"
+          },
+          {
+            "name": "certificate.nonce",
+            "in": "query",
+            "description": "Random number generated to indicate Proof of Possession.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "certificateNonce"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/provisioningServices/{provisioningServiceName}/certificates/{certificateName}/generateVerificationCode": {
+      "post": {
+        "operationId": "DpsCertificate_GenerateVerificationCode",
+        "tags": [
+          "CertificateResponses"
+        ],
+        "description": "Generate verification code for Proof of Possession.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "provisioningServiceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "certificateName",
+            "in": "path",
+            "description": "Name of the certificate to retrieve.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag of the certificate. This is required to update an existing certificate, and ignored while creating a brand new certificate.",
+            "required": true,
+            "type": "string",
+            "x-ms-client-name": "ifMatch"
+          },
+          {
+            "name": "certificate.name",
+            "in": "query",
+            "description": "Common Name for the certificate.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "certificate.rawBytes",
+            "in": "query",
+            "description": "Raw data of certificate.",
+            "required": false,
+            "type": "string",
+            "format": "byte",
+            "x-ms-client-name": "certificateRawBytes"
+          },
+          {
+            "name": "certificate.isVerified",
+            "in": "query",
+            "description": "Indicates if the certificate has been verified by owner of the private key.",
+            "required": false,
+            "type": "boolean",
+            "x-ms-client-name": "certificateIsVerified"
+          },
+          {
+            "name": "certificate.purpose",
+            "in": "query",
+            "description": "Description mentioning the purpose of the certificate.",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "clientAuthentication",
+              "serverAuthentication"
+            ],
+            "x-ms-enum": {
+              "name": "CertificatePurpose",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "clientAuthentication",
+                  "value": "clientAuthentication"
+                },
+                {
+                  "name": "serverAuthentication",
+                  "value": "serverAuthentication"
+                }
+              ]
+            },
+            "x-ms-client-name": "certificatePurpose"
+          },
+          {
+            "name": "certificate.created",
+            "in": "query",
+            "description": "Time the certificate is created.",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "x-ms-client-name": "certificateCreated"
+          },
+          {
+            "name": "certificate.lastUpdated",
+            "in": "query",
+            "description": "Certificate last updated time.",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "x-ms-client-name": "certificateLastUpdated"
+          },
+          {
+            "name": "certificate.hasPrivateKey",
+            "in": "query",
+            "description": "Indicates if the certificate contains private key.",
+            "required": false,
+            "type": "boolean",
+            "x-ms-client-name": "certificateHasPrivateKey"
+          },
+          {
+            "name": "certificate.nonce",
+            "in": "query",
+            "description": "Random number generated to indicate Proof of Possession.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "certificateNonce"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VerificationCodeResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/provisioningServices/{provisioningServiceName}/certificates/{certificateName}/verify": {
+      "post": {
+        "operationId": "DpsCertificate_VerifyCertificate",
+        "tags": [
+          "CertificateResponses"
+        ],
+        "description": "Verifies the certificate's private key possession by providing the leaf cert issued by the verifying pre uploaded certificate.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "provisioningServiceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "certificateName",
+            "in": "path",
+            "description": "Name of the certificate to retrieve.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag of the certificate.",
+            "required": true,
+            "type": "string",
+            "x-ms-client-name": "ifMatch"
+          },
+          {
+            "name": "certificate.name",
+            "in": "query",
+            "description": "Common Name for the certificate.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "certificate.rawBytes",
+            "in": "query",
+            "description": "Raw data of certificate.",
+            "required": false,
+            "type": "string",
+            "format": "byte",
+            "x-ms-client-name": "certificateRawBytes"
+          },
+          {
+            "name": "certificate.isVerified",
+            "in": "query",
+            "description": "Indicates if the certificate has been verified by owner of the private key.",
+            "required": false,
+            "type": "boolean",
+            "x-ms-client-name": "certificateIsVerified"
+          },
+          {
+            "name": "certificate.purpose",
+            "in": "query",
+            "description": "Describe the purpose of the certificate.",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "clientAuthentication",
+              "serverAuthentication"
+            ],
+            "x-ms-enum": {
+              "name": "CertificatePurpose",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "clientAuthentication",
+                  "value": "clientAuthentication"
+                },
+                {
+                  "name": "serverAuthentication",
+                  "value": "serverAuthentication"
+                }
+              ]
+            },
+            "x-ms-client-name": "certificatePurpose"
+          },
+          {
+            "name": "certificate.created",
+            "in": "query",
+            "description": "Time the certificate is created.",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "x-ms-client-name": "certificateCreated"
+          },
+          {
+            "name": "certificate.lastUpdated",
+            "in": "query",
+            "description": "Certificate last updated time.",
+            "required": false,
+            "type": "string",
+            "format": "date-time",
+            "x-ms-client-name": "certificateLastUpdated"
+          },
+          {
+            "name": "certificate.hasPrivateKey",
+            "in": "query",
+            "description": "Indicates if the certificate contains private key.",
+            "required": false,
+            "type": "boolean",
+            "x-ms-client-name": "certificateHasPrivateKey"
+          },
+          {
+            "name": "certificate.nonce",
+            "in": "query",
+            "description": "Random number generated to indicate Proof of Possession.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "certificateNonce"
+          },
+          {
+            "name": "request",
+            "in": "body",
+            "description": "The name of the certificate",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VerificationCodeRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CertificateResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/provisioningServices/{provisioningServiceName}/keys/{keyName}/listkeys": {
+      "post": {
+        "operationId": "IotDpsResource_ListKeysForKeyName",
+        "tags": [
+          "ProvisioningServiceDescriptions"
+        ],
+        "description": "List primary and secondary keys for a specific key name",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "provisioningServiceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "keyName",
+            "in": "path",
+            "description": "Logical key name to get key-values for.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SharedAccessSignatureAuthorizationRuleAccessRightsDescription"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/provisioningServices/{provisioningServiceName}/listkeys": {
+      "post": {
+        "operationId": "IotDpsResource_ListKeys",
+        "tags": [
+          "ProvisioningServiceDescriptions"
+        ],
+        "description": "List the primary and secondary keys for a provisioning service.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "provisioningServiceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SharedAccessSignatureAuthorizationRuleListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/provisioningServices/{provisioningServiceName}/operationresults/{operationId}": {
+      "get": {
+        "operationId": "IotDpsResource_GetOperationResult",
+        "description": "Gets the status of a long running operation, such as create, update or delete a provisioning service.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "provisioningServiceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "operationId",
+            "in": "path",
+            "description": "Operation id corresponding to long running operation. Use this to poll for the status.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "asyncinfo",
+            "in": "query",
+            "description": "Async header used to poll on the status of the operation, obtained while creating the long running operation.",
+            "required": true,
+            "type": "string",
+            "default": "true"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AsyncOperationResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/provisioningServices/{resourceName}/privateEndpointConnections": {
+      "get": {
+        "operationId": "IotDpsResource_ListPrivateEndpointConnections",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "List private endpoint connection properties",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnectionsList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/provisioningServices/{resourceName}/privateEndpointConnections/{privateEndpointConnectionName}": {
+      "get": {
+        "operationId": "IotDpsResource_GetPrivateEndpointConnection",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "Get private endpoint connection properties",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The name of the private endpoint connection",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "IotDpsResource_CreateOrUpdatePrivateEndpointConnection",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "Create or update the status of a private endpoint connection with the specified name",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The name of the private endpoint connection",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "privateEndpointConnection",
+            "in": "body",
+            "description": "The private endpoint connection with updated properties",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'PrivateEndpointConnection' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "201": {
+            "description": "Resource 'PrivateEndpointConnection' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "IotDpsResource_DeletePrivateEndpointConnection",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "Delete private endpoint connection with the specified name",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The name of the private endpoint connection",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/provisioningServices/{resourceName}/privateLinkResources": {
+      "get": {
+        "operationId": "IotDpsResource_ListPrivateLinkResources",
+        "tags": [
+          "GroupIdInformations"
+        ],
+        "description": "List private link resources for the given provisioning service",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateLinkResources"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/provisioningServices/{resourceName}/privateLinkResources/{groupId}": {
+      "get": {
+        "operationId": "IotDpsResource_GetPrivateLinkResources",
+        "tags": [
+          "GroupIdInformations"
+        ],
+        "description": "Get the specified private link resource for the given provisioning service",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "groupId",
+            "in": "path",
+            "description": "The name of the private link resource",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/GroupIdInformation"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/provisioningServices/{provisioningServiceName}/skus": {
+      "get": {
+        "operationId": "IotDpsResource_listValidSkus",
+        "tags": [
+          "ProvisioningServiceDescriptions"
+        ],
+        "description": "Gets the list of valid SKUs and tiers for a provisioning service.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "provisioningServiceName",
+            "in": "path",
+            "description": "Name of the provisioning service to retrieve.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/IotDpsSkuDefinitionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "AccessRightsDescription": {
+      "type": "string",
+      "description": "Rights that this key has.",
+      "enum": [
+        "ServiceConfig",
+        "EnrollmentRead",
+        "EnrollmentWrite",
+        "DeviceConnect",
+        "RegistrationStatusRead",
+        "RegistrationStatusWrite"
+      ],
+      "x-ms-enum": {
+        "name": "AccessRightsDescription",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ServiceConfig",
+            "value": "ServiceConfig"
+          },
+          {
+            "name": "EnrollmentRead",
+            "value": "EnrollmentRead"
+          },
+          {
+            "name": "EnrollmentWrite",
+            "value": "EnrollmentWrite"
+          },
+          {
+            "name": "DeviceConnect",
+            "value": "DeviceConnect"
+          },
+          {
+            "name": "RegistrationStatusRead",
+            "value": "RegistrationStatusRead"
+          },
+          {
+            "name": "RegistrationStatusWrite",
+            "value": "RegistrationStatusWrite"
+          }
+        ]
+      }
+    },
+    "AllocationPolicy": {
+      "type": "string",
+      "description": "Allocation policy to be used by this provisioning service.",
+      "enum": [
+        "Hashed",
+        "GeoLatency",
+        "Static"
+      ],
+      "x-ms-enum": {
+        "name": "AllocationPolicy",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Hashed",
+            "value": "Hashed"
+          },
+          {
+            "name": "GeoLatency",
+            "value": "GeoLatency"
+          },
+          {
+            "name": "Static",
+            "value": "Static"
+          }
+        ]
+      }
+    },
+    "AsyncOperationResult": {
+      "type": "object",
+      "description": "Result of a long running operation.",
+      "properties": {
+        "status": {
+          "type": "string",
+          "description": "current status of a long running operation."
+        },
+        "error": {
+          "$ref": "#/definitions/ErrorMessage",
+          "description": "Error message containing code, description and details"
+        }
+      }
+    },
+    "CertificateListDescription": {
+      "type": "object",
+      "description": "The JSON-serialized array of Certificate objects.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The array of Certificate objects.",
+          "items": {
+            "$ref": "#/definitions/CertificateResponse"
+          }
+        }
+      }
+    },
+    "CertificateProperties": {
+      "type": "object",
+      "description": "The description of an X509 CA Certificate.",
+      "properties": {
+        "subject": {
+          "type": "string",
+          "description": "The certificate's subject name.",
+          "readOnly": true
+        },
+        "expiry": {
+          "type": "string",
+          "format": "date-time-rfc7231",
+          "description": "The certificate's expiration date and time.",
+          "readOnly": true
+        },
+        "thumbprint": {
+          "type": "string",
+          "description": "The certificate's thumbprint.",
+          "readOnly": true
+        },
+        "isVerified": {
+          "type": "boolean",
+          "description": "Determines whether certificate has been verified."
+        },
+        "certificate": {
+          "type": "string",
+          "format": "byte",
+          "description": "base-64 representation of X509 certificate .cer file or just .pem file content."
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time-rfc7231",
+          "description": "The certificate's creation date and time.",
+          "readOnly": true
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time-rfc7231",
+          "description": "The certificate's last update date and time.",
+          "readOnly": true
+        }
+      }
+    },
+    "CertificateResponse": {
+      "type": "object",
+      "description": "The X509 Certificate.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/CertificateProperties",
+          "description": "properties of a certificate"
+        },
+        "etag": {
+          "type": "string",
+          "description": "The entity tag.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "DeviceRegistryNamespaceAuthenticationType": {
+      "type": "string",
+      "description": "Device Registry Namespace MI authentication type: UserAssigned, SystemAssigned.",
+      "enum": [
+        "UserAssigned",
+        "SystemAssigned"
+      ],
+      "x-ms-enum": {
+        "name": "DeviceRegistryNamespaceAuthenticationType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "UserAssigned",
+            "value": "UserAssigned",
+            "description": "User assigned authentication type."
+          },
+          {
+            "name": "SystemAssigned",
+            "value": "SystemAssigned",
+            "description": "System assigned authentication type."
+          }
+        ]
+      }
+    },
+    "DeviceRegistryNamespaceDescription": {
+      "type": "object",
+      "description": "Description of the Device Registry namespace that is linked to the provisioning service.",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The ARM resource ID of the Device Registry namespace.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.DeviceRegistry/namespaces"
+              }
+            ]
+          }
+        },
+        "authenticationType": {
+          "$ref": "#/definitions/DeviceRegistryNamespaceAuthenticationType",
+          "description": "Device Registry Namespace MI authentication type: UserAssigned, SystemAssigned."
+        },
+        "selectedUserAssignedIdentityResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The selected user-assigned identity resource Id associated with Device Registry namespace. This is required when authenticationType is UserAssigned.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.ManagedIdentity/userAssignedIdentities"
+              }
+            ]
+          }
+        }
+      },
+      "required": [
+        "resourceId",
+        "authenticationType"
+      ]
+    },
+    "ErrorDetails": {
+      "type": "object",
+      "description": "Error details.",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The error code.",
+          "readOnly": true
+        },
+        "httpStatusCode": {
+          "type": "string",
+          "description": "The HTTP status code.",
+          "readOnly": true
+        },
+        "message": {
+          "type": "string",
+          "description": "The error message.",
+          "readOnly": true
+        },
+        "details": {
+          "type": "string",
+          "description": "The error details.",
+          "readOnly": true
+        }
+      }
+    },
+    "ErrorMessage": {
+      "type": "object",
+      "description": "Error response containing message and code.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "standard error code"
+        },
+        "message": {
+          "type": "string",
+          "description": "standard error description"
+        },
+        "details": {
+          "type": "string",
+          "description": "detailed summary of error"
+        }
+      }
+    },
+    "GroupIdInformation": {
+      "type": "object",
+      "description": "The group information for creating a private endpoint on a provisioning service",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/GroupIdInformationProperties",
+          "description": "The properties for a group information object"
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "GroupIdInformationProperties": {
+      "type": "object",
+      "description": "The properties for a group information object",
+      "properties": {
+        "groupId": {
+          "type": "string",
+          "description": "The group id"
+        },
+        "requiredMembers": {
+          "type": "array",
+          "description": "The required members for a specific group id",
+          "items": {
+            "type": "string"
+          }
+        },
+        "requiredZoneNames": {
+          "type": "array",
+          "description": "The required DNS zones for a specific group id",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "IotDpsPropertiesDescription": {
+      "type": "object",
+      "description": "the service specific properties of a provisioning service, including keys, linked iot hubs, current state, and system generated properties such as hostname and idScope",
+      "properties": {
+        "state": {
+          "$ref": "#/definitions/State",
+          "description": "Current state of the provisioning service."
+        },
+        "publicNetworkAccess": {
+          "$ref": "#/definitions/PublicNetworkAccess",
+          "description": "Whether requests from Public Network are allowed"
+        },
+        "ipFilterRules": {
+          "type": "array",
+          "description": "The IP filter rules.",
+          "items": {
+            "$ref": "#/definitions/IpFilterRule"
+          }
+        },
+        "privateEndpointConnections": {
+          "type": "array",
+          "description": "Private endpoint connections created on this IotHub",
+          "items": {
+            "$ref": "#/definitions/PrivateEndpointConnection"
+          }
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "The ARM provisioning state of the provisioning service."
+        },
+        "iotHubs": {
+          "type": "array",
+          "description": "List of IoT hubs associated with this provisioning service.",
+          "items": {
+            "$ref": "#/definitions/IotHubDefinitionDescription"
+          }
+        },
+        "deviceRegistryNamespace": {
+          "$ref": "#/definitions/DeviceRegistryNamespaceDescription",
+          "description": "The Device Registry namespace that is linked to the provisioning service."
+        },
+        "allocationPolicy": {
+          "$ref": "#/definitions/AllocationPolicy",
+          "description": "Allocation policy to be used by this provisioning service."
+        },
+        "serviceOperationsHostName": {
+          "type": "string",
+          "description": "Service endpoint for provisioning service.",
+          "readOnly": true
+        },
+        "deviceProvisioningHostName": {
+          "type": "string",
+          "description": "Device endpoint for this provisioning service.",
+          "readOnly": true
+        },
+        "idScope": {
+          "type": "string",
+          "description": "Unique identifier of this provisioning service.",
+          "readOnly": true
+        },
+        "authorizationPolicies": {
+          "type": "array",
+          "description": "List of authorization keys for a provisioning service.",
+          "items": {
+            "$ref": "#/definitions/SharedAccessSignatureAuthorizationRuleAccessRightsDescription"
+          }
+        },
+        "enableDataResidency": {
+          "type": "boolean",
+          "description": "Optional.\nIndicates if the DPS instance has Data Residency enabled, removing the cross geo-pair disaster recovery."
+        },
+        "portalOperationsHostName": {
+          "type": "string",
+          "description": "Portal endpoint to enable CORS for this provisioning service."
+        },
+        "disableLocalAuth": {
+          "type": "boolean",
+          "description": "Disables all authentication methods other than Azure RBAC"
+        }
+      }
+    },
+    "IotDpsSku": {
+      "type": "string",
+      "description": "Sku name.",
+      "enum": [
+        "S1"
+      ],
+      "x-ms-enum": {
+        "name": "IotDpsSku",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "S1",
+            "value": "S1"
+          }
+        ]
+      }
+    },
+    "IotDpsSkuDefinition": {
+      "type": "object",
+      "description": "Available SKUs of tier and units.",
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/IotDpsSku",
+          "description": "Sku name."
+        }
+      }
+    },
+    "IotDpsSkuDefinitionListResult": {
+      "type": "object",
+      "description": "List of available SKUs.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The IotDpsSkuDefinition items on this page",
+          "items": {
+            "$ref": "#/definitions/IotDpsSkuDefinition"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "IotDpsSkuInfo": {
+      "type": "object",
+      "description": "List of possible provisioning service SKUs.",
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/IotDpsSku",
+          "description": "Sku name."
+        },
+        "tier": {
+          "type": "string",
+          "description": "Pricing tier name of the provisioning service.",
+          "readOnly": true
+        },
+        "capacity": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The number of units to provision"
+        }
+      }
+    },
+    "IotHubDefinitionDescription": {
+      "type": "object",
+      "description": "Description of the IoT hub.",
+      "properties": {
+        "applyAllocationPolicy": {
+          "type": "boolean",
+          "description": "flag for applying allocationPolicy or not for a given iot hub."
+        },
+        "allocationWeight": {
+          "type": "integer",
+          "format": "int32",
+          "description": "weight to apply for a given iot h."
+        },
+        "name": {
+          "type": "string",
+          "description": "Host name of the IoT hub.",
+          "readOnly": true
+        },
+        "connectionString": {
+          "type": "string",
+          "description": "Connection string of the IoT hub."
+        },
+        "location": {
+          "type": "string",
+          "description": "ARM region of the IoT hub."
+        }
+      },
+      "required": [
+        "connectionString",
+        "location"
+      ]
+    },
+    "IpFilterActionType": {
+      "type": "string",
+      "description": "The desired action for requests captured by this rule.",
+      "enum": [
+        "Accept",
+        "Reject"
+      ],
+      "x-ms-enum": {
+        "name": "IpFilterActionType",
+        "modelAsString": false
+      }
+    },
+    "IpFilterRule": {
+      "type": "object",
+      "description": "The IP filter rules for a provisioning Service.",
+      "properties": {
+        "filterName": {
+          "type": "string",
+          "description": "The name of the IP filter rule."
+        },
+        "action": {
+          "$ref": "#/definitions/IpFilterActionType",
+          "description": "The desired action for requests captured by this rule."
+        },
+        "ipMask": {
+          "type": "string",
+          "description": "A string that contains the IP address range in CIDR notation for the rule."
+        },
+        "target": {
+          "$ref": "#/definitions/IpFilterTargetType",
+          "description": "Target for requests captured by this rule."
+        }
+      },
+      "required": [
+        "filterName",
+        "action",
+        "ipMask"
+      ]
+    },
+    "IpFilterTargetType": {
+      "type": "string",
+      "description": "Target for requests captured by this rule.",
+      "enum": [
+        "all",
+        "serviceApi",
+        "deviceApi"
+      ],
+      "x-ms-enum": {
+        "name": "IpFilterTargetType",
+        "modelAsString": false
+      }
+    },
+    "NameAvailabilityInfo": {
+      "type": "object",
+      "description": "Description of name availability.",
+      "properties": {
+        "nameAvailable": {
+          "type": "boolean",
+          "description": "specifies if a name is available or not"
+        },
+        "reason": {
+          "$ref": "#/definitions/NameUnavailabilityReason",
+          "description": "specifies the reason a name is unavailable"
+        },
+        "message": {
+          "type": "string",
+          "description": "message containing a detailed reason name is unavailable"
+        }
+      }
+    },
+    "NameUnavailabilityReason": {
+      "type": "string",
+      "description": "specifies the reason a name is unavailable",
+      "enum": [
+        "Invalid",
+        "AlreadyExists"
+      ],
+      "x-ms-enum": {
+        "name": "NameUnavailabilityReason",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "AlreadyExists",
+            "value": "AlreadyExists"
+          }
+        ]
+      }
+    },
+    "Operation": {
+      "type": "object",
+      "description": "Represents an operation.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the operation.",
+          "readOnly": true
+        },
+        "display": {
+          "type": "object",
+          "description": "The display information for the operation.",
+          "properties": {
+            "provider": {
+              "type": "string",
+              "description": "Service provider: Microsoft Devices.",
+              "readOnly": true
+            },
+            "resource": {
+              "type": "string",
+              "description": "Resource Type: ProvisioningServices.",
+              "readOnly": true
+            },
+            "operation": {
+              "type": "string",
+              "description": "Name of the operation.",
+              "readOnly": true
+            }
+          }
+        }
+      }
+    },
+    "OperationInputs": {
+      "type": "object",
+      "description": "Input values for operation results call.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the Provisioning Service to check."
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "OperationListResult": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "[Placeholder] Description for value property",
+          "items": {
+            "$ref": "#/definitions/Operation"
+          },
+          "readOnly": true
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "[Placeholder] Description for nextLink property."
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PrivateEndpoint": {
+      "type": "object",
+      "description": "The private endpoint property of a private endpoint connection",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The resource identifier.",
+          "readOnly": true
+        }
+      }
+    },
+    "PrivateEndpointConnection": {
+      "type": "object",
+      "description": "The private endpoint connection of a provisioning service",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PrivateEndpointConnectionProperties",
+          "description": "The properties of a private endpoint connection"
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "PrivateEndpointConnectionProperties": {
+      "type": "object",
+      "description": "The properties of a private endpoint connection",
+      "properties": {
+        "privateEndpoint": {
+          "$ref": "#/definitions/PrivateEndpoint",
+          "description": "The private endpoint property of a private endpoint connection"
+        },
+        "privateLinkServiceConnectionState": {
+          "$ref": "#/definitions/PrivateLinkServiceConnectionState",
+          "description": "The current state of a private endpoint connection"
+        }
+      },
+      "required": [
+        "privateLinkServiceConnectionState"
+      ]
+    },
+    "PrivateEndpointConnectionsList": {
+      "type": "array",
+      "description": "Represents a list of private endpoint connections.",
+      "items": {
+        "$ref": "#/definitions/PrivateEndpointConnection"
+      }
+    },
+    "PrivateLinkResources": {
+      "type": "object",
+      "description": "The available private link resources for a provisioning service",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The list of available private link resources for a provisioning service",
+          "items": {
+            "$ref": "#/definitions/GroupIdInformation"
+          }
+        }
+      }
+    },
+    "PrivateLinkServiceConnectionState": {
+      "type": "object",
+      "description": "The current state of a private endpoint connection",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/PrivateLinkServiceConnectionStatus",
+          "description": "The status of a private endpoint connection"
+        },
+        "description": {
+          "type": "string",
+          "description": "The description for the current state of a private endpoint connection"
+        },
+        "actionsRequired": {
+          "type": "string",
+          "description": "Actions required for a private endpoint connection"
+        }
+      },
+      "required": [
+        "status",
+        "description"
+      ]
+    },
+    "PrivateLinkServiceConnectionStatus": {
+      "type": "string",
+      "description": "The status of a private endpoint connection",
+      "enum": [
+        "Pending",
+        "Approved",
+        "Rejected",
+        "Disconnected"
+      ],
+      "x-ms-enum": {
+        "name": "PrivateLinkServiceConnectionStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Pending",
+            "value": "Pending"
+          },
+          {
+            "name": "Approved",
+            "value": "Approved"
+          },
+          {
+            "name": "Rejected",
+            "value": "Rejected"
+          },
+          {
+            "name": "Disconnected",
+            "value": "Disconnected"
+          }
+        ]
+      }
+    },
+    "ProvisioningServiceDescription": {
+      "type": "object",
+      "description": "The description of the provisioning service.",
+      "properties": {
+        "etag": {
+          "type": "string",
+          "description": "The Etag field is *not* required. If it is provided in the response body, it must also be provided as a header per the normal ETag convention."
+        },
+        "resourcegroup": {
+          "type": "string",
+          "description": "The resource group of the resource."
+        },
+        "subscriptionid": {
+          "type": "string",
+          "description": "The subscription id of the resource."
+        },
+        "properties": {
+          "$ref": "#/definitions/IotDpsPropertiesDescription",
+          "description": "Service specific properties for a provisioning service"
+        },
+        "sku": {
+          "$ref": "#/definitions/IotDpsSkuInfo",
+          "description": "Sku info for a provisioning Service."
+        },
+        "identity": {
+          "$ref": "../../../../../../common-types/resource-management/v3/managedidentity.json#/definitions/ManagedServiceIdentity",
+          "description": "The managed service identities assigned to this resource."
+        }
+      },
+      "required": [
+        "properties",
+        "sku"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "ProvisioningServiceDescriptionListResult": {
+      "type": "object",
+      "description": "The response of a ProvisioningServiceDescription list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ProvisioningServiceDescription items on this page",
+          "items": {
+            "$ref": "#/definitions/ProvisioningServiceDescription"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PublicNetworkAccess": {
+      "type": "string",
+      "description": "Whether requests from Public Network are allowed",
+      "enum": [
+        "Enabled",
+        "Disabled"
+      ],
+      "x-ms-enum": {
+        "name": "PublicNetworkAccess",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Enabled",
+            "value": "Enabled"
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled"
+          }
+        ]
+      }
+    },
+    "SharedAccessSignatureAuthorizationRuleAccessRightsDescription": {
+      "type": "object",
+      "description": "Description of the shared access key.",
+      "properties": {
+        "keyName": {
+          "type": "string",
+          "description": "Name of the key."
+        },
+        "primaryKey": {
+          "type": "string",
+          "description": "Primary SAS key value."
+        },
+        "secondaryKey": {
+          "type": "string",
+          "description": "Secondary SAS key value."
+        },
+        "rights": {
+          "$ref": "#/definitions/AccessRightsDescription",
+          "description": "Rights that this key has."
+        }
+      },
+      "required": [
+        "keyName",
+        "rights"
+      ]
+    },
+    "SharedAccessSignatureAuthorizationRuleListResult": {
+      "type": "object",
+      "description": "List of shared access keys.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The SharedAccessSignatureAuthorizationRuleAccessRightsDescription items on this page",
+          "items": {
+            "$ref": "#/definitions/SharedAccessSignatureAuthorizationRuleAccessRightsDescription"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "State": {
+      "type": "string",
+      "description": "Current state of the provisioning service.",
+      "enum": [
+        "Activating",
+        "Active",
+        "Deleting",
+        "Deleted",
+        "ActivationFailed",
+        "DeletionFailed",
+        "Transitioning",
+        "Suspending",
+        "Suspended",
+        "Resuming",
+        "FailingOver",
+        "FailoverFailed"
+      ],
+      "x-ms-enum": {
+        "name": "State",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Activating",
+            "value": "Activating"
+          },
+          {
+            "name": "Active",
+            "value": "Active"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting"
+          },
+          {
+            "name": "Deleted",
+            "value": "Deleted"
+          },
+          {
+            "name": "ActivationFailed",
+            "value": "ActivationFailed"
+          },
+          {
+            "name": "DeletionFailed",
+            "value": "DeletionFailed"
+          },
+          {
+            "name": "Transitioning",
+            "value": "Transitioning"
+          },
+          {
+            "name": "Suspending",
+            "value": "Suspending"
+          },
+          {
+            "name": "Suspended",
+            "value": "Suspended"
+          },
+          {
+            "name": "Resuming",
+            "value": "Resuming"
+          },
+          {
+            "name": "FailingOver",
+            "value": "FailingOver"
+          },
+          {
+            "name": "FailoverFailed",
+            "value": "FailoverFailed"
+          }
+        ]
+      }
+    },
+    "TagsResource": {
+      "type": "object",
+      "description": "A container holding only the Tags for a resource, allowing the user to update the tags on a Provisioning Service instance.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "VerificationCodeRequest": {
+      "type": "object",
+      "description": "The JSON-serialized leaf certificate",
+      "properties": {
+        "certificate": {
+          "type": "string",
+          "description": "base-64 representation of X509 certificate .cer file or just .pem file content."
+        }
+      }
+    },
+    "VerificationCodeResponse": {
+      "type": "object",
+      "description": "Description of the response of the verification code.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of certificate.",
+          "readOnly": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "Request etag.",
+          "readOnly": true
+        },
+        "id": {
+          "type": "string",
+          "description": "The resource identifier.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "The resource type.",
+          "readOnly": true
+        },
+        "properties": {
+          "$ref": "#/definitions/VerificationCodeResponseProperties"
+        }
+      }
+    },
+    "VerificationCodeResponseProperties": {
+      "type": "object",
+      "properties": {
+        "verificationCode": {
+          "type": "string",
+          "description": "Verification code."
+        },
+        "subject": {
+          "type": "string",
+          "description": "Certificate subject."
+        },
+        "expiry": {
+          "type": "string",
+          "description": "Code expiry."
+        },
+        "thumbprint": {
+          "type": "string",
+          "description": "Certificate thumbprint."
+        },
+        "isVerified": {
+          "type": "boolean",
+          "description": "Indicate if the certificate is verified by owner of private key."
+        },
+        "certificate": {
+          "type": "string",
+          "format": "byte",
+          "description": "base-64 representation of X509 certificate .cer file or just .pem file content."
+        },
+        "created": {
+          "type": "string",
+          "description": "Certificate created time."
+        },
+        "updated": {
+          "type": "string",
+          "description": "Certificate updated time."
+        }
+      }
+    }
+  },
+  "parameters": {}
+}


### PR DESCRIPTION
## Summary

This PR introduces a new GA API version (2026-10-01) for the Device Provisioning Service (DPS) ARM TypeSpec project and adds the `disableLocalAuth` property.

## Changes

- **main.tsp**: Added `v2026_10_01: "2026-10-01"` to the `Versions` enum
- **models.tsp**: Added `disableLocalAuth?: boolean` property to `IotDpsPropertiesDescription`, gated with `@added(Versions.v2026_10_01)`
- **stable/2026-10-01/iotdps.json**: Generated GA swagger output via `tsp compile`
- **examples/2026-10-01/**: Curated examples demonstrating disableLocalAuth in create, patch, and get operations
- **readme.md**: Added `package-2026-10` tag and set it as the default

## Property Details

| Property | Type | Required | Default Behavior |
|----------|------|----------|-----------------|
| disableLocalAuth | boolean | No | When true, disables all authentication methods other than Azure RBAC |

## Validation

- TypeSpec compilation: exit code 0
- Version-gating confirmed: disableLocalAuth appears only in 2026-10-01 swagger, not in earlier versions
- Generated swagger validated for correct schema structure