### PR TITLE
Compute 2026-03-01: add FutureCapacityReservation related fields

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/examples/2026-03-01/capacityReservationExamples/CapacityReservation_CreateOrUpdate.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/examples/2026-03-01/capacityReservationExamples/CapacityReservation_CreateOrUpdate.json
@@ -14,7 +14,13 @@
       },
       "zones": [
         "1"
-      ]
+      ],
+      "properties": {
+        "scheduleProfile": {
+          "start": "2026-04-20",
+          "minimumCommitmentDays": 31
+        }
+      }
     },
     "capacityReservationGroupName": "myCapacityReservationGroup",
     "capacityReservationName": "myCapacityReservation"

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/examples/2026-03-01/capacityReservationExamples/CapacityReservation_Get.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/examples/2026-03-01/capacityReservationExamples/CapacityReservation_Get.json
@@ -39,6 +39,9 @@
                 }
               ]
             },
+            "reservationStateInfo": {
+              "reservationState": "Pending"
+            },
             "statuses": [
               {
                 "code": "ProvisioningState/succeeded",

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/models.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/models.tsp
@@ -8566,6 +8566,12 @@ model CapacityReservationInstanceView {
   utilizationInfo?: CapacityReservationUtilization;
 
   /**
+   * The reservation state information of the capacity reservation.
+   */
+  @visibility(Lifecycle.Read)
+  reservationStateInfo?: ReservationStateInfo;
+
+  /**
    * The resource status information.
    */
   @identifiers(#[])
@@ -8583,9 +8589,27 @@ model ScheduleProfile {
   start?: string;
 
   /**
+   * The minimum number of days the capacity reservation must be committed.
+   */
+  @added(Versions.v2026_03_01)
+  minimumCommitmentDays?: int32;
+
+  /**
    * The required end date for block capacity reservations. Must be after the start date, with a duration of either 1–14 whole days or 3–26 whole weeks. Example: 2025-06-28.
    */
   end?: string;
+}
+
+/**
+ * The reservation state information of the capacity reservation.
+ */
+@added(Versions.v2026_03_01)
+model ReservationStateInfo {
+  /**
+   * The reservation state of the capacity reservation.
+   */
+  @visibility(Lifecycle.Read)
+  reservationState?: string;
 }
 
 /**

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-01/ComputeRP.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-01/ComputeRP.json
@@ -13218,6 +13218,11 @@
           "$ref": "#/definitions/CapacityReservationUtilization",
           "description": "Unutilized capacity of the capacity reservation."
         },
+        "reservationStateInfo": {
+          "$ref": "#/definitions/ReservationStateInfo",
+          "readOnly": true,
+          "description": "The reservation state information of the capacity reservation."
+        },
         "statuses": {
           "type": "array",
           "description": "The resource status information.",
@@ -17764,6 +17769,17 @@
         }
       }
     },
+    "ReservationStateInfo": {
+      "type": "object",
+      "description": "The reservation state information of the capacity reservation.",
+      "properties": {
+        "reservationState": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The reservation state of the capacity reservation."
+        }
+      }
+    },
     "ScheduleProfile": {
       "type": "object",
       "description": "Defines the schedule for Block-type capacity reservations. Specifies the schedule during which capacity reservation is active and VM or VMSS resource can be allocated using reservation. This property is required and only supported when the capacity reservation group type is 'Block'. The scheduleProfile, start, and end fields are immutable after creation. Minimum API version: 2025-04-01. Please refer to https://aka.ms/blockcapacityreservation for more details.",
@@ -17771,6 +17787,11 @@
         "start": {
           "type": "string",
           "description": "The required start date for block capacity reservations. Must be today or within 56 days in the future. For same-day scheduling, requests must be submitted before 11:30 AM UTC. Example: 2025-06-27."
+        },
+        "minimumCommitmentDays": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The minimum number of days the capacity reservation must be committed."
         },
         "end": {
           "type": "string",

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-01/examples/capacityReservationExamples/CapacityReservation_CreateOrUpdate.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-01/examples/capacityReservationExamples/CapacityReservation_CreateOrUpdate.json
@@ -14,7 +14,13 @@
       },
       "zones": [
         "1"
-      ]
+      ],
+      "properties": {
+        "scheduleProfile": {
+          "start": "2026-04-20",
+          "minimumCommitmentDays": 31
+        }
+      }
     },
     "capacityReservationGroupName": "myCapacityReservationGroup",
     "capacityReservationName": "myCapacityReservation"

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-01/examples/capacityReservationExamples/CapacityReservation_Get.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-01/examples/capacityReservationExamples/CapacityReservation_Get.json
@@ -39,6 +39,9 @@
                 }
               ]
             },
+            "reservationStateInfo": {
+              "reservationState": "Pending"
+            },
             "statuses": [
               {
                 "code": "ProvisioningState/succeeded",


### PR DESCRIPTION
## Summary
- Added `minimumCommitmentDays` (int32) in `ScheduleProfile` definition
- Added `reservationStateInfo` in `CapacityReservationInstanceView` with new `ReservationStateInfo` definition containing `reservationState` property
- Updated CapacityReservation create and get examples in both stable and Compute example paths to reflect new fields

## Files Changed
1. `specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-01/ComputeRP.json` — Schema definitions
2. `specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-01/examples/capacityReservationExamples/CapacityReservation_CreateOrUpdate.json`
3. `specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-01/examples/capacityReservationExamples/CapacityReservation_Get.json`
4. `specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/examples/2026-03-01/capacityReservationExamples/CapacityReservation_CreateOrUpdate.json`
5. `specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/examples/2026-03-01/capacityReservationExamples/CapacityReservation_Get.json`

## Validation
✅ `npx oav validate-spec` passed  
✅ `npx oav validate-example` passed