### PR TITLE
feat: add description to tspconfig.yaml for @azure/arm-resourcesdeployments

### DIFF
--- a/specification/resources/resource-manager/Microsoft.Resources/deployments/tspconfig.yaml
+++ b/specification/resources/resource-manager/Microsoft.Resources/deployments/tspconfig.yaml
@@ -38,6 +38,7 @@ options:
     experimental-extensible-enums: true
     package-details:
       name: "@azure/arm-resourcesdeployments"
+      description: "Azure Resource Deployments Management Client"
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/resources"
     emitter-output-dir: "{output-dir}/{service-dir}/armdeployments"


### PR DESCRIPTION
## Description

Adds `description` field to `package-details` under `@azure-tools/typespec-ts` in `tspconfig.yaml` for `@azure/arm-resourcesdeployments`.

Related to Azure/azure-sdk-for-js#38355