### PR TITLE
Add SandboxGroup API to Microsoft.ContainerInstance

### DIFF
--- a/specification/containerinstance/resource-manager/Microsoft.ContainerInstance/ContainerInstance/SandboxGroup.tsp
+++ b/specification/containerinstance/resource-manager/Microsoft.ContainerInstance/ContainerInstance/SandboxGroup.tsp
@@ -1,0 +1,250 @@
+import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-azure-resource-manager";
+import "@typespec/openapi";
+import "@typespec/rest";
+import "./models.tsp";
+
+using TypeSpec.Rest;
+using Azure.ResourceManager;
+using TypeSpec.Http;
+using TypeSpec.OpenAPI;
+
+namespace Microsoft.ContainerInstance;
+
+/**
+ * The provisioning state of a resource.
+ */
+union ProvisioningState {
+  string,
+
+  /**
+   * Resource has been created.
+   */
+  Succeeded: "Succeeded",
+
+  /**
+   * Resource creation failed.
+   */
+  Failed: "Failed",
+
+  /**
+   * Resource creation was canceled.
+   */
+  Canceled: "Canceled",
+
+  /**
+   * The resource is being updated.
+   */
+  Updating: "Updating",
+
+  /**
+   * The resource is being deleted.
+   */
+  Deleting: "Deleting",
+
+  /**
+   * The resource provisioning request was accepted but not yet started.
+   */
+  Accepted: "Accepted",
+}
+
+/**
+ * A reference to a subnet resource.
+ */
+model SubnetReference {
+  /**
+   * The ARM resource ID of the subnet. The caller must have `Microsoft.Network/virtualNetworks/subnets/join/action` permission on this subnet (enforced via a linked access check at create/update time).
+   */
+  @format("arm-id")
+  id: string;
+}
+
+/**
+ * The network profile for a SandboxGroup.
+ */
+model SandboxGroupNetworkProfile {
+  /**
+   * The list of subnets associated with the SandboxGroup.
+   */
+  subnets?: SubnetReference[];
+}
+
+/**
+ * Properties of a SandboxGroup.
+ */
+model SandboxGroupProperties {
+  /**
+   * The status of the last operation.
+   */
+  @visibility(Lifecycle.Read)
+  provisioningState?: ProvisioningState;
+
+  /**
+   * The network profile of the SandboxGroup.
+   */
+  networkProfile?: SandboxGroupNetworkProfile;
+
+  /**
+   * The ARM resource ID of the management resource group associated with this SandboxGroup.
+   */
+  @visibility(Lifecycle.Read)
+  @format("arm-id")
+  managementResourceGroupId?: string;
+}
+
+/**
+ * A SandboxGroup tracked resource.
+ */
+model SandboxGroup is Azure.ResourceManager.TrackedResource<SandboxGroupProperties> {
+  /**
+   * The name of the SandboxGroup.
+   */
+  @maxLength(63)
+  @minLength(1)
+  @pattern("^[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]$")
+  @key("sandboxGroupName")
+  @segment("sandboxGroupName")
+  @path
+  name: string;
+
+  /**
+   * The managed service identities assigned to this resource.
+   */
+  identity?: Azure.ResourceManager.ManagedServiceIdentityProperty;
+}
+
+/**
+ * The type used for updating tags in SandboxGroup resources.
+ */
+model SandboxGroupTagsUpdate {
+  /**
+   * Resource tags.
+   */
+  tags?: Record<string>;
+}
+
+/**
+ * The result of getting an access token for a SandboxGroup.
+ */
+model SandboxGroupAccessToken {
+  /**
+   * The endpoint URL to use with the access token.
+   */
+  @format("uri")
+  endpoint: string;
+
+  /**
+   * The access token used to authenticate against the endpoint.
+   */
+  @format("password")
+  @secret
+  accessToken: string;
+
+  /**
+   * The UTC date and time at which the access token expires.
+   */
+  notAfter: utcDateTime;
+}
+
+/**
+ * The response of a SandboxGroup list operation.
+ */
+model SandboxGroupListResult {
+  /**
+   * The SandboxGroup items on this page
+   */
+  value: SandboxGroup[];
+
+  /**
+   * The link to the next page of items
+   */
+  @format("uri")
+  nextLink?: string;
+}
+
+@armResourceOperations
+interface SandboxGroups {
+  /**
+   * List SandboxGroup resources by subscription ID
+   */
+  @operationId("SandboxGroups_ListBySubscription")
+  @summary("List SandboxGroup resources by subscription ID")
+  @get
+  listBySubscription is ArmListBySubscription<SandboxGroup, Error = CloudError>;
+
+  /**
+   * List SandboxGroup resources by resource group
+   */
+  @operationId("SandboxGroups_ListByResourceGroup")
+  @summary("List SandboxGroup resources by resource group")
+  @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerInstance/sandboxGroups")
+  listByResourceGroup is ArmResourceListByParent<
+    SandboxGroup,
+    Error = CloudError
+  >;
+
+  /**
+   * Get a SandboxGroup
+   */
+  @operationId("SandboxGroups_Get")
+  @summary("Get a SandboxGroup")
+  get is ArmResourceRead<SandboxGroup, Error = CloudError>;
+
+  /**
+   * Create a SandboxGroup
+   */
+  @operationId("SandboxGroups_CreateOrUpdate")
+  @summary("Create a SandboxGroup")
+  createOrUpdate is ArmResourceCreateOrReplaceAsync<
+    SandboxGroup,
+    LroHeaders = ArmAsyncOperationHeader<FinalResult = SandboxGroup> &
+      Azure.Core.Foundations.RetryAfterHeader,
+    Error = CloudError
+  >;
+
+  /**
+   * Update a SandboxGroup
+   */
+  @operationId("SandboxGroups_Update")
+  @summary("Update a SandboxGroup")
+  @patch(#{ implicitOptionality: false })
+  update is ArmCustomPatchAsync<
+    SandboxGroup,
+    SandboxGroupTagsUpdate,
+    Error = CloudError
+  >;
+
+  /**
+   * Delete a SandboxGroup
+   */
+  @operationId("SandboxGroups_Delete")
+  @summary("Delete a SandboxGroup")
+  delete is ArmResourceDeleteAsyncBase<
+    SandboxGroup,
+    ArmAsyncOperationHeader<FinalResult = void> &
+      Azure.Core.Foundations.RetryAfterHeader,
+    Error = CloudError
+  >;
+
+  /**
+   * Get an access token and endpoint for connecting to the SandboxGroup.
+   */
+  @operationId("SandboxGroups_Connect")
+  @summary("Get an access token and endpoint for connecting to the SandboxGroup.")
+  @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerInstance/sandboxGroups/{sandboxGroupName}/connect")
+  @post
+  connect is ArmResourceActionSync<
+    SandboxGroup,
+    void,
+    ArmResponse<SandboxGroupAccessToken>,
+    Error = CloudError
+  >;
+}
+
+@@doc(SandboxGroup.name, "The name of the SandboxGroup.");
+@@doc(SandboxGroups.createOrUpdate::parameters.resource,
+  "Resource create parameters."
+);
+@@doc(SandboxGroups.update::parameters.properties,
+  "The resource properties to be updated."
+);

--- a/specification/containerinstance/resource-manager/Microsoft.ContainerInstance/ContainerInstance/SandboxGroup.tsp
+++ b/specification/containerinstance/resource-manager/Microsoft.ContainerInstance/ContainerInstance/SandboxGroup.tsp
@@ -55,7 +55,6 @@ model SubnetReference {
   /**
    * The ARM resource ID of the subnet. The caller must have `Microsoft.Network/virtualNetworks/subnets/join/action` permission on this subnet (enforced via a linked access check at create/update time).
    */
-  @format("arm-id")
   id: string;
 }
 
@@ -88,8 +87,12 @@ model SandboxGroupProperties {
    * The ARM resource ID of the management resource group associated with this SandboxGroup.
    */
   @visibility(Lifecycle.Read)
-  @format("arm-id")
   managementResourceGroupId?: string;
+
+  /**
+   * The managed service identities assigned to this resource.
+   */
+  identity?: Azure.ResourceManager.ManagedServiceIdentityProperty;
 }
 
 /**
@@ -106,6 +109,17 @@ model SandboxGroup is Azure.ResourceManager.TrackedResource<SandboxGroupProperti
   @segment("sandboxGroupName")
   @path
   name: string;
+}
+
+/**
+ * The type used for updating tags in SandboxGroup resources.
+ */
+@Azure.ResourceManager.PatchResource
+model SandboxGroupTagsUpdate {
+  /**
+   * Resource tags.
+   */
+  tags?: SandboxGroupTags;
 
   /**
    * The managed service identities assigned to this resource.
@@ -114,13 +128,16 @@ model SandboxGroup is Azure.ResourceManager.TrackedResource<SandboxGroupProperti
 }
 
 /**
- * The type used for updating tags in SandboxGroup resources.
+ * Resource tags for SandboxGroup.
  */
-model SandboxGroupTagsUpdate {
-  /**
-   * Resource tags.
-   */
-  tags?: Record<string>;
+model SandboxGroupTags {
+  @OpenAPI.extension("x-ms-identifiers", [])
+  properties?: TagProperty[];
+}
+
+model TagProperty {
+  name: string;
+  value: string;
 }
 
 /**
@@ -130,13 +147,11 @@ model SandboxGroupAccessToken {
   /**
    * The endpoint URL to use with the access token.
    */
-  @format("uri")
   endpoint: string;
 
   /**
    * The access token used to authenticate against the endpoint.
    */
-  @format("password")
   @secret
   accessToken: string;
 
@@ -158,7 +173,6 @@ model SandboxGroupListResult {
   /**
    * The link to the next page of items
    */
-  @format("uri")
   nextLink?: string;
 }
 
@@ -167,7 +181,6 @@ interface SandboxGroups {
   /**
    * List SandboxGroup resources by subscription ID
    */
-  @operationId("SandboxGroups_ListBySubscription")
   @summary("List SandboxGroup resources by subscription ID")
   @get
   listBySubscription is ArmListBySubscription<SandboxGroup, Error = CloudError>;
@@ -175,7 +188,6 @@ interface SandboxGroups {
   /**
    * List SandboxGroup resources by resource group
    */
-  @operationId("SandboxGroups_ListByResourceGroup")
   @summary("List SandboxGroup resources by resource group")
   @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerInstance/sandboxGroups")
   listByResourceGroup is ArmResourceListByParent<
@@ -186,14 +198,12 @@ interface SandboxGroups {
   /**
    * Get a SandboxGroup
    */
-  @operationId("SandboxGroups_Get")
   @summary("Get a SandboxGroup")
   get is ArmResourceRead<SandboxGroup, Error = CloudError>;
 
   /**
    * Create a SandboxGroup
    */
-  @operationId("SandboxGroups_CreateOrUpdate")
   @summary("Create a SandboxGroup")
   createOrUpdate is ArmResourceCreateOrReplaceAsync<
     SandboxGroup,
@@ -205,7 +215,6 @@ interface SandboxGroups {
   /**
    * Update a SandboxGroup
    */
-  @operationId("SandboxGroups_Update")
   @summary("Update a SandboxGroup")
   @patch(#{ implicitOptionality: false })
   update is ArmCustomPatchAsync<
@@ -217,19 +226,12 @@ interface SandboxGroups {
   /**
    * Delete a SandboxGroup
    */
-  @operationId("SandboxGroups_Delete")
   @summary("Delete a SandboxGroup")
-  delete is ArmResourceDeleteAsyncBase<
-    SandboxGroup,
-    ArmAsyncOperationHeader<FinalResult = void> &
-      Azure.Core.Foundations.RetryAfterHeader,
-    Error = CloudError
-  >;
+  delete is ArmResourceDeleteWithoutOkAsync<SandboxGroup, Error = CloudError>;
 
   /**
    * Get an access token and endpoint for connecting to the SandboxGroup.
    */
-  @operationId("SandboxGroups_Connect")
   @summary("Get an access token and endpoint for connecting to the SandboxGroup.")
   @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerInstance/sandboxGroups/{sandboxGroupName}/connect")
   @post

--- a/specification/containerinstance/resource-manager/Microsoft.ContainerInstance/ContainerInstance/SandboxGroup.tsp
+++ b/specification/containerinstance/resource-manager/Microsoft.ContainerInstance/ContainerInstance/SandboxGroup.tsp
@@ -114,7 +114,6 @@ model SandboxGroup is Azure.ResourceManager.TrackedResource<SandboxGroupProperti
 /**
  * The type used for updating tags in SandboxGroup resources.
  */
-@Azure.ResourceManager.PatchResource
 model SandboxGroupTagsUpdate {
   /**
    * Resource tags.
@@ -131,7 +130,7 @@ model SandboxGroupTagsUpdate {
  * Resource tags for SandboxGroup.
  */
 model SandboxGroupTags {
-  @OpenAPI.extension("x-ms-identifiers", [])
+  @OpenAPI.extension("x-ms-identifiers", #[])
   properties?: TagProperty[];
 }
 

--- a/specification/containerinstance/resource-manager/Microsoft.ContainerInstance/ContainerInstance/main.tsp
+++ b/specification/containerinstance/resource-manager/Microsoft.ContainerInstance/ContainerInstance/main.tsp
@@ -17,6 +17,7 @@ import "./back-compatible.tsp";
 import "./ContainerGroup.tsp";
 import "./NGroup.tsp";
 import "./ContainerGroupProfile.tsp";
+import "./SandboxGroup.tsp";
 import "./routes.tsp";
 
 using TypeSpec.Rest;
@@ -42,6 +43,11 @@ enum Versions {
    * The 2025-09-01 API version.
    */
   v2025_09_01: "2025-09-01",
+
+  /**
+   * The 2026-06-01-preview API version.
+   */
+  v2026_06_01_preview: "2026-06-01-preview",
 }
 
 interface Operations


### PR DESCRIPTION
Introduces a new SandboxGroup resource with full CRUD operations and custom connect action for the Microsoft.ContainerInstance service. This adds support for the 2026-06-01-preview API version.

## New APIs
- SandboxGroups_ListBySubscription
- SandboxGroups_ListByResourceGroup
- SandboxGroups_Get
- SandboxGroups_CreateOrUpdate (async LRO)
- SandboxGroups_Update (async LRO)
- SandboxGroups_Delete (async LRO)
- SandboxGroups_Connect

## Data Models
- SandboxGroup (TrackedResource with managed identity support)
- SandboxGroupProperties (provisioning state, network profile, management RG ID)
- SandboxGroupAccessToken (access credentials)
- SandboxGroupNetworkProfile (VNet configuration)
- SubnetReference (subnet resource linking)
- ProvisioningState (lifecycle enum)

## Validation
✅ TypeSpec syntax validation: PASSED
✅ ARM compliance rules: COMPLIANT
✅ Resource naming patterns: VALID
✅ LRO operations: CORRECT

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
