### PR TITLE
feat: add description to tspconfig.yaml for @azure/arm-operationalinsights

### DIFF
--- a/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/tspconfig.yaml
+++ b/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/tspconfig.yaml
@@ -35,6 +35,7 @@ options:
     experimental-extensible-enums: true
     package-details:
       name: "@azure/arm-operationalinsights"
+      description: "Azure Operational Insights Management Client"
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/operationalinsights"
     emitter-output-dir: "{output-dir}/{service-dir}/armoperationalinsights"


### PR DESCRIPTION
## Description  Adds `description` field to `package-details` under `@azure-tools/typespec-ts` in `tspconfig.yaml` for `@azure/arm-operationalinsights`.  Related to Azure/azure-sdk-for-js#38355