### PR TITLE
CP: Added Private Endpoint Billing Sku Property in 2025-07-01 (#42367)

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/Network/Common/main.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Common/main.tsp
@@ -215,6 +215,24 @@ union PrivateEndpointIPVersionType {
 }
 
 /**
+ * The billing sku of the private endpoint.
+ */
+@added(Versions.v2025_07_01)
+union PrivateEndpointBillingSku {
+  string,
+
+  /**
+   * PayAsYouGo sku is the default price for private endpoints.
+   */
+  PayAsYouGo: "PayAsYouGo",
+
+  /**
+   * Fixed sku is best for high data processing private endpoints.
+   */
+  Fixed: "Fixed",
+}
+
+/**
  * Name of a load balancer SKU.
  */
 union LoadBalancerSkuName {
@@ -2862,6 +2880,12 @@ model PrivateEndpointProperties {
    * The custom name of the network interface attached to the private endpoint.
    */
   customNetworkInterfaceName?: string;
+
+  /**
+   * The billing sku of the private endpoint.
+   */
+  @added(Versions.v2025_07_01)
+  billingSku?: PrivateEndpointBillingSku;
 }
 
 /**

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
@@ -26100,8 +26100,6 @@ model ExpressRoutePortAuthorizationListResult
 model ExpressRoutePortsLocationListResult
   is Azure.Core.Page<ExpressRoutePortsLocation>;
 
-model BastionHostListResult is Azure.Core.Page<BastionHost>;
-
 @@Azure.ClientGenerator.Core.clientName(ListVirtualHubRouteTableV2SResult,
   "ListVirtualHubRouteTableV2sResult"
 );

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2018-10-01/vmssNetwork.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2018-10-01/vmssNetwork.json
@@ -3038,6 +3038,30 @@
         }
       ]
     },
+    "Common.PrivateEndpointBillingSku": {
+      "type": "string",
+      "description": "The billing sku of the private endpoint.",
+      "enum": [
+        "PayAsYouGo",
+        "Fixed"
+      ],
+      "x-ms-enum": {
+        "name": "PrivateEndpointBillingSku",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "PayAsYouGo",
+            "value": "PayAsYouGo",
+            "description": "PayAsYouGo sku is the default price for private endpoints."
+          },
+          {
+            "name": "Fixed",
+            "value": "Fixed",
+            "description": "Fixed sku is best for high data processing private endpoints."
+          }
+        ]
+      }
+    },
     "Common.PrivateEndpointConnection": {
       "type": "object",
       "description": "PrivateEndpointConnection resource.",
@@ -3222,6 +3246,10 @@
         "customNetworkInterfaceName": {
           "type": "string",
           "description": "The custom name of the network interface attached to the private endpoint."
+        },
+        "billingSku": {
+          "$ref": "#/definitions/Common.PrivateEndpointBillingSku",
+          "description": "The billing sku of the private endpoint."
         }
       }
     },

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/common.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/common.json
@@ -2699,6 +2699,30 @@
         ]
       }
     },
+    "Common.PrivateEndpointBillingSku": {
+      "type": "string",
+      "description": "The billing sku of the private endpoint.",
+      "enum": [
+        "PayAsYouGo",
+        "Fixed"
+      ],
+      "x-ms-enum": {
+        "name": "PrivateEndpointBillingSku",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "PayAsYouGo",
+            "value": "PayAsYouGo",
+            "description": "PayAsYouGo sku is the default price for private endpoints."
+          },
+          {
+            "name": "Fixed",
+            "value": "Fixed",
+            "description": "Fixed sku is best for high data processing private endpoints."
+          }
+        ]
+      }
+    },
     "Common.PrivateEndpointVNetPolicies": {
       "type": "string",
       "description": "Private Endpoint VNet Policies.",

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/virtualNetwork.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/virtualNetwork.json
@@ -15780,6 +15780,10 @@
         "customNetworkInterfaceName": {
           "type": "string",
           "description": "The custom name of the network interface attached to the private endpoint."
+        },
+        "billingSku": {
+          "$ref": "./common.json#/definitions/Common.PrivateEndpointBillingSku",
+          "description": "The billing sku of the private endpoint."
         }
       }
     },


### PR DESCRIPTION
This is CP from original [PR link](https://github.com/Azure/azure-rest-api-specs/pull/42367)

* Added PrivateEndpoints to 2025-07-01

* Added billing sku property to private endpoint

* Update references in PrivateEndpoint to Common file and Update Readme with 2025-07-01 PrivateEndpoint

* Reverted changes- Added BillingSku to PrivateEndpoint resource in VirtualNetwork file

* Restored and Updated/Generated swagger change with TypeSpec

* Removed extra line

* added vmss for typespec validation

* Default description

* Descriptions

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
