### PR TITLE
Spec: add build_packages_remotely to CodeConfiguration

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -14036,7 +14036,7 @@
         "required": [
           "runtime",
           "entry_point",
-          "build_packages_remotely"
+          "dependency_resolution"
         ],
         "properties": {
           "runtime": {
@@ -14050,10 +14050,14 @@
             },
             "description": "The entry point command and arguments for the code execution."
           },
-          "build_packages_remotely": {
-            "type": "boolean",
-            "description": "Indicates how package dependencies are resolved at deployment time.\nWhen `true`, the service builds dependencies remotely from the manifest\nincluded in the uploaded zip. When `false` (the default), the caller is\nresponsible for bundling all dependencies into the uploaded zip and the\nservice performs no remote build.",
-            "default": false
+          "dependency_resolution": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CodeDependencyResolution"
+              }
+            ],
+            "description": "How package dependencies are resolved at deployment time. Defaults to `bundled`,\nwhere the caller bundles all dependencies into the uploaded zip and the service\nperforms no remote build. `remote_build` instructs the service to build\ndependencies remotely from the manifest included in the uploaded zip.",
+            "default": "bundled"
           },
           "content_hash": {
             "type": "string",
@@ -14067,6 +14071,21 @@
             "CodeAgents=V1Preview"
           ]
         }
+      },
+      "CodeDependencyResolution": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "bundled",
+              "remote_build"
+            ]
+          }
+        ],
+        "description": "How package dependencies are resolved at deployment time for a code-based hosted agent."
       },
       "CompletionMessageToolCallChunk": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -14049,6 +14049,10 @@
             },
             "description": "The entry point command and arguments for the code execution."
           },
