### PR TITLE
[Network] Remove unsupported tags field from DDoS protection plan properties

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/virtualNetwork.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/virtualNetwork.json
@@ -17530,13 +17530,6 @@
           "description": "Properties of the DDoS protection plan.",
           "x-ms-client-flatten": true
         },
-        "tags": {
-          "type": "object",
-          "description": "Resource tags.",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
         "etag": {
           "type": "string",
           "description": "A unique read-only string that changes whenever the resource is updated.",


### PR DESCRIPTION
## Summary
- removes the 	ags property from the DDoS protection plan properties schema in irtualNetwork.json

## Validation
- scoped diff reviewed for the network 2025-07-01 stable spec