### PR TITLE
Scope mongocluster clientName for startIpAddress/endIpAddress to csharp

### DIFF
--- a/specification/mongocluster/resource-manager/Microsoft.DocumentDB/MongoCluster/client.tsp
+++ b/specification/mongocluster/resource-manager/Microsoft.DocumentDB/MongoCluster/client.tsp
@@ -68,8 +68,8 @@ using Microsoft.DocumentDB;
   "MongoClusterFirewallRuleProperties",
   "csharp"
 );
-@@clientName(FirewallRuleProperties.startIpAddress, "startIPAddress");
-@@clientName(FirewallRuleProperties.endIpAddress, "endIPAddress");
+@@clientName(FirewallRuleProperties.startIpAddress, "startIPAddress", "csharp");
+@@clientName(FirewallRuleProperties.endIpAddress, "endIPAddress", "csharp");
 @@clientName(PrivateEndpointConnectionResource,
   "MongoClusterPrivateEndpointConnectionResource",
   "csharp"


### PR DESCRIPTION
The unscoped @@clientName decorators were renaming startIpAddress to startIPAddress for all languages, causing a breaking change in Java SDK. Scope these renames to csharp only so other languages keep the original camelCase property names.

caused by .NET dev https://github.com/Azure/azure-rest-api-specs/pull/39360#discussion_r3185756295