### PR TITLE
feat: add description to tspconfig.yaml for @azure/arm-appinsights

### DIFF
--- a/specification/applicationinsights/resource-manager/Microsoft.Insights/ApplicationInsights/tspconfig.yaml
+++ b/specification/applicationinsights/resource-manager/Microsoft.Insights/ApplicationInsights/tspconfig.yaml
@@ -22,6 +22,7 @@ options:
     experimental-extensible-enums: true
     package-details:
       name: "@azure/arm-appinsights"
+      description: "Azure Application Insights Management Client"
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/applicationinsights"
     emitter-output-dir: "{output-dir}/{service-dir}/armapplicationinsights"


### PR DESCRIPTION
## Description

Adds `description` field to `package-details` under `@azure-tools/typespec-ts` in `tspconfig.yaml` for `@azure/arm-appinsights`.

Related to Azure/azure-sdk-for-js#38355