### PR TITLE
Address PR #42764 review feedback (April Kwong May 1)

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/client.tsp
@@ -167,7 +167,7 @@ using Azure.AI.Projects;
 @@clientName(Evaluators.listLatestVersions, "list");
 
 // Evaluator generation jobs — renamed for Python SDK discoverability
-@@clientName(EvaluatorGenerationJobs.create, "generate_job", "python");
+@@clientName(EvaluatorGenerationJobs.create, "create_generation_job", "python");
 @@clientName(EvaluatorGenerationJobs.get, "get_generation_job", "python");
 @@clientName(EvaluatorGenerationJobs.list, "list_generation_jobs", "python");
 @@clientName(EvaluatorGenerationJobs.cancel, "cancel_generation_job", "python");

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -16930,33 +16930,28 @@
       },
       "EvaluatorGenerationArtifacts": {
         "type": "object",
+        "required": [
+          "dataset",
+          "kinds"
+        ],
         "properties": {
-          "spec": {
+          "dataset": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/DatasetReference"
               }
             ],
-            "description": "Reference to the generated evaluation specification — a Markdown document describing what the evaluator measures, design decisions, and intended scope. Always present for generated evaluators."
+            "description": "Reference to the single Foundry Dataset (one combined JSONL file, version-aligned to `EvaluatorVersion.version`) holding all artifacts produced by the generation pipeline. Each row in the JSONL carries a `kind` field discriminating its content (e.g. `spec`, `tools`, `context`)."
           },
-          "tools": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/DatasetReference"
-              }
-            ],
-            "description": "Reference to the tool schemas inferred during spec generation, when the generation pipeline produced them. JSONL of OpenAI tool-schema objects. Optional: absent when the generation pipeline did not produce or infer tools."
-          },
-          "context": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/DatasetReference"
-              }
-            ],
-            "description": "Reference to the supplementary context materials used during generation (e.g., file uploads, trace samples). Optional: absent when generation used only inline prompt/agent inputs with no supplementary files."
+          "kinds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The kinds of rows present in `dataset`. Always contains `\"spec\"` (the generated evaluation specification, a Markdown document describing what the evaluator measures). May additionally contain `\"tools\"` (when the generation pipeline produced or inferred OpenAI tool schemas) and/or `\"context\"` (when supplementary materials such as file uploads or trace samples were used during generation)."
           }
         },
-        "description": "Service-managed provenance artifacts produced by an evaluator generation job. Present only on EvaluatorVersion resources created via the generation pipeline. All references are read-only and resolve to versioned Foundry Datasets in a service-reserved namespace."
+        "description": "Service-managed provenance artifacts produced by an evaluator generation job. Present only on EvaluatorVersion resources created via the generation pipeline. The combined-JSONL Foundry Dataset is read-only and resolves to a versioned dataset in a service-reserved namespace."
       },
       "EvaluatorGenerationInputs": {
         "type": "object",
@@ -41956,6 +41951,10 @@
               "traces"
             ],
             "description": "The source type for this source, which is Traces."
+          },
+          "agent_id": {
+            "type": "string",
+            "description": "The unique agent ID used to filter traces. Optional — when omitted, traces are filtered by `agent_name` (and `agent_version` if specified)."
           },
           "agent_name": {
             "type": "string",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -19599,33 +19599,28 @@
       },
       "EvaluatorGenerationArtifacts": {
         "type": "object",
+        "required": [
+          "dataset",
+          "kinds"
+        ],
         "properties": {
-          "spec": {
+          "dataset": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/DatasetReference"
               }
             ],
-            "description": "Reference to the generated evaluation specification — a Markdown document describing what the evaluator measures, design decisions, and intended scope. Always present for generated evaluators."
+            "description": "Reference to the single Foundry Dataset (one combined JSONL file, version-aligned to `EvaluatorVersion.version`) holding all artifacts produced by the generation pipeline. Each row in the JSONL carries a `kind` field discriminating its content (e.g. `spec`, `tools`, `context`)."
           },
-          "tools": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/DatasetReference"
-              }
-            ],
-            "description": "Reference to the tool schemas inferred during spec generation, when the generation pipeline produced them. JSONL of OpenAI tool-schema objects. Optional: absent when the generation pipeline did not produce or infer tools."
-          },
-          "context": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/DatasetReference"
-              }
-            ],
-            "description": "Reference to the supplementary context materials used during generation (e.g., file uploads, trace samples). Optional: absent when generation used only inline prompt/agent inputs with no supplementary files."
+          "kinds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The kinds of rows present in `dataset`. Always contains `\"spec\"` (the generated evaluation specification, a Markdown document describing what the evaluator measures). May additionally contain `\"tools\"` (when the generation pipeline produced or inferred OpenAI tool schemas) and/or `\"context\"` (when supplementary materials such as file uploads or trace samples were used during generation)."
           }
         },
-        "description": "Service-managed provenance artifacts produced by an evaluator generation job. Present only on EvaluatorVersion resources created via the generation pipeline. All references are read-only and resolve to versioned Foundry Datasets in a service-reserved namespace."
+        "description": "Service-managed provenance artifacts produced by an evaluator generation job. Present only on EvaluatorVersion resources created via the generation pipeline. The combined-JSONL Foundry Dataset is read-only and resolves to a versioned dataset in a service-reserved namespace."
       },
       "EvaluatorGenerationInputs": {
         "type": "object",
@@ -44891,6 +44886,10 @@
               "traces"
             ],
             "description": "The source type for this source, which is Traces."
