### PR TITLE
[fleet] Readd accidently removed MAF fields from TSPs

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2026-05-01-preview/fleets.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2026-05-01-preview/fleets.json
@@ -5782,6 +5782,11 @@
           "maxLength": 50,
           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
         },
+        "maxAllowedFailures": {
+          "type": "string",
+          "description": "Limits the number of member (cluster) upgrade failures tolerated within this group.\nFailures are evaluated over members within this group only. \nAccepts either:\n  • A fixed count n, where n >= 0\n  • A percentage p%, where 0 <= p <= 100\n    Percentage resolves at stage start using: resolvedThreshold = ceil(p * N), \n    where p is the percentage as als decimal and N is the number of members in this group at scope start.\nExamples:\n  • \"3\"   --> up to 3 member upgrade failures are tolerated within this group. The 4th failure would cause the entire stage to fail.\n  • \"25%\" --> up to 25% of the members in this group can fail their upgrade before the group is considered failed.",
+          "pattern": "^(?:0|[1-9]\\d*|(?:0|[1-9]\\d?|100)%)$"
+        },
         "maxConcurrency": {
           "type": "string",
           "description": "The max number of upgrades that can run concurrently in this specific group.\nActs as a ceiling (and not a quota) for the number of concurrent upgrades within the group you want to tolerate at a time.\nActual concurrency may be lower depending on stage-level concurrency limits or individual member conditions.\nGroup maxConcurrency has a min value of \"1\". The max value is min(number of clusters in the group, the stage maxConcurrency).\nIf no value is provided, defaults to 1.\nAccepts either:\n    • A fixed count, e.g. \"3\"\n    • A percentage, e.g. \"25%\" (range 1–100). Percentage is of the number of clusters in the group. \n      Fractional results are rounded down. A minimum of 1 upgrade is enforced.\nExamples:\n    • \"3\" --> up to 3 members from this group upgrade at once.\n    • \"100%\" --> “all at once”, up to all members for this group upgrade at the same time.\n    • \"25%\" --> up to 25% of the members in the group will be upgraded at the same time.",
@@ -6089,6 +6094,12 @@
           "$ref": "#/definitions/NodeImageSelectionStatus",
           "description": "The node image upgrade specs for the update run. It is only set in update run when `NodeImageSelection.type` is `Consistent`.",
           "readOnly": true
+        },
+        "failureCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Total member upgrade failures across the entire UpdateRun.",
+          "readOnly": true
         }
       }
     },
@@ -6144,6 +6155,11 @@
           "type": "integer",
           "format": "int32",
           "description": "The time in seconds to wait at the end of this stage before starting the next one. Defaults to 0 seconds if unspecified."
+        },
+        "maxAllowedFailures": {
+          "type": "string",
+          "description": "Limits the number of member (cluster) upgrade failures tolerated within this stage.\nFailures are evaluated over all members within all groups within this stage. \nAccepts either:\n  • A fixed count n, where n >= 0\n  • A percentage p%, where 0 <= p <= 100\n    Percentage resolves at stage start using: resolvedThreshold = ceil(p * N), \n    where p is the percentage as a decimal and N is the number of members in this stage at scope start.\nExamples:\n  • \"3\"   --> up to 3 member upgrade failures are tolerated within this stage. The 4th failure would cause the entire stage to fail.\n  • \"25%\" --> up to 25% of the members in this stage can fail their upgrade before the stage is considered failed.",
+          "pattern": "^(?:0|[1-9]\\d*|(?:0|[1-9]\\d?|100)%)$"
         },
         "maxConcurrency": {
           "type": "string",

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/update/common.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/update/common.tsp
@@ -48,6 +48,22 @@ model UpdateStage {
   afterStageWaitInSeconds?: int32;
 
   @doc("""
+  Limits the number of member (cluster) upgrade failures tolerated within this stage.
+  Failures are evaluated over all members within all groups within this stage. 
+  Accepts either:
+    • A fixed count n, where n >= 0
+    • A percentage p%, where 0 <= p <= 100
+      Percentage resolves at stage start using: resolvedThreshold = ceil(p * N), 
+      where p is the percentage as a decimal and N is the number of members in this stage at scope start.
+  Examples:
+    • "3"   --> up to 3 member upgrade failures are tolerated within this stage. The 4th failure would cause the entire stage to fail.
+    • "25%" --> up to 25% of the members in this stage can fail their upgrade before the stage is considered failed.
+  """)
+  @pattern("^(?:0|[1-9]\\d*|(?:0|[1-9]\\d?|100)%)$")
+  @added(Versions.v2026_05_01_preview)
+  maxAllowedFailures?: string;
+
+  @doc("""
     The max number of upgrades that can run concurrently across all groups in this stage.
     Acts as a ceiling (and not a quota) for the number of concurrent upgrades within the stage you want to tolerate at a time.
     Actual concurrency may be lower depending on group-level concurrency limits or individual member conditions.
@@ -105,6 +121,22 @@ model UpdateGroup {
   @minLength(1)
   @maxLength(50)
   name: string;
+
+  @doc("""
+  Limits the number of member (cluster) upgrade failures tolerated within this group.
+  Failures are evaluated over members within this group only. 
+  Accepts either:
+    • A fixed count n, where n >= 0
+    • A percentage p%, where 0 <= p <= 100
+      Percentage resolves at stage start using: resolvedThreshold = ceil(p * N), 
+      where p is the percentage as als decimal and N is the number of members in this group at scope start.
+  Examples:
+    • "3"   --> up to 3 member upgrade failures are tolerated within this group. The 4th failure would cause the entire stage to fail.
+    • "25%" --> up to 25% of the members in this group can fail their upgrade before the group is considered failed.
+  """)
+  @pattern("^(?:0|[1-9]\\d*|(?:0|[1-9]\\d?|100)%)$")
+  @added(Versions.v2026_05_01_preview)
+  maxAllowedFailures?: string;
 
   @doc("""
     The max number of upgrades that can run concurrently in this specific group.

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/update/run.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/update/run.tsp
@@ -229,6 +229,11 @@ model UpdateRunStatus {
   @doc("The node image upgrade specs for the update run. It is only set in update run when `NodeImageSelection.type` is `Consistent`.")
   @added(Versions.v2023_06_15_preview)
   nodeImageSelection?: NodeImageSelectionStatus;
+
+  @visibility(Lifecycle.Read)
+  @doc("Total member upgrade failures across the entire UpdateRun.")
+  @added(Versions.v2026_05_01_preview)
+  failureCount?: int32;
 }
 
 @doc("The node image upgrade specs for the update run.")


### PR DESCRIPTION
Readding fields that were removed during a possible rebase merge conflict that overwrite the files...
https://github.com/Azure/azure-rest-api-specs/pull/42330

[See missing field maxAllowedFailures in common.tsp](https://github.com/Azure/azure-rest-api-specs/blob/75159537bf8de7446beeb8f5728421d3491f6c0f/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/update/common.tsp#L49)
