### PR TITLE
feat: add description to tspconfig.yaml for @azure/arm-msi

### DIFF
--- a/specification/msi/resource-manager/Microsoft.ManagedIdentity/ManagedIdentity/tspconfig.yaml
+++ b/specification/msi/resource-manager/Microsoft.ManagedIdentity/ManagedIdentity/tspconfig.yaml
@@ -35,6 +35,7 @@ options:
     experimental-extensible-enums: true
     package-details:
       name: "@azure/arm-msi"
+      description: "Azure Managed Service Identity Management Client"
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/msi"
     emitter-output-dir: "{output-dir}/{service-dir}/armmsi"


### PR DESCRIPTION
## Description

Adds `description` field to `package-details` under `@azure-tools/typespec-ts` in `tspconfig.yaml` for `@azure/arm-msi`.

Related to Azure/azure-sdk-for-js#38355