### PR TITLE
Add saasResourceId and make planId optional for Confluent SaaS decoupling

### DIFF
--- a/specification/confluent/Confluent.Management/models.tsp
+++ b/specification/confluent/Confluent.Management/models.tsp
@@ -427,6 +427,11 @@ model OrganizationResourceProperties {
    * Link an existing Confluent organization
    */
   linkOrganization?: LinkOrganization;
+
+  /**
+   * The Marketplace SaaS Resource Id linked to the organization
+   */
+  saasResourceId?: string;
 }
 
 /**
@@ -449,7 +454,7 @@ model OfferDetail {
    * Offer Plan Id
    */
   @maxLength(200)
-  planId: string;
+  planId?: string;
 
   /**
    * Offer Plan Name

--- a/specification/confluent/resource-manager/Microsoft.Confluent/preview/2025-07-17-preview/confluent.json
+++ b/specification/confluent/resource-manager/Microsoft.Confluent/preview/2025-07-17-preview/confluent.json
@@ -4359,7 +4359,6 @@
       "required": [
         "publisherId",
         "id",
-        "planId",
         "planName",
         "termUnit"
       ]
@@ -4500,6 +4499,10 @@
         "linkOrganization": {
           "$ref": "#/definitions/LinkOrganization",
           "description": "Link an existing Confluent organization"
+        },
+        "saasResourceId": {
+          "type": "string",
+          "description": "The Marketplace SaaS Resource Id linked to the organization"
         }
       },
       "required": [

--- a/specification/confluent/resource-manager/Microsoft.Confluent/preview/2025-08-18-preview/confluent.json
+++ b/specification/confluent/resource-manager/Microsoft.Confluent/preview/2025-08-18-preview/confluent.json
@@ -4379,7 +4379,6 @@
       "required": [
         "publisherId",
         "id",
-        "planId",
         "planName",
         "termUnit"
       ]
@@ -4520,6 +4519,10 @@
         "linkOrganization": {
           "$ref": "#/definitions/LinkOrganization",
           "description": "Link an existing Confluent organization"
+        },
+        "saasResourceId": {
+          "type": "string",
+          "description": "The Marketplace SaaS Resource Id linked to the organization"
         }
       },
       "required": [

--- a/specification/confluent/resource-manager/Microsoft.Confluent/stable/2024-07-01/confluent.json
+++ b/specification/confluent/resource-manager/Microsoft.Confluent/stable/2024-07-01/confluent.json
@@ -4269,7 +4269,6 @@
       "required": [
         "publisherId",
         "id",
-        "planId",
         "planName",
         "termUnit"
       ]
@@ -4410,6 +4409,10 @@
         "linkOrganization": {
           "$ref": "#/definitions/LinkOrganization",
           "description": "Link an existing Confluent organization"
+        },
+        "saasResourceId": {
+          "type": "string",
+          "description": "The Marketplace SaaS Resource Id linked to the organization"
         }
       },
       "required": [


### PR DESCRIPTION
## Summary

This PR adds support for the SaaS Decoupling flow in Confluent by making two changes to the TypeSpec models:

### Changes Made

| # | Change | Details |
|---|--------|---------|
| 1 | Added `saasResourceId` property | New optional string field in `OrganizationResourceProperties` — stores the Marketplace SaaS Resource Id |
| 2 | Made `planId` optional in `OfferDetail` | Changed from `planId: string` to `planId?: string` |

### Backward Compatibility — No Impact on Existing Flow

- When the SaaS decoupled flow is **not** used, `saasResourceId` is absent and `planId` continues to be provided as before
- Both fields are optional, so no existing client behavior changes
- When using the earlier flow, `saasResourceId` will be `null` by default

### Swagger Regenerated

Swagger regenerated for all 3 API versions:
- `stable/2024-07-01/confluent.json`
- `preview/2025-07-17-preview/confluent.json`
- `preview/2025-08-18-preview/confluent.json`

### Reference
- Reference PR: https://github.com/Azure/azure-rest-api-specs-pr/pull/27414