### PR TITLE
feat: add description to tspconfig.yaml for @azure/arm-authorization

### DIFF
--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/tspconfig.yaml
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/tspconfig.yaml
@@ -30,6 +30,7 @@ options:
     experimental-extensible-enums: true
     package-details:
       name: "@azure/arm-authorization"
+      description: "Azure Authorization Management Client"
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/authorization"
     emitter-output-dir: "{output-dir}/{service-dir}/armauthorization"


### PR DESCRIPTION
## Description

Adds `description` field to `package-details` under `@azure-tools/typespec-ts` in `tspconfig.yaml` for `@azure/arm-authorization`.

Related to Azure/azure-sdk-for-js#38355