### PR TITLE
Fix "npx tsp compile client.tsp", and update generation job method names for JS

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/client.tsp
@@ -164,7 +164,16 @@ using Azure.AI.Projects;
 // --------------------------------------------------------------------------------
 // Evaluators sub‐client
 // --------------------------------------------------------------------------------
-@@clientName(Evaluators.listLatestVersions, "list");
+
+// Need to explicitly mention both languages to avoid compile error
+@@clientName(Evaluators.listLatestVersions, "list", "python, javascript");
+
+// Evaluator generation jobs — renamed for JavaScript SDK discoverability
+@@clientName(EvaluatorGenerationJobs.create, "createGenerationJob", "javascript");
+@@clientName(EvaluatorGenerationJobs.get, "getGenerationJob", "javascript");
+@@clientName(EvaluatorGenerationJobs.list, "listGenerationJobs", "javascript");
+@@clientName(EvaluatorGenerationJobs.cancel, "cancelGenerationJob", "javascript");
+@@clientName(EvaluatorGenerationJobs.delete, "deleteGenerationJob", "javascript");
 
 // Evaluator generation jobs — renamed for Python SDK discoverability
 @@clientName(EvaluatorGenerationJobs.create, "create_generation_job", "python");


### PR DESCRIPTION
The TypeSpec  (without this change) does not compile when your run `npx tsp compile client.tsp`.

This PR fixes the error.

Also, since we are merging `Evaluator` and `EvaluatorGenerationJobs` into one ".evaluator" sub-client in JS and Python SDKs (per `relocate-beta-operations.tsp`), we need to make sure they have unique names that are descriptive enough. This was done for Python but not for JS. This PR fixes the issue.