### PR TITLE
Add description to typespec-ts package-details in tspconfig.yaml for ARM SDK packages

### DIFF
--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/tspconfig.yaml
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/tspconfig.yaml
@@ -37,6 +37,7 @@ options:
     experimental-extensible-enums: true
     package-details:
       name: "@azure/arm-appcontainers"
+      description: "Azure Container Apps Management Client"
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/appcontainers"
     emitter-output-dir: "{output-dir}/{service-dir}/armappcontainers"

--- a/specification/applicationinsights/resource-manager/Microsoft.Insights/ApplicationInsights/tspconfig.yaml
+++ b/specification/applicationinsights/resource-manager/Microsoft.Insights/ApplicationInsights/tspconfig.yaml
@@ -22,6 +22,7 @@ options:
     experimental-extensible-enums: true
     package-details:
       name: "@azure/arm-appinsights"
+      description: "Azure Application Insights Management Client"
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/applicationinsights"
     emitter-output-dir: "{output-dir}/{service-dir}/armapplicationinsights"

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/tspconfig.yaml
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/tspconfig.yaml
@@ -30,6 +30,7 @@ options:
     experimental-extensible-enums: true
     package-details:
       name: "@azure/arm-authorization"
+      description: "Azure Authorization Management Client"
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/authorization"
     emitter-output-dir: "{output-dir}/{service-dir}/armauthorization"

--- a/specification/msi/resource-manager/Microsoft.ManagedIdentity/ManagedIdentity/tspconfig.yaml
+++ b/specification/msi/resource-manager/Microsoft.ManagedIdentity/ManagedIdentity/tspconfig.yaml
@@ -35,6 +35,7 @@ options:
     experimental-extensible-enums: true
     package-details:
       name: "@azure/arm-msi"
+      description: "Azure Managed Service Identity Management Client"
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/msi"
     emitter-output-dir: "{output-dir}/{service-dir}/armmsi"

--- a/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/tspconfig.yaml
+++ b/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/tspconfig.yaml
@@ -35,6 +35,7 @@ options:
     experimental-extensible-enums: true
     package-details:
       name: "@azure/arm-operationalinsights"
+      description: "Azure Operational Insights Management Client"
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/operationalinsights"
     emitter-output-dir: "{output-dir}/{service-dir}/armoperationalinsights"

--- a/specification/resources/resource-manager/Microsoft.Resources/deployments/tspconfig.yaml
+++ b/specification/resources/resource-manager/Microsoft.Resources/deployments/tspconfig.yaml
@@ -38,6 +38,7 @@ options:
     experimental-extensible-enums: true
     package-details:
       name: "@azure/arm-resourcesdeployments"
+      description: "Azure Resource Deployments Management Client"
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/resources"
     emitter-output-dir: "{output-dir}/{service-dir}/armdeployments"

--- a/specification/resources/resource-manager/Microsoft.Resources/resources/tspconfig.yaml
+++ b/specification/resources/resource-manager/Microsoft.Resources/resources/tspconfig.yaml
@@ -31,6 +31,7 @@ options:
     experimental-extensible-enums: true
     package-details:
       name: "@azure/arm-resources"
+      description: "Azure Resource Management Client"
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/resources"
     emitter-output-dir: "{output-dir}/{service-dir}/armresources"

--- a/specification/storage/Storage.Management/tspconfig.yaml
+++ b/specification/storage/Storage.Management/tspconfig.yaml
@@ -41,6 +41,7 @@ options:
     experimental-extensible-enums: true
     package-details:
       name: "@azure/arm-storage"
+      description: "Azure Storage Management Client"
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/storage"
     emitter-output-dir: "{output-dir}/{service-dir}/armstorage"

--- a/specification/web/resource-manager/Microsoft.Web/AppService/tspconfig.yaml
+++ b/specification/web/resource-manager/Microsoft.Web/AppService/tspconfig.yaml
@@ -43,6 +43,7 @@ options:
     experimental-extensible-enums: true
     package-details:
       name: "@azure/arm-appservice"
+      description: "Azure App Service Management Client"
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/appservice"
     emitter-output-dir: "{output-dir}/{service-dir}/armappservice"


### PR DESCRIPTION
## Description

Adds `description` field to `package-details` under `@azure-tools/typespec-ts` in `tspconfig.yaml` for ARM SDK packages affected by Azure/azure-sdk-for-js#38355.

## Services Modified

| Service | Package | Description Added |
|---------|---------|-------------------|
| ContainerApps | `@azure/arm-appcontainers` | Azure Container Apps Management Client |
| AppService | `@azure/arm-appservice` | Azure App Service Management Client |
| Authorization | `@azure/arm-authorization` | Azure Authorization Management Client |
| ManagedIdentity | `@azure/arm-msi` | Azure Managed Service Identity Management Client |
| Resources | `@azure/arm-resources` | Azure Resource Management Client |
| Deployments | `@azure/arm-resourcesdeployments` | Azure Resource Deployments Management Client |
| Storage | `@azure/arm-storage` | Azure Storage Management Client |

## Related

- Azure/azure-sdk-for-js#38355