### PR TITLE
Spec: include code-based agent deploy routes in v1

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -75,8 +75,7 @@
   "paths": {
     "/agents": {
       "post": {
-        "operationId": "Agents_createAgent",
-        "description": "Creates the agent.",
+        "operationId": "Agents_createAgent_Agents_createAgentFromCode",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -96,8 +95,28 @@
               "type": "string"
             },
             "explode": false
+          },
+          {
+            "name": "x-ms-agent-name",
+            "in": "header",
+            "required": false,
+            "description": "The unique name that identifies the agent. Max 63 chars, must start and end with alphanumeric, hyphens allowed in the middle.",
+            "schema": {
+              "type": "string",
+              "maxLength": 63
+            }
+          },
+          {
+            "name": "x-ms-code-zip-sha256",
+            "in": "header",
+            "required": false,
+            "description": "SHA-256 hex digest of the uploaded code zip. Used for change detection (dedup) and integrity verification.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
+        "description": "Creates the agent. Creates a new code-based agent. Uploads the code zip and creates the agent in a single call.\nThe agent name is provided in the `x-ms-agent-name` header since POST /agents has no name in the URL path.\nThe SHA-256 hex digest of the zip is provided in the `x-ms-code-zip-sha256` header for integrity and dedup.\nThe request body is multipart/form-data with a JSON metadata part and a binary code part (part order is irrelevant).\nMaximum upload size is 250 MB.",
         "responses": {
           "200": {
             "description": "The request has succeeded.",
@@ -120,6 +139,11 @@
             }
           }
         },
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "CodeAgents=V1Preview"
+          ]
+        },
         "tags": [
           "Agents"
         ],
@@ -130,16 +154,18 @@
               "schema": {
                 "$ref": "#/components/schemas/CreateAgentRequest"
               }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAgentFromCodeContent"
+              },
+              "encoding": {
+                "metadata": {
+                  "contentType": "application/json"
+                }
+              }
             }
           }
-        },
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "HostedAgents=V1Preview",
-            "ContainerAgents=V1Preview",
-            "WorkflowAgents=V1Preview",
-            "CodeAgents=V1Preview"
-          ]
         }
       },
       "get": {
@@ -314,8 +340,7 @@
         ]
       },
       "post": {
-        "operationId": "Agents_updateAgent",
-        "description": "Updates the agent by adding a new version if there are any changes to the agent definition.\nIf no changes, returns the existing agent version.",
+        "operationId": "Agents_updateAgent_Agents_updateAgentFromCode",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -344,8 +369,18 @@
               "type": "string"
             },
             "explode": false
+          },
+          {
+            "name": "x-ms-code-zip-sha256",
+            "in": "header",
+            "required": false,
+            "description": "SHA-256 hex digest of the uploaded code zip. Used for change detection (dedup) and integrity verification.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
+        "description": "Updates the agent by adding a new version if there are any changes to the agent definition.\nIf no changes, returns the existing agent version. Updates a code-based agent by uploading new code and creating a new version.\nIf the code and definition are unchanged (matched by x-ms-code-zip-sha256 header), returns the existing version.\nThe request body is multipart/form-data with a JSON metadata part and a binary code part (part order is irrelevant).\nMaximum upload size is 250 MB.",
         "responses": {
           "200": {
             "description": "The request has succeeded.",
@@ -368,6 +403,11 @@
             }
           }
         },
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "CodeAgents=V1Preview"
+          ]
+        },
         "tags": [
           "Agents"
         ],
@@ -377,6 +417,16 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/UpdateAgentRequest"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAgentVersionFromCodeContent"
+              },
+              "encoding": {
+                "metadata": {
+                  "contentType": "application/json"
+                }
               }
             }
           }
@@ -506,6 +556,76 @@
         "x-ms-foundry-meta": {
           "required_previews": [
             "AgentEndpoints=V1Preview"
+          ]
+        }
+      }
+    },
+    "/agents/{agent_name}/code:download": {
+      "get": {
+        "operationId": "Agents_downloadAgentCode",
+        "description": "Download the code zip for the latest version of a code-based hosted agent.\nReturns the previously-uploaded zip (`application/zip`).\nThe SHA-256 digest of the returned bytes matches the `content_hash` on the latest version's `code_configuration`.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "CodeAgents=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "agent_name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the agent whose latest-version code zip should be downloaded.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response body for downloading a hosted agent's code zip.\nBody is the raw zip bytes; `Content-Type` declares `application/zip` so clients\ncan route to a zip-aware handler. Streaming is preserved (`bytes` body) regardless\nof the content-type label.",
+            "content": {
+              "application/zip": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Agents"
+        ],
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "CodeAgents=V1Preview"
           ]
         }
       }
