### PR TITLE
Bug Bash: Add Rust emitter to ApiCenter.DataApi tspconfig.yaml

### DIFF
--- a/specification/apicenter/ApiCenter.DataApi/tspconfig.yaml
+++ b/specification/apicenter/ApiCenter.DataApi/tspconfig.yaml
@@ -36,6 +36,11 @@ options:
     emitter-output-dir: "{output-dir}/{service-dir}/azure-apicenter"
     namespace: com.azure.apicenter
     flavor: azure
+  "@azure-tools/typespec-rust":
+    crate-name: "azure_apicenter"
+    crate-version: "0.0.1"
+    emitter-output-dir: "{output-dir}/{service-dir}/{crate-name}"
+    omit-constructors: true
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/data-plane"


### PR DESCRIPTION
This PR adds Rust emitter configuration to the ApiCenter DataApi TypeSpec project to enable Rust SDK generation.

## Changes
- Added `@azure-tools/typespec-rust` emitter block to `specification/apicenter/ApiCenter.DataApi/tspconfig.yaml`