### PR TITLE
Rename endpoint to communicationEndpoint in WorkspaceProperties

### DIFF
--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-05-01-preview/openapi.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-05-01-preview/openapi.json
@@ -7479,9 +7479,9 @@
           "description": "Most recent provisioning state for the given Workspace resource.",
           "readOnly": true
         },
-        "endpoint": {
+        "communicationEndpoint": {
           "type": "string",
-          "description": "The endpoint of the workspace used by Chaos agents to connect and communicate with the service.",
+          "description": "The communication endpoint used to connect and communicate with the workspace for fault-injection orchestration.",
           "readOnly": true
         },
         "scopes": {

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/workspace.models.tsp
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/workspace.models.tsp
@@ -56,10 +56,10 @@ model WorkspaceProperties {
   provisioningState?: ProvisioningState;
 
   /**
-   * The endpoint of the workspace used by Chaos agents to connect and communicate with the service.
+   * The communication endpoint used to connect and communicate with the workspace for fault-injection orchestration.
    */
   @visibility(Lifecycle.Read)
-  endpoint?: string;
+  communicationEndpoint?: string;
 
   /**
    * The intended workspace-level resource scope to be used by child scenarios.


### PR DESCRIPTION
Renames `endpoint` to `communicationEndpoint` on `WorkspaceProperties` in the Chaos Studio 2026-05-01-preview API for better clarity on the property's purpose.

## Context

The Workspace exposes a communication endpoint that serves as the base URL for inbound connections — primarily Chaos agent connectivity today, but designed to support any future inbound connections (AKS agents, customer-managed agents, etc.) for fault-injection orchestration.

For background on the Agents-in-Workspaces design, see the [research docs](https://dev.azure.com/msazure/Squall/_git/Chaos?path=/docs/research/agents-in-workspaces).

## Changes

- **workspace.models.tsp** — Renamed `endpoint` → `communicationEndpoint`, updated doc comment
- **preview/2026-05-01-preview/openapi.json** — Regenerated

## Property Details

```typescript
/**
 * The communication endpoint used to connect and communicate with the workspace for fault-injection orchestration.
 */
@visibility(Lifecycle.Read)
communicationEndpoint?: string;
```

- **Read-only**: Service-computed, not user-settable
- **Optional**: May not be populated until provisioning completes
- **Type**: `string` (consistent with ARM conventions)

## Why `communicationEndpoint`?

The previous name `endpoint` was too generic. `communicationEndpoint` follows the `{purpose}Endpoint` naming convention used across Azure RPs (e.g. Cosmos DB's `documentEndpoint`, Azure Monitor's `prometheusQueryEndpoint`) and clearly describes the property's role — the endpoint through which agents and tooling communicate with the workspace.