+          },
+          "agent_id": {
+            "type": "string",
+            "description": "The unique agent ID used to filter traces. Optional — when omitted, traces are filtered by `agent_name` (and `agent_version` if specified)."
           },
           "agent_name": {
             "type": "string",

--- a/specification/ai-foundry/data-plane/Foundry/src/common/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/common/models.tsp
@@ -153,6 +153,9 @@ model TracesJobSource {
   @doc("The source type for this source, which is Traces.")
   type: "traces";
 
+  @doc("The unique agent ID used to filter traces. Optional — when omitted, traces are filtered by `agent_name` (and `agent_version` if specified).")
+  agent_id?: string;
+
   @doc("The agent name to fetch traces for.")
   agent_name: string;
 

--- a/specification/ai-foundry/data-plane/Foundry/src/evaluators/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/evaluators/models.tsp
@@ -152,16 +152,13 @@ model DatasetReference {
   version: string;
 }
 
-@doc("Service-managed provenance artifacts produced by an evaluator generation job. Present only on EvaluatorVersion resources created via the generation pipeline. All references are read-only and resolve to versioned Foundry Datasets in a service-reserved namespace.")
+@doc("Service-managed provenance artifacts produced by an evaluator generation job. Present only on EvaluatorVersion resources created via the generation pipeline. The combined-JSONL Foundry Dataset is read-only and resolves to a versioned dataset in a service-reserved namespace.")
 model EvaluatorGenerationArtifacts {
-  @doc("Reference to the generated evaluation specification — a Markdown document describing what the evaluator measures, design decisions, and intended scope. Always present for generated evaluators.")
-  spec?: DatasetReference;
+  @doc("Reference to the single Foundry Dataset (one combined JSONL file, version-aligned to `EvaluatorVersion.version`) holding all artifacts produced by the generation pipeline. Each row in the JSONL carries a `kind` field discriminating its content (e.g. `spec`, `tools`, `context`).")
+  dataset: DatasetReference;
 
-  @doc("Reference to the tool schemas inferred during spec generation, when the generation pipeline produced them. JSONL of OpenAI tool-schema objects. Optional: absent when the generation pipeline did not produce or infer tools.")
-  tools?: DatasetReference;
-
-  @doc("Reference to the supplementary context materials used during generation (e.g., file uploads, trace samples). Optional: absent when generation used only inline prompt/agent inputs with no supplementary files.")
-  context?: DatasetReference;
+  @doc("The kinds of rows present in `dataset`. Always contains `\"spec\"` (the generated evaluation specification, a Markdown document describing what the evaluator measures). May additionally contain `\"tools\"` (when the generation pipeline produced or inferred OpenAI tool schemas) and/or `\"context\"` (when supplementary materials such as file uploads or trace samples were used during generation).")
+  kinds: string[];
 }
 
 // ============================================================================


### PR DESCRIPTION
Child PR into #42764 addressing April Kwong's three open review comments from May 1.

## Changes

### 1. `TracesJobSource`: add optional `agent_id` field
Thread: https://github.com/Azure/azure-rest-api-specs/pull/42764#discussion_r3171825101

Adds `agent_id?: string` to `TracesJobSource` (`common/models.tsp:152`). Matches the existing pattern in `TracesPreviewEvalRunDataSource` (`openai-evaluations/models.tsp:350`). When omitted, traces fall back to filtering by `agent_name` (and `agent_version` if specified).

### 2. `EvaluatorGenerationArtifacts`: 3 fields → 1 dataset + kinds[]
Thread: https://github.com/Azure/azure-rest-api-specs/pull/42764#discussion_r3171828994

The TypeSpec was lagging the Apr 27 C1 reshape that already shipped in vienna PR #2056752. Was:
```typespec
model EvaluatorGenerationArtifacts {
  spec?: DatasetReference;
  tools?: DatasetReference;
  context?: DatasetReference;
}
```
Now:
```typespec
model EvaluatorGenerationArtifacts {
  dataset: DatasetReference;     // single combined-JSONL Foundry Dataset
  kinds: string[];               // which kinds appear as rows
}
```
ACA writes this shape today; spec just hadn't caught up.

### 3. Python `clientName` for `EvaluatorGenerationJobs.create`: `generate_job` → `create_generation_job`
Thread: https://github.com/Azure/azure-rest-api-specs/pull/42764#discussion_r3171833803

Updates dargilco's Apr 28 resolution (https://github.com/Azure/azure-rest-api-specs/pull/42264#discussion_r3154791029) per April's May 1 follow-up. All five operations now consistently use the `*_generation_job(s)` form:
- `create_generation_job` (was `generate_job`)
- `get_generation_job`
- `list_generation_jobs`
- `cancel_generation_job`
- `delete_generation_job`

### Regenerated artifacts
Both `openapi3/virtual-public-preview/microsoft-foundry-openapi3.json` and `openapi3/v1/microsoft-foundry-openapi3.json`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
