### PR TITLE
feat: add description to tspconfig.yaml for @azure/arm-storage

### DIFF
--- a/specification/storage/Storage.Management/tspconfig.yaml
+++ b/specification/storage/Storage.Management/tspconfig.yaml
@@ -41,6 +41,7 @@ options:
     experimental-extensible-enums: true
     package-details:
       name: "@azure/arm-storage"
+      description: "Azure Storage Management Client"
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/storage"
     emitter-output-dir: "{output-dir}/{service-dir}/armstorage"


### PR DESCRIPTION
## Description

Adds `description` field to `package-details` under `@azure-tools/typespec-ts` in `tspconfig.yaml` for `@azure/arm-storage`.

Related to Azure/azure-sdk-for-js#38355