### PR TITLE
feat: add description to tspconfig.yaml for @azure/arm-appservice

### DIFF
--- a/specification/web/resource-manager/Microsoft.Web/AppService/tspconfig.yaml
+++ b/specification/web/resource-manager/Microsoft.Web/AppService/tspconfig.yaml
@@ -43,6 +43,7 @@ options:
     experimental-extensible-enums: true
     package-details:
       name: "@azure/arm-appservice"
+      description: "Azure App Service Management Client"
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/appservice"
     emitter-output-dir: "{output-dir}/{service-dir}/armappservice"


### PR DESCRIPTION
## Description

Adds `description` field to `package-details` under `@azure-tools/typespec-ts` in `tspconfig.yaml` for `@azure/arm-appservice`.

Related to Azure/azure-sdk-for-js#38355