+          "build_packages_remotely": {
+            "type": "boolean",
+            "description": "When true, the service builds Python package dependencies remotely (e.g. installs from `requirements.txt` in the uploaded zip) during deployment. When false, the caller has already bundled all dependencies into the zip and no remote build is performed. When omitted, the service applies its default behavior."
+          },
           "content_hash": {
             "type": "string",
             "description": "The SHA-256 hex digest of the uploaded code zip. Set by the service from the `x-ms-code-zip-sha256` request header; read-only in responses and never accepted in request payloads.",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -14035,7 +14035,8 @@
         "type": "object",
         "required": [
           "runtime",
-          "entry_point"
+          "entry_point",
+          "build_packages_remotely"
         ],
         "properties": {
           "runtime": {
@@ -14051,7 +14052,8 @@
           },
           "build_packages_remotely": {
             "type": "boolean",
-            "description": "When true, the service builds Python package dependencies remotely (e.g. installs from `requirements.txt` in the uploaded zip) during deployment. When false, the caller has already bundled all dependencies into the zip and no remote build is performed. When omitted, the service applies its default behavior."
+            "description": "Indicates how package dependencies are resolved at deployment time.\nWhen `true`, the service builds dependencies remotely from the manifest\nincluded in the uploaded zip. When `false` (the default), the caller is\nresponsible for bundling all dependencies into the uploaded zip and the\nservice performs no remote build.",
+            "default": false
           },
           "content_hash": {
             "type": "string",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -9324,6 +9324,7 @@ components:
       required:
         - runtime
         - entry_point
+        - dependency_resolution
       properties:
         runtime:
           type: string
@@ -9333,6 +9334,15 @@ components:
           items:
             type: string
           description: The entry point command and arguments for the code execution.
+        dependency_resolution:
+          allOf:
+            - $ref: '#/components/schemas/CodeDependencyResolution'
+          description: |-
+            How package dependencies are resolved at deployment time. Defaults to `bundled`,
+            where the caller bundles all dependencies into the uploaded zip and the service
+            performs no remote build. `remote_build` instructs the service to build
+            dependencies remotely from the manifest included in the uploaded zip.
+          default: bundled
         content_hash:
           type: string
           description: The SHA-256 hex digest of the uploaded code zip. Set by the service from the `x-ms-code-zip-sha256` request header; read-only in responses and never accepted in request payloads.
@@ -9341,6 +9351,14 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - CodeAgents=V1Preview
+    CodeDependencyResolution:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - bundled
+            - remote_build
+      description: How package dependencies are resolved at deployment time for a code-based hosted agent.
     CompletionMessageToolCallChunk:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -16288,6 +16288,10 @@
             },
             "description": "The entry point command and arguments for the code execution."
           },
+          "build_packages_remotely": {
+            "type": "boolean",
+            "description": "When true, the service builds Python package dependencies remotely (e.g. installs from `requirements.txt` in the uploaded zip) during deployment. When false, the caller has already bundled all dependencies into the zip and no remote build is performed. When omitted, the service applies its default behavior."
+          },
           "content_hash": {
             "type": "string",
             "description": "The SHA-256 hex digest of the uploaded code zip. Set by the service from the `x-ms-code-zip-sha256` request header; read-only in responses and never accepted in request payloads.",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -16274,7 +16274,8 @@
         "type": "object",
         "required": [
           "runtime",
-          "entry_point"
+          "entry_point",
+          "build_packages_remotely"
         ],
         "properties": {
           "runtime": {
@@ -16290,7 +16291,8 @@
           },
           "build_packages_remotely": {
             "type": "boolean",
-            "description": "When true, the service builds Python package dependencies remotely (e.g. installs from `requirements.txt` in the uploaded zip) during deployment. When false, the caller has already bundled all dependencies into the zip and no remote build is performed. When omitted, the service applies its default behavior."
+            "description": "Indicates how package dependencies are resolved at deployment time.\nWhen `true`, the service builds dependencies remotely from the manifest\nincluded in the uploaded zip. When `false` (the default), the caller is\nresponsible for bundling all dependencies into the uploaded zip and the\nservice performs no remote build.",
+            "default": false
           },
           "content_hash": {
             "type": "string",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -16275,7 +16275,7 @@
         "required": [
           "runtime",
           "entry_point",
-          "build_packages_remotely"
+          "dependency_resolution"
         ],
         "properties": {
           "runtime": {
@@ -16289,10 +16289,14 @@
             },
             "description": "The entry point command and arguments for the code execution."
           },
-          "build_packages_remotely": {
-            "type": "boolean",
-            "description": "Indicates how package dependencies are resolved at deployment time.\nWhen `true`, the service builds dependencies remotely from the manifest\nincluded in the uploaded zip. When `false` (the default), the caller is\nresponsible for bundling all dependencies into the uploaded zip and the\nservice performs no remote build.",
-            "default": false
+          "dependency_resolution": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CodeDependencyResolution"
+              }
+            ],
+            "description": "How package dependencies are resolved at deployment time. Defaults to `bundled`,\nwhere the caller bundles all dependencies into the uploaded zip and the service\nperforms no remote build. `remote_build` instructs the service to build\ndependencies remotely from the manifest included in the uploaded zip.",
+            "default": "bundled"
           },
           "content_hash": {
             "type": "string",
@@ -16306,6 +16310,21 @@
             "CodeAgents=V1Preview"
           ]
         }
+      },
+      "CodeDependencyResolution": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "bundled",
+              "remote_build"
+            ]
+          }
+        ],
+        "description": "How package dependencies are resolved at deployment time for a code-based hosted agent."
       },
       "CompletionMessageToolCallChunk": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -10853,6 +10853,7 @@ components:
       required:
         - runtime
         - entry_point
+        - dependency_resolution
       properties:
         runtime:
           type: string
@@ -10862,6 +10863,15 @@ components:
           items:
             type: string
           description: The entry point command and arguments for the code execution.
+        dependency_resolution:
+          allOf:
+            - $ref: '#/components/schemas/CodeDependencyResolution'
+          description: |-
+            How package dependencies are resolved at deployment time. Defaults to `bundled`,
+            where the caller bundles all dependencies into the uploaded zip and the service
+            performs no remote build. `remote_build` instructs the service to build
+            dependencies remotely from the manifest included in the uploaded zip.
+          default: bundled
         content_hash:
           type: string
           description: The SHA-256 hex digest of the uploaded code zip. Set by the service from the `x-ms-code-zip-sha256` request header; read-only in responses and never accepted in request payloads.