@@ -1650,8 +1770,7 @@
     },
     "/agents/{agent_name}/versions": {
       "post": {
-        "operationId": "Agents_createAgentVersion",
-        "description": "Create a new agent version.",
+        "operationId": "Agents_createAgentVersion_Agents_createAgentVersionFromCode",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -1681,8 +1800,18 @@
               "type": "string"
             },
             "explode": false
+          },
+          {
+            "name": "x-ms-code-zip-sha256",
+            "in": "header",
+            "required": false,
+            "description": "SHA-256 hex digest of the uploaded code zip. Used for change detection (dedup) and integrity verification.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
+        "description": "Create a new agent version.",
         "responses": {
           "200": {
             "description": "The request has succeeded.",
@@ -1705,6 +1834,11 @@
             }
           }
         },
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "CodeAgents=V1Preview"
+          ]
+        },
         "tags": [
           "Agents"
         ],
@@ -1715,16 +1849,18 @@
               "schema": {
                 "$ref": "#/components/schemas/CreateAgentVersionRequest"
               }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAgentVersionFromCodeContent"
+              },
+              "encoding": {
+                "metadata": {
+                  "contentType": "application/json"
+                }
+              }
             }
           }
-        },
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "HostedAgents=V1Preview",
-            "ContainerAgents=V1Preview",
-            "WorkflowAgents=V1Preview",
-            "CodeAgents=V1Preview"
-          ]
         }
       },
       "get": {
@@ -1964,6 +2100,85 @@
         "tags": [
           "Agents"
         ]
+      }
+    },
+    "/agents/{agent_name}/versions/{agent_version}/code:download": {
+      "get": {
+        "operationId": "Agents_downloadAgentVersionCode",
+        "description": "Download the code zip for a specific version of a code-based hosted agent.\nReturns the previously-uploaded zip (`application/zip`).\nThe SHA-256 digest of the returned bytes matches the `content_hash` on the agent version's `code_configuration`.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "CodeAgents=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "agent_name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the agent.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "agent_version",
+            "in": "path",
+            "required": true,
+            "description": "The version of the agent whose code zip should be downloaded.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response body for downloading a hosted agent's code zip.\nBody is the raw zip bytes; `Content-Type` declares `application/zip` so clients\ncan route to a zip-aware handler. Streaming is preserved (`bytes` body) regardless\nof the content-type label.",
+            "content": {
+              "application/zip": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Agents"
+        ],
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "CodeAgents=V1Preview"
+          ]
+        }
       }
     },
     "/agents/{agent_name}/versions/{agent_version}/sessions/{session_id}:logstream": {
@@ -11654,7 +11869,8 @@
           "HostedAgents=V1Preview",
           "WorkflowAgents=V1Preview",
           "ContainerAgents=V1Preview",
-          "AgentEndpoints=V1Preview"
+          "AgentEndpoints=V1Preview",
+          "CodeAgents=V1Preview"
         ],
         "description": "Feature opt-in keys for agent definition operations supporting hosted or workflow agents."
       },
@@ -14505,6 +14721,28 @@
         ],
         "description": "CosmosDB Vector Store Index Definition"
       },
