### PR TITLE
feat: add description to tspconfig.yaml for @azure/arm-resources

### DIFF
--- a/specification/resources/resource-manager/Microsoft.Resources/resources/tspconfig.yaml
+++ b/specification/resources/resource-manager/Microsoft.Resources/resources/tspconfig.yaml
@@ -31,6 +31,7 @@ options:
     experimental-extensible-enums: true
     package-details:
       name: "@azure/arm-resources"
+      description: "Azure Resource Management Client"
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/resources"
     emitter-output-dir: "{output-dir}/{service-dir}/armresources"


### PR DESCRIPTION
## Description

Adds `description` field to `package-details` under `@azure-tools/typespec-ts` in `tspconfig.yaml` for `@azure/arm-resources`.

Related to Azure/azure-sdk-for-js#38355