@@ -10870,6 +10880,14 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - CodeAgents=V1Preview
+    CodeDependencyResolution:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - bundled
+            - remote_build
+      description: How package dependencies are resolved at deployment time for a code-based hosted agent.
     CompletionMessageToolCallChunk:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -416,8 +416,14 @@ model CodeConfiguration {
   @doc("The entry point command and arguments for the code execution.")
   entry_point: string[];
 
-  @doc("When true, the service builds Python package dependencies remotely (e.g. installs from `requirements.txt` in the uploaded zip) during deployment. When false, the caller has already bundled all dependencies into the zip and no remote build is performed. When omitted, the service applies its default behavior.")
-  build_packages_remotely?: boolean;
+  @doc("""
+    Indicates how package dependencies are resolved at deployment time.
+    When `true`, the service builds dependencies remotely from the manifest
+    included in the uploaded zip. When `false` (the default), the caller is
+    responsible for bundling all dependencies into the uploaded zip and the
+    service performs no remote build.
+    """)
+  build_packages_remotely: boolean = false;
 
   @visibility(Lifecycle.Read)
   @doc("The SHA-256 hex digest of the uploaded code zip. Set by the service from the `x-ms-code-zip-sha256` request header; read-only in responses and never accepted in request payloads.")

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -416,6 +416,9 @@ model CodeConfiguration {
   @doc("The entry point command and arguments for the code execution.")
   entry_point: string[];
 
+  @doc("When true, the service builds Python package dependencies remotely (e.g. installs from `requirements.txt` in the uploaded zip) during deployment. When false, the caller has already bundled all dependencies into the zip and no remote build is performed. When omitted, the service applies its default behavior.")
+  build_packages_remotely?: boolean;
+
   @visibility(Lifecycle.Read)
   @doc("The SHA-256 hex digest of the uploaded code zip. Set by the service from the `x-ms-code-zip-sha256` request header; read-only in responses and never accepted in request payloads.")
   content_hash?: string;

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -417,17 +417,27 @@ model CodeConfiguration {
   entry_point: string[];
 
   @doc("""
-    Indicates how package dependencies are resolved at deployment time.
-    When `true`, the service builds dependencies remotely from the manifest
-    included in the uploaded zip. When `false` (the default), the caller is
-    responsible for bundling all dependencies into the uploaded zip and the
-    service performs no remote build.
+    How package dependencies are resolved at deployment time. Defaults to `bundled`,
+    where the caller bundles all dependencies into the uploaded zip and the service
+    performs no remote build. `remote_build` instructs the service to build
+    dependencies remotely from the manifest included in the uploaded zip.
     """)
-  build_packages_remotely: boolean = false;
+  dependency_resolution: CodeDependencyResolution = CodeDependencyResolution.bundled;
 
   @visibility(Lifecycle.Read)
   @doc("The SHA-256 hex digest of the uploaded code zip. Set by the service from the `x-ms-code-zip-sha256` request header; read-only in responses and never accepted in request payloads.")
   content_hash?: string;
+}
+
+@doc("How package dependencies are resolved at deployment time for a code-based hosted agent.")
+union CodeDependencyResolution {
+  string,
+
+  @doc("The caller has bundled all dependencies into the uploaded zip; the service performs no remote build.")
+  bundled: "bundled",
+
+  @doc("The service builds dependencies remotely from the manifest included in the uploaded zip.")
+  remote_build: "remote_build",
 }
 
 @doc("The hosted agent definition.")


### PR DESCRIPTION
## What
Adds an optional boolean property `build_packages_remotely` to the `CodeConfiguration` model on `HostedAgentDefinition`.

## Why
Lets callers signal how dependencies should be resolved at deployment time:
- **`true`** — service builds Python package dependencies remotely (e.g. `pip install` from `requirements.txt` in the uploaded zip).
- **`false`** — caller has already vendored all dependencies into the zip; the service performs no remote build.
- **omitted** — service applies its default behavior.

This unblocks both vendored-deps scenarios (air-gapped / strict-supply-chain customers) and the simpler "just ship sources + requirements.txt" flow without forcing one or the other at the API contract level.

## Scope
- `specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp` — adds one field on `CodeConfiguration`.
- Regenerated `microsoft-foundry-openapi3.json` (v1 + virtual-public-preview).

No example, client.tsp, or SDK changes — the field is optional and existing examples remain valid.