+      "CreateAgentFromCodeContent": {
+        "type": "object",
+        "properties": {
+          "metadata": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CreateAgentVersionFromCodeRequest"
+              }
+            ],
+            "description": "JSON metadata including description and hosted definition."
+          },
+          "code": {
+            "type": "string",
+            "format": "binary",
+            "description": "The code zip file (max 250 MB)."
+          }
+        },
+        "required": [
+          "metadata",
+          "code"
+        ]
+      },
       "CreateAgentFromManifestRequest": {
         "type": "object",
         "required": [
@@ -14655,6 +14893,63 @@
         "x-ms-foundry-meta": {
           "required_previews": [
             "AgentEndpoints=V1Preview"
+          ]
+        }
+      },
+      "CreateAgentVersionFromCodeContent": {
+        "type": "object",
+        "properties": {
+          "metadata": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CreateAgentVersionFromCodeRequest"
+              }
+            ],
+            "description": "JSON metadata including description and hosted definition."
+          },
+          "code": {
+            "type": "string",
+            "format": "binary",
+            "description": "The code zip file (max 250 MB)."
+          }
+        },
+        "required": [
+          "metadata",
+          "code"
+        ]
+      },
+      "CreateAgentVersionFromCodeRequest": {
+        "type": "object",
+        "required": [
+          "definition"
+        ],
+        "properties": {
+          "description": {
+            "type": "string",
+            "maxLength": 512,
+            "description": "A human-readable description of the agent."
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Set of 16 key-value pairs that can be attached to an object. This can be\nuseful for storing additional information about the object in a structured\nformat, and querying for objects via API or the dashboard.\n\nKeys are strings with a maximum length of 64 characters. Values are strings\nwith a maximum length of 512 characters.",
+            "x-oaiTypeLabel": "map"
+          },
+          "definition": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HostedAgentDefinition"
+              }
+            ],
+            "description": "The hosted agent definition including code_configuration (runtime, entry_point), cpu, memory, and protocol_versions."
+          }
+        },
+        "description": "JSON metadata for code-based agent operations (create, update, create version).\nThe agent name comes from the URL path parameter or the `x-ms-agent-name` header,\nso it is not included in this model.\nThe content hash (SHA-256 of the zip) is carried in the `x-ms-code-zip-sha256` header.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "CodeAgents=V1Preview"
           ]
         }
       },

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
@@ -51,7 +51,6 @@ interface Agents {
     "x-ms-foundry-meta",
     #{ required_previews: #[AgentDefinitionOptInKeys.code_agents_v1_preview] }
   )
-  @removed(Versions.v1)
   createAgentFromCode is FoundryDataPlanePreviewOperation<
     AgentDefinitionOptInKeys,
     {
@@ -103,7 +102,6 @@ interface Agents {
     "x-ms-foundry-meta",
     #{ required_previews: #[AgentDefinitionOptInKeys.code_agents_v1_preview] }
   )
-  @removed(Versions.v1)
   updateAgentFromCode is FoundryDataPlanePreviewOperation<
     AgentDefinitionOptInKeys,
     {
@@ -313,7 +311,6 @@ interface Agents {
     "x-ms-foundry-meta",
     #{ required_previews: #[AgentDefinitionOptInKeys.code_agents_v1_preview] }
   )
-  @removed(Versions.v1)
   createAgentVersionFromCode is FoundryDataPlanePreviewOperation<
     AgentDefinitionOptInKeys,
     {
@@ -349,7 +346,6 @@ interface Agents {
     "x-ms-foundry-meta",
     #{ required_previews: #[AgentDefinitionOptInKeys.code_agents_v1_preview] }
   )
-  @removed(Versions.v1)
   downloadAgentVersionCode is FoundryDataPlanePreviewOperation<
     AgentDefinitionOptInKeys.code_agents_v1_preview,
     {
@@ -373,7 +369,6 @@ interface Agents {
     "x-ms-foundry-meta",
     #{ required_previews: #[AgentDefinitionOptInKeys.code_agents_v1_preview] }
   )
-  @removed(Versions.v1)
   downloadAgentCode is FoundryDataPlanePreviewOperation<
     AgentDefinitionOptInKeys.code_agents_v1_preview,
     {

--- a/specification/ai-foundry/data-plane/Foundry/src/servicepatterns.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/servicepatterns.tsp
@@ -41,7 +41,6 @@ union AgentDefinitionOptInKeys {
   container_agents_v1_preview: "ContainerAgents=V1Preview",
   agent_endpoint_v1_preview: "AgentEndpoints=V1Preview",
 
-  @removed(Versions.v1)
   code_agents_v1_preview: "CodeAgents=V1Preview",
 }
 


### PR DESCRIPTION
Remove @removed(Versions.v1) from code-based agent deploy operations (createAgentFromCode, updateAgentFromCode, createAgentVersionFromCode, downloadAgentCode, downloadAgentVersionCode) and the supporting code_agents_v1_preview opt-in key so the surface is available in v1.

