### PR TITLE
remove isolation key field that had wrong header

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -659,7 +659,6 @@ model AgentEndpointAuthorizationScheme {
 )
 model EntraAuthorizationScheme extends AgentEndpointAuthorizationScheme {
   type: AgentEndpointAuthorizationSchemeType.Entra;
-  isolation_key_source: IsolationKeySource;
 }
 
 @extension(

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
@@ -359,10 +359,6 @@ interface Agents {
       /** The name of the agent to create a session for. */
       @path agent_name: string;
 
-      /** Isolation key used by the agent endpoint to enforce session ownership for session-mutating operations. */
-      @header("x-session-isolation-key")
-      isolation_key: string;
-
       ...CreateAgentSessionRequest;
     },
     ResourceCreatedResponse<AgentSessionResource>
@@ -411,10 +407,6 @@ interface Agents {
 
       /** The session identifier. */
       @path session_id: string;
-
-      /** Isolation key used by the agent endpoint to enforce session ownership for session-mutating operations. */
-      @header("x-session-isolation-key")
-      isolation_key: string;
     },
     NoContentResponse
   >;


### PR DESCRIPTION
# Data Plane API Specification Update Pull Request

Is this review for (select one):

- [ ] a private preview
- [x] a public preview
- [ ] GA release

### Change Scope
This will cause a breaking change to clients, but I think it's necessary. The client is sending a different header than the backend is looking for. Fixing it to send the right header could break people's apps silently. So it's actually safest to push the break, let people stop sending wrong header, then re-introduce the field sending the correct header so that customers can actually test it